### PR TITLE
Fix CssSyntaxError: @apply should not be used with 'group' utility

### DIFF
--- a/blog5/templates/header.html
+++ b/blog5/templates/header.html
@@ -93,7 +93,7 @@
 
     /* Card hover effect */
     .case-card {
-      @apply block p-8 border border-white/10 rounded-3xl bg-surface-alt/30 backdrop-blur-md transition-all duration-300 relative group overflow-hidden;
+      @apply block p-8 border border-white/10 rounded-3xl bg-surface-alt/30 backdrop-blur-md transition-all duration-300 relative overflow-hidden;
     }
     .case-card:hover {
       @apply -translate-y-1 shadow-2xl shadow-primary/10 border-primary/30;


### PR DESCRIPTION
Removes `group` from `.case-card` `@apply` directive to fix `CssSyntaxError`. Confirmed `group` is present in HTML usage.

---
*PR created automatically by Jules for task [13540113109035561955](https://jules.google.com/task/13540113109035561955) started by @hahwul*