### PR TITLE
Fix CssSyntaxError in landing1 due to invalid @apply usage

### DIFF
--- a/landing1/templates/header.html
+++ b/landing1/templates/header.html
@@ -84,7 +84,7 @@
 
     /* Feature card */
     .feature-card {
-      @apply p-8 rounded-2xl glass hover:bg-white/10 transition-all duration-300 group;
+      @apply p-8 rounded-2xl glass hover:bg-white/10 transition-all duration-300;
     }
     .feature-card .feature-icon {
       @apply text-4xl mb-4 text-transparent bg-clip-text bg-gradient-to-br from-primary-light to-accent inline-block transition-transform duration-300 group-hover:scale-110;
@@ -131,7 +131,7 @@
 
     /* Blog card */
     .blog-card {
-      @apply block p-0 bg-surface-alt/30 rounded-2xl border border-white/5 overflow-hidden transition-all duration-300 hover:border-primary/30 hover:shadow-2xl hover:shadow-primary/10 group;
+      @apply block p-0 bg-surface-alt/30 rounded-2xl border border-white/5 overflow-hidden transition-all duration-300 hover:border-primary/30 hover:shadow-2xl hover:shadow-primary/10;
     }
     .blog-card-image {
       @apply h-48 bg-surface-alt w-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500;

--- a/landing1/templates/section.html
+++ b/landing1/templates/section.html
@@ -4,7 +4,7 @@
     {% if page.description %}<p class="text-muted text-lg mb-8">{{ page.description }}</p>{% endif %}
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       {% for post in section.pages %}
-      <a href="{{ post.url }}" class="blog-card">
+      <a href="{{ post.url }}" class="blog-card group">
         <h2>{{ post.title }}</h2>
         {% if post.date %}<time class="text-sm text-muted">{{ post.date | date("%B %d, %Y") }}</time>{% endif %}
         {% if post.description %}<p class="text-muted text-sm mt-2 mb-0">{{ post.description }}</p>{% endif %}

--- a/landing1/templates/shortcodes/feature.html
+++ b/landing1/templates/shortcodes/feature.html
@@ -1,4 +1,4 @@
-<div class="feature-card">
+<div class="feature-card group">
   <div class="feature-icon">{{ icon }}</div>
   <h3>{{ title }}</h3>
   <p>{{ description }}</p>


### PR DESCRIPTION
Removed `group` from `@apply` in `landing1/templates/header.html` and added it to HTML templates to fix a CSS syntax error during rendering.

---
*PR created automatically by Jules for task [10674801356719880002](https://jules.google.com/task/10674801356719880002) started by @hahwul*