### PR TITLE
Fix blog4 broken CSS due to config parsing errors

### DIFF
--- a/blog4/templates/header.html
+++ b/blog4/templates/header.html
@@ -10,7 +10,7 @@
   <!-- Google Fonts: Inter & JetBrains Mono for that cyber feel -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
 
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -20,14 +20,14 @@
       theme: {
         extend: {
           colors: {
-            primary: '#34d399',      /* Emerald 400 */
-            'primary-light': '#6ee7b7', /* Emerald 300 */
-            'primary-dark': '#059669',  /* Emerald 600 */
-            surface: '#0f172a',      /* Slate 900 */
-            'surface-alt': '#1e293b', /* Slate 800 */
-            border: '#334155',       /* Slate 700 */
-            muted: '#94a3b8',        /* Slate 400 */
-            text: '#e2e8f0',         /* Slate 200 */
+            primary: '#34d399',
+            'primary-light': '#6ee7b7',
+            'primary-dark': '#059669',
+            surface: '#0f172a',
+            'surface-alt': '#1e293b',
+            border: '#334155',
+            muted: '#94a3b8',
+            text: '#e2e8f0',
           },
           fontFamily: {
             mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],


### PR DESCRIPTION
This PR fixes the broken CSS on the blog4 page. The issue was caused by inline comments in the Tailwind configuration object within the `<script>` tag, which were not being parsed correctly by the Tailwind CDN script. Additionally, an unescaped ampersand in the Google Fonts URL was corrected.

Changes:
- Modified `blog4/templates/header.html` to remove `/* ... */` comments from the Tailwind config.
- Modified `blog4/templates/header.html` to escape `&` to `&amp;` in the Google Fonts `<link>` tag.

Verification:
- Created a temporary `test_verification.html` replicating the header structure.
- Verified that styles (colors, fonts, layout) are correctly applied using a Playwright script and screenshot analysis.

---
*PR created automatically by Jules for task [8024667135961965043](https://jules.google.com/task/8024667135961965043) started by @hahwul*