### PR TITLE
Fix blog4 CSS rendering error by removing 'group' from @apply

### DIFF
--- a/blog4/templates/header.html
+++ b/blog4/templates/header.html
@@ -71,7 +71,7 @@
 
     /* Timeline / Post List */
     .timeline-item {
-      @apply flex flex-col sm:flex-row gap-4 p-5 rounded-xl border border-transparent transition-all duration-300 hover:bg-surface-alt hover:border-border hover:shadow-lg hover:shadow-primary/5 group;
+      @apply flex flex-col sm:flex-row gap-4 p-5 rounded-xl border border-transparent transition-all duration-300 hover:bg-surface-alt hover:border-border hover:shadow-lg hover:shadow-primary/5;
     }
     /* We remove the dot timeline style for a cleaner card/list look */
 


### PR DESCRIPTION
Addressed the `CssSyntaxError: ... @apply should not be used with the 'group' utility` issue reported during blog4 rendering. Modified `blog4/templates/header.html` to remove `group` from the `.timeline-item` CSS definition. Verified that the `group` class is correctly applied in the HTML markup where needed.

---
*PR created automatically by Jules for task [11308274783783080390](https://jules.google.com/task/11308274783783080390) started by @hahwul*