### PR TITLE
Fix feature-card grid layout in landing1

### DIFF
--- a/landing1/content/index.md
+++ b/landing1/content/index.md
@@ -56,19 +56,12 @@ description = "Team collaboration, reimagined"
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-
   {{ feature(icon="⚡", title="Real-time Sync", description="See changes instantly across your team. No refresh needed — every update appears in real-time.") }}
-
   {{ feature(icon="📋", title="Smart Boards", description="Kanban, timeline, and list views. Organize work the way your team thinks, with drag-and-drop simplicity.") }}
-
   {{ feature(icon="🔗", title="Integrations", description="Connect with GitHub, Slack, Figma, and 100+ tools your team already uses. No context switching.") }}
-
   {{ feature(icon="📊", title="Analytics", description="Track velocity, burndown, and team workload. Make data-driven decisions with beautiful dashboards.") }}
-
   {{ feature(icon="🔒", title="Enterprise Security", description="SOC 2 Type II certified. SSO, SCIM provisioning, audit logs, and data encryption at rest.") }}
-
   {{ feature(icon="🌍", title="Global CDN", description="Lightning-fast performance worldwide. Your data is served from the edge, closest to your team.") }}
-
   </div>
 
   <div class="text-center max-w-2xl mx-auto mb-16 mt-32">
@@ -77,13 +70,9 @@ description = "Team collaboration, reimagined"
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
-
   {{ pricing(name="Starter", price="$0", description="For individuals and small projects", f1="Up to 5 users", f2="10 projects", f3="Basic analytics", f4="Community support") }}
-
   {{ pricing(name="Pro", price="$12", description="For growing teams that need more", highlight="true", f1="Unlimited users", f2="Unlimited projects", f3="Advanced analytics", f4="Priority support", f5="Custom integrations") }}
-
   {{ pricing(name="Enterprise", price="$49", description="For large organizations", f1="Everything in Pro", f2="SSO & SCIM", f3="Audit logs", f4="Dedicated CSM", f5="99.99% SLA") }}
-
   </div>
 
   {{ cta(title="Ready to transform your workflow?", description="Join 10,000+ teams already using FlowSync to ship faster.", button="Start Free Trial") }}


### PR DESCRIPTION
The `landing1` site's feature cards were rendering as a single vertical column (or broken layout) because blank lines inside the `<div class="grid ...">` block caused the Markdown parser to close the `div` early. This left the shortcodes outside the grid container.

I removed the blank lines within the `div` blocks for both the features and pricing sections in `landing1/content/index.md`. This forces the parser to treat the entire block as raw HTML, preserving the nesting and ensuring the grid styles are applied correctly.

I also verified the fix by inspecting the file content and confirmed that the blank lines are removed. Frontend verification was skipped due to the absence of the `hwaro` build tool, but the fix aligns with standard Markdown behavior for HTML blocks.

---
*PR created automatically by Jules for task [17248804269077313785](https://jules.google.com/task/17248804269077313785) started by @hahwul*