### PR TITLE
Fix CSS syntax error in resume1 by removing group from @apply

### DIFF
--- a/resume1/templates/header.html
+++ b/resume1/templates/header.html
@@ -105,7 +105,7 @@
 
     /* Project card */
     .project-card {
-      @apply block p-6 rounded-xl bg-surface/40 border border-white/5 backdrop-blur-md transition-all duration-300 group relative overflow-hidden;
+      @apply block p-6 rounded-xl bg-surface/40 border border-white/5 backdrop-blur-md transition-all duration-300 relative overflow-hidden;
     }
     .project-card::before {
       content: "";


### PR DESCRIPTION
Removed the `group` utility class from the `@apply` directive in `resume1/templates/header.html` as it causes a `CssSyntaxError`. Verified that `group` is applied directly in the HTML markup where `.project-card` is used.

---
*PR created automatically by Jules for task [8426590047501010731](https://jules.google.com/task/8426590047501010731) started by @hahwul*