### PR TITLE
⚡ Enable Lazy Loading for HWARO.386

### DIFF
--- a/hwaro.386/config.toml
+++ b/hwaro.386/config.toml
@@ -57,4 +57,4 @@ sections = ["posts"]
 
 [markdown]
 safe = false
-lazy_loading = false
+lazy_loading = true


### PR DESCRIPTION
💡 **What:** Enabled lazy loading for markdown-generated images by setting `lazy_loading = true` in `hwaro.386/config.toml`.

🎯 **Why:** Lazy loading delays the loading of images off-screen until the user scrolls near them, reducing initial page load time, network payload, and memory usage.

📊 **Measured Improvement:** I was unable to show a meaningful performance improvement because the `hwaro` static site generator binary is not installed in the environment (and cannot be easily built since `crystal` is also not installed). Therefore, a local build and benchmark (e.g., measuring TTFB or page load speed before and after the change) was not possible. However, enabling native lazy loading for images is a well-known web performance best practice that mathematically reduces the bytes transferred on initial page load for pages with multiple images below the fold.

---
*PR created automatically by Jules for task [4118472130506293248](https://jules.google.com/task/4118472130506293248) started by @hahwul*