### PR TITLE
⚡ perf: Enable lazy loading for images in HwaroNight

### DIFF
--- a/hwaronight/config.toml
+++ b/hwaronight/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)


### PR DESCRIPTION
⚡ **What:** Enabled `lazy_loading` for images in `hwaronight/config.toml`.

🎯 **Why:** To improve performance by deferring the loading of off-screen images until the user scrolls near them.

📊 **Measured Improvement:** Since the Hwaro compiler is not installed in the current environment to build and benchmark the generated site directly, a direct performance measurement couldn't be collected here. However, enabling native lazy loading (`loading="lazy"`) is a standard browser feature that predictably reduces initial page load times, bandwidth consumption, and improves core web vitals (like LCP and FCP) on pages containing multiple images.

---
*PR created automatically by Jules for task [6800443419276797757](https://jules.google.com/task/6800443419276797757) started by @hahwul*