### PR TITLE
⚡ Enable Lazy Loading for Markdown Images (Hermit Theme)

### DIFF
--- a/hermit/config.toml
+++ b/hermit/config.toml
@@ -124,4 +124,4 @@ sections = []
 
 [markdown]
 safe = false
-lazy_loading = false
+lazy_loading = true


### PR DESCRIPTION
💡 **What:** Enabled the `lazy_loading` option under the `[markdown]` block in `hermit/config.toml`.
🎯 **Why:** Lazy loading defers the loading of off-screen images until the user scrolls near them. This optimization significantly reduces the initial payload and bandwidth usage, accelerating the Largest Contentful Paint (LCP) and improving overall page rendering performance.
📊 **Measured Improvement:** As this is a configuration change for a static site generator (`hwaro`) that is currently uninstalled in the environment, direct local benchmarking of the output was not possible. However, setting the native HTML `loading="lazy"` attribute on images is a well-established best practice that dramatically improves performance, particularly on image-heavy markdown pages, by preventing non-critical assets from blocking rendering.

---
*PR created automatically by Jules for task [15095812093935983194](https://jules.google.com/task/15095812093935983194) started by @hahwul*