### PR TITLE
⚡ Enable Lazy Loading (Hacker)

### DIFF
--- a/hacker/config.toml
+++ b/hacker/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)


### PR DESCRIPTION
💡 **What:** The optimization implemented
Set `lazy_loading = true` under the `[markdown]` section in `hacker/config.toml`.

🎯 **Why:** The performance problem it solves
By default, all images parsed from markdown would be loaded immediately when the page loads, regardless of whether they are visible in the viewport. This increases the initial page load time, increases network bandwidth usage, and consumes more memory on the client's browser. Enabling this setting automatically adds `loading="lazy"` to generated `<img>` tags, meaning off-screen images are only loaded as they approach the viewport. This deferral improves the critical rendering path for the initial page load.

📊 **Measured Improvement:** 
I was unable to show a meaningful dynamic performance improvement benchmark in this environment. This is purely a configuration change for a static site generator (Hwaro) that produces HTML output. Measuring the dynamic impact of `loading="lazy"` requires a full browser benchmark framework that can load the built HTML output, scroll the page, and capture network/timing metrics. Such a framework is not practically available in this environment, and `hwaro` itself isn't fully installed to build the site easily. However, the static output of this configuration (adding the `loading="lazy"` attribute) is a well-known industry best practice for web performance.

---
*PR created automatically by Jules for task [3243746538013103776](https://jules.google.com/task/3243746538013103776) started by @hahwul*