### PR TITLE
⚡ Enable lazy loading for images in config.toml

### DIFF
--- a/blog1/config.toml
+++ b/blog1/config.toml
@@ -79,4 +79,4 @@ sections = ["posts"]
 
 [markdown]
 safe = false
-lazy_loading = true
+lazy_loading = true  # Enable lazy loading for images

--- a/even/config.toml
+++ b/even/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)

--- a/folio/config.toml
+++ b/folio/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)

--- a/hacker/config.toml
+++ b/hacker/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)

--- a/hermit/config.toml
+++ b/hermit/config.toml
@@ -124,4 +124,4 @@ sections = []
 
 [markdown]
 safe = false
-lazy_loading = false
+lazy_loading = true

--- a/hwaro.386/config.toml
+++ b/hwaro.386/config.toml
@@ -57,4 +57,4 @@ sections = ["posts"]
 
 [markdown]
 safe = false
-lazy_loading = false
+lazy_loading = true

--- a/hwaronight/config.toml
+++ b/hwaronight/config.toml
@@ -192,7 +192,7 @@ sections = []   # Limit to specific sections, e.g., ["posts"]
 
 [markdown]
 safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
-lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+lazy_loading = true  # If true, automatically add loading="lazy" to img tags
 
 # =============================================================================
 # Build Hooks (Optional)


### PR DESCRIPTION
💡 **What:** Enabled lazy loading for markdown-generated images by changing `lazy_loading = false` to `true` globally across `config.toml` files in all themes (e.g., `even`, `folio`, `hacker`, `hermit`, `hwaro.386`, `hwaronight`). Also touched `blog1/config.toml` to explicitly ensure lazy loading is documented as optimized since it was already set to `true` there.
🎯 **Why:** To improve page load performance and save bandwidth by adding `loading="lazy"` automatically to all image tags rendered by the static site generator.
📊 **Measured Improvement:** As this is a single-line configuration change supported by the Hwaro framework to enable standard HTML lazy loading (`loading="lazy"`), no profiling/benchmark script was created. The change is known to systematically improve Web Vitals (such as Largest Contentful Paint and page load times) by deferring offscreen images without requiring additional JS or manual HTML edits.

---
*PR created automatically by Jules for task [14712924602413003661](https://jules.google.com/task/14712924602413003661) started by @hahwul*