### PR TITLE
🧹 Remove developer assumption notes in blog4 templates

### DIFF
--- a/blog4/templates/taxonomy.html
+++ b/blog4/templates/taxonomy.html
@@ -1,20 +1,16 @@
 {% include "header.html" %}
-  <main class="max-w-4xl mx-auto px-6 py-12 flex-grow w-full">
-    <header class="mb-12 text-center">
-      <h1 class="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-primary via-primary-light to-white mb-4 tracking-tight">
-        Tags
-      </h1>
-      <p class="text-lg text-muted max-w-2xl mx-auto">Explore content by topic</p>
-    </header>
+<main class="max-w-4xl mx-auto px-6 py-12 flex-grow w-full">
+  <header class="mb-12 text-center">
+    <h1
+      class="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-primary via-primary-light to-white mb-4 tracking-tight"
+    >
+      Tags
+    </h1>
+    <p class="text-lg text-muted max-w-2xl mx-auto">Explore content by topic</p>
+  </header>
 
-    <div class="flex flex-wrap justify-center gap-3">
-      <!-- Assuming content contains the tags list rendered by the engine, but usually we iterate taxonomies here.
-           If content is empty or just text, we might need a loop.
-           However, sticking to the original which just had {{ content }}.
-           But to be safe, I'll wrap it in a nice container. -->
-      <div class="prose max-w-none w-full text-center">
-        {{ content }}
-      </div>
-    </div>
-  </main>
+  <div class="flex flex-wrap justify-center gap-3">
+    <div class="prose max-w-none w-full text-center">{{ content }}</div>
+  </div>
+</main>
 {% include "footer.html" %}

--- a/blog4/templates/taxonomy_term.html
+++ b/blog4/templates/taxonomy_term.html
@@ -1,24 +1,20 @@
 {% include "header.html" %}
-  <main class="max-w-4xl mx-auto px-6 py-12 flex-grow w-full">
-    <header class="mb-12 text-center border-b border-border/50 pb-8">
-      <div class="inline-block px-3 py-1 mb-4 text-xs font-mono font-semibold tracking-wider text-primary uppercase bg-primary/10 rounded-full border border-primary/20">
-        Tag
-      </div>
-      <h1 class="text-4xl md:text-5xl font-extrabold text-white mb-4 tracking-tight">
-        #{{ page.title }}
-      </h1>
-    </header>
-
-    <div class="space-y-4">
-      <!-- Assuming content renders the list. If not, this might be empty.
-           But usually taxonomy_term should look like section.html.
-           Let's duplicate section.html logic here if possible?
-           The original had {{ content }}. If the engine injects the list into content, then good.
-           If not, and the engine expects the template to loop, the original was broken or minimal.
-           I'll stick to content but wrapped nicely. -->
-      <div class="prose max-w-none prose-lg">
-        {{ content }}
-      </div>
+<main class="max-w-4xl mx-auto px-6 py-12 flex-grow w-full">
+  <header class="mb-12 text-center border-b border-border/50 pb-8">
+    <div
+      class="inline-block px-3 py-1 mb-4 text-xs font-mono font-semibold tracking-wider text-primary uppercase bg-primary/10 rounded-full border border-primary/20"
+    >
+      Tag
     </div>
-  </main>
+    <h1
+      class="text-4xl md:text-5xl font-extrabold text-white mb-4 tracking-tight"
+    >
+      #{{ page.title }}
+    </h1>
+  </header>
+
+  <div class="space-y-4">
+    <div class="prose max-w-none prose-lg">{{ content }}</div>
+  </div>
+</main>
 {% include "footer.html" %}


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary developer assumption comment from `blog4/templates/taxonomy.html` and a similar note in `blog4/templates/taxonomy_term.html`.
💡 **Why:** These comments were developer notes discussing internal templating logic ("Assuming content contains the tags list..."). They provide no value to the template structure and clutter the file, reducing maintainability.
✅ **Verification:** Formatted the files with Prettier (`npx prettier --write`) to ensure HTML structure consistency and valid formatting. Verified the changes did not alter any HTML elements or template variables.
✨ **Result:** A cleaner template file with reduced noise and improved readability.

---
*PR created automatically by Jules for task [11231219642149867451](https://jules.google.com/task/11231219642149867451) started by @hahwul*