### PR TITLE
🧹 Remove developer notes in blog4 section template

### DIFF
--- a/blog4/templates/section.html
+++ b/blog4/templates/section.html
@@ -29,12 +29,8 @@
            {% endif %}
 
            {% if post.tags %}
-           <div class="flex flex-wrap gap-2 mt-2 relative z-20 pointer-events-none"> <!-- z-20 so tags are visible but click goes to post if needed, or make them clickable links -->
+           <div class="flex flex-wrap gap-2 mt-2 relative z-20 pointer-events-none">
               {% for tag in post.tags %}
-                 <!-- Wait, if the whole card is clickable via absolute inset, individual links might be tricky.
-                      Let's make the card clickable but allow tag clicking if we position them above.
-                      Actually, simpler to just not wrap the whole card or accept the whole card is the link.
-                      I'll just make the whole card the link for UX simplicity. -->
                  <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium uppercase tracking-wider bg-surface-alt text-muted border border-border group-hover:text-primary-light group-hover:border-primary/30 transition-colors">
                     #{{ tag }}
                  </span>


### PR DESCRIPTION
🎯 **What:** Removed leftover developer comments from `blog4/templates/section.html`.
💡 **Why:** Developer notes are not necessary in the production template and removing them improves the readability and maintainability of the code.
✅ **Verification:** Verified that the removal of HTML comments does not affect the rendering of the template.
✨ **Result:** A cleaner and more maintainable HTML template without unnecessary developer clutter.

---
*PR created automatically by Jules for task [9016700482818048605](https://jules.google.com/task/9016700482818048605) started by @hahwul*