### PR TITLE
⚡ Prevent External CSS Blocking by adding font-display swap

### DIFF
--- a/hwaro.386/templates/header.html
+++ b/hwaro.386/templates/header.html
@@ -14,6 +14,7 @@
       src: url('https://cdn.jsdelivr.net/gh/nicholasgasior/bootstrap-386@master/dist/fonts/PxPlus_IBM_VGA8.woff2') format('woff2');
       font-weight: normal;
       font-style: normal;
+      font-display: swap;
     }
 
     :root {


### PR DESCRIPTION
💡 **What:** Added `font-display: swap;` to the custom @font-face declaration.
🎯 **Why:** To prevent external CSS blocking and avoid Flash of Invisible Text (FOIT) by allowing text to render immediately with a fallback font while the custom font is downloading.
📊 **Measured Improvement:** Conceptually, this change directly improves First Contentful Paint metrics as text rendering is no longer blocked by the external font file loading. Direct metric changes were unmeasured due to lack of a browser testing environment but this is a standard and highly effective frontend optimization.

---
*PR created automatically by Jules for task [10130687378444758411](https://jules.google.com/task/10130687378444758411) started by @hahwul*