### PR TITLE
🧹 Extract inline JS logic to external file (Hermit)

### DIFF
--- a/hermit/static/js/main.js
+++ b/hermit/static/js/main.js
@@ -1,0 +1,16 @@
+function toggleMobileMenu() {
+  var menu = document.getElementById('mobile-menu');
+  if (menu.style.display === 'block') {
+    menu.style.display = 'none';
+  } else {
+    menu.style.display = 'block';
+  }
+}
+
+document.addEventListener('click', function(e) {
+  var menu = document.getElementById('mobile-menu');
+  var btn = document.getElementById('menu-btn');
+  if (menu && btn && !menu.contains(e.target) && !btn.contains(e.target)) {
+    menu.style.display = 'none';
+  }
+});

--- a/hermit/templates/footer.html
+++ b/hermit/templates/footer.html
@@ -7,24 +7,7 @@
     </p>
   </footer>
 
-  <script>
-    function toggleMobileMenu() {
-      var menu = document.getElementById('mobile-menu');
-      if (menu.style.display === 'block') {
-        menu.style.display = 'none';
-      } else {
-        menu.style.display = 'block';
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var menu = document.getElementById('mobile-menu');
-      var btn = document.getElementById('menu-btn');
-      if (menu && btn && !menu.contains(e.target) && !btn.contains(e.target)) {
-        menu.style.display = 'none';
-      }
-    });
-  </script>
+  <script src="{{ base_url }}/js/main.js"></script>
   {{ highlight_js }}
   {{ auto_includes_js }}
 </body>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted inline JavaScript from `hermit/templates/footer.html` to an external file `hermit/static/js/main.js`.

💡 **Why:** How this improves maintainability
Separating HTML structure from JavaScript behavior improves code readability and maintainability. External files can be cached by browsers, minified during build steps (if applicable), and are easier to lint and test in isolation.

✅ **Verification:** How you confirmed the change is safe
Verified the exact JavaScript logic was copied into the new file without modification, and confirmed the new `<script src="...">` tag correctly uses the `{{ base_url }}` template variable according to Hwaro conventions for static assets.

✨ **Result:** The improvement achieved
A cleaner `footer.html` template and a dedicated JavaScript file that adheres to standard web development separation of concerns.

---
*PR created automatically by Jules for task [18381109226613464311](https://jules.google.com/task/18381109226613464311) started by @hahwul*