### PR TITLE
🧹 Refactor alert shortcode to use CSS instead of inline styles

### DIFF
--- a/folio/templates/header.html
+++ b/folio/templates/header.html
@@ -359,6 +359,15 @@
       .site-nav { gap: 1.2rem; }
       .portfolio-grid { grid-template-columns: 1fr; }
     }
+
+    /* Alerts */
+    .alert {
+      padding: 1rem;
+      border: 1px solid #ddd;
+      background-color: #f9f9f9;
+      border-left: 5px solid #0070f3;
+      margin: 1rem 0;
+    }
   </style>
   {{ highlight_css }}
   {{ auto_includes_css }}

--- a/folio/templates/shortcodes/alert.html
+++ b/folio/templates/shortcodes/alert.html
@@ -1,3 +1,3 @@
-<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+<div class="alert">
   <strong>{{ type | upper }}:</strong> {{ message }}
 </div>


### PR DESCRIPTION
🎯 **What:** The inline `style` attribute in `folio/templates/shortcodes/alert.html` was extracted to a `.alert` CSS class in `folio/templates/header.html`.
💡 **Why:** This improves maintainability and readability by separating concerns, placing styling in the primary CSS block instead of scattering it as inline styles.
✅ **Verification:** Verified locally by creating a test HTML file with the extracted CSS rule, rendering it via Playwright, and confirming the visual layout remains identical. Leftover testing artifacts were removed before submission.
✨ **Result:** A cleaner template file and a centralized location for alert styling, improving the code health of the Folio theme.

---
*PR created automatically by Jules for task [17794670451158382574](https://jules.google.com/task/17794670451158382574) started by @hahwul*