### PR TITLE
🧹 Refactor: Extract inline styles to CSS in Hermit alert shortcode

### DIFF
--- a/hermit/templates/header.html
+++ b/hermit/templates/header.html
@@ -500,6 +500,17 @@
 
     .highlight-copy-btn:hover { opacity: 1; }
 
+    /* Alert Shortcode */
+    .alert {
+      padding: 1rem;
+      border: 1px solid var(--dark-grey);
+      background-color: var(--midnightblue);
+      border-left: 5px solid var(--theme);
+      margin: 1rem 0;
+      border-radius: 4px;
+      color: var(--text);
+    }
+
     /* Animations */
     @keyframes fadeIn {
       from { opacity: 0; }

--- a/hermit/templates/shortcodes/alert.html
+++ b/hermit/templates/shortcodes/alert.html
@@ -1,3 +1,3 @@
-<div class="alert" style="padding: 1rem; border: 1px solid #3b3e48; background-color: #31333d; border-left: 5px solid #018574; margin: 1rem 0; border-radius: 4px; color: #c6cddb;">
+<div class="alert">
   <strong>{{ type | upper }}:</strong> {{ message }}
 </div>


### PR DESCRIPTION
🎯 **What:** Moved inline styles from `hermit/templates/shortcodes/alert.html` to a new `.alert` CSS class in `hermit/templates/header.html`. Hardcoded hex colors were dynamically replaced with CSS variables (`var(--theme)`, `var(--text)`, etc.) already provided by the theme.
💡 **Why:** Having inline styling makes code maintenance harder, violates separation of concerns, and prevents styling from reusing theme definitions. Moving it into a class that uses the theme's CSS variables improves code health and DRY-ness.
✅ **Verification:** Generated a test HTML combining the theme's variables, the new `.alert` CSS definition, and the newly updated alert `div` class structure. Visually confirmed via a Playwright screenshot that the resulting element perfectly matches the expected style.
✨ **Result:** Improved separation of concerns, increased maintainability, and correctly mapped static colors to dynamic theme variables.

---
*PR created automatically by Jules for task [497517757953537187](https://jules.google.com/task/497517757953537187) started by @hahwul*