### PR TITLE
🧹 refactor(folio): extract inline styles from alert shortcode to header

### DIFF
--- a/folio/templates/header.html
+++ b/folio/templates/header.html
@@ -229,6 +229,15 @@
       color: #555;
     }
 
+    /* Shortcodes */
+    .alert {
+      padding: 1rem;
+      border: 1px solid #ddd;
+      background-color: #f9f9f9;
+      border-left: 5px solid #0070f3;
+      margin: 1rem 0;
+    }
+
     /* Tags */
     .tag-list {
       display: flex;

--- a/folio/templates/shortcodes/alert.html
+++ b/folio/templates/shortcodes/alert.html
@@ -1,3 +1,3 @@
-<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+<div class="alert">
   <strong>{{ type | upper }}:</strong> {{ message }}
 </div>


### PR DESCRIPTION
🎯 **What:** Extracted inline styles from the `alert` shortcode template (`folio/templates/shortcodes/alert.html`) into a new `.alert` CSS class within the site's main stylesheet section (`folio/templates/header.html`).
💡 **Why:** Moving styles to a centralized CSS location improves maintainability, reduces code duplication, and makes it easier to globally update the appearance of all alert components.
✅ **Verification:** A Python script utilizing Playwright was used to locally render the `alert.html` shortcode embedded within the `header.html` structure. A screenshot was generated and visually verified to confirm that the alert component retains the exact same layout, colors, padding, and borders as before the extraction.
✨ **Result:** The codebase is cleaner and follows better CSS practices by removing inline styles, without introducing any visual regressions to the final rendered output.

---
*PR created automatically by Jules for task [17974268573944242363](https://jules.google.com/task/17974268573944242363) started by @hahwul*