### PR TITLE
🧹 Move inline styles to CSS in Hacker theme alert shortcode

### DIFF
--- a/hacker/templates/header.html
+++ b/hacker/templates/header.html
@@ -275,6 +275,19 @@
       opacity: 0.6;
     }
 
+    .alert {
+      padding: 1rem;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      background-color: rgba(0, 0, 0, 0.3);
+      border-left: 5px solid #b5e853;
+      margin: 1rem 0;
+      color: #eaeaea;
+    }
+
+    .alert-title {
+      color: #b5e853;
+    }
+
     /* Responsive */
     @media (max-width: 1000px) {
       .site-header-inner {

--- a/hacker/templates/shortcodes/alert.html
+++ b/hacker/templates/shortcodes/alert.html
@@ -1,3 +1,3 @@
-<div class="alert" style="padding: 1rem; border: 1px solid rgba(255, 255, 255, 0.15); background-color: rgba(0, 0, 0, 0.3); border-left: 5px solid #b5e853; margin: 1rem 0; color: #eaeaea;">
-  <strong style="color: #b5e853;">{{ type | upper }}:</strong> {{ message }}
+<div class="alert">
+  <strong class="alert-title">{{ type | upper }}:</strong> {{ message }}
 </div>


### PR DESCRIPTION
🎯 **What:** Moved inline CSS styles from `hacker/templates/shortcodes/alert.html` into corresponding CSS classes (`.alert` and `.alert-title`) within the `<style>` block in `hacker/templates/header.html`.
💡 **Why:** This resolves a code health issue where styles were tightly coupled to the HTML structure, improving maintainability, reusability, and readability of the codebase.
✅ **Verification:** A Python script utilizing Playwright was created and executed. The script locally rendered the updated HTML files and took a screenshot, visually confirming that the alert component retains identical styling and functionality compared to the original inline styles.
✨ **Result:** The codebase is now cleaner, with styling separated from the alert component's markup while preserving exact visual appearance.

---
*PR created automatically by Jules for task [9766941563039881895](https://jules.google.com/task/9766941563039881895) started by @hahwul*