### PR TITLE
🧹 Refactor taxonomy templates to remove inline opacity styles

### DIFF
--- a/hermit/templates/taxonomy.html
+++ b/hermit/templates/taxonomy.html
@@ -1,8 +1,10 @@
 {% include "header.html" %}
 
   <main class="site-main section-inner thin animated fadeIn">
-    <h1>{{ page.title }}</h1>
-    <p class="post-meta" style="opacity: 0.6;">Browse all terms:</p>
+    <header class="post-header">
+      <h1>{{ page.title }}</h1>
+      <p class="post-meta">Browse all terms:</p>
+    </header>
     {{ content }}
   </main>
 

--- a/hermit/templates/taxonomy_term.html
+++ b/hermit/templates/taxonomy_term.html
@@ -1,8 +1,10 @@
 {% include "header.html" %}
 
   <main class="site-main section-inner thin animated fadeIn">
-    <h1>{{ page.title }}</h1>
-    <p class="post-meta" style="opacity: 0.6;">Posts tagged with this term:</p>
+    <header class="post-header">
+      <h1>{{ page.title }}</h1>
+      <p class="post-meta">Posts tagged with this term:</p>
+    </header>
     {{ content }}
   </main>
 


### PR DESCRIPTION
🎯 **What:** Removed inline `opacity: 0.6;` styles from `p.post-meta` tags in `hermit/templates/taxonomy.html` and `hermit/templates/taxonomy_term.html`.
💡 **Why:** Inline styles hurt maintainability. By wrapping the content in a `<header class="post-header">` container, the templates now correctly utilize the existing, standardized CSS styles defined in `header.html` for `.post-header .post-meta`.
✅ **Verification:** Verified visually by rendering the updated HTML structure via Playwright to ensure the target CSS classes apply properly and there are no syntactical errors.
✨ **Result:** Improved code health and semantic structure consistency across the project's templates without changing the visual behavior.

---
*PR created automatically by Jules for task [15009706807285634258](https://jules.google.com/task/15009706807285634258) started by @hahwul*