### PR TITLE
Add new example: cactus (Hexo Cactus inspired)

### DIFF
--- a/cactus/config.toml
+++ b/cactus/config.toml
@@ -1,0 +1,181 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Cactus"
+description = "A clean blog theme with signature green accent, inspired by Hexo Cactus."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = true
+per_page = 5
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+# =============================================================================
+# SEO: Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+# =============================================================================
+# SEO: Robots.txt
+# =============================================================================
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+]
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "atom"
+filename = "atom.xml"
+truncate = 0
+limit = 20
+sections = ["posts"]
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/cactus/content/about.md
+++ b/cactus/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "About"
++++
+
+## About Cactus
+
+Cactus is a clean, dark blog theme inspired by the popular [hexo-theme-cactus](https://github.com/probberechts/hexo-theme-cactus) (~3.5k stars). It brings the signature green accent and whitespace-focused design to the [Hwaro](https://github.com/hahwul/hwaro) static site generator.
+
+### Features
+
+- Dark theme with signature `#2bbc8a` green accent
+- Monospace typography with Fira Mono
+- Whitespace-focused, distraction-free reading
+- Projects showcase section
+- Responsive and mobile-friendly
+- Syntax highlighting with Monokai theme
+- Atom feed support
+
+### Getting Started
+
+1. Copy the `cactus` directory into your Hwaro project
+2. Run `hwaro serve` from the terminal
+3. Open `http://localhost:3000/`
+
+Or scaffold a new site from this example:
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/cactus
+```

--- a/cactus/content/index.md
+++ b/cactus/content/index.md
@@ -1,0 +1,19 @@
++++
+title = "Home"
++++
+
+<div class="cactus-ascii">
+     _    _
+    | \  / |
+     \ \/ /
+      \  /
+      |  |
+     _|  |_
+    /______\
+</div>
+
+Hi, I'm **Cactus** -- a minimal blog theme for [Hwaro](https://github.com/hahwul/hwaro), inspired by [hexo-theme-cactus](https://github.com/probberechts/hexo-theme-cactus).
+
+Clean, dark, whitespace-focused. No distractions, just your content.
+
+Browse the [latest posts](/posts/), check out [projects](/projects/), or learn more [about this site](/about/).

--- a/cactus/content/posts/_index.md
+++ b/cactus/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+pagination_enabled = true
+paginate = 5
++++

--- a/cactus/content/posts/code-and-syntax.md
+++ b/cactus/content/posts/code-and-syntax.md
@@ -1,0 +1,72 @@
++++
+title = "Code & Syntax Highlighting"
+date = "2026-03-17"
+tags = ["code", "tutorial"]
+categories = ["tutorial"]
+description = "Showcasing code blocks and syntax highlighting with the Monokai theme."
++++
+
+Cactus uses the Monokai syntax highlighting theme, which pairs well with the dark background.
+
+## Inline Code
+
+Use backticks for `inline code` like variable names or `commands`.
+
+## Code Blocks
+
+### JavaScript
+
+```javascript
+function fibonacci(n) {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+console.log(fibonacci(10)); // 55
+```
+
+### Python
+
+```python
+def quicksort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quicksort(left) + middle + quicksort(right)
+```
+
+### Go
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    ch := make(chan string)
+    go func() {
+        ch <- "hello from goroutine"
+    }()
+    fmt.Println(<-ch)
+}
+```
+
+### Crystal
+
+```crystal
+class Greeter
+  def initialize(@name : String)
+  end
+
+  def greet
+    puts "Hello, #{@name}!"
+  end
+end
+
+Greeter.new("Cactus").greet
+```
+
+The Monokai theme gives a warm, readable look to code blocks against the dark background.

--- a/cactus/content/posts/hello-world.md
+++ b/cactus/content/posts/hello-world.md
@@ -1,0 +1,38 @@
++++
+title = "Hello World"
+date = "2026-03-15"
+tags = ["hello", "first-post"]
+categories = ["general"]
+description = "The first post on this blog."
++++
+
+Welcome to the Cactus theme for Hwaro. This is a minimal, dark-themed blog that puts your content first.
+
+Like its namesake, this theme thrives in minimal conditions -- clean design, subtle green accents, and plenty of whitespace.
+
+<!-- more -->
+
+## Why Cactus?
+
+The original [hexo-theme-cactus](https://github.com/probberechts/hexo-theme-cactus) has been one of the most popular minimal blog themes, with over 3,500 stars on GitHub. This Hwaro adaptation captures the same spirit:
+
+- **Dark by default** -- easy on the eyes
+- **Monospace accents** -- a nod to the terminal
+- **Green highlights** -- the signature cactus color
+- **Whitespace** -- let your content breathe
+
+## Getting Started
+
+Creating new posts is simple:
+
+```bash
+hwaro new content/posts/my-new-post.md -t "My New Post"
+```
+
+Then start the dev server:
+
+```bash
+hwaro serve --open
+```
+
+Happy writing!

--- a/cactus/content/posts/markdown-features.md
+++ b/cactus/content/posts/markdown-features.md
@@ -1,0 +1,50 @@
++++
+title = "Markdown Features"
+date = "2026-03-19"
+tags = ["markdown", "tutorial"]
+categories = ["tutorial"]
+description = "A tour of supported markdown features in the Cactus theme."
++++
+
+A quick overview of how common markdown elements render in the Cactus theme.
+
+## Text Formatting
+
+This is **bold text** and this is *italic text*. You can also use ~~strikethrough~~.
+
+## Blockquotes
+
+> Simplicity is the ultimate sophistication.
+> -- Leonardo da Vinci
+
+## Lists
+
+### Unordered
+
+- Dark theme with green accent
+- Monospace typography
+- Whitespace-focused layout
+- Mobile responsive
+
+### Ordered
+
+1. Install Hwaro
+2. Choose the Cactus theme
+3. Write your content
+4. Deploy
+
+## Links
+
+Visit the [Hwaro documentation](https://hwaro.hahwul.com) for more details.
+
+## Images
+
+Images are displayed full-width within the content area with subtle rounded corners.
+
+## Horizontal Rules
+
+Use three dashes for a horizontal rule:
+
+---
+
+That's a quick tour of the typography in Cactus.

--- a/cactus/content/projects/_index.md
+++ b/cactus/content/projects/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Projects"
+sort_by = "weight"
+template = "projects"
++++

--- a/cactus/content/projects/cactus-theme.md
+++ b/cactus/content/projects/cactus-theme.md
@@ -1,0 +1,9 @@
++++
+title = "Cactus Theme"
+weight = 2
+description = "A minimal dark blog theme for Hwaro, inspired by hexo-theme-cactus."
+[extra]
+url = "https://github.com/hahwul/hwaro-examples"
++++
+
+Clean dark blog theme with signature green accent, monospace typography, and whitespace-focused design.

--- a/cactus/content/projects/hwaro.md
+++ b/cactus/content/projects/hwaro.md
@@ -1,0 +1,9 @@
++++
+title = "Hwaro"
+weight = 1
+description = "A fast static site generator written in Crystal."
+[extra]
+url = "https://github.com/hahwul/hwaro"
++++
+
+A fast static site generator written in Crystal. Supports Jinja2 templates, markdown content, taxonomies, feeds, and more.

--- a/cactus/templates/404.html
+++ b/cactus/templates/404.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+        <article>
+          <h1>404 - Page not found</h1>
+          <p>The page you're looking for doesn't exist. Go back to the <a href="{{ base_url }}/">homepage</a>.</p>
+          <div class="cactus-ascii">
+    _  _
+   | \/ |
+    \  /
+    /  \
+   |    |
+   |    |
+  _|    |_
+ |________|
+          </div>
+        </article>
+
+{% include "footer.html" %}

--- a/cactus/templates/footer.html
+++ b/cactus/templates/footer.html
@@ -1,0 +1,12 @@
+    </main>
+  </div>
+
+  <!-- Footer -->
+  <footer class="site-footer">
+    <span>&copy; {{ current_year }} {{ site.title }} | Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></span>
+  </footer>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cactus/templates/header.html
+++ b/cactus/templates/header.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{% if page.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Noto+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+  <!-- RSS -->
+  <link href="{{ base_url }}/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed">
+
+  <style>
+    /* ========================================
+       Cactus Theme - Hwaro
+       Inspired by hexo-theme-cactus
+       ======================================== */
+
+    /* -- Reset -- */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /* -- Variables via raw values -- */
+    /* accent: #2bbc8a  bg: #1d1f21  fg: #c9cacc  muted: #6a737d */
+
+    html {
+      background-color: #1d1f21;
+      color: #c9cacc;
+      font-size: 16px;
+      line-height: 1.7;
+    }
+
+    body {
+      font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Links -- */
+    a { color: #2bbc8a; text-decoration: none; }
+    a:hover { color: #33d695; }
+
+    /* ========================================
+       Typography
+       ======================================== */
+    h1, h2, h3, h4, h5, h6 {
+      color: #e0e0e0;
+      font-weight: 600;
+      line-height: 1.3;
+    }
+    h1 { font-size: 1.8rem; margin-bottom: 0.5em; }
+    h2 { font-size: 1.4rem; margin: 1.5em 0 0.5em; }
+    h3 { font-size: 1.15rem; margin: 1.2em 0 0.4em; }
+
+    p { margin-bottom: 1.2em; }
+    ul, ol { margin-bottom: 1.2em; padding-left: 1.5em; }
+    li { margin-bottom: 0.3em; }
+
+    blockquote {
+      border-left: 3px solid #2bbc8a;
+      padding: 0.5em 1em;
+      margin: 1.5em 0;
+      color: #8a8f98;
+      font-style: italic;
+    }
+
+    code {
+      font-family: 'Fira Mono', 'Consolas', monospace;
+      font-size: 0.9em;
+      background-color: #282a2e;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+      color: #e0e0e0;
+    }
+
+    pre {
+      background-color: #282a2e;
+      padding: 1em 1.2em;
+      border-radius: 4px;
+      overflow-x: auto;
+      margin-bottom: 1.5em;
+      line-height: 1.5;
+    }
+    pre code {
+      background: none;
+      padding: 0;
+      font-size: 0.85em;
+    }
+
+    img {
+      max-width: 100%;
+      border-radius: 4px;
+      margin: 1em 0;
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid #333;
+      margin: 2em 0;
+    }
+
+    /* ========================================
+       Layout
+       ======================================== */
+    .site-wrapper {
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      flex: 1;
+      width: 100%;
+    }
+
+    /* -- Header / Navigation -- */
+    .site-header {
+      padding: 3rem 0 1.5rem;
+    }
+
+    .site-title {
+      font-family: 'Fira Mono', monospace;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #e0e0e0;
+    }
+    .site-title:hover { color: #2bbc8a; }
+
+    .site-nav {
+      margin-top: 1rem;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      gap: 1.5rem;
+    }
+    .site-nav a {
+      color: #c9cacc;
+      font-size: 0.95rem;
+    }
+    .site-nav a:hover { color: #2bbc8a; }
+
+    .header-divider {
+      width: 100%;
+      height: 1px;
+      background: linear-gradient(to right, #2bbc8a, transparent);
+      margin-top: 1.5rem;
+    }
+
+    /* -- Main Content -- */
+    .site-main {
+      padding: 2rem 0;
+    }
+
+    /* -- Post List -- */
+    .post-list { list-style: none; padding: 0; }
+    .post-list li { margin-bottom: 0; }
+
+    ul.section-list {
+      list-style: none;
+      padding: 0;
+    }
+    ul.section-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 0.5em 0;
+      border-bottom: 1px dashed #333;
+    }
+    ul.section-list li a {
+      color: #c9cacc;
+      font-weight: 400;
+    }
+    ul.section-list li a:hover { color: #2bbc8a; }
+    ul.section-list li .post-date {
+      color: #6a737d;
+      font-family: 'Fira Mono', monospace;
+      font-size: 0.85em;
+      white-space: nowrap;
+      margin-left: 1em;
+    }
+
+    /* -- Single Post -- */
+    .post-header { margin-bottom: 2rem; }
+    .post-header h1 { margin-bottom: 0.3em; }
+    .post-meta {
+      color: #6a737d;
+      font-size: 0.9em;
+      font-family: 'Fira Mono', monospace;
+    }
+    .post-meta a { color: #2bbc8a; }
+
+    .post-content { line-height: 1.8; }
+    .post-content a { border-bottom: 1px solid #2bbc8a40; }
+    .post-content a:hover { border-bottom-color: #2bbc8a; }
+
+    .post-tags {
+      margin-top: 2em;
+      padding-top: 1em;
+      border-top: 1px solid #333;
+    }
+    .post-tags a {
+      display: inline-block;
+      font-family: 'Fira Mono', monospace;
+      font-size: 0.85em;
+      color: #2bbc8a;
+      margin-right: 0.8em;
+    }
+    .post-tags a::before { content: "#"; }
+
+    /* -- Projects Section -- */
+    .projects-list {
+      list-style: none;
+      padding: 0;
+    }
+    .projects-list li {
+      padding: 0.8em 0;
+      border-bottom: 1px dashed #333;
+    }
+    .projects-list li:last-child { border-bottom: none; }
+    .project-name {
+      color: #2bbc8a;
+      font-weight: 600;
+    }
+    .project-desc {
+      color: #6a737d;
+      font-size: 0.9em;
+      margin-top: 0.2em;
+    }
+
+    /* -- Pagination -- */
+    .pagination {
+      display: flex;
+      justify-content: center;
+      gap: 0.5em;
+      margin: 2em 0;
+    }
+    .page-item {
+      display: inline-block;
+      padding: 0.4em 0.9em;
+      border-radius: 3px;
+      font-size: 0.9em;
+      font-family: 'Fira Mono', monospace;
+    }
+    a .page-item,
+    a.page-item {
+      background-color: #282a2e;
+      color: #c9cacc;
+    }
+    a .page-item:hover,
+    a.page-item:hover {
+      background-color: #2bbc8a;
+      color: #1d1f21;
+    }
+    span.page-item {
+      background-color: #2bbc8a;
+      color: #1d1f21;
+      font-weight: 600;
+    }
+
+    /* -- Taxonomy -- */
+    .taxonomy-list { list-style: none; padding: 0; }
+    .taxonomy-list li { display: inline-block; margin: 0.25em; }
+    .taxonomy-list li a {
+      display: inline-block;
+      padding: 0.25em 0.7em;
+      background-color: #282a2e;
+      color: #2bbc8a;
+      border-radius: 3px;
+      font-family: 'Fira Mono', monospace;
+      font-size: 0.85em;
+    }
+    .taxonomy-list li a:hover {
+      background-color: #2bbc8a;
+      color: #1d1f21;
+    }
+
+    /* -- Footer -- */
+    .site-footer {
+      padding: 2rem 0;
+      text-align: center;
+      color: #6a737d;
+      font-size: 0.85em;
+      border-top: 1px solid #333;
+      margin-top: auto;
+    }
+    .site-footer a { color: #2bbc8a; }
+
+    /* -- ASCII cactus -- */
+    .cactus-ascii {
+      font-family: 'Fira Mono', monospace;
+      color: #2bbc8a;
+      font-size: 0.7rem;
+      line-height: 1.2;
+      white-space: pre;
+      margin: 1.5rem 0;
+      opacity: 0.7;
+    }
+
+    /* -- Alert Shortcode -- */
+    .alert {
+      padding: 0.8em 1em;
+      border-radius: 4px;
+      margin: 1.5em 0;
+      border-left: 3px solid;
+      font-size: 0.95em;
+    }
+    .alert-info { background-color: #1a2a3a; border-color: #58a6ff; color: #a8d1ff; }
+    .alert-warning { background-color: #2a2a1a; border-color: #d29922; color: #e3b341; }
+    .alert-error { background-color: #2a1a1a; border-color: #f85149; color: #ffa198; }
+    .alert-success { background-color: #1a2a1a; border-color: #2bbc8a; color: #56d4a0; }
+
+    /* -- Responsive -- */
+    @media (max-width: 600px) {
+      .site-header { padding: 2rem 0 1rem; }
+      .site-nav { gap: 1rem; }
+      ul.section-list li { flex-direction: column; gap: 0.2em; }
+      ul.section-list li .post-date { margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+
+    <!-- Header -->
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+      <nav>
+        <ul class="site-nav">
+          <li><a href="{{ base_url }}/">Home</a></li>
+          <li><a href="{{ base_url }}/posts/">Posts</a></li>
+          <li><a href="{{ base_url }}/projects/">Projects</a></li>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+      <div class="header-divider"></div>
+    </header>
+
+    <!-- Main content -->
+    <main class="site-main">

--- a/cactus/templates/page.html
+++ b/cactus/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+        <article>
+          <div class="post-header">
+            <h1>{{ page.title }}</h1>
+            {% if page.date %}
+            <div class="post-meta">
+              <time>{{ page.date | date("%Y-%m-%d") }}</time>
+              {% if page.tags %}
+                &middot;
+                {% for tag in page.tags %}
+                  <a href="{{ base_url }}/tags/{{ tag | slugify }}/">#{{ tag }}</a>
+                {% endfor %}
+              {% endif %}
+            </div>
+            {% endif %}
+          </div>
+          <div class="post-content">
+            {{ content }}
+          </div>
+          {% if page.tags %}
+          <div class="post-tags">
+            {% for tag in page.tags %}
+              <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </article>
+
+{% include "footer.html" %}

--- a/cactus/templates/projects.html
+++ b/cactus/templates/projects.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+
+        <h1>Projects</h1>
+        <ul class="projects-list">
+          {% for project in section.pages %}
+          <li>
+            {% if project.extra and project.extra.url %}
+            <a class="project-name" href="{{ project.extra.url }}">{{ project.title }}</a>
+            {% else %}
+            <a class="project-name" href="{{ project.url }}">{{ project.title }}</a>
+            {% endif %}
+            <p class="project-desc">{{ project.description }}</p>
+          </li>
+          {% endfor %}
+        </ul>
+
+{% include "footer.html" %}

--- a/cactus/templates/section.html
+++ b/cactus/templates/section.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+        {{ section.list }}
+
+        {{ pagination }}
+
+{% include "footer.html" %}

--- a/cactus/templates/shortcodes/alert.html
+++ b/cactus/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/cactus/templates/taxonomy.html
+++ b/cactus/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+
+        <article>
+          <h1>{{ page.title }}</h1>
+          {{ content }}
+        </article>
+
+{% include "footer.html" %}

--- a/cactus/templates/taxonomy_term.html
+++ b/cactus/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+
+        <article>
+          <h1>{{ page.title }}</h1>
+          {{ content }}
+        </article>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,6 +1,7 @@
 {
   "acme-docs": ["light", "docs"],
   "beautiful-hwaro": ["light", "blog"],
+  "cactus": ["dark", "blog", "minimal"],
   "console": ["dark", "blog", "minimal"],
   "devconf": ["dark", "event", "landing"],
   "devlog": ["dark", "blog", "minimal"],


### PR DESCRIPTION
## Summary
- Add `cactus/` example: dark minimal blog theme inspired by [hexo-theme-cactus](https://github.com/probberechts/hexo-theme-cactus) (~3.5k stars)
- Signature `#2bbc8a` green accent, Fira Mono + Noto Sans typography, whitespace-focused layout
- Dedicated projects section with custom template, Monokai syntax highlighting, alert shortcode

## Details
- **Tags**: `["dark", "blog", "minimal"]`
- **Content**: 3 posts (hello-world, code-and-syntax, markdown-features), 2 projects, about page
- **Templates**: header, footer, page, section, projects, taxonomy, taxonomy_term, 404, shortcodes/alert
- **Build**: 9 pages, no warnings

Closes #40

## Test plan
- [ ] `hwaro build` succeeds without warnings
- [ ] `hwaro serve --open` renders correctly
- [ ] CI deploys to examples.hwaro.hahwul.com/cactus/
- [ ] Tag filter on index page shows cactus under dark/blog/minimal