### PR TITLE
Add new example: papermod (Hugo PaperMod inspired)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ hwaro-examples/
 ├── hwaronight/                     # Tokyo Night theme (dark, blog)
 ├── modern-blog/                    # Modern personal blog (dark, blog)
 ├── no-style-please/                # No-CSS minimal theme (light, blog, minimal)
+├── papermod/                       # PaperMod-inspired profile blog (light, blog)
 ├── portfolio-blog/                 # Multilingual portfolio blog (dark, blog, portfolio)
 ├── pulse-api/                      # API documentation (dark, docs)
 ├── resume/                         # Resume/CV site (light, resume)

--- a/papermod/config.toml
+++ b/papermod/config.toml
@@ -1,0 +1,213 @@
+# =============================================================================
+# PaperMod Theme - Site Configuration
+# =============================================================================
+# A clean, fast profile blog inspired by Hugo PaperMod
+# https://github.com/adityatelange/hugo-PaperMod
+
+title = "PaperMod"
+description = "A fast, clean blog with profile mode and dark/light toggle"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = true
+per_page = 5
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+# =============================================================================
+# SEO: Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# SEO: Robots.txt
+# =============================================================================
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] }
+]
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/papermod/content/about.md
+++ b/papermod/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "About"
++++
+
+## About Me
+
+Hi, I'm a software developer passionate about building fast, accessible web experiences. I write about web development, open-source tools, and productivity.
+
+When I'm not coding, you'll find me reading, exploring new technologies, or contributing to open-source projects.
+
+## About This Site
+
+This blog is built with [Hwaro](https://github.com/hahwul/hwaro) using the **PaperMod** theme — inspired by the popular [Hugo PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme.
+
+### Features
+
+- **Profile mode** homepage with social links
+- **Dark / Light** theme toggle
+- **Cover images** on posts
+- **Card-style archive** page
+- **Built-in search** powered by Fuse.js
+- **Excellent Lighthouse** scores
+- **RSS feed** for subscribers
+- **SEO-optimized** with Open Graph and Twitter Cards
+
+## Contact
+
+- GitHub: [github.com](https://github.com)
+- Twitter: [twitter.com](https://twitter.com)
+- Email: hello@example.com

--- a/papermod/content/archive.md
+++ b/papermod/content/archive.md
@@ -1,0 +1,4 @@
++++
+title = "Archive"
+template = "archive"
++++

--- a/papermod/content/index.md
+++ b/papermod/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+template = "home"
++++

--- a/papermod/content/posts/_index.md
+++ b/papermod/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
++++

--- a/papermod/content/posts/cover-images-and-cards.md
+++ b/papermod/content/posts/cover-images-and-cards.md
@@ -1,0 +1,45 @@
++++
+title = "Cover Images and Card Layouts"
+date = "2026-03-10"
+description = "How to use cover images and card-style layouts in PaperMod."
+tags = ["design", "images", "tutorial"]
+categories = ["guide"]
+image = "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=800"
++++
+
+One of PaperMod's signature features is its cover image support. Every post can have a hero image that appears at the top of the article and in post listings.
+
+## Adding a Cover Image
+
+Add an `image` field to your post's front matter:
+
+```toml
++++
+title = "My Post"
+image = "https://example.com/my-image.jpg"
++++
+```
+
+The image is displayed as a full-width banner at the top of the post page and as a thumbnail in list views.
+
+## Card-Style Archive
+
+The archive page renders all posts as cards with cover images, dates, and descriptions. This gives readers a visual way to browse your content.
+
+## Image Best Practices
+
+- Use images with a **16:9 aspect ratio** for consistent card layouts
+- Optimize images for web — aim for under **200KB** per image
+- Add descriptive `alt` text for accessibility
+- Consider using **WebP** format for smaller file sizes
+
+## Lazy Loading
+
+Hwaro supports native lazy loading for images. Enable it in `config.toml`:
+
+```toml
+[markdown]
+lazy_loading = true
+```
+
+This improves initial page load times by deferring off-screen images.

--- a/papermod/content/posts/dark-mode-and-performance.md
+++ b/papermod/content/posts/dark-mode-and-performance.md
@@ -1,0 +1,51 @@
++++
+title = "Dark Mode and Performance Tips"
+date = "2026-03-15"
+description = "Optimize your PaperMod site for speed and user comfort."
+tags = ["performance", "dark-mode", "tips"]
+categories = ["blog"]
+image = "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=800"
++++
+
+PaperMod is designed to be fast out of the box. Here are some tips to keep your site performing at its best.
+
+## Dark Mode
+
+The theme toggle stores the user's preference in `localStorage` and applies it instantly on page load — no flash of unstyled content (FOUC).
+
+CSS variables power the entire color scheme:
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: #1d1d1f;
+  --border: #e0e0e0;
+}
+
+[data-theme="dark"] {
+  --bg: #1d1d1f;
+  --text: #e0e0e0;
+  --border: #333333;
+}
+```
+
+Changing these variables lets you customize the entire palette in seconds.
+
+## Performance Checklist
+
+1. **Enable lazy loading** for images in `config.toml`
+2. **Minimize external requests** — PaperMod uses only Tailwind CDN
+3. **Use system fonts** — no web font downloads needed
+4. **Enable gzip/brotli** on your hosting provider
+5. **Serve static assets** with long cache headers
+
+## Lighthouse Scores
+
+With these optimizations, a typical PaperMod site achieves:
+
+- **Performance**: 95+
+- **Accessibility**: 100
+- **Best Practices**: 100
+- **SEO**: 100
+
+The minimal JavaScript footprint (only theme toggle and optional search) keeps the bundle size tiny.

--- a/papermod/content/posts/getting-started-with-papermod.md
+++ b/papermod/content/posts/getting-started-with-papermod.md
@@ -1,0 +1,49 @@
++++
+title = "Getting Started with PaperMod"
+date = "2026-03-01"
+description = "A quick guide to setting up your PaperMod-powered blog with Hwaro."
+tags = ["hwaro", "tutorial", "getting-started"]
+categories = ["guide"]
+image = "https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=800"
++++
+
+Welcome to PaperMod! This theme brings the beloved Hugo PaperMod design to Hwaro — clean typography, fast loading, and a profile-first homepage.
+
+## Installation
+
+Install Hwaro via Homebrew:
+
+```bash
+brew install hahwul/hwaro/hwaro
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/hahwul/hwaro.git
+cd hwaro && make build
+```
+
+## Creating Your Site
+
+Start by copying this example directory and customizing `config.toml`:
+
+```toml
+title = "My Blog"
+description = "Personal thoughts and tutorials"
+```
+
+## Profile Mode
+
+The homepage features a centered profile section with your name, bio, and social links. Edit the `home.html` template to customize your profile information.
+
+## Dark / Light Toggle
+
+PaperMod includes a theme toggle button in the header. It respects the user's system preference by default and saves their choice in `localStorage`.
+
+## What's Next
+
+- Add your first post in `content/posts/`
+- Customize colors via CSS variables in `header.html`
+- Enable search in `config.toml`
+- Deploy with your favorite hosting provider

--- a/papermod/content/search.md
+++ b/papermod/content/search.md
@@ -1,0 +1,4 @@
++++
+title = "Search"
+template = "search"
++++

--- a/papermod/templates/404.html
+++ b/papermod/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <div class="error-404">
+      <h1>404</h1>
+      <p>The page you're looking for doesn't exist.</p>
+      <a href="{{ base_url }}/">Back to Home</a>
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/archive.html
+++ b/papermod/templates/archive.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <h1>{{ page.title }}</h1>
+
+    {% set last_year = "" %}
+    {% for item in site.pages %}
+    {% if item.date %}
+    {% set year = item.date | date("%Y") %}
+    {% if year != last_year %}
+    {% if last_year != "" %}</div>{% endif %}
+    <h2 class="archive-year">{{ year }}</h2>
+    <div class="archive-posts">
+    {% set last_year = year %}
+    {% endif %}
+      <article class="archive-card">
+        <a href="{{ item.url }}">
+          {% if item.image %}
+          <img src="{{ item.image }}" alt="{{ item.title }}" loading="lazy">
+          {% endif %}
+          <div class="archive-card-body">
+            <h3>{{ item.title }}</h3>
+            <div class="date">{{ item.date }}</div>
+          </div>
+        </a>
+      </article>
+    {% endif %}
+    {% endfor %}
+    {% if last_year != "" %}</div>{% endif %}
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/footer.html
+++ b/papermod/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="wrapper">
+      <p>&copy; {{ current_year }} {{ site.title }} &middot; Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </div>
+  </footer>
+
+  <script>
+    function toggleTheme() {
+      var html = document.documentElement;
+      var current = html.getAttribute('data-theme');
+      var next = current === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+    }
+  </script>
+</body>
+</html>

--- a/papermod/templates/header.html
+++ b/papermod/templates/header.html
@@ -1,0 +1,658 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <style>
+    /* ==========================================================================
+       PaperMod Theme for Hwaro
+       Inspired by Hugo PaperMod by adityatelange
+       ========================================================================== */
+
+    :root {
+      --bg: #ffffff;
+      --text: #1d1d1f;
+      --text-secondary: #6e6e73;
+      --border: #e0e0e0;
+      --card-bg: #f5f5f7;
+      --accent: #0071e3;
+      --code-bg: #f5f5f7;
+      --header-bg: #ffffff;
+      --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      --shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.12);
+      --radius: 8px;
+    }
+
+    [data-theme="dark"] {
+      --bg: #1d1d1f;
+      --text: #f5f5f7;
+      --text-secondary: #a1a1a6;
+      --border: #333336;
+      --card-bg: #2c2c2e;
+      --accent: #2997ff;
+      --code-bg: #2c2c2e;
+      --header-bg: #1d1d1f;
+      --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+      --shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    /* Reset */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+      line-height: 1.7;
+      scroll-behavior: smooth;
+      transition: background 0.3s, color 0.3s;
+    }
+
+    body { margin: 0; }
+
+    a {
+      color: var(--accent);
+      text-decoration: none;
+      transition: opacity 0.2s;
+    }
+
+    a:hover { opacity: 0.75; }
+
+    img { max-width: 100%; height: auto; border-radius: var(--radius); }
+
+    h1, h2, h3, h4 {
+      line-height: 1.3;
+      margin: 1.5em 0 0.5em;
+    }
+
+    h1 { font-size: 2rem; font-weight: 800; }
+    h2 { font-size: 1.5rem; font-weight: 700; }
+    h3 { font-size: 1.2rem; font-weight: 600; }
+
+    p { margin: 1em 0; }
+
+    ul, ol {
+      padding-left: 1.5em;
+      margin: 1em 0;
+    }
+
+    li { margin: 0.3em 0; }
+
+    blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 1em;
+      margin: 1.5em 0;
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    pre {
+      background: var(--code-bg);
+      border-radius: var(--radius);
+      padding: 1em;
+      overflow-x: auto;
+      font-size: 0.9em;
+      line-height: 1.5;
+      margin: 1.5em 0;
+    }
+
+    code {
+      font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+
+    :not(pre) > code {
+      background: var(--code-bg);
+      padding: 0.2em 0.4em;
+      border-radius: 4px;
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 2em 0;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 1.5em 0;
+    }
+
+    th, td {
+      border: 1px solid var(--border);
+      padding: 0.6em 1em;
+      text-align: left;
+    }
+
+    th { font-weight: 600; background: var(--card-bg); }
+
+    /* Layout */
+    .wrapper {
+      max-width: 768px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    /* Header */
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--header-bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      transition: background 0.3s, border-color 0.3s;
+    }
+
+    .site-header .wrapper {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      height: 56px;
+    }
+
+    .site-brand {
+      font-size: 1.2rem;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    .site-brand:hover { opacity: 1; color: var(--text); }
+
+    .site-nav {
+      display: flex;
+      align-items: center;
+      gap: 1.2rem;
+    }
+
+    .site-nav a {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .site-nav a:hover { color: var(--text); opacity: 1; }
+
+    .theme-toggle {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--text-secondary);
+      padding: 4px;
+      display: flex;
+      align-items: center;
+      transition: color 0.2s;
+    }
+
+    .theme-toggle:hover { color: var(--text); }
+
+    .theme-toggle .icon-sun,
+    .theme-toggle .icon-moon { width: 20px; height: 20px; }
+
+    [data-theme="light"] .theme-toggle .icon-sun { display: none; }
+    [data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+
+    #menu-toggle { display: none; }
+
+    .hamburger {
+      display: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--text-secondary);
+      padding: 4px;
+    }
+
+    /* Mobile menu */
+    @media (max-width: 640px) {
+      .site-nav {
+        position: fixed;
+        top: 56px;
+        left: 0;
+        right: 0;
+        background: var(--header-bg);
+        border-bottom: 1px solid var(--border);
+        flex-direction: column;
+        padding: 1rem 1.5rem;
+        gap: 0.8rem;
+        display: none;
+      }
+
+      #menu-toggle:checked ~ .site-nav { display: flex; }
+
+      .hamburger { display: flex; align-items: center; }
+    }
+
+    /* Footer */
+    .site-footer {
+      margin-top: 4rem;
+      padding: 2rem 0;
+      text-align: center;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      border-top: 1px solid var(--border);
+    }
+
+    .site-footer a { color: var(--text-secondary); }
+    .site-footer a:hover { color: var(--accent); }
+
+    /* Profile / Home */
+    .profile {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      padding: 4rem 0 2rem;
+    }
+
+    .profile-name {
+      font-size: 2.2rem;
+      font-weight: 800;
+      margin: 0;
+    }
+
+    .profile-subtitle {
+      color: var(--text-secondary);
+      font-size: 1.1rem;
+      margin-top: 0.5rem;
+    }
+
+    .profile-links {
+      display: flex;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .profile-links a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--text);
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .profile-links a:hover {
+      border-color: var(--accent);
+      background: var(--card-bg);
+      opacity: 1;
+    }
+
+    /* Post List */
+    .post-list { margin-top: 2rem; }
+
+    .post-entry {
+      padding: 1.5rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .post-entry:first-child { border-top: 1px solid var(--border); }
+
+    .post-entry a { color: var(--text); }
+    .post-entry a:hover { opacity: 1; }
+
+    .post-entry .entry-cover {
+      width: 100%;
+      height: 200px;
+      object-fit: cover;
+      border-radius: var(--radius);
+      margin-bottom: 1rem;
+    }
+
+    .entry-header h2 {
+      font-size: 1.3rem;
+      font-weight: 700;
+      margin: 0;
+      line-height: 1.4;
+    }
+
+    .entry-meta {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      margin-top: 0.3rem;
+    }
+
+    .entry-content {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      margin-top: 0.5rem;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .read-more {
+      display: inline-block;
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+      font-weight: 500;
+    }
+
+    /* Single Post */
+    .post-single { margin-top: 2rem; }
+
+    .post-title {
+      font-size: 2rem;
+      font-weight: 800;
+      margin: 0;
+      line-height: 1.3;
+    }
+
+    .post-meta {
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      margin-top: 0.5rem;
+    }
+
+    .post-cover {
+      width: 100%;
+      max-height: 400px;
+      object-fit: cover;
+      border-radius: var(--radius);
+      margin: 1.5rem 0;
+    }
+
+    .post-content {
+      margin-top: 1.5rem;
+    }
+
+    .post-content a {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    /* Post Tags */
+    .post-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 2rem;
+    }
+
+    .post-tags a {
+      padding: 0.3rem 0.8rem;
+      background: var(--card-bg);
+      border-radius: 20px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      transition: background 0.2s, color 0.2s;
+    }
+
+    .post-tags a:hover {
+      background: var(--accent);
+      color: #fff;
+      opacity: 1;
+    }
+
+    /* Post Navigation */
+    .post-nav {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-top: 2rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .post-nav a {
+      flex: 1;
+      padding: 1rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      transition: border-color 0.2s;
+    }
+
+    .post-nav a:hover { border-color: var(--accent); opacity: 1; }
+
+    .post-nav .nav-label {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .post-nav .nav-title {
+      font-weight: 600;
+      margin-top: 0.3rem;
+    }
+
+    .post-nav .nav-next { text-align: right; }
+
+    /* Archive Cards */
+    .archive-year {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin: 2rem 0 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid var(--border);
+    }
+
+    .archive-posts {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+
+    .archive-card {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      transition: box-shadow 0.2s, transform 0.2s;
+    }
+
+    .archive-card:hover {
+      box-shadow: var(--shadow-hover);
+      transform: translateY(-2px);
+    }
+
+    .archive-card a { color: var(--text); }
+    .archive-card a:hover { opacity: 1; }
+
+    .archive-card img {
+      width: 100%;
+      height: 140px;
+      object-fit: cover;
+      border-radius: 0;
+    }
+
+    .archive-card-body {
+      padding: 0.8rem 1rem;
+    }
+
+    .archive-card-body h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin: 0;
+      line-height: 1.4;
+    }
+
+    .archive-card-body .date {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      margin-top: 0.3rem;
+    }
+
+    /* Search */
+    .search-container { margin-top: 2rem; }
+
+    .search-input {
+      width: 100%;
+      padding: 0.8rem 1rem;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg);
+      color: var(--text);
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    .search-input:focus { border-color: var(--accent); }
+
+    .search-results {
+      margin-top: 1.5rem;
+      list-style: none;
+      padding: 0;
+    }
+
+    .search-results li {
+      padding: 1rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .search-results li a {
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .search-results li p {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+      margin: 0.3rem 0 0;
+    }
+
+    /* Taxonomy */
+    .taxonomy-list {
+      list-style: none;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      margin-top: 1.5rem;
+    }
+
+    .taxonomy-list a {
+      padding: 0.4rem 1rem;
+      background: var(--card-bg);
+      border-radius: 20px;
+      color: var(--text);
+      font-size: 0.9rem;
+      transition: background 0.2s;
+    }
+
+    .taxonomy-list a:hover {
+      background: var(--accent);
+      color: #fff;
+      opacity: 1;
+    }
+
+    .taxonomy-posts { margin-top: 1.5rem; }
+
+    .taxonomy-posts li {
+      list-style: none;
+      padding: 0.8rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .taxonomy-posts a {
+      font-weight: 500;
+      color: var(--text);
+    }
+
+    /* 404 */
+    .error-404 {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 50vh;
+      text-align: center;
+    }
+
+    .error-404 h1 { font-size: 6rem; margin: 0; opacity: 0.2; }
+    .error-404 p { color: var(--text-secondary); margin: 1rem 0; }
+
+    .error-404 a {
+      padding: 0.6rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    .error-404 a:hover { border-color: var(--accent); opacity: 1; }
+
+    /* Pagination */
+    nav.pagination { margin: 2rem 0; }
+
+    nav.pagination .pagination-list {
+      list-style: none;
+      padding: 0;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    nav.pagination a {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-size: 0.9rem;
+    }
+
+    nav.pagination a:hover { border-color: var(--accent); opacity: 1; }
+
+    .pagination-current span {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border-radius: var(--radius);
+      background: var(--accent);
+      color: #fff;
+    }
+
+    /* Scrollbar */
+    ::-webkit-scrollbar { width: 6px; height: 6px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--text-secondary); }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <script>
+    // Apply saved theme immediately to prevent FOUC
+    (function() {
+      var saved = localStorage.getItem('theme');
+      if (saved) {
+        document.documentElement.setAttribute('data-theme', saved);
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
+</head>
+<body>
+
+  <header class="site-header">
+    <div class="wrapper">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <input type="checkbox" id="menu-toggle" hidden>
+      <label for="menu-toggle" class="hamburger" aria-label="Menu">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </label>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/archive/">Archive</a>
+        <a href="{{ base_url }}/search/">Search</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
+          <svg class="icon-moon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          <svg class="icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>

--- a/papermod/templates/home.html
+++ b/papermod/templates/home.html
@@ -1,0 +1,48 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="profile">
+      <h1 class="profile-name">Jane Developer</h1>
+      <p class="profile-subtitle">Software engineer, open-source enthusiast, and writer.</p>
+      <div class="profile-links">
+        <a href="https://github.com" target="_blank" rel="noopener">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3M23 19V15a5 5 0 0 0-4-5 5 5 0 0 0-4 0 5 5 0 0 0-4 0 5 5 0 0 0-4 5v4"/><path d="M16 11a4 4 0 1 0-8 0 4 4 0 0 0 8 0z"/></svg>
+          GitHub
+        </a>
+        <a href="https://twitter.com" target="_blank" rel="noopener">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"/></svg>
+          Twitter
+        </a>
+        <a href="{{ base_url }}/about/">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          About
+        </a>
+      </div>
+    </section>
+
+    <section class="post-list">
+      <h2>Recent Posts</h2>
+      {% for item in site.pages %}
+      <article class="post-entry">
+        <a href="{{ item.url }}">
+          {% if item.image %}
+          <img class="entry-cover" src="{{ item.image }}" alt="{{ item.title }}" loading="lazy">
+          {% endif %}
+          <header class="entry-header">
+            <h2>{{ item.title }}</h2>
+            <div class="entry-meta">
+              {% if item.date %}{{ item.date }}{% endif %}
+              {% if item.reading_time %} &middot; {{ item.reading_time }} min read{% endif %}
+            </div>
+          </header>
+          {% if item.description %}
+          <p class="entry-content">{{ item.description }}</p>
+          {% endif %}
+          <span class="read-more">Read more &rarr;</span>
+        </a>
+      </article>
+      {% endfor %}
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/page.html
+++ b/papermod/templates/page.html
@@ -1,0 +1,46 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <article class="post-single">
+      <header>
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta">
+          {% if page.date %}{{ page.date }}{% endif %}
+          {% if page.reading_time %} &middot; {{ page.reading_time }} min read{% endif %}
+        </div>
+      </header>
+
+      {% if page.image %}
+      <img class="post-cover" src="{{ page.image }}" alt="{{ page.title }}" loading="lazy">
+      {% endif %}
+
+      <div class="post-content">
+        {{ content }}
+      </div>
+
+      {% if page.tags %}
+      <div class="post-tags">
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/">#{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <nav class="post-nav">
+        {% if page.higher %}
+        <a class="nav-prev" href="{{ page.higher.url }}">
+          <span class="nav-label">&larr; Newer</span>
+          <div class="nav-title">{{ page.higher.title }}</div>
+        </a>
+        {% endif %}
+        {% if page.lower %}
+        <a class="nav-next" href="{{ page.lower.url }}">
+          <span class="nav-label">Older &rarr;</span>
+          <div class="nav-title">{{ page.lower.title }}</div>
+        </a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/search.html
+++ b/papermod/templates/search.html
@@ -1,0 +1,51 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <h1>{{ page.title }}</h1>
+
+    <div class="search-container">
+      <input class="search-input" id="search-input" type="text" placeholder="Search posts..." autofocus>
+      <ul class="search-results" id="search-results"></ul>
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+  <script>
+    (function() {
+      var input = document.getElementById('search-input');
+      var results = document.getElementById('search-results');
+      var fuse;
+
+      function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+      }
+
+      fetch('{{ base_url }}/search.json')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          fuse = new Fuse(data, {
+            keys: ['title', 'content'],
+            threshold: 0.3,
+            includeMatches: true
+          });
+        });
+
+      input.addEventListener('input', function() {
+        var query = this.value.trim();
+        if (!query || !fuse) {
+          results.innerHTML = '';
+          return;
+        }
+        var matches = fuse.search(query).slice(0, 10);
+        results.innerHTML = matches.map(function(m) {
+          var item = m.item;
+          return '<li><a href="' + escapeHtml(item.permalink) + '">' + escapeHtml(item.title) + '</a>' +
+            (item.description ? '<p>' + escapeHtml(item.description) + '</p>' : '') + '</li>';
+        }).join('');
+      });
+    })();
+  </script>
+
+{% include "footer.html" %}

--- a/papermod/templates/section.html
+++ b/papermod/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <h1>{{ page.title }}</h1>
+
+    {{ content }}
+
+    <div class="post-list">
+      {% for item in section.pages %}
+      <article class="post-entry">
+        <a href="{{ item.url }}">
+          {% if item.image %}
+          <img class="entry-cover" src="{{ item.image }}" alt="{{ item.title }}" loading="lazy">
+          {% endif %}
+          <header class="entry-header">
+            <h2>{{ item.title }}</h2>
+            <div class="entry-meta">
+              {% if item.date %}{{ item.date }}{% endif %}
+              {% if item.reading_time %} &middot; {{ item.reading_time }} min read{% endif %}
+            </div>
+          </header>
+          {% if item.description %}
+          <p class="entry-content">{{ item.description }}</p>
+          {% endif %}
+          <span class="read-more">Read more &rarr;</span>
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+
+    {{ pagination }}
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/taxonomy.html
+++ b/papermod/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <h1>{{ page.title }}</h1>
+    <ul class="taxonomy-list">
+      {{ content }}
+    </ul>
+  </main>
+
+{% include "footer.html" %}

--- a/papermod/templates/taxonomy_term.html
+++ b/papermod/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <h1>#{{ page.title }}</h1>
+    <ul class="taxonomy-posts">
+      {{ content }}
+    </ul>
+  </main>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -15,6 +15,7 @@
   "hwaronight": ["dark", "blog"],
   "modern-blog": ["dark", "blog"],
   "no-style-please": ["light", "blog", "minimal"],
+  "papermod": ["light", "blog", "minimal"],
   "portfolio-blog": ["dark", "blog", "portfolio"],
   "pulse-api": ["dark", "docs"],
   "resume": ["light", "resume"],


### PR DESCRIPTION
## Summary
- Hugo PaperMod에서 영감을 받은 프로필 블로그 예제 추가
- 프로필 모드 홈페이지, 다크/라이트 토글, 커버 이미지, 카드형 아카이브, Fuse.js 검색 포함
- `tags.json`, `AGENTS.md` 업데이트

## Test plan
- [ ] `cd papermod && hwaro serve --open`으로 로컬 프리뷰 확인
- [ ] 다크/라이트 토글 동작 확인
- [ ] 검색 페이지에서 포스트 검색 동작 확인
- [ ] 아카이브 페이지 카드 레이아웃 확인
- [ ] 모바일 반응형 확인

Closes #38