### PR TITLE
Add new example: terminal (Hugo Terminal inspired)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -18,5 +18,6 @@
   "portfolio-blog": ["dark", "blog", "portfolio"],
   "pulse-api": ["dark", "docs"],
   "resume": ["light", "resume"],
-  "studio": ["dark", "landing", "portfolio"]
+  "studio": ["dark", "landing", "portfolio"],
+  "terminal": ["dark", "blog"]
 }

--- a/terminal/AGENTS.md
+++ b/terminal/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Hwaro Usage
+
+### Installation
+
+**Homebrew:**
+```bash
+brew tap hahwul/hwaro
+brew install hwaro
+```
+
+**From Source (Crystal):**
+```bash
+git clone https://github.com/hahwul/hwaro.git
+cd hwaro
+shards install
+shards build --release --no-debug --production
+# Binary: ./bin/hwaro
+```
+
+### Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro init [DIR]` | Initialize a new site |
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro version` | Show version information |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+
+### Build & Serve Options
+
+- **Drafts:** `hwaro build --drafts` / `hwaro serve --drafts` (Include content with `draft = true`)
+- **Port:** `hwaro serve -p 8080` (Default: 3000)
+- **Open:** `hwaro serve --open` (Open browser automatically)
+- **Base URL:** `hwaro build --base-url "https://example.com"`
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   ├── about.md         # About page
+│   └── blog/            # Blog section
+│       ├── _index.md    # Blog listing page
+│       └── *.md         # Individual blog posts
+├── templates/           # Jinja2 templates (.html, .j2)
+│   ├── header.html      # Site header partial
+│   ├── footer.html      # Site footer partial
+│   ├── page.html        # Default page template
+│   ├── section.html     # Section listing template
+│   └── 404.html         # Not found page
+└── static/              # Static assets (copied as-is)
+```
+
+## Content Management
+
+### Creating New Pages
+
+Create a new `.md` file in the `content/` directory.
+
+**Example Front Matter (TOML):**
+```toml
++++
+title = "Page Title"
+date = "2024-01-01"
+draft = false
+tags = ["tag1", "tag2"]
++++
+
+Your markdown content here.
+```
+
+### Creating Sections
+
+1. Create a directory under `content/` (e.g., `content/projects/`)
+2. Add `_index.md` for the section listing page
+3. Add individual `.md` files for section items
+
+**Section `_index.md` Example:**
+```toml
++++
+title = "Projects"
+paginate = 10
+pagination_enabled = true
+sort_by = "date"   # "date" | "title" | "weight"
+reverse = false
++++
+```
+
+### Front Matter Fields
+
+| Field       | Type     | Description                              |
+|-------------|----------|------------------------------------------|
+| title       | string   | Page title (required)                    |
+| date        | string   | Publication date (YYYY-MM-DD)            |
+| draft       | boolean  | If true, excluded from production build  |
+| description | string   | Page description for SEO                 |
+| image       | string   | Featured image URL for social sharing    |
+| tags        | array    | List of tags                             |
+| categories  | array    | List of categories                       |
+| template    | string   | Custom template name (without extension) |
+| weight      | integer  | Sort order (lower = first)               |
+| slug        | string   | Custom URL slug                          |
+| aliases     | array    | URL redirects to this page               |
+
+### Markdown Features
+
+- **Standard Markdown:** Headers, lists, code blocks, etc.
+- **Tables:** Supported.
+- **Footnotes:** Supported.
+- **Raw HTML:** Supported (unless `safe = true` in config).
+
+## Template Development
+
+### Template Location
+
+All templates are in the `templates/` directory using Jinja2 syntax (powered by Crinja).
+
+### Key Variables
+
+#### Global Objects
+- `site`: Site configuration and metadata (`site.title`, `site.base_url`).
+- `page`: Current page object (available in page templates).
+- `section`: Current section object (available in section templates).
+
+#### Page Variables
+Variables can be accessed via the `page` object:
+- `{{ page.title }}` - Page title
+- `{{ page.content }}` - Rendered content
+- `{{ page.date }}` - Date object
+- `{{ page.url }}` - Relative URL (e.g., `/blog/post/`)
+- `{{ page.permalink }}` - Absolute URL
+- `{{ page.section }}` - Section name
+- `{{ page.params.custom_field }}` - Access extra front matter fields
+
+### Common Jinja2 Syntax
+
+- **Output:** `{{ variable }}`
+- **Logic:** `{% if condition %}...{% endif %}`
+- **Loops:** `{% for item in items %}...{% endfor %}`
+- **Comments:** `{# comment #}`
+- **Filters:** `{{ value | filter }}`
+
+### Template Inheritance
+
+**Base Template (`templates/base.html`):**
+```jinja
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{% block title %}{{ site.title }}{% endblock %}</title>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>
+```
+
+**Child Template (`templates/page.html`):**
+```jinja
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} - {{ site.title }}{% endblock %}
+
+{% block content %}
+  <article>
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+  </article>
+{% endblock %}
+```
+
+### Partials
+
+Include reusable components:
+```jinja
+{% include "header.html" %}
+{% include "footer.html" %}
+```
+
+### Custom Filters
+
+- `{{ date | date("%Y-%m-%d") }}` - Format date
+- `{{ text | truncate_words(50) }}` - Truncate text
+- `{{ text | slugify }}` - Convert to slug
+- `{{ url | absolute_url }}` - Make URL absolute
+- `{{ url | relative_url }}` - Prefix with base_url
+- `{{ html | strip_html }}` - Remove HTML tags
+- `{{ markdown | markdownify }}` - Render markdown
+
+## Styling & Assets
+
+### CSS Location
+- Place CSS files in `static/css/`.
+- Reference in templates: `<link rel="stylesheet" href="{{ base_url }}/css/style.css">`.
+
+### Static Files
+- Any file in `static/` is copied to the root of the output directory.
+- Example: `static/robots.txt` -> `public/robots.txt`.
+
+## Notes for AI Agents
+
+1. **Always preserve front matter** when editing content files.
+2. **Use `hwaro serve`** to preview changes.
+3. **Check `config.toml`** for site-wide settings (e.g., markdown safety, pagination).
+4. **Template Syntax:** Use standard Jinja2 syntax.
+5. **Validate TOML syntax** in config.toml after edits.
+6. **Keep URLs relative** using `{{ base_url }}` prefix where appropriate, or `page.url`.
+7. **Escape user content** with `{{ value | escape }}` when needed.

--- a/terminal/config.toml
+++ b/terminal/config.toml
@@ -1,0 +1,230 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Terminal"
+description = "A modern terminal-inspired blog theme with blinking cursor and color accents."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# SEO: Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# SEO: Robots.txt
+# =============================================================================
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# SEO: LLMs.txt
+# =============================================================================
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+limit = 10
+sections = []
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/terminal/content/about.md
+++ b/terminal/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About"
++++
+
+## whoami
+
+A developer who lives in the terminal. I build tools, break things, and write about it.
+
+## Stack
+
+- Languages: Go, Ruby, Crystal, Python
+- Editor: Neovim
+- Shell: Zsh + Tmux
+- OS: macOS / Arch Linux
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/terminal/content/index.md
+++ b/terminal/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Home"
++++
+
+Hello, I'm a developer who loves the terminal. This is my personal blog where I write about programming, security, and open source tools.
+
+Check out the latest posts in the [Posts](/posts/) section, or browse by [Tags](/tags/).

--- a/terminal/content/posts/_index.md
+++ b/terminal/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+paginate = 10
+pagination_enabled = true
++++
+
+All posts, sorted by date.

--- a/terminal/content/posts/getting-started-with-hwaro.md
+++ b/terminal/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,41 @@
++++
+title = "Getting Started with Hwaro"
+date = "2024-01-20"
+tags = ["tutorial", "hwaro"]
+categories = ["tutorials"]
+description = "A quick guide to building your site with Hwaro."
++++
+
+Setting up a new site with Hwaro takes about 30 seconds.
+
+## Installation
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Create a site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+Open `http://localhost:3000` and you're done.
+
+## Project structure
+
+```
+my-blog/
+├── config.toml
+├── content/
+│   ├── index.md
+│   └── posts/
+├── templates/
+└── static/
+```
+
+Simple and predictable.

--- a/terminal/content/posts/hello-world.md
+++ b/terminal/content/posts/hello-world.md
@@ -1,0 +1,20 @@
++++
+title = "Hello World"
+date = "2024-01-15"
+tags = ["introduction", "hello"]
+categories = ["general"]
+description = "First post from the terminal."
++++
+
+Welcome to my blog. This site is powered by [Hwaro](https://github.com/hahwul/hwaro), a fast static site generator written in Crystal.
+
+## Why a terminal theme?
+
+Because the terminal is where the real work happens. No distractions, no bloat — just content.
+
+```bash
+$ echo "Hello, World!"
+Hello, World!
+```
+
+Stay tuned for more posts.

--- a/terminal/content/posts/markdown-tips.md
+++ b/terminal/content/posts/markdown-tips.md
@@ -1,0 +1,35 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2024-01-25"
+tags = ["markdown", "writing"]
+categories = ["tutorials"]
+description = "Useful Markdown formatting techniques for your posts."
++++
+
+Hwaro uses Markdown for content. Here are some tips.
+
+## Text formatting
+
+- **Bold** with `**bold**`
+- *Italic* with `*italic*`
+- `Inline code` with backticks
+
+## Code blocks
+
+Use triple backticks with a language identifier:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Blockquotes
+
+> The terminal is not just an interface.
+> It's a way of thinking.
+
+## Links
+
+- [Hwaro](https://github.com/hahwul/hwaro)
+- [Markdown Guide](https://www.markdownguide.org)
+
+Happy writing.

--- a/terminal/static/css/style.css
+++ b/terminal/static/css/style.css
@@ -1,0 +1,665 @@
+@charset "utf-8";
+
+/* ==========================================================================
+   Terminal Theme for Hwaro
+   Inspired by hugo-theme-terminal (https://github.com/panr/hugo-theme-terminal)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --background: #1d1f21;
+  --foreground: #c5c8c6;
+  --accent: #ff6c2f;
+  --accent-alpha: rgba(255, 108, 47, 0.15);
+  --border-color: #ff6c2f;
+  --code-bg: #282a2e;
+  --selection-bg: #ff6c2f;
+  --selection-fg: #1d1f21;
+  --muted: #969896;
+  --link: #ff6c2f;
+  --link-hover: #c5c8c6;
+  --font-mono: "Fira Code", "Source Code Pro", "Cascadia Code", monospace;
+  --container-width: 820px;
+  --gap: 24px;
+}
+
+/* --------------------------------------------------------------------------
+   Reset & Base
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+::selection {
+  background: var(--selection-bg);
+  color: var(--selection-fg);
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1.7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* --------------------------------------------------------------------------
+   Layout
+   -------------------------------------------------------------------------- */
+.container {
+  width: 100%;
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 0 var(--gap);
+}
+
+/* --------------------------------------------------------------------------
+   Typography
+   -------------------------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6 {
+  color: var(--foreground);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+h1 { font-size: 1.6rem; }
+h2 { font-size: 1.3rem; }
+h3 { font-size: 1.1rem; }
+
+p {
+  margin-bottom: 1rem;
+  word-wrap: break-word;
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+}
+
+strong { color: #fff; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 0.5rem 1rem;
+  margin: 1.5rem 0;
+  color: var(--muted);
+  font-style: italic;
+}
+
+hr {
+  border: none;
+  border-top: 1px dashed var(--muted);
+  margin: 2rem 0;
+}
+
+ul, ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+li {
+  margin-bottom: 0.3rem;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* --------------------------------------------------------------------------
+   Code
+   -------------------------------------------------------------------------- */
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  background: var(--code-bg);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  line-height: 1.6;
+  border: 1px solid #373b41;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Header
+   -------------------------------------------------------------------------- */
+.site-header {
+  padding: 2.5rem 0 0;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.logo:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.logo::after {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 1.3rem;
+  background: var(--accent);
+  animation: blink 1s step-end infinite;
+  margin-left: 2px;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* --------------------------------------------------------------------------
+   Navigation
+   -------------------------------------------------------------------------- */
+.site-nav {
+  border-top: 2px solid var(--accent);
+  border-bottom: 2px solid var(--accent);
+  margin: 1rem 0 2rem;
+}
+
+.site-nav .container {
+  display: flex;
+  justify-content: flex-start;
+  gap: 0;
+}
+
+.site-nav a {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  color: var(--foreground);
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.site-nav a:hover,
+.site-nav a.active {
+  background: var(--accent);
+  color: var(--background);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Main content
+   -------------------------------------------------------------------------- */
+.site-main {
+  flex: 1;
+  padding-bottom: 3rem;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.page-title::before {
+  content: ">>";
+  color: var(--muted);
+  font-weight: 400;
+}
+
+/* --------------------------------------------------------------------------
+   Post list
+   -------------------------------------------------------------------------- */
+.post-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.post-list li {
+  padding: 1rem 0;
+  border-bottom: 1px dashed #373b41;
+}
+
+.post-list li:last-child {
+  border-bottom: none;
+}
+
+.post-list .post-date {
+  color: var(--accent);
+  font-size: 0.85rem;
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.post-list .post-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.post-list .post-title a {
+  color: var(--foreground);
+}
+
+.post-list .post-title a:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.post-list .post-excerpt {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: 0.3rem;
+}
+
+.post-list .post-tags {
+  margin-top: 0.4rem;
+}
+
+.post-list .post-tags a {
+  font-size: 0.8rem;
+  color: var(--muted);
+  border: 1px solid #373b41;
+  padding: 0.1rem 0.5rem;
+  border-radius: 3px;
+  margin-right: 0.3rem;
+}
+
+.post-list .post-tags a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Section list (generic)
+   -------------------------------------------------------------------------- */
+ul.section-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul.section-list li {
+  padding: 0.75rem 0;
+  border-bottom: 1px dashed #373b41;
+}
+
+ul.section-list li:last-child {
+  border-bottom: none;
+}
+
+ul.section-list li a {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Single post
+   -------------------------------------------------------------------------- */
+.post-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid var(--accent);
+}
+
+.post-header h1 {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  color: var(--foreground);
+}
+
+.post-meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.post-meta .tag {
+  color: var(--accent);
+}
+
+.post-content {
+  margin-bottom: 2rem;
+}
+
+.post-content h2 {
+  border-bottom: 1px solid #373b41;
+  padding-bottom: 0.3rem;
+}
+
+.post-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+}
+
+.post-content th,
+.post-content td {
+  border: 1px solid #373b41;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.post-content th {
+  background: var(--code-bg);
+  color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Taxonomy pages
+   -------------------------------------------------------------------------- */
+.taxonomy-desc {
+  color: var(--muted);
+  margin-bottom: 1rem;
+}
+
+.taxonomy-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.taxonomy-list li {
+  margin-bottom: 0.5rem;
+}
+
+.taxonomy-list li::before {
+  content: "$";
+  color: var(--accent);
+  margin-right: 0.5rem;
+  font-weight: 700;
+}
+
+.taxonomy-list a {
+  color: var(--foreground);
+}
+
+.taxonomy-list a:hover {
+  color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Pagination
+   -------------------------------------------------------------------------- */
+nav.pagination {
+  margin: 1.5rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid #373b41;
+  border-radius: 3px;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+nav.pagination a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  background: var(--accent-alpha);
+  color: var(--accent);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid #373b41;
+  border-radius: 3px;
+  color: var(--muted);
+  opacity: 0.5;
+}
+
+/* --------------------------------------------------------------------------
+   Footer
+   -------------------------------------------------------------------------- */
+.site-footer {
+  padding: 1.5rem 0;
+  border-top: 2px solid var(--accent);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.site-footer .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.site-footer a {
+  color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Search overlay
+   -------------------------------------------------------------------------- */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 100;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.search-overlay.open {
+  display: flex;
+}
+
+.search-modal {
+  background: var(--background);
+  border: 2px solid var(--accent);
+  border-radius: 6px;
+  width: 90%;
+  max-width: 560px;
+  overflow: hidden;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #373b41;
+  color: var(--muted);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  outline: none;
+}
+
+.search-input-wrap input::placeholder {
+  color: var(--muted);
+}
+
+.search-input-wrap kbd {
+  background: var(--code-bg);
+  border: 1px solid #373b41;
+  border-radius: 3px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+}
+
+.search-results {
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.search-result-item:hover,
+.search-result-item.active {
+  background: var(--accent-alpha);
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.search-result-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.1rem;
+}
+
+.search-result-snippet {
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-result-snippet mark {
+  background: var(--accent-alpha);
+  color: var(--accent);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-no-results {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.search-hint {
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  border-top: 1px solid #373b41;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.search-hint kbd {
+  font-size: 0.65rem;
+  padding: 0 0.3rem;
+  border: 1px solid #373b41;
+  border-radius: 3px;
+  background: var(--code-bg);
+  font-family: var(--font-mono);
+}
+
+/* --------------------------------------------------------------------------
+   404
+   -------------------------------------------------------------------------- */
+.not-found {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.not-found h1 {
+  font-size: 3rem;
+  color: var(--accent);
+}
+
+.not-found p {
+  color: var(--muted);
+}
+
+/* --------------------------------------------------------------------------
+   Alert shortcode
+   -------------------------------------------------------------------------- */
+.alert {
+  padding: 0.75rem 1rem;
+  margin: 1.5rem 0;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-alpha);
+  color: var(--foreground);
+  border-radius: 0 4px 4px 0;
+}
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 600px) {
+  html { font-size: 14px; }
+  .site-header .container { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .site-nav .container { flex-wrap: wrap; }
+  .site-footer .container { flex-direction: column; gap: 0.5rem; text-align: center; }
+  .post-meta { flex-direction: column; gap: 0.3rem; }
+}

--- a/terminal/static/js/search.js
+++ b/terminal/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"][href*="/css/"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('open');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('open');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('open')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('open')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/terminal/templates/404.html
+++ b/terminal/templates/404.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <main class="site-main">
+    <div class="container not-found">
+      <h1>404</h1>
+      <p>$ cat page.md</p>
+      <p>cat: page.md: No such file or directory</p>
+      <p><a href="{{ base_url }}/">cd ~</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terminal/templates/footer.html
+++ b/terminal/templates/footer.html
@@ -1,0 +1,11 @@
+  <footer class="site-footer">
+    <div class="container">
+      <span>Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></span>
+      <span>&copy; {{ current_year }}</span>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  <script src="{{ base_url }}/js/search.js"></script>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/terminal/templates/header.html
+++ b/terminal/templates/header.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>

--- a/terminal/templates/page.html
+++ b/terminal/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <span>$</span>
+        <input type="text" id="searchInput" placeholder="grep -r ..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+  <main class="site-main">
+    <div class="container">
+      <h1 class="page-title">{{ page.title }}</h1>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terminal/templates/post.html
+++ b/terminal/templates/post.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <span>$</span>
+        <input type="text" id="searchInput" placeholder="grep -r ..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+  <main class="site-main">
+    <div class="container">
+      <article>
+        <header class="post-header">
+          <h1>{{ page.title }}</h1>
+          <div class="post-meta">
+            <time>{{ page.date | date("%Y-%m-%d") }}</time>
+            {% if page.tags %}
+              {% for tag in page.tags %}
+                <a class="tag" href="{{ base_url }}/tags/{{ tag | slugify }}/">#{{ tag }}</a>
+              {% endfor %}
+            {% endif %}
+          </div>
+        </header>
+        <div class="post-content">
+          {{ content }}
+        </div>
+      </article>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terminal/templates/section.html
+++ b/terminal/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <span>$</span>
+        <input type="text" id="searchInput" placeholder="grep -r ..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+  <main class="site-main">
+    <div class="container">
+      <h1 class="page-title">{{ page.title }}</h1>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terminal/templates/shortcodes/alert.html
+++ b/terminal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>[{{ type | upper }}]</strong> {{ message }}
+</div>

--- a/terminal/templates/taxonomy.html
+++ b/terminal/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <main class="site-main">
+    <div class="container">
+      <h1 class="page-title">{{ page.title }}</h1>
+      <p class="taxonomy-desc">$ ls ~/{{ page.title | lower }}/</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terminal/templates/taxonomy_term.html
+++ b/terminal/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="container">
+      <a href="{{ base_url }}/posts/">~/posts</a>
+      <a href="{{ base_url }}/tags/">~/tags</a>
+      <a href="{{ base_url }}/about/">~/about</a>
+    </div>
+  </nav>
+  <main class="site-main">
+    <div class="container">
+      <h1 class="page-title">{{ page.title }}</h1>
+      <p class="taxonomy-desc">$ grep -l "{{ page.title }}" ~/posts/*</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Hugo Terminal 테마에서 영감받은 새 예제 추가
- 다크 배경, 블링킹 커서, 오렌지 액센트 컬러, Fira Code 폰트
- 터미널 스타일 UX: `~/posts` 네비게이션, `$` 프롬프트 검색, `grep` 스타일 taxonomy, `cat` 스타일 404

## Details
- CSS 단일 파일, 최소 JS (검색만)
- 기존 `console` 예제와 차별화: 더 큰 타이포그래피(16px vs 12.5px), 컬러 액센트, 모던 레이아웃
- `tags.json`에 `["dark", "blog"]` 태그 추가

## Test plan
- [x] `hwaro build` 성공 (6 pages)
- [x] `hwaro serve`로 로컬 프리뷰 확인
- [x] `hwaro tool doctor --fix` 실행 완료

Closes #44