### PR TITLE
Add sketch example: hand-drawn doodle theme

### DIFF
--- a/sketch/AGENTS.md
+++ b/sketch/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/sketch/config.toml
+++ b/sketch/config.toml
@@ -1,0 +1,139 @@
+title = "Sketch"
+description = "A hand-drawn doodle style blog with sketchbook aesthetics."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = true
+per_page = 6
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/sketch/content/about.md
+++ b/sketch/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About"
+description = "About this sketchbook blog."
++++
+
+## About This Sketchbook
+
+This is a hand-drawn themed blog built with Hwaro, a fast static site generator. The design draws inspiration from doodles in a sketchbook -- rough borders, playful fonts, and the warm tones of pencil on paper.
+
+### What makes it different
+
+Everything here is intentionally imperfect. The dashed borders mimic hand-drawn lines, the typography feels like handwriting on a notebook page, and the layout breathes like a sketchpad with plenty of margin space.
+
+### Built with
+
+- **Hwaro** -- a Crystal-based static site generator
+- **Patrick Hand** -- a font that captures casual handwriting
+- **Caveat** -- a marker-style font for headings
+- Pure CSS -- no JavaScript frameworks, just pencil and paper aesthetics

--- a/sketch/content/index.md
+++ b/sketch/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Welcome to Sketch"
+template = "home"
+description = "A hand-drawn doodle style blog built with Hwaro."
++++
+
+# Sketch
+
+A blog that feels like flipping through a notebook filled with doodles and ideas, scribbled in the margins between coffee stains and torn edges.

--- a/sketch/content/posts/_index.md
+++ b/sketch/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+paginate = 6
+template = "section"
+generate_feeds = true
++++

--- a/sketch/content/posts/color-like-crayons.md
+++ b/sketch/content/posts/color-like-crayons.md
@@ -1,0 +1,40 @@
++++
+title = "Color Like Crayons"
+date = "2026-03-12"
+description = "Building a color palette that feels warm, natural, and hand-picked."
+tags = ["design", "color"]
+categories = ["creative"]
+template = "post"
++++
+
+The color palette for this site was not picked from a design system generator. It was picked the way you would pick crayons from a box -- by feel.
+
+## Warm over cool
+
+Screens default to cool tones. Blue-white backgrounds, steel-gray text, electric blue links. These are fine for productivity tools, but they feel sterile for creative work.
+
+Instead, this palette leans warm:
+
+| Role | Color | Feeling |
+|------|-------|---------|
+| Background | `#f5f0e8` | Aged paper |
+| Text | `#3d3229` | Charcoal pencil |
+| Accent | `#c05746` | Terracotta crayon |
+| Secondary | `#4a7c6f` | Forest green pencil |
+| Muted | `#8b7e6a` | Worn eraser smudge |
+
+## No pure black, no pure white
+
+Pure black (`#000`) on pure white (`#fff`) creates harsh contrast that tires the eyes. Real pencil marks are never truly black -- they are dark gray with texture. Real paper is never truly white -- it has warmth, grain, and slight yellowing.
+
+By softening both ends of the spectrum, the reading experience becomes gentler without sacrificing legibility.
+
+## Choosing accent colors
+
+The terracotta accent was chosen because it stands out against the warm background without screaming for attention. It is the color of a crayon you would grab instinctively to underline something important.
+
+The forest green secondary is its complement -- calm where the terracotta is energetic. It shows up in blockquote borders and occasional highlights, providing contrast without competition.
+
+## A rule of thumb
+
+When building a natural palette, try this: look at a photograph of an old wooden desk with art supplies on it. Sample the colors you see. You will end up with a palette that feels coherent because it comes from a real-world scene, not a color wheel algorithm.

--- a/sketch/content/posts/margins-and-whitespace.md
+++ b/sketch/content/posts/margins-and-whitespace.md
@@ -1,0 +1,36 @@
++++
+title = "Margins and Whitespace"
+date = "2026-03-15"
+description = "The empty space around your content is not wasted -- it is working."
+tags = ["design", "typography"]
+categories = ["creative"]
+template = "post"
++++
+
+Open any well-loved sketchbook and you will notice something: the margins are never empty. They are filled with tiny doodles, side notes, dates, and stray thoughts that did not fit the main drawing.
+
+## Whitespace is not empty
+
+In web design, whitespace often gets treated as wasted real estate. Stakeholders want every pixel filled. But whitespace is what gives content room to breathe.
+
+Consider a page of handwritten notes:
+
+- Too tight, and the words blur together
+- Too loose, and the eye wanders without direction
+- Just right, and each idea stands on its own while remaining part of a whole
+
+## The notebook principle
+
+Notebooks teach us something about layout that grid systems sometimes obscure: **content determines spacing, not the other way around**.
+
+A sketch that fills an entire page feels different from one that sits small in the center. Both are valid. The margin is part of the composition.
+
+## Applying this to the web
+
+When building this theme, the spacing was set generously on purpose:
+
+- Wide line-height for readability
+- Generous padding inside cards
+- Breathing room between sections
+
+It might look "empty" to someone used to dense dashboards. But for a reading experience, this emptiness is the whole point. It says: slow down, there is room here.

--- a/sketch/content/posts/static-sites-and-simplicity.md
+++ b/sketch/content/posts/static-sites-and-simplicity.md
@@ -1,0 +1,46 @@
++++
+title = "Static Sites and Simplicity"
+date = "2026-03-10"
+description = "Why static site generators pair well with a hand-drawn aesthetic."
+tags = ["web", "tools"]
+categories = ["tech"]
+template = "post"
++++
+
+There is a philosophical alignment between hand-drawn design and static sites. Both reject complexity in favor of directness.
+
+## No layers of abstraction
+
+A static site generator takes Markdown and templates, and produces HTML files. There is no database, no server-side rendering, no state management. What you write is what gets served.
+
+This directness mirrors the sketch ethos: pencil touches paper, mark appears. There is no "build step" between thought and expression.
+
+## Hwaro in particular
+
+Hwaro is written in Crystal, which makes it fast. But speed is not the point. The point is that it stays out of your way:
+
+- Write content in Markdown
+- Design templates with familiar Jinja syntax
+- Drop in CSS for styling
+- Run `hwaro build` and you are done
+
+No plugin ecosystem to navigate. No configuration rabbit holes. Just the essentials.
+
+## When simple is enough
+
+Not every site needs a component library, a design token system, and a CI/CD pipeline. Sometimes you just need:
+
+```
+content/
+templates/
+static/css/
+config.toml
+```
+
+Four directories. One config file. That is the whole architecture. And for a personal blog, a portfolio, or a collection of notes -- that is more than enough.
+
+## The cost of complexity
+
+Every dependency is a future maintenance burden. Every abstraction is a concept someone has to learn. Every build tool is a thing that can break.
+
+A hand-drawn sketch does not break. A static HTML file does not break. There is something reassuring about that.

--- a/sketch/content/posts/the-joy-of-sketching.md
+++ b/sketch/content/posts/the-joy-of-sketching.md
@@ -1,0 +1,39 @@
++++
+title = "The Joy of Sketching"
+date = "2026-03-20"
+description = "Why rough lines and imperfect strokes carry more life than pixel-perfect designs."
+tags = ["design", "sketching"]
+categories = ["creative"]
+template = "post"
++++
+
+There is something deeply satisfying about putting pencil to paper without a plan. No grids, no alignment tools, no undo button. Just the raw movement of graphite across a page.
+
+## Why imperfection matters
+
+The best sketches are never the cleanest ones. They are the ones where the artist's hand moved faster than their doubt. A crooked line has character. A smudged edge tells a story.
+
+When we design for the web, we often chase perfection -- pixel-aligned borders, mathematically precise spacing, uniform typography. But what if we let go of that?
+
+## Bringing sketch to the screen
+
+This blog is an experiment in that idea. Dashed borders instead of solid ones. Handwritten fonts instead of geometric sans-serifs. A color palette that feels like crayons on kraft paper rather than a corporate style guide.
+
+```css
+border: 2px dashed #b8a99a;
+font-family: "Patrick Hand", cursive;
+background: #f5f0e8;
+```
+
+It is not for every project. But for a personal space, where thoughts are half-formed and ideas still have rough edges, this feels right.
+
+## A quick exercise
+
+Next time you open a design tool, try this:
+
+1. Turn off snap-to-grid
+2. Use only one font
+3. Draw your layout with the pencil tool, freehand
+4. Keep the first version -- do not refine it
+
+You might be surprised how alive it feels.

--- a/sketch/content/posts/tools-of-the-trade.md
+++ b/sketch/content/posts/tools-of-the-trade.md
@@ -1,0 +1,33 @@
++++
+title = "Tools of the Trade"
+date = "2026-03-18"
+description = "A look at analog and digital tools that keep the sketching spirit alive."
+tags = ["tools", "sketching"]
+categories = ["creative"]
+template = "post"
++++
+
+Every craft has its tools. For sketching, the list is deceptively simple but endlessly debatable.
+
+## The analog essentials
+
+A good sketchbook matters more than you think. The weight of the paper, the way it accepts ink, the size that fits in your bag -- these are not trivial choices.
+
+- **Pencils** -- HB for general work, 2B for dark confident lines, 4H for light construction marks
+- **Pens** -- A fine-tip felt pen for inking over pencil sketches
+- **Eraser** -- Kneaded erasers pick up graphite without tearing the paper
+- **Sketchbook** -- Something with at least 100gsm paper, spiral-bound for flat opening
+
+## The digital crossover
+
+When sketches move to screens, the challenge is preserving that hand-drawn feeling. Some tools do this well:
+
+- **Procreate** on iPad, with textured brushes that mimic real media
+- **Excalidraw** for quick diagrams that look hand-drawn
+- **Rough.js** for rendering sketch-style graphics on the web
+
+The key is resistance. Real pencils push back against the paper. Digital tools that simulate this friction produce better results than frictionless vector drawing.
+
+## The best tool
+
+Honestly, the best tool is the one within arm's reach. A napkin and a borrowed pen have produced some of history's most important sketches. Do not let the pursuit of the perfect setup stop you from putting marks on a surface.

--- a/sketch/static/css/style.css
+++ b/sketch/static/css/style.css
@@ -1,0 +1,697 @@
+/* ============================================
+   Sketch — Hand-drawn doodle theme
+   ============================================ */
+
+:root {
+  --bg: #f5f0e8;
+  --bg-card: #faf7f2;
+  --text: #3d3229;
+  --text-muted: #8b7e6a;
+  --accent: #c05746;
+  --accent-hover: #a3473a;
+  --secondary: #4a7c6f;
+  --border: #b8a99a;
+  --border-dark: #8b7e6a;
+  --font-body: "Patrick Hand", cursive;
+  --font-heading: "Caveat", cursive;
+  --max-width: 740px;
+}
+
+/* Reset */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+/* SVG filter defs — hidden */
+.sketch-defs {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+/* Base */
+html {
+  font-size: 18px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Layout */
+.site-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.site-main {
+  min-height: calc(100vh - 220px);
+  padding-bottom: 2rem;
+}
+
+/* Header */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 2px dashed var(--border);
+  margin-bottom: 2.5rem;
+  position: relative;
+}
+
+.site-logo {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 2rem;
+  color: var(--text);
+  text-decoration: none;
+  position: relative;
+}
+
+.site-logo::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 2px;
+  transform: rotate(-1deg);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-header nav a {
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  position: relative;
+  transition: color 0.2s;
+}
+
+.site-header nav a:hover {
+  color: var(--accent);
+}
+
+.site-header nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -3px;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.25s;
+}
+
+.site-header nav a:hover::after {
+  width: 100%;
+}
+
+/* Typography */
+h1, h2, h3, h4 {
+  font-family: var(--font-heading);
+  line-height: 1.25;
+  margin-top: 1.5em;
+  margin-bottom: 0.4em;
+  color: var(--text);
+}
+
+h1 {
+  font-size: 2.6rem;
+  font-weight: 700;
+  margin-top: 0;
+}
+
+h2 {
+  font-size: 2rem;
+  font-weight: 600;
+  position: relative;
+  display: inline-block;
+}
+
+h2::after {
+  content: "";
+  display: block;
+  width: 105%;
+  height: 2px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 2px;
+  transform: rotate(-0.5deg);
+}
+
+h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+p {
+  margin: 0.8em 0;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--accent);
+  transition: color 0.2s, border-color 0.2s;
+}
+
+a:hover {
+  color: var(--accent-hover);
+  border-bottom-style: solid;
+}
+
+blockquote {
+  border-left: 3px solid var(--secondary);
+  margin: 1.5em 0;
+  padding: 0.5em 1.2em;
+  color: var(--text-muted);
+  font-style: italic;
+  background: var(--bg-card);
+  border-radius: 0 4px 4px 0;
+}
+
+hr {
+  border: none;
+  border-top: 2px dashed var(--border);
+  margin: 2em 0;
+}
+
+/* Code */
+code {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.82em;
+  background: var(--bg-card);
+  padding: 0.15rem 0.4rem;
+  border: 1px dashed var(--border);
+  border-radius: 3px;
+}
+
+pre {
+  background: var(--bg-card);
+  padding: 1.2rem;
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 1.5em 0;
+  position: relative;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border: none;
+}
+
+/* Images */
+img {
+  max-width: 100%;
+  height: auto;
+  border: 2px dashed var(--border);
+  border-radius: 3px;
+  padding: 4px;
+  background: #fff;
+}
+
+/* Lists */
+ul, ol {
+  padding-left: 1.5em;
+}
+
+li {
+  margin-bottom: 0.3em;
+}
+
+li::marker {
+  color: var(--accent);
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5em 0;
+}
+
+th, td {
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  border: 1px dashed var(--border);
+}
+
+th {
+  background: var(--bg-card);
+  font-family: var(--font-heading);
+  font-size: 1.1em;
+}
+
+/* ============================================
+   Home
+   ============================================ */
+
+.home-intro {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px dashed var(--border);
+}
+
+.home-intro h1 {
+  font-size: 3rem;
+  margin-bottom: 0.2em;
+}
+
+.home-intro p {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.home-section-title {
+  font-family: var(--font-heading);
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  position: relative;
+  display: inline-block;
+}
+
+.home-section-title::before {
+  content: "* ";
+  color: var(--accent);
+}
+
+/* ============================================
+   Post List
+   ============================================ */
+
+.post-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.post-item {
+  margin-bottom: 1.8rem;
+  padding: 1.2rem 1.4rem;
+  background: var(--bg-card);
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.post-item:hover {
+  border-color: var(--accent);
+}
+
+.post-item::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: 12px;
+  width: 20px;
+  height: 8px;
+  background: var(--bg);
+  border-left: 2px dashed var(--border);
+  border-right: 2px dashed var(--border);
+}
+
+.post-item-title {
+  font-family: var(--font-heading);
+  font-size: 1.7rem;
+  font-weight: 600;
+  margin: 0 0 0.2em;
+}
+
+.post-item-title a {
+  color: var(--text);
+  border-bottom: none;
+}
+
+.post-item-title a:hover {
+  color: var(--accent);
+}
+
+.post-item-meta {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5em;
+}
+
+.post-item-meta .date::before {
+  content: "// ";
+  color: var(--border-dark);
+}
+
+.post-item-summary {
+  margin: 0.4em 0 0;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.post-item-tags {
+  margin-top: 0.6em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.55rem;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: 3px;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--secondary);
+  color: var(--secondary);
+}
+
+/* ============================================
+   Single Post
+   ============================================ */
+
+.post-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 2px dashed var(--border);
+}
+
+.post-header h1 {
+  margin-bottom: 0.3em;
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.post-meta .date::before {
+  content: "// ";
+  color: var(--border-dark);
+}
+
+.post-meta .reading-time::before {
+  content: " | ";
+  color: var(--border-dark);
+}
+
+.post-content {
+  margin-bottom: 2rem;
+}
+
+.post-tags {
+  margin: 2rem 0;
+  padding-top: 1.5rem;
+  border-top: 2px dashed var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.post-tags-label {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  margin-right: 0.3rem;
+}
+
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  margin: 2rem 0;
+  padding-top: 1.5rem;
+  border-top: 2px dashed var(--border);
+  gap: 1rem;
+}
+
+.post-nav a {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+.post-nav .prev::before {
+  content: "<-- ";
+  color: var(--border-dark);
+}
+
+.post-nav .next::after {
+  content: " -->";
+  color: var(--border-dark);
+}
+
+/* ============================================
+   Section List (fallback)
+   ============================================ */
+
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-card);
+  border: 1px dashed var(--border);
+  border-radius: 3px;
+}
+
+ul.section-list li a {
+  font-weight: 500;
+  border-bottom: none;
+}
+
+/* ============================================
+   Taxonomy
+   ============================================ */
+
+.taxonomy-desc {
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  font-size: 1.05rem;
+}
+
+.taxonomy-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.taxonomy-item {
+  display: inline-block;
+}
+
+.taxonomy-item a {
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+  background: var(--bg-card);
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  text-decoration: none;
+}
+
+.taxonomy-item a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.taxonomy-item .count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* ============================================
+   Pagination
+   ============================================ */
+
+nav.pagination {
+  margin: 2rem 0;
+  padding-top: 1rem;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border: 1px dashed var(--border);
+  border-radius: 3px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+nav.pagination a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border: 2px dashed var(--accent);
+  border-radius: 3px;
+  color: var(--accent);
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border: 1px dashed var(--border);
+  border-radius: 3px;
+  color: var(--text-muted);
+  opacity: 0.5;
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+/* ============================================
+   Footer
+   ============================================ */
+
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 0;
+  border-top: 2px dashed var(--border);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.footer-doodle {
+  color: var(--border);
+  font-size: 0.85rem;
+  letter-spacing: 2px;
+  margin-bottom: 0.5rem;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+.site-footer a {
+  border-bottom: none;
+}
+
+/* ============================================
+   404 Page
+   ============================================ */
+
+.not-found {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.not-found h1 {
+  font-size: 5rem;
+  color: var(--border);
+  margin-bottom: 0;
+}
+
+.not-found p {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+/* ============================================
+   Decorations
+   ============================================ */
+
+.sketch-arrow {
+  display: inline-block;
+  color: var(--border-dark);
+  font-size: 1.2rem;
+}
+
+.sketch-divider {
+  text-align: center;
+  color: var(--border);
+  font-size: 1rem;
+  letter-spacing: 4px;
+  margin: 2rem 0;
+}
+
+.view-all {
+  display: inline-block;
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  margin-top: 0.5rem;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+
+@media (max-width: 640px) {
+  html {
+    font-size: 16px;
+  }
+
+  .site-header {
+    flex-direction: column;
+    gap: 0.8rem;
+    align-items: flex-start;
+  }
+
+  .site-wrapper {
+    padding: 0 1rem;
+  }
+
+  .home-intro h1 {
+    font-size: 2.2rem;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  h2 {
+    font-size: 1.6rem;
+  }
+
+  .post-nav {
+    flex-direction: column;
+  }
+
+  .post-item {
+    padding: 1rem;
+  }
+}

--- a/sketch/templates/404.html
+++ b/sketch/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="not-found">
+      <h1>404</h1>
+      <p>Oops, this page seems to have been erased from the sketchbook.</p>
+      <p><a href="{{ base_url }}/">Back to the drawing board</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/footer.html
+++ b/sketch/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <div class="footer-doodle" aria-hidden="true">~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~</div>
+      <p>Powered by Hwaro</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/sketch/templates/header.html
+++ b/sketch/templates/header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Patrick+Hand&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <svg class="sketch-defs" aria-hidden="true">
+    <filter id="rough">
+      <feTurbulence type="turbulence" baseFrequency="0.03" numOctaves="4" result="noise" />
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.5" />
+    </filter>
+  </svg>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>

--- a/sketch/templates/home.html
+++ b/sketch/templates/home.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="home-intro">
+      {{ content | safe }}
+    </div>
+
+    {% if section.pages | length > 0 %}
+    <div class="home-posts">
+      <h2 class="home-section-title">Recent Sketches</h2>
+      <ul class="post-list">
+        {% for post in section.pages %}
+        <li class="post-item">
+          <h3 class="post-item-title">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+          </h3>
+          <div class="post-item-meta">
+            <span class="date">{{ post.date | date("%B %d, %Y") }}</span>
+          </div>
+          {% if post.summary %}
+          <p class="post-item-summary">{{ post.summary }}</p>
+          {% endif %}
+          {% if post.tags | length > 0 %}
+          <div class="post-item-tags">
+            {% for tag in post.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/page.html
+++ b/sketch/templates/page.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/post.html
+++ b/sketch/templates/post.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article>
+      <div class="post-header">
+        <h1>{{ page.title }}</h1>
+        <div class="post-meta">
+          <span class="date">{{ page.date | date("%B %d, %Y") }}</span>
+          {% if page.reading_time %}
+          <span class="reading-time">{{ page.reading_time }} min read</span>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="post-content">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags | length > 0 %}
+      <div class="post-tags">
+        <span class="post-tags-label">Tags:</span>
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <nav class="post-nav">
+        {% if page.lower %}
+        <a href="{{ page.lower.url }}" class="prev">{{ page.lower.title }}</a>
+        {% else %}
+        <span></span>
+        {% endif %}
+        {% if page.higher %}
+        <a href="{{ page.higher.url }}" class="next">{{ page.higher.title }}</a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/section.html
+++ b/sketch/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    {{ content | safe }}
+
+    {% if section.pages | length > 0 %}
+    <ul class="post-list">
+      {% for post in section.pages %}
+      <li class="post-item">
+        <h3 class="post-item-title">
+          <a href="{{ post.url }}">{{ post.title }}</a>
+        </h3>
+        <div class="post-item-meta">
+          <span class="date">{{ post.date | date("%B %d, %Y") }}</span>
+        </div>
+        {% if post.summary %}
+        <p class="post-item-summary">{{ post.summary }}</p>
+        {% endif %}
+        {% if post.tags | length > 0 %}
+        <div class="post-item-tags">
+          {% for tag in post.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <ul class="section-list">
+      {{ section.list | safe }}
+    </ul>
+    {% endif %}
+    {{ pagination | safe }}
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/shortcodes/alert.html
+++ b/sketch/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/sketch/templates/taxonomy.html
+++ b/sketch/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/sketch/templates/taxonomy_term.html
+++ b/sketch/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -50,5 +50,6 @@
   "typewriter": ["light", "blog", "vintage"],
   "wanderlust": ["light", "blog", "travel"],
   "wiki": ["light", "docs", "wiki"],
-  "zen": ["light", "blog", "zen"]
+  "zen": ["light", "blog", "zen"],
+  "sketch": ["light", "blog", "handdrawn"]
 }


### PR DESCRIPTION
## Summary
- Add new `sketch` example with hand-drawn doodle style theme (light, sketchbook paper aesthetic)
- Uses dashed borders, handwriting fonts (Patrick Hand, Caveat), and warm crayon-inspired color palette
- Includes 5 sample blog posts, home/about pages, full taxonomy support, and pagination
- Tags: `light`, `blog`, `handdrawn`

Closes #91

## Test plan
- [ ] Verify `hwaro build` succeeds in the `sketch/` directory
- [ ] Run `hwaro serve` and check home, posts, about, tags pages render correctly
- [ ] Verify responsive layout on mobile viewport
- [ ] Confirm no gradients or emojis are used in the design