### PR TITLE
Add new example: darkroom (photography portfolio dark theme)

### DIFF
--- a/darkroom/AGENTS.md
+++ b/darkroom/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/darkroom/config.toml
+++ b/darkroom/config.toml
@@ -1,0 +1,162 @@
+title = "Darkroom"
+description = "A photography portfolio with a dark theme, inspired by the analog darkroom experience."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 12
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/darkroom/content/about.md
+++ b/darkroom/content/about.md
@@ -1,0 +1,23 @@
++++
+title = "About"
+template = "page"
++++
+
+<div class="page-content">
+  <h1>About</h1>
+  <div class="page-body">
+    <p>Darkroom is a photography portfolio built with Hwaro, designed around the analog darkroom experience. The pure black background lets each photograph speak for itself, the way prints emerge from developer solution under safelight.</p>
+
+<h2>The Approach</h2>
+
+<p>Every photograph carries its own technical story. EXIF metadata is displayed alongside each image, bridging the gap between artistic vision and technical craft. Camera body, lens, aperture, shutter speed, ISO — these are the decisions that shape the final frame.</p>
+
+<h2>Technical Details</h2>
+
+<p>This site is built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>, a fast static site generator written in Crystal. The dark theme is intentional: black backgrounds maximize perceived contrast and color accuracy, just as a well-calibrated monitor would in a professional editing environment.</p>
+
+<h2>Features</h2>
+
+<p>Full-screen gallery layout with hover reveals. Lightbox-style image viewing for examining detail. EXIF metadata display for every photograph. Responsive design that works from mobile to ultrawide. Pure CSS animations with no JavaScript dependencies for the interface.</p>
+  </div>
+</div>

--- a/darkroom/content/index.md
+++ b/darkroom/content/index.md
@@ -1,0 +1,54 @@
++++
+title = "Gallery"
+template = "page"
++++
+
+<section class="hero-section">
+  <h1 class="hero-title">Darkroom</h1>
+  <p class="hero-subtitle">A curated collection of photographs. Light, shadow, and everything between.</p>
+</section>
+
+<div class="featured-grid">
+  <a href="photos/morning-fog/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=533&fit=crop" alt="Morning Fog Over the Valley">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">Morning Fog Over the Valley</span>
+      <span class="gallery-item-meta">Sony A7R IV</span>
+    </div>
+  </a>
+  <a href="photos/steel-and-glass/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1486325212027-8081e485255e?w=800&h=533&fit=crop" alt="Steel and Glass">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">Steel and Glass</span>
+      <span class="gallery-item-meta">Leica Q2</span>
+    </div>
+  </a>
+  <a href="photos/last-light/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?w=800&h=533&fit=crop" alt="Last Light">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">Last Light</span>
+      <span class="gallery-item-meta">Fujifilm X-T5</span>
+    </div>
+  </a>
+  <a href="photos/the-crossing/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=800&h=533&fit=crop" alt="The Crossing">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">The Crossing</span>
+      <span class="gallery-item-meta">Nikon Z8</span>
+    </div>
+  </a>
+  <a href="photos/quiet-morning/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1439853949127-fa647821eba0?w=800&h=533&fit=crop" alt="Quiet Morning">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">Quiet Morning</span>
+      <span class="gallery-item-meta">Canon EOS R5</span>
+    </div>
+  </a>
+  <a href="photos/monochrome-street/" class="featured-item">
+    <img src="https://images.unsplash.com/photo-1444723121867-7a241cacace9?w=800&h=533&fit=crop" alt="Monochrome Street">
+    <div class="gallery-overlay">
+      <span class="gallery-item-title">Monochrome Street</span>
+      <span class="gallery-item-meta">Leica M11</span>
+    </div>
+  </a>
+</div>

--- a/darkroom/content/photos/_index.md
+++ b/darkroom/content/photos/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Archive"
+sort_by = "date"
+reverse = true
+paginate = 12
+pagination_enabled = true
++++
+
+All photographs, sorted by date.

--- a/darkroom/content/photos/last-light.md
+++ b/darkroom/content/photos/last-light.md
@@ -1,0 +1,19 @@
++++
+title = "Last Light"
+date = "2024-09-03"
+tags = ["landscape", "golden-hour", "nature"]
+image = "https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Fujifilm X-T5"
+lens = "XF 16-55mm f/2.8 R LM WR"
+focal_length = "23mm"
+aperture = "f/11"
+shutter = "1/60s"
+iso = "160"
+location = "Tuscany, Italy"
++++
+
+The final minutes before the sun drops below the horizon. Fields lit from behind, every blade of grass outlined in gold. The warmth of Fujifilm's color science was the right choice for this scene.
+
+There is a narrow window for this kind of light — perhaps ten minutes. The shadows lengthen so quickly that what works at 7:42 is gone by 7:48.

--- a/darkroom/content/photos/monochrome-street.md
+++ b/darkroom/content/photos/monochrome-street.md
@@ -1,0 +1,19 @@
++++
+title = "Monochrome Street"
+date = "2024-06-10"
+tags = ["street", "black-and-white", "urban"]
+image = "https://images.unsplash.com/photo-1444723121867-7a241cacace9?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Leica M11"
+lens = "Summicron 35mm f/2 ASPH"
+focal_length = "35mm"
+aperture = "f/4"
+shutter = "1/320s"
+iso = "400"
+location = "London, UK"
++++
+
+The absence of color strips a scene to its bones: light, shadow, form. Shooting with the Leica M11 in monochrome mode means committing to the decision at capture, not in post. That constraint sharpens your eye.
+
+This intersection had perfect overhead light cutting sharp diagonals across the pavement. Waited for a single figure to enter the frame and break the geometry.

--- a/darkroom/content/photos/morning-fog.md
+++ b/darkroom/content/photos/morning-fog.md
@@ -1,0 +1,19 @@
++++
+title = "Morning Fog Over the Valley"
+date = "2024-11-15"
+tags = ["landscape", "nature", "fog"]
+image = "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Sony A7R IV"
+lens = "Sony FE 24-70mm f/2.8 GM II"
+focal_length = "35mm"
+aperture = "f/8"
+shutter = "1/125s"
+iso = "100"
+location = "Dolomites, Italy"
++++
+
+First light spilling into the valley, with fog layering between the ridges. Shot at dawn from a ridge overlooking the valley floor. The stillness was absolute — no wind, no sound, just the slow crawl of fog through the passes.
+
+Waited nearly forty minutes for the light to hit the far ridge. The fog moved faster than expected, requiring quick recomposition from the original plan.

--- a/darkroom/content/photos/quiet-morning.md
+++ b/darkroom/content/photos/quiet-morning.md
@@ -1,0 +1,19 @@
++++
+title = "Quiet Morning"
+date = "2024-07-22"
+tags = ["landscape", "minimal", "nature"]
+image = "https://images.unsplash.com/photo-1439853949127-fa647821eba0?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Canon EOS R5"
+lens = "RF 70-200mm f/2.8L IS USM"
+focal_length = "135mm"
+aperture = "f/4"
+shutter = "1/250s"
+iso = "200"
+location = "Lake District, England"
++++
+
+Compression at 135mm flattens the layers of hills into something almost abstract. The muted palette before sunrise — all greys and soft blues — reduces the landscape to its essential forms.
+
+No filters, no processing tricks. Just the natural atmosphere doing what decades of landscape painters tried to replicate.

--- a/darkroom/content/photos/steel-and-glass.md
+++ b/darkroom/content/photos/steel-and-glass.md
@@ -1,0 +1,19 @@
++++
+title = "Steel and Glass"
+date = "2024-10-28"
+tags = ["architecture", "urban", "geometry"]
+image = "https://images.unsplash.com/photo-1486325212027-8081e485255e?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Leica Q2"
+lens = "Summilux 28mm f/1.7"
+focal_length = "28mm"
+aperture = "f/5.6"
+shutter = "1/500s"
+iso = "200"
+location = "Tokyo, Japan"
++++
+
+The repeating geometry of modern architecture has its own rhythm. This building caught afternoon light in a way that turned each panel into a small mirror, reflecting fragments of the surrounding city.
+
+Shot from street level, tilting up slightly to exaggerate the convergence. The Leica's 28mm lens captures just enough distortion to add tension without becoming a gimmick.

--- a/darkroom/content/photos/the-crossing.md
+++ b/darkroom/content/photos/the-crossing.md
@@ -1,0 +1,19 @@
++++
+title = "The Crossing"
+date = "2024-08-17"
+tags = ["urban", "street", "night"]
+image = "https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=1600&h=1067&fit=crop"
+
+[extra]
+camera = "Nikon Z8"
+lens = "Nikkor Z 50mm f/1.2 S"
+focal_length = "50mm"
+aperture = "f/1.8"
+shutter = "1/200s"
+iso = "3200"
+location = "New York, NY"
++++
+
+City intersections are small theaters. Everyone moving with purpose, paths crossing for fractions of a second. The high ISO was necessary to freeze motion in fading light, but the Z8 handles noise with remarkable restraint.
+
+The 50mm focal length forces you into the scene rather than observing from a distance. You become part of the current.

--- a/darkroom/static/css/style.css
+++ b/darkroom/static/css/style.css
@@ -1,0 +1,658 @@
+/* ============================================================
+   Darkroom — Photography Portfolio Dark Theme
+   ============================================================ */
+
+:root {
+  --bg: #0a0a0a;
+  --bg-surface: #111111;
+  --bg-elevated: #1a1a1a;
+  --text: #e8e8e8;
+  --text-secondary: #888888;
+  --text-muted: #555555;
+  --accent: #c8a86e;
+  --border: #222222;
+  --border-subtle: #1a1a1a;
+  --font-sans: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "DM Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+/* Reset */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  font-weight: 300;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--text); }
+
+img { display: block; max-width: 100%; height: auto; }
+
+/* ---- Header ---- */
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: rgba(10, 10, 10, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--text);
+  font-weight: 400;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.site-logo:hover { color: var(--accent); }
+
+.logo-mark {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.site-nav { display: flex; gap: 1.75rem; }
+
+.site-nav a {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 400;
+}
+
+.site-nav a:hover { color: var(--text); }
+
+/* ---- Main ---- */
+
+.site-main {
+  padding-top: 60px;
+  min-height: 100vh;
+}
+
+/* ---- Footer ---- */
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  margin-top: 4rem;
+}
+
+.footer-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  text-align: center;
+}
+
+.footer-text {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* ---- Homepage / Gallery Grid ---- */
+
+.hero-section {
+  padding: 6rem 2rem 3rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.hero-title {
+  font-size: 2.4rem;
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--text);
+  margin-bottom: 0.75rem;
+}
+
+.hero-subtitle {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  font-weight: 300;
+  max-width: 480px;
+}
+
+.featured-grid {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+}
+
+.featured-item {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: var(--bg-surface);
+  display: block;
+}
+
+.featured-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s ease, opacity 0.4s ease;
+  opacity: 0.85;
+}
+
+.featured-item:hover img {
+  transform: scale(1.03);
+  opacity: 1;
+}
+
+.featured-item .gallery-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 1.25rem 1.25rem;
+  background: rgba(0, 0, 0, 0.85);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.featured-item:hover .gallery-overlay { opacity: 1; }
+
+.featured-item .gallery-item-title {
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+.featured-item .gallery-item-meta {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+/* ---- Section / Archive ---- */
+
+.section-header {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 5rem 2rem 2rem;
+}
+
+.section-title {
+  font-size: 1.6rem;
+  font-weight: 300;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
+.section-header p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.gallery-grid {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+}
+
+.gallery-item {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: var(--bg-surface);
+  display: block;
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s ease, opacity 0.4s ease;
+  opacity: 0.85;
+}
+
+.gallery-item:hover img {
+  transform: scale(1.03);
+  opacity: 1;
+}
+
+.gallery-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 1.25rem 1.25rem;
+  background: rgba(0, 0, 0, 0.85);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.gallery-item:hover .gallery-overlay { opacity: 1; }
+
+.gallery-item-title {
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+.gallery-item-meta {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+.gallery-placeholder {
+  width: 100%;
+  height: 100%;
+  background: var(--bg-surface);
+}
+
+/* ---- Photo Detail ---- */
+
+.photo-detail {
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.photo-hero {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+}
+
+.photo-hero img {
+  max-height: 80vh;
+  width: auto;
+  max-width: 100%;
+  cursor: zoom-in;
+  transition: opacity 0.3s;
+}
+
+.photo-hero img:hover { opacity: 0.9; }
+
+.photo-info {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 3rem 2rem 4rem;
+}
+
+.photo-title {
+  font-size: 1.5rem;
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.25rem;
+}
+
+.photo-date {
+  display: block;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  margin-bottom: 2rem;
+}
+
+/* ---- EXIF Data ---- */
+
+.exif-data {
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.exif-heading {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.exif-list {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+}
+
+.exif-item {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.exif-item dt {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.15rem;
+}
+
+.exif-item dd {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+/* ---- Photo Content ---- */
+
+.photo-content {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+.photo-content p { margin-bottom: 1em; }
+
+.photo-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.tag {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border);
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.tag:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ---- Lightbox ---- */
+
+.lightbox {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.96);
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox.active {
+  display: flex;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+  z-index: 1001;
+}
+
+.lightbox-close:hover { color: var(--text); }
+
+.lightbox-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 90vw;
+  max-height: 90vh;
+}
+
+.lightbox-img {
+  max-width: 90vw;
+  max-height: 80vh;
+  object-fit: contain;
+}
+
+.lightbox-meta {
+  display: flex;
+  gap: 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ---- About / Static Pages ---- */
+
+.page-content {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 5rem 2rem 4rem;
+}
+
+.page-content h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+}
+
+.page-content .page-body {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.8;
+}
+
+.page-content .page-body p { margin-bottom: 1.2em; }
+.page-content .page-body h2 {
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--text);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.page-content .page-body a { color: var(--accent); }
+.page-content .page-body a:hover { color: var(--text); }
+
+/* ---- Taxonomy Pages ---- */
+
+.taxonomy-page {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 5rem 2rem 4rem;
+}
+
+.taxonomy-desc {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+.taxonomy-page ul {
+  list-style: none;
+}
+
+.taxonomy-page ul li {
+  border-bottom: 1px solid var(--border);
+}
+
+.taxonomy-page ul li a {
+  display: block;
+  padding: 0.75rem 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.taxonomy-page ul li a:hover { color: var(--accent); }
+
+/* ---- Error Page ---- */
+
+.error-page {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 10rem 2rem;
+  text-align: center;
+}
+
+.error-page h1 {
+  font-size: 5rem;
+  font-weight: 300;
+  color: var(--text-muted);
+  letter-spacing: 0.1em;
+}
+
+.error-page p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin: 1rem 0 2rem;
+}
+
+.back-link {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.15rem;
+}
+
+.back-link:hover { border-color: var(--accent); }
+
+/* ---- Pagination ---- */
+
+nav.pagination {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.4rem 0.7rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  border: 1px solid var(--border);
+  transition: border-color 0.2s, color 0.2s;
+}
+
+nav.pagination a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.4rem 0.7rem;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  border: 1px solid var(--accent);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.4rem 0.7rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  border: 1px solid var(--border);
+  opacity: 0.4;
+}
+
+/* ---- Responsive ---- */
+
+@media (max-width: 900px) {
+  .featured-grid,
+  .gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .header-inner { padding: 0 1rem; }
+
+  .site-logo { font-size: 0.85rem; }
+  .site-nav { gap: 1rem; }
+  .site-nav a { font-size: 0.75rem; }
+
+  .hero-section { padding: 5rem 1rem 2rem; }
+  .hero-title { font-size: 1.6rem; }
+  .hero-subtitle { font-size: 0.85rem; }
+
+  .featured-grid,
+  .gallery-grid {
+    grid-template-columns: 1fr;
+    padding: 0 1rem 3rem;
+  }
+
+  .section-header { padding: 4rem 1rem 1.5rem; }
+
+  .photo-info { padding: 2rem 1rem 3rem; }
+  .exif-list { grid-template-columns: 1fr; }
+
+  .page-content,
+  .taxonomy-page { padding: 4rem 1rem 3rem; }
+}

--- a/darkroom/templates/404.html
+++ b/darkroom/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <h1>404</h1>
+      <p>This frame is empty.</p>
+      <a href="{{ base_url }}/" class="back-link">Return to Gallery</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/darkroom/templates/footer.html
+++ b/darkroom/templates/footer.html
@@ -1,0 +1,50 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-text">Powered by Hwaro</p>
+    </div>
+  </footer>
+  <div class="lightbox" id="lightbox">
+    <button class="lightbox-close" aria-label="Close">&times;</button>
+    <div class="lightbox-content">
+      <img src="" alt="" class="lightbox-img" id="lightbox-img">
+      <div class="lightbox-meta" id="lightbox-meta"></div>
+    </div>
+  </div>
+  <script>
+    (function() {
+      var lightbox = document.getElementById('lightbox');
+      var lightboxImg = document.getElementById('lightbox-img');
+      var lightboxMeta = document.getElementById('lightbox-meta');
+      var closeBtn = document.querySelector('.lightbox-close');
+
+      document.querySelectorAll('[data-lightbox]').forEach(function(el) {
+        el.addEventListener('click', function(e) {
+          e.preventDefault();
+          var src = el.getAttribute('data-lightbox');
+          var meta = el.getAttribute('data-meta') || '';
+          lightboxImg.src = src;
+          lightboxImg.alt = el.getAttribute('data-alt') || '';
+          lightboxMeta.innerHTML = meta;
+          lightbox.classList.add('active');
+          document.body.style.overflow = 'hidden';
+        });
+      });
+
+      function closeLightbox() {
+        lightbox.classList.remove('active');
+        document.body.style.overflow = '';
+        lightboxImg.src = '';
+      }
+
+      closeBtn.addEventListener('click', closeLightbox);
+      lightbox.addEventListener('click', function(e) {
+        if (e.target === lightbox) closeLightbox();
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') closeLightbox();
+      });
+    })();
+  </script>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/darkroom/templates/header.html
+++ b/darkroom/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500&family=DM+Mono:wght@300;400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-mark"></span>
+        <span class="logo-text">Darkroom</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Gallery</a>
+        <a href="{{ base_url }}/photos/">Archive</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>

--- a/darkroom/templates/page.html
+++ b/darkroom/templates/page.html
@@ -1,0 +1,81 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.image %}
+    <article class="photo-detail">
+      <div class="photo-hero">
+        <img src="{{ page.image }}" alt="{{ page.title }}"
+             data-lightbox="{{ page.image }}"
+             data-alt="{{ page.title }}"
+             data-meta="{% if page.extra.camera %}<span>{{ page.extra.camera }}</span>{% endif %}{% if page.extra.lens %}<span>{{ page.extra.lens }}</span>{% endif %}{% if page.extra.aperture %}<span>{{ page.extra.aperture }}</span>{% endif %}{% if page.extra.shutter %}<span>{{ page.extra.shutter }}</span>{% endif %}{% if page.extra.iso %}<span>ISO {{ page.extra.iso }}</span>{% endif %}">
+      </div>
+      <div class="photo-info">
+        <h1 class="photo-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <time class="photo-date">{{ page.date | date("%B %d, %Y") }}</time>
+        {% endif %}
+        {% if page.extra.camera or page.extra.lens or page.extra.aperture or page.extra.shutter or page.extra.iso or page.extra.location %}
+        <div class="exif-data">
+          <h2 class="exif-heading">EXIF</h2>
+          <dl class="exif-list">
+            {% if page.extra.camera %}
+            <div class="exif-item">
+              <dt>Camera</dt>
+              <dd>{{ page.extra.camera }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.lens %}
+            <div class="exif-item">
+              <dt>Lens</dt>
+              <dd>{{ page.extra.lens }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.focal_length %}
+            <div class="exif-item">
+              <dt>Focal Length</dt>
+              <dd>{{ page.extra.focal_length }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.aperture %}
+            <div class="exif-item">
+              <dt>Aperture</dt>
+              <dd>{{ page.extra.aperture }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.shutter %}
+            <div class="exif-item">
+              <dt>Shutter Speed</dt>
+              <dd>{{ page.extra.shutter }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.iso %}
+            <div class="exif-item">
+              <dt>ISO</dt>
+              <dd>{{ page.extra.iso }}</dd>
+            </div>
+            {% endif %}
+            {% if page.extra.location %}
+            <div class="exif-item">
+              <dt>Location</dt>
+              <dd>{{ page.extra.location }}</dd>
+            </div>
+            {% endif %}
+          </dl>
+        </div>
+        {% endif %}
+        <div class="photo-content">
+          {{ content | safe }}
+        </div>
+        {% if page.tags %}
+        <div class="photo-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+    </article>
+    {% else %}
+    {{ content | safe }}
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/darkroom/templates/section.html
+++ b/darkroom/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+    <div class="gallery-grid">
+      {% for post in section.pages %}
+      <a href="{{ post.url }}" class="gallery-item">
+        {% if post.image %}
+        <img src="{{ post.image }}" alt="{{ post.title }}" loading="lazy">
+        {% else %}
+        <div class="gallery-placeholder"></div>
+        {% endif %}
+        <div class="gallery-overlay">
+          <span class="gallery-item-title">{{ post.title }}</span>
+          {% if post.extra.camera %}
+          <span class="gallery-item-meta">{{ post.extra.camera }}</span>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/darkroom/templates/taxonomy.html
+++ b/darkroom/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="taxonomy-page">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/darkroom/templates/taxonomy_term.html
+++ b/darkroom/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="taxonomy-page">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <p class="taxonomy-desc">Photos tagged with this term:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -11,6 +11,7 @@
   "cinema": ["dark", "blog", "review"],
   "comic": ["light", "blog", "comic"],
   "console": ["dark", "blog", "minimal"],
+  "darkroom": ["dark", "portfolio", "photography"],
   "dashboard": ["dark", "landing", "dashboard"],
   "devconf": ["dark", "event", "landing"],
   "devlog": ["dark", "blog", "minimal"],


### PR DESCRIPTION
## Summary
- Add `darkroom` example: a photography portfolio with a dark theme inspired by the analog darkroom experience
- Full-screen gallery grid layout with hover overlay metadata
- Individual photo pages with EXIF data display (camera, lens, aperture, shutter speed, ISO, location)
- Lightbox-style image zoom on photo detail pages
- Pure black background to maximize photograph color and contrast
- Responsive design (3-column, 2-column, single-column)
- 6 sample photo entries with realistic EXIF metadata
- Updated `tags.json` with `darkroom: ["dark", "portfolio", "photography"]`

Closes #88

## Test plan
- [ ] `hwaro build` succeeds without errors
- [ ] Homepage displays 3-column featured grid with hover overlays
- [ ] Individual photo pages show full EXIF metadata panel
- [ ] Lightbox opens on hero image click, closes on Escape/overlay click
- [ ] Responsive layout works at mobile, tablet, and desktop widths
- [ ] No gradients or emojis present in the design
- [ ] Archive page (`/photos/`) shows gallery grid with pagination