### PR TITLE
Add monolith example: one-page long-scroll dark landing

### DIFF
--- a/monolith/AGENTS.md
+++ b/monolith/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/monolith/config.toml
+++ b/monolith/config.toml
@@ -1,0 +1,121 @@
+title = "Monolith"
+description = "One-page long-scroll landing with bold dark design and fullscreen sections"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/monolith/content/index.md
+++ b/monolith/content/index.md
@@ -1,0 +1,168 @@
++++
+title = "Monolith"
+description = "One-page long-scroll landing with bold dark design"
++++
+
+<section class="section section-hero" id="hero">
+  <div class="section-inner">
+    <p class="hero-label">Design Studio</p>
+    <h1 class="hero-title">We build things<br>that matter.</h1>
+    <p class="hero-sub">Strategy, design, and engineering for companies that refuse to blend in. We turn ambitious ideas into digital products people remember.</p>
+    <a href="#work" class="btn">See our work</a>
+  </div>
+</section>
+
+<section class="section section-alt" id="about">
+  <div class="section-inner">
+    <p class="section-label">About</p>
+    <h2 class="section-title">Precision over decoration.</h2>
+    <div class="two-col">
+      <div class="col">
+        <p>We are a small, focused team of designers and engineers based in Seoul. Since 2019, we have partnered with startups and established companies to ship products that perform.</p>
+        <p>Our approach is rooted in clarity. Every decision we make serves the end user, from information architecture to the final pixel. No filler, no fluff.</p>
+      </div>
+      <div class="col">
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="stat-num">47</span>
+            <span class="stat-label">Projects delivered</span>
+          </div>
+          <div class="stat">
+            <span class="stat-num">12</span>
+            <span class="stat-label">Industries served</span>
+          </div>
+          <div class="stat">
+            <span class="stat-num">6</span>
+            <span class="stat-label">Years in operation</span>
+          </div>
+          <div class="stat">
+            <span class="stat-num">98%</span>
+            <span class="stat-label">Client retention</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="services">
+  <div class="section-inner">
+    <p class="section-label">Services</p>
+    <h2 class="section-title">What we do well.</h2>
+    <div class="card-grid">
+      <div class="card">
+        <span class="card-num">01</span>
+        <h3>Brand Strategy</h3>
+        <p>Positioning, messaging, and visual identity systems built to scale. We define who you are before we design how you look.</p>
+      </div>
+      <div class="card">
+        <span class="card-num">02</span>
+        <h3>Product Design</h3>
+        <p>End-to-end UX and UI for web and mobile. Research-driven interfaces that are intuitive, accessible, and built for real users.</p>
+      </div>
+      <div class="card">
+        <span class="card-num">03</span>
+        <h3>Web Development</h3>
+        <p>Performant, semantic, and maintainable code. Static sites, web apps, and everything in between. We ship fast and iterate faster.</p>
+      </div>
+      <div class="card">
+        <span class="card-num">04</span>
+        <h3>Motion & Interaction</h3>
+        <p>Purposeful animation that guides attention and enhances comprehension. Subtle transitions that make interfaces feel alive.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section section-alt" id="work">
+  <div class="section-inner">
+    <p class="section-label">Selected Work</p>
+    <h2 class="section-title">Results speak louder.</h2>
+    <div class="work-list">
+      <div class="work-item">
+        <div class="work-meta">
+          <span class="work-year">2025</span>
+          <span class="work-cat">Product Design</span>
+        </div>
+        <h3>Vantage Analytics Platform</h3>
+        <p>Complete redesign of a B2B analytics dashboard serving 50,000+ daily active users. Reduced time-to-insight by 40% through simplified navigation and contextual data visualization.</p>
+      </div>
+      <div class="work-item">
+        <div class="work-meta">
+          <span class="work-year">2025</span>
+          <span class="work-cat">Brand & Web</span>
+        </div>
+        <h3>Meridian Architecture</h3>
+        <p>Brand identity and portfolio website for a contemporary architecture firm. Minimal design language that lets the work take center stage.</p>
+      </div>
+      <div class="work-item">
+        <div class="work-meta">
+          <span class="work-year">2024</span>
+          <span class="work-cat">Web Development</span>
+        </div>
+        <h3>Noctis E-Commerce</h3>
+        <p>High-performance storefront built on a headless CMS. Sub-second page loads, accessibility-first approach, and a 25% increase in conversion rate post-launch.</p>
+      </div>
+      <div class="work-item">
+        <div class="work-meta">
+          <span class="work-year">2024</span>
+          <span class="work-cat">Product Design</span>
+        </div>
+        <h3>Relay Messaging</h3>
+        <p>Mobile-first messaging platform for distributed teams. Designed and prototyped the full experience from onboarding to daily use in under 8 weeks.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="team">
+  <div class="section-inner">
+    <p class="section-label">Team</p>
+    <h2 class="section-title">Small team, big reach.</h2>
+    <p class="section-desc">We keep our team lean so every person has real ownership. No layers, no hand-offs -- just senior practitioners who care about the outcome.</p>
+    <div class="team-grid">
+      <div class="team-member">
+        <div class="team-avatar">JK</div>
+        <h3>Jiwon Kim</h3>
+        <p>Design Director</p>
+      </div>
+      <div class="team-member">
+        <div class="team-avatar">SL</div>
+        <h3>Seunghyun Lee</h3>
+        <p>Lead Engineer</p>
+      </div>
+      <div class="team-member">
+        <div class="team-avatar">YP</div>
+        <h3>Yuna Park</h3>
+        <p>Brand Strategist</p>
+      </div>
+      <div class="team-member">
+        <div class="team-avatar">MH</div>
+        <h3>Minjae Han</h3>
+        <p>Product Designer</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section section-alt" id="contact">
+  <div class="section-inner section-inner-narrow">
+    <p class="section-label">Contact</p>
+    <h2 class="section-title">Let's build something.</h2>
+    <p class="section-desc">Have a project in mind? We'd like to hear about it. Drop us a line and we'll get back to you within 24 hours.</p>
+    <div class="contact-links">
+      <a href="mailto:hello@monolith.studio" class="contact-link">
+        <span class="contact-link-label">Email</span>
+        <span class="contact-link-value">hello@monolith.studio</span>
+      </a>
+      <a href="#" class="contact-link">
+        <span class="contact-link-label">Twitter</span>
+        <span class="contact-link-value">@monolithstudio</span>
+      </a>
+      <a href="#" class="contact-link">
+        <span class="contact-link-label">LinkedIn</span>
+        <span class="contact-link-value">monolith-studio</span>
+      </a>
+    </div>
+  </div>
+</section>

--- a/monolith/static/css/style.css
+++ b/monolith/static/css/style.css
@@ -1,0 +1,535 @@
+/* ==========================================================================
+   Monolith — One-page long-scroll dark landing theme
+   ========================================================================== */
+
+:root {
+  --bg: #0a0a0a;
+  --bg-alt: #111111;
+  --text: #e8e8e8;
+  --text-muted: #777777;
+  --accent: #c9a84c;
+  --border: #1e1e1e;
+  --font: "Space Grotesk", system-ui, -apple-system, sans-serif;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+}
+
+body {
+  font-family: var(--font);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+/* ==========================================================================
+   Navigation
+   ========================================================================== */
+
+.top-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  transition: background 0.3s, box-shadow 0.3s;
+}
+
+.top-nav.scrolled {
+  background: rgba(10, 10, 10, 0.95);
+  box-shadow: 0 1px 0 var(--border);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.nav-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.25rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-logo {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--text);
+  transition: color 0.2s;
+}
+
+.nav-logo:hover {
+  color: var(--accent);
+}
+
+.nav-links {
+  display: flex;
+  gap: 2rem;
+}
+
+.nav-links a {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover {
+  color: var(--text);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text);
+  transition: transform 0.3s, opacity 0.3s;
+}
+
+.nav-toggle.active span:first-child {
+  transform: translateY(3.5px) rotate(45deg);
+}
+
+.nav-toggle.active span:last-child {
+  transform: translateY(-3.5px) rotate(-45deg);
+}
+
+/* ==========================================================================
+   Sections (shared)
+   ========================================================================== */
+
+.section {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  padding: 6rem 2rem;
+}
+
+.section-alt {
+  background: var(--bg-alt);
+}
+
+.section-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.section-inner-narrow {
+  max-width: 720px;
+}
+
+.section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-size: 2.75rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin-bottom: 2rem;
+}
+
+.section-desc {
+  font-size: 1.125rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+  max-width: 600px;
+  margin-bottom: 3rem;
+}
+
+/* ==========================================================================
+   Hero
+   ========================================================================== */
+
+.section-hero {
+  min-height: 100vh;
+  padding-top: 10rem;
+  padding-bottom: 6rem;
+}
+
+.hero-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  margin-bottom: 1.5rem;
+}
+
+.hero-title {
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  margin-bottom: 1.5rem;
+}
+
+.hero-sub {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+  max-width: 540px;
+  margin-bottom: 2.5rem;
+}
+
+/* ==========================================================================
+   Button
+   ========================================================================== */
+
+.btn {
+  display: inline-block;
+  padding: 0.875rem 2rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bg);
+  background: var(--accent);
+  border: none;
+  transition: opacity 0.2s;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+/* ==========================================================================
+   Two-column layout
+   ========================================================================== */
+
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4rem;
+  align-items: start;
+}
+
+.two-col p {
+  color: var(--text-muted);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  margin-bottom: 1rem;
+}
+
+/* ==========================================================================
+   Stats
+   ========================================================================== */
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-num {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.stat-label {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ==========================================================================
+   Cards (Services)
+   ========================================================================== */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+}
+
+.card {
+  padding: 2.5rem;
+  background: var(--bg);
+}
+
+.card-num {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 1.25rem;
+}
+
+.card h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+.card p {
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+}
+
+/* ==========================================================================
+   Work list
+   ========================================================================== */
+
+.work-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.work-item {
+  padding: 2.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.work-item:first-child {
+  border-top: 1px solid var(--border);
+}
+
+.work-meta {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.work-year,
+.work-cat {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.work-cat {
+  color: var(--accent);
+}
+
+.work-item h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.02em;
+}
+
+.work-item p {
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+  max-width: 680px;
+}
+
+/* ==========================================================================
+   Team
+   ========================================================================== */
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+}
+
+.team-member {
+  text-align: center;
+}
+
+.team-avatar {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.team-member h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.team-member p {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+/* ==========================================================================
+   Contact
+   ========================================================================== */
+
+.contact-links {
+  display: flex;
+  flex-direction: column;
+}
+
+.contact-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--border);
+  transition: color 0.2s;
+}
+
+.contact-link:first-child {
+  border-top: 1px solid var(--border);
+}
+
+.contact-link:hover {
+  color: var(--accent);
+}
+
+.contact-link-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.contact-link-value {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.site-footer {
+  padding: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  .nav-links {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--bg);
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+  }
+
+  .nav-links.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .nav-links a {
+    font-size: 1.25rem;
+  }
+
+  .nav-toggle {
+    display: flex;
+    z-index: 101;
+  }
+
+  .section {
+    padding: 4rem 1.25rem;
+    min-height: auto;
+  }
+
+  .section-hero {
+    min-height: 100vh;
+    padding-top: 8rem;
+  }
+
+  .section-title {
+    font-size: 2rem;
+  }
+
+  .two-col {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .team-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: center;
+  }
+}

--- a/monolith/templates/404.html
+++ b/monolith/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="section section-hero">
+  <div class="section-inner">
+    <h1 class="hero-title">404</h1>
+    <p class="hero-sub">Page not found.</p>
+    <a href="{{ base_url }}/" class="btn">Back to home</a>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/monolith/templates/footer.html
+++ b/monolith/templates/footer.html
@@ -1,0 +1,36 @@
+
+<footer class="site-footer">
+  <div class="section-inner footer-inner">
+    <span>Monolith Studio</span>
+    <span>{{ current_year }}</span>
+  </div>
+</footer>
+
+<script>
+(function() {
+  var nav = document.getElementById('top-nav');
+  var toggle = document.querySelector('.nav-toggle');
+  var links = document.querySelector('.nav-links');
+
+  window.addEventListener('scroll', function() {
+    nav.classList.toggle('scrolled', window.scrollY > 60);
+  });
+
+  if (toggle) {
+    toggle.addEventListener('click', function() {
+      links.classList.toggle('open');
+      toggle.classList.toggle('active');
+    });
+  }
+
+  document.querySelectorAll('.nav-links a').forEach(function(a) {
+    a.addEventListener('click', function() {
+      links.classList.remove('open');
+      toggle.classList.remove('active');
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/monolith/templates/header.html
+++ b/monolith/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
+  {{ og_all_tags }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<nav class="top-nav" id="top-nav">
+  <div class="nav-inner">
+    <a href="{{ base_url }}/#hero" class="nav-logo">Monolith</a>
+    <div class="nav-links">
+      <a href="{{ base_url }}/#about">About</a>
+      <a href="{{ base_url }}/#services">Services</a>
+      <a href="{{ base_url }}/#work">Work</a>
+      <a href="{{ base_url }}/#team">Team</a>
+      <a href="{{ base_url }}/#contact">Contact</a>
+    </div>
+    <button class="nav-toggle" aria-label="Menu">
+      <span></span>
+      <span></span>
+    </button>
+  </div>
+</nav>

--- a/monolith/templates/page.html
+++ b/monolith/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+
+{{ content | safe }}
+
+{% include "footer.html" %}

--- a/monolith/templates/section.html
+++ b/monolith/templates/section.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<section class="section section-hero">
+  <div class="section-inner">
+    <h1 class="section-title">{{ page.title }}</h1>
+    {{ content | safe }}
+    {{ pagination }}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/monolith/templates/taxonomy.html
+++ b/monolith/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<section class="section section-hero">
+  <div class="section-inner">
+    <h1 class="section-title">{{ page.title }}</h1>
+    {{ content | safe }}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/monolith/templates/taxonomy_term.html
+++ b/monolith/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<section class="section section-hero">
+  <div class="section-inner">
+    <h1 class="section-title">{{ page.title }}</h1>
+    {{ content | safe }}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -186,6 +186,11 @@
     "blog",
     "microblog"
   ],
+  "monolith": [
+    "dark",
+    "landing",
+    "onepage"
+  ],
   "modern-blog": [
     "dark",
     "blog"


### PR DESCRIPTION
## Summary
- New `monolith` example: single long-scroll landing page with dark theme, bold typography, and fullscreen sections
- Sections: Hero, About (with stats), Services (grid cards), Work (project list), Team, Contact
- Fixed top navigation with scroll-based background and mobile hamburger menu
- Alternating dark/darker section backgrounds, Space Grotesk font, gold accent color
- Fully responsive design with custom CSS (no framework)

## Test plan
- [ ] `hwaro build` succeeds without errors
- [ ] `hwaro serve` renders all 6 sections correctly
- [ ] Fixed nav shows background on scroll
- [ ] Anchor navigation scrolls to correct sections
- [ ] Mobile hamburger menu opens/closes properly
- [ ] Alternating section backgrounds are visible
- [ ] Deploy preview renders correctly

Closes #103