### PR TITLE
Add new example: postcard (single-page postcard theme)

### DIFF
--- a/postcard/AGENTS.md
+++ b/postcard/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/postcard/config.toml
+++ b/postcard/config.toml
@@ -1,0 +1,48 @@
+title = "Postcard"
+description = "A vintage postcard-themed blog where every post feels like a handwritten letter from somewhere far away."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/postcard/content/about.md
+++ b/postcard/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About This Collection"
++++
+
+This is a collection of postcards -- short notes and reflections gathered over time. Each one is a small window into a moment, a place, or a thought worth preserving.
+
+Like real postcards, these messages are brief. They are meant to be read slowly, held for a moment, and then set down.
+
+If you'd like to send your own postcard, the mailbox is always open.

--- a/postcard/content/index.md
+++ b/postcard/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Postcard Collection"
+template = "home"
++++
+
+A collection of postcards from places near and far. Each card carries a short message, a memory, a fleeting thought written in ink and sent with care.

--- a/postcard/content/posts/_index.md
+++ b/postcard/content/posts/_index.md
@@ -1,0 +1,9 @@
++++
+title = "All Postcards"
+sort_by = "date"
+reverse = true
+paginate = 12
+template = "section"
++++
+
+Every postcard in the collection, from newest to oldest.

--- a/postcard/content/posts/getting-started-with-hwaro.md
+++ b/postcard/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,20 @@
++++
+title = "Notes from the Mountain"
+date = "2026-03-10"
+tags = ["travel", "mountain"]
+categories = ["journeys"]
+description = "A postcard from high altitude, where the air is thin and the views are endless."
+template = "post"
+location = "Alpine Ridge, 2400m"
+stamp_text = "ALPINE"
++++
+
+The climb took most of the morning. The trail switchbacked through pine forest, then broke above the treeline into open rock and sky.
+
+<!-- more -->
+
+At the summit there is nothing but wind and the feeling of being very small. The valleys below look like creased paper, and the clouds move at eye level.
+
+I sat on a flat stone and ate bread and cheese. The simplest meal I have had in months, and the best.
+
+The descent will be faster. I will write again from the valley.

--- a/postcard/content/posts/hello-world.md
+++ b/postcard/content/posts/hello-world.md
@@ -1,0 +1,18 @@
++++
+title = "Greetings from the Coast"
+date = "2026-03-15"
+tags = ["travel", "coast"]
+categories = ["journeys"]
+description = "A first postcard from a windswept shoreline."
+template = "post"
+location = "Somewhere by the Sea"
+stamp_text = "SEASIDE"
++++
+
+The salt air is thick here, and the gulls never stop calling. I arrived this morning before the fog lifted, and for a while the whole world was just grey wool and the sound of waves.
+
+<!-- more -->
+
+By noon the sun came through. The beach stretched out long and pale, and I walked until my shoes were full of sand. There is a lighthouse at the far end that has been dark for years, but it still stands watch.
+
+Wish you were here to see it.

--- a/postcard/content/posts/markdown-tips.md
+++ b/postcard/content/posts/markdown-tips.md
@@ -1,0 +1,20 @@
++++
+title = "A Quiet Afternoon in the Old Town"
+date = "2026-03-05"
+tags = ["travel", "city"]
+categories = ["journeys"]
+description = "A postcard from narrow streets and afternoon light."
+template = "post"
+location = "Old Quarter"
+stamp_text = "POSTE"
++++
+
+The streets here are so narrow that the buildings almost touch overhead. Laundry hangs between the windows like bunting, and every doorway opens onto a different century.
+
+<!-- more -->
+
+I found a cafe with four tables and no menu. The owner brought coffee without being asked, dark and sweet, in a cup no bigger than an egg. We sat and watched the pigeons argue on the cobblestones.
+
+There is a church bell that rings at odd hours, never on time, as if the bell-ringer is always distracted by something more interesting.
+
+I could stay here a while.

--- a/postcard/content/search.md
+++ b/postcard/content/search.md
@@ -1,0 +1,4 @@
++++
+title = "Search Postcards"
+template = "search"
++++

--- a/postcard/static/css/style.css
+++ b/postcard/static/css/style.css
@@ -1,0 +1,1001 @@
+:root {
+  --cream: #faf6f0;
+  --cream-dark: #f0e8db;
+  --parchment: #f5efe5;
+  --ink: #2c2418;
+  --ink-light: #5c5040;
+  --ink-muted: #9c8e78;
+  --border: #d4c8b4;
+  --border-light: #e6ddd0;
+  --accent: #8b4513;
+  --accent-hover: #6e3610;
+  --stamp-red: #b04040;
+  --stamp-blue: #3a5a80;
+  --postmark: #7a8a6a;
+  --content-max-w: 780px;
+  --radius: 4px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: "Libre Baskerville", "Georgia", serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--ink);
+  background: var(--cream);
+  -webkit-font-smoothing: antialiased;
+}
+
+.handwritten {
+  font-family: "Caveat", cursive;
+}
+
+.handwritten-body {
+  font-family: "Libre Baskerville", "Georgia", serif;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+::selection { background: rgba(139, 69, 19, 0.15); }
+
+img { max-width: 100%; height: auto; }
+
+/* ─── Site Wrapper ─── */
+.site-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Header ─── */
+.site-header {
+  border-bottom: 2px solid var(--border);
+  background: var(--cream);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  max-width: var(--content-max-w);
+  margin: 0 auto;
+  padding: 0.8rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  font-family: "Caveat", cursive;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.site-logo:hover { color: var(--accent); text-decoration: none; }
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink-light);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover { color: var(--ink); text-decoration: none; }
+
+/* ─── Main Content ─── */
+.site-main {
+  flex: 1;
+  max-width: var(--content-max-w);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+  width: 100%;
+}
+
+/* ─── Hero (Home) ─── */
+.hero {
+  margin-bottom: 3rem;
+}
+
+.hero-postcard {
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  position: relative;
+  box-shadow: 2px 3px 0 var(--border-light);
+}
+
+.hero-postcard::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  border: 1px solid var(--border-light);
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.postcard-decoration {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.5rem;
+}
+
+.stamp {
+  width: 64px;
+  height: 76px;
+  border: 2px solid var(--stamp-red);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  background: #fff;
+}
+
+.stamp::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border: 1px dashed var(--stamp-red);
+}
+
+.stamp-value {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--stamp-red);
+}
+
+.stamp-label {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.55rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--stamp-red);
+  margin-top: 2px;
+}
+
+.postmark {
+  position: absolute;
+  top: 1rem;
+  right: 6rem;
+}
+
+.postmark-circle {
+  width: 52px;
+  height: 52px;
+  border: 2px solid var(--postmark);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+  transform: rotate(-15deg);
+}
+
+.postmark-text {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  color: var(--postmark);
+}
+
+.hero-content {
+  max-width: 70%;
+}
+
+.hero-title {
+  font-family: "Caveat", cursive;
+  font-size: 2.4rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 0.75rem;
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  font-size: 1.3rem;
+  color: var(--ink-light);
+  line-height: 1.6;
+}
+
+/* ─── Section Title ─── */
+.section-title {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+/* ─── Postcard Card Grid ─── */
+.card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+.postcard-card {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--ink);
+  transition: box-shadow 0.2s, transform 0.2s;
+  overflow: hidden;
+  box-shadow: 1px 2px 0 var(--border-light);
+}
+
+.postcard-card:hover {
+  box-shadow: 3px 5px 0 var(--border-light);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.card-front {
+  background: var(--parchment);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-right: 2px dashed var(--border-light);
+  min-height: 140px;
+}
+
+.card-location {
+  font-family: "Caveat", cursive;
+  font-size: 1.4rem;
+  color: var(--ink);
+  line-height: 1.3;
+}
+
+.card-stamp-small {
+  align-self: flex-end;
+}
+
+.card-stamp-small span {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--stamp-red);
+  border: 1.5px solid var(--stamp-red);
+  padding: 3px 6px;
+  display: inline-block;
+}
+
+.card-back {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+}
+
+.card-back::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: var(--border-light);
+}
+
+.card-back::after {
+  content: "";
+  position: absolute;
+  top: 70%;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: var(--border-light);
+}
+
+.card-lines {
+  position: relative;
+  z-index: 1;
+}
+
+.card-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  line-height: 1.2;
+}
+
+.card-excerpt {
+  font-size: 0.85rem;
+  color: var(--ink-light);
+  line-height: 1.5;
+}
+
+.card-meta {
+  position: relative;
+  z-index: 1;
+  margin-top: 0.75rem;
+}
+
+.card-meta time {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ─── Postcard Detail ─── */
+.postcard-detail {
+  max-width: var(--content-max-w);
+}
+
+.postcard-envelope {
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 2px 3px 0 var(--border-light);
+  overflow: hidden;
+}
+
+.postcard-envelope::before {
+  content: "";
+  display: block;
+  height: 6px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--stamp-red) 0px,
+    var(--stamp-red) 20px,
+    var(--stamp-blue) 20px,
+    var(--stamp-blue) 40px
+  );
+}
+
+.postcard-front-side {
+  padding: 2rem 2.5rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.front-decoration {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.front-location {
+  font-size: 1.8rem;
+  color: var(--ink-light);
+}
+
+.postcard-divider {
+  margin: 0 2.5rem;
+  height: 1px;
+  border-top: 2px dashed var(--border);
+}
+
+.postcard-back-side {
+  padding: 2rem 2.5rem 2.5rem;
+}
+
+.address-block {
+  float: right;
+  width: 220px;
+  padding: 1rem;
+  margin: 0 0 1rem 1.5rem;
+  border-left: 2px solid var(--border-light);
+}
+
+.address-label {
+  display: block;
+  font-family: "Caveat", cursive;
+  font-size: 1.1rem;
+  color: var(--ink);
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.address-detail {
+  display: block;
+  font-family: "Caveat", cursive;
+  font-size: 1rem;
+  color: var(--ink-muted);
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 0.25rem;
+}
+
+.message-block {
+  overflow: hidden;
+}
+
+.post-title {
+  font-size: 2.2rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 0.75rem;
+  line-height: 1.2;
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.post-meta time {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-muted);
+  letter-spacing: 0.04em;
+}
+
+.post-tags {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--ink-muted);
+  text-decoration: none;
+  background: var(--parchment);
+}
+
+.tag:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.post-content {
+  font-size: 1rem;
+  line-height: 1.85;
+  color: var(--ink);
+}
+
+.post-content p {
+  margin-bottom: 1.2rem;
+}
+
+.post-content h2 {
+  font-size: 1.3rem;
+  margin: 2rem 0 0.75rem;
+  color: var(--ink);
+}
+
+.post-content h3 {
+  font-size: 1.1rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.post-content blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 0.5rem 1rem;
+  margin: 1.2rem 0;
+  background: var(--parchment);
+  color: var(--ink-light);
+  font-style: italic;
+}
+
+.post-content blockquote p { margin-bottom: 0; }
+
+.post-content ul, .post-content ol {
+  margin-bottom: 1.2rem;
+  padding-left: 1.5rem;
+}
+
+.post-content li {
+  margin-bottom: 0.3rem;
+}
+
+.post-content code {
+  background: var(--parchment);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  color: var(--ink);
+}
+
+.post-content pre {
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  margin: 1rem 0 1.5rem;
+  background: var(--parchment);
+}
+
+.post-content pre code { background: none; padding: 0; font-size: 0.82rem; }
+
+.post-nav {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.back-link {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 2px;
+}
+
+.back-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+/* ─── Page (About, etc.) ─── */
+.postcard-page {
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  box-shadow: 2px 3px 0 var(--border-light);
+  position: relative;
+}
+
+.postcard-page::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  border: 1px solid var(--border-light);
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.postcard-page h1 {
+  font-family: "Caveat", cursive;
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.page-body {
+  line-height: 1.85;
+}
+
+.page-body p {
+  margin-bottom: 1rem;
+}
+
+/* ─── Section Page ─── */
+.section-page .section-title {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+/* ─── Taxonomy ─── */
+.taxonomy-page {
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  box-shadow: 1px 2px 0 var(--border-light);
+}
+
+.taxonomy-page h1 {
+  font-family: "Caveat", cursive;
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+}
+
+.taxonomy-desc {
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.taxonomy-page ul {
+  list-style: none;
+  padding: 0;
+}
+
+.taxonomy-page li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.taxonomy-page li:last-child { border-bottom: none; }
+
+.taxonomy-page li a {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+/* ─── Pagination ─── */
+nav.pagination { margin: 2rem 0; }
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+nav.pagination a {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--ink-light);
+  text-decoration: none;
+}
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
+.pagination-current span {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  color: var(--accent);
+  background: var(--parchment);
+}
+.pagination-disabled span {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8rem;
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  color: var(--ink-muted);
+  opacity: 0.4;
+}
+
+/* ─── Footer ─── */
+.site-footer {
+  border-top: 2px solid var(--border);
+  background: var(--cream);
+}
+
+.footer-inner {
+  max-width: var(--content-max-w);
+  margin: 0 auto;
+  padding: 1.2rem 1.5rem;
+  text-align: center;
+}
+
+.footer-text {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+  letter-spacing: 0.04em;
+}
+
+.footer-text a {
+  color: var(--ink-muted);
+  text-decoration: underline;
+}
+
+.footer-text a:hover { color: var(--accent); }
+
+/* ─── Search Trigger ─── */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  padding: 0.3rem;
+  border: none;
+  background: none;
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+
+.search-trigger:hover { color: var(--ink); }
+
+/* ─── Search Overlay ─── */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 36, 24, 0.3);
+  z-index: 200;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.search-overlay.active { display: flex; }
+
+.search-modal {
+  width: 520px;
+  max-width: 90vw;
+  max-height: 70vh;
+  background: #fff;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 4px 6px 0 var(--border-light);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.search-input-wrap svg { flex-shrink: 0; color: var(--ink-muted); }
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  font-family: "Libre Baskerville", serif;
+  color: var(--ink);
+  background: transparent;
+}
+
+.search-input-wrap input::placeholder { color: var(--ink-muted); }
+
+.search-input-wrap kbd {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.6rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--parchment);
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+
+.search-results { overflow-y: auto; padding: 0.5rem; }
+
+.search-result-item {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.search-result-item:hover, .search-result-item.active {
+  background: var(--parchment);
+  text-decoration: none;
+}
+
+.search-result-item .search-result-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 0.15rem;
+}
+
+.search-result-item .search-result-snippet {
+  font-size: 0.8rem;
+  color: var(--ink-light);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-result-item .search-result-snippet mark {
+  background: rgba(139, 69, 19, 0.12);
+  color: var(--accent);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-no-results {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.search-hint {
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  border-top: 1px solid var(--border-light);
+  color: var(--ink-muted);
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.65rem;
+}
+
+.search-hint kbd {
+  font-size: 0.6rem;
+  padding: 0 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--parchment);
+  font-family: inherit;
+}
+
+/* ─── Search Page ─── */
+.search-page-input input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  font-family: "Libre Baskerville", serif;
+  font-size: 1rem;
+  color: var(--ink);
+  background: #fff;
+  outline: none;
+  margin-bottom: 1rem;
+}
+
+.search-page-input input:focus {
+  border-color: var(--accent);
+}
+
+/* ─── 404 ─── */
+.error-page {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.error-page h1 {
+  font-family: "Caveat", cursive;
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.error-page p {
+  color: var(--ink-light);
+  margin-bottom: 1rem;
+}
+
+/* ─── Section list (fallback) ─── */
+ul.section-list { list-style: none; padding: 0; }
+
+ul.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.6rem 0.8rem;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+}
+
+ul.section-list li a { color: var(--accent); font-weight: 500; }
+
+/* ─── Responsive ─── */
+@media (max-width: 640px) {
+  .hero-postcard {
+    padding: 1.5rem;
+  }
+
+  .hero-postcard::before {
+    display: none;
+  }
+
+  .hero-content {
+    max-width: 100%;
+  }
+
+  .hero-title {
+    font-size: 1.8rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1.1rem;
+  }
+
+  .postcard-decoration {
+    position: static;
+    margin-bottom: 1rem;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .postmark {
+    position: static;
+    display: none;
+  }
+
+  .postcard-card {
+    grid-template-columns: 1fr;
+  }
+
+  .card-front {
+    border-right: none;
+    border-bottom: 2px dashed var(--border-light);
+    min-height: auto;
+    padding: 1rem;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .card-back {
+    padding: 1rem;
+  }
+
+  .card-back::before, .card-back::after {
+    display: none;
+  }
+
+  .postcard-front-side {
+    padding: 1.5rem;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .postcard-back-side {
+    padding: 1.5rem;
+  }
+
+  .address-block {
+    float: none;
+    width: 100%;
+    margin: 0 0 1rem 0;
+    border-left: none;
+    border-bottom: 1px solid var(--border-light);
+    padding: 0 0 0.75rem 0;
+  }
+
+  .post-title {
+    font-size: 1.6rem;
+  }
+
+  .site-nav a:not(:first-child):not(:last-child) {
+    display: none;
+  }
+
+  .postcard-page {
+    padding: 1.5rem;
+  }
+
+  .postcard-page::before {
+    display: none;
+  }
+}

--- a/postcard/static/js/search.js
+++ b/postcard/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/postcard/templates/404.html
+++ b/postcard/templates/404.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main">
+    <div class="error-page">
+      <h1>Return to Sender</h1>
+      <p>This postcard could not be delivered. The address does not exist.</p>
+      <p><a href="{{ base_url }}/">Back to the collection</a></p>
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/footer.html
+++ b/postcard/templates/footer.html
@@ -1,0 +1,9 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-text">Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </div>
+  </footer>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+</body>
+</html>

--- a/postcard/templates/header.html
+++ b/postcard/templates/header.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;600&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+</head>
+<body>

--- a/postcard/templates/home.html
+++ b/postcard/templates/home.html
@@ -1,0 +1,77 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <button class="search-trigger" onclick="openSearch()" title="Search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search postcards..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+
+  <main class="site-main">
+    <section class="hero">
+      <div class="hero-postcard">
+        <div class="postcard-decoration">
+          <div class="stamp">
+            <span class="stamp-value">POST</span>
+            <span class="stamp-label">CARD</span>
+          </div>
+        </div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ page.title }}</h1>
+          <p class="hero-subtitle handwritten">{{ content | striptags }}</p>
+        </div>
+        <div class="postmark">
+          <div class="postmark-circle">
+            <span class="postmark-text">{{ current_year }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="postcards-grid">
+      <h2 class="section-title">Recent Postcards</h2>
+      <div class="card-grid">
+        {% for post in site.pages %}
+          {% if post.section == "posts" %}
+          <a href="{{ base_url }}{{ post.url }}" class="postcard-card">
+            <div class="card-front">
+              <div class="card-location">{{ post.extra.location | default(value="Somewhere") }}</div>
+              <div class="card-stamp-small">
+                <span>{{ post.extra.stamp_text | default(value="MAIL") }}</span>
+              </div>
+            </div>
+            <div class="card-back">
+              <div class="card-lines">
+                <h3 class="card-title handwritten">{{ post.title }}</h3>
+                <p class="card-excerpt">{{ post.description }}</p>
+              </div>
+              <div class="card-meta">
+                <time>{{ post.date }}</time>
+              </div>
+            </div>
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/page.html
+++ b/postcard/templates/page.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <button class="search-trigger" onclick="openSearch()" title="Search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search postcards..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+
+  <main class="site-main">
+    <article class="page-content postcard-single">
+      <div class="postcard-page">
+        <h1>{{ page.title }}</h1>
+        <div class="page-body">
+          {{ content }}
+        </div>
+      </div>
+    </article>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/post.html
+++ b/postcard/templates/post.html
@@ -1,0 +1,81 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <button class="search-trigger" onclick="openSearch()" title="Search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search postcards..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+
+  <main class="site-main">
+    <article class="postcard-detail">
+      <div class="postcard-envelope">
+        <div class="postcard-front-side">
+          <div class="front-decoration">
+            <div class="stamp">
+              <span class="stamp-value">{{ page.extra.stamp_text | default(value="MAIL") }}</span>
+              <span class="stamp-label">POSTCARD</span>
+            </div>
+            <div class="postmark">
+              <div class="postmark-circle">
+                <span class="postmark-text">{{ page.date }}</span>
+              </div>
+            </div>
+          </div>
+          <div class="front-location handwritten">{{ page.extra.location | default(value="Somewhere") }}</div>
+        </div>
+
+        <div class="postcard-divider"></div>
+
+        <div class="postcard-back-side">
+          <div class="address-block">
+            <div class="address-lines">
+              <span class="address-label">To: The Reader</span>
+              <span class="address-detail">Wherever you may be</span>
+            </div>
+          </div>
+
+          <div class="message-block">
+            <h1 class="post-title handwritten">{{ page.title }}</h1>
+            <div class="post-meta">
+              <time>{{ page.date }}</time>
+              {% if page.tags %}
+              <div class="post-tags">
+                {% for tag in page.tags %}
+                <a href="{{ base_url }}/tags/{{ tag }}/" class="tag">{{ tag }}</a>
+                {% endfor %}
+              </div>
+              {% endif %}
+            </div>
+            <div class="post-content handwritten-body">
+              {{ content }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <nav class="post-nav">
+        <a href="{{ base_url }}/posts/" class="back-link">Back to all postcards</a>
+      </nav>
+    </article>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/search.html
+++ b/postcard/templates/search.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main">
+    <section class="section-page">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="search-page-input">
+        <input type="text" id="searchInput" placeholder="Search postcards..." autocomplete="off">
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/section.html
+++ b/postcard/templates/section.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <button class="search-trigger" onclick="openSearch()" title="Search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search postcards..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+
+  <main class="site-main">
+    <section class="section-page">
+      <h1 class="section-title">{{ section.title }}</h1>
+      <div class="card-grid">
+        {% for post in section.pages %}
+        <a href="{{ base_url }}{{ post.url }}" class="postcard-card">
+          <div class="card-front">
+            <div class="card-location">{{ post.extra.location | default(value="Somewhere") }}</div>
+            <div class="card-stamp-small">
+              <span>{{ post.extra.stamp_text | default(value="MAIL") }}</span>
+            </div>
+          </div>
+          <div class="card-back">
+            <div class="card-lines">
+              <h3 class="card-title handwritten">{{ post.title }}</h3>
+              <p class="card-excerpt">{{ post.description }}</p>
+            </div>
+            <div class="card-meta">
+              <time>{{ post.date }}</time>
+            </div>
+          </div>
+        </a>
+        {% endfor %}
+      </div>
+      {{ pagination }}
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/taxonomy.html
+++ b/postcard/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main">
+    <div class="taxonomy-page">
+      <h1>{{ page.title }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/postcard/templates/taxonomy_term.html
+++ b/postcard/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Postcards</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main">
+    <div class="taxonomy-page">
+      <h1>{{ page.title }}</h1>
+      <p class="taxonomy-desc">Postcards tagged with this term:</p>
+      {{ content }}
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -240,6 +240,11 @@
     "blog",
     "sidebar"
   ],
+  "postcard": [
+    "light",
+    "blog",
+    "postcard"
+  ],
   "polaroid": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Add `postcard` example: vintage postcard-themed blog where each post looks like a handwritten letter
- Card layout with front side (location, stamp decoration) and back side (message, address block)
- Uses Caveat (handwritten), Libre Baskerville (serif body), DM Sans (UI) fonts
- Vintage color palette: cream/parchment backgrounds, warm ink tones, stamp-red accents
- Updated `tags.json` with `["light", "blog", "postcard"]` tags

Closes #101

## Test plan
- [ ] `hwaro build` completes successfully (7 pages)
- [ ] Home page renders hero postcard with stamp/postmark decorations
- [ ] Section page shows postcard card grid with location and stamp text
- [ ] Post detail page renders as full postcard envelope with front/back sides
- [ ] Extra fields (location, stamp_text) display correctly on all pages
- [ ] Search overlay works
- [ ] Responsive layout on mobile viewports