### PR TITLE
Add almanac example: calendar / seasonal theme

### DIFF
--- a/almanac/AGENTS.md
+++ b/almanac/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/almanac/config.toml
+++ b/almanac/config.toml
@@ -1,0 +1,212 @@
+# =============================================================================
+# Almanac Theme - Site Configuration
+# =============================================================================
+# A calendar / seasonal content blog with date grid and list views
+
+title = "Almanac"
+description = "A calendar and seasonal content blog with date grid and list views"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = true
+per_page = 12
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+# =============================================================================
+# SEO: Sitemap
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# SEO: Robots.txt
+# =============================================================================
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] }
+]
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/almanac/content/about.md
+++ b/almanac/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "About"
++++
+
+## About Almanac
+
+Almanac is a calendar-style blog theme for [Hwaro](https://github.com/hahwul/hwaro). It organizes content around dates and seasons, providing both a grid calendar view and a list view for browsing entries.
+
+## Features
+
+- **Calendar grid view** -- browse content laid out on a monthly calendar
+- **List view** -- switch to a chronological list for quick scanning
+- **Seasonal theming** -- colors shift with the seasons: pink in spring, green in summer, orange in autumn, blue in winter
+- **Today highlight** -- the current date stands out on the calendar
+- **Event markers** -- holidays and notable dates are marked on the grid
+- **Light theme** -- clean, desk-calendar aesthetic with warm typography
+- **RSS feed** -- subscribe to new entries
+- **Search** -- client-side full-text search
+
+## Design
+
+The design takes cues from paper desk calendars: clean borders, restrained type, and color used sparingly to mark what matters. Playfair Display provides editorial weight for headings while Inter keeps body text crisp and legible.
+
+## Contact
+
+- GitHub: [github.com/hahwul](https://github.com/hahwul)

--- a/almanac/content/index.md
+++ b/almanac/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+template = "home"
++++

--- a/almanac/content/posts/_index.md
+++ b/almanac/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
++++

--- a/almanac/content/posts/autumn-kitchen-journal.md
+++ b/almanac/content/posts/autumn-kitchen-journal.md
@@ -1,0 +1,40 @@
++++
+title = "Autumn Kitchen Journal"
+date = "2026-10-05"
+description = "Seasonal cooking notes as the harvest comes in and the kitchen shifts to warmer dishes."
+tags = ["autumn", "cooking", "seasonal"]
+categories = ["seasonal"]
++++
+
+October brings a change in the kitchen. The salads and cold plates of summer give way to roasted roots, soups, and slow-cooked meals. The oven is on more often than not.
+
+## What Is In Season
+
+The market stalls look different now:
+
+- **Squash** -- butternut, delicata, kabocha. Roast them. All of them.
+- **Apples** -- beyond eating fresh, they go into crisps, sauces, and cider
+- **Root vegetables** -- parsnips, turnips, beets. Roast with olive oil and salt.
+- **Greens** -- kale and chard are at their best after the first cool nights
+- **Mushrooms** -- chanterelles if you are lucky, cremini if you are practical
+
+## A Simple Template
+
+Most autumn meals follow the same structure:
+
+1. Roast a tray of seasonal vegetables at high heat
+2. Cook a grain -- farro, rice, or crusty bread
+3. Add something sharp -- pickled onions, a vinaigrette, a squeeze of lemon
+4. Finish with something rich -- a crumble of cheese, a drizzle of tahini, a fried egg
+
+This framework handles Monday through Friday without requiring a recipe.
+
+## Preserving the Season
+
+What you cannot eat now, put away for later:
+
+- Applesauce freezes well in small containers
+- Roasted squash puree is a soup base waiting to happen
+- Herb butter can be frozen in ice cube trays
+
+The work of October feeds January.

--- a/almanac/content/posts/spring-gardening-notes.md
+++ b/almanac/content/posts/spring-gardening-notes.md
@@ -1,0 +1,35 @@
++++
+title = "Spring Gardening Notes"
+date = "2026-03-15"
+description = "Early spring observations on soil preparation, seed starting, and the first signs of growth."
+tags = ["spring", "gardening", "nature"]
+categories = ["seasonal"]
++++
+
+The ground is thawing and it is time to plan the season ahead. These are working notes from the first weeks of spring.
+
+## Soil Preparation
+
+Before planting anything, the soil needs attention. Winter compacts it and depletes nutrients near the surface.
+
+- Turn the top 15cm with a fork, not a spade -- less disruption to worm channels
+- Mix in aged compost at a ratio of roughly 1:4
+- Test pH if you suspect drift from last year's amendments
+- Wait until the soil no longer clumps when squeezed before working it
+
+## Seed Starting Indoors
+
+Some crops benefit from an indoor head start while nights are still cold:
+
+1. **Tomatoes** -- start 6-8 weeks before last frost
+2. **Peppers** -- need warmth, bottom heat helps germination
+3. **Herbs** -- basil and parsley are slow starters, sow early
+4. **Flowers** -- marigolds and zinnias transplant well
+
+Use a sterile seed-starting mix, not garden soil. Label everything. You will forget what you planted where.
+
+## First Signs
+
+Even before deliberate planting, the garden shows signs of life. Crocuses push through mulch. Garlic planted last autumn sends up green shoots. The rhubarb crown swells visibly day by day.
+
+These early signals are the gardener's calendar -- more reliable than any app.

--- a/almanac/content/posts/summer-reading-list.md
+++ b/almanac/content/posts/summer-reading-list.md
@@ -1,0 +1,31 @@
++++
+title = "Summer Reading List"
+date = "2026-06-10"
+description = "Books and long reads for the warmer months, from fiction to technical depth."
+tags = ["summer", "reading", "books"]
+categories = ["seasonal"]
++++
+
+Summer is for longer reads. The days stretch out and there is time for books that demand sustained attention. Here is what is on the list this year.
+
+## Fiction
+
+- **The Overstory** by Richard Powers -- a novel about trees and the people whose lives intertwine with them. Dense and rewarding.
+- **Piranesi** by Susanna Clarke -- a quiet, strange story set in a house of infinite halls. Short enough for a weekend.
+- **Klara and the Sun** by Kazuo Ishiguro -- an AI narrator observes human behavior with unsettling precision.
+
+## Non-Fiction
+
+- **Four Thousand Weeks** by Oliver Burkeman -- on time management and its limits. The thesis: you cannot optimize your way out of finitude.
+- **A Pattern Language** by Christopher Alexander -- architecture and design patterns that apply far beyond buildings.
+
+## Technical
+
+- **Designing Data-Intensive Applications** by Martin Kleppmann -- if you build systems that store or move data, this is the reference.
+- **The Art of Doing Science and Engineering** by Richard Hamming -- lectures on how to do work that matters.
+
+## How to Read More
+
+The trick is not finding time. It is reducing friction. Keep the book where you sit. Close the laptop earlier. Read for twenty minutes before reaching for your phone in the morning.
+
+Consistency beats ambition. A chapter a day adds up.

--- a/almanac/content/posts/welcome-to-almanac.md
+++ b/almanac/content/posts/welcome-to-almanac.md
@@ -1,0 +1,36 @@
++++
+title = "Welcome to Almanac"
+date = "2026-03-22"
+description = "Introducing Almanac, a calendar-style theme that organizes content by date and season."
+tags = ["hwaro", "almanac", "getting-started"]
+categories = ["guide"]
++++
+
+Almanac is a theme that puts time at the center of your content. Every post has a place on the calendar, and the design shifts with the seasons.
+
+## How It Works
+
+The homepage shows a calendar grid for the current month. Each day cell can display events or link to posts published on that date. You can switch between grid view and list view using the toggle in the top right.
+
+## Seasonal Colors
+
+The theme automatically detects the current season and adjusts its color palette:
+
+- **Spring** (March--May) -- soft pinks and warm tones
+- **Summer** (June--August) -- deep greens and earthy hues
+- **Autumn** (September--November) -- burnt orange and amber
+- **Winter** (December--February) -- cool blues and slate
+
+No configuration needed. The colors follow the calendar.
+
+## Getting Started
+
+```bash
+brew install hahwul/tap/hwaro
+
+cp -r almanac my-blog
+cd my-blog
+hwaro serve
+```
+
+Edit `config.toml` to set your title, then add posts in `content/posts/`. Each post's `date` field determines where it appears on the calendar.

--- a/almanac/content/posts/winter-workshop-setup.md
+++ b/almanac/content/posts/winter-workshop-setup.md
@@ -1,0 +1,42 @@
++++
+title = "Winter Workshop Setup"
+date = "2026-12-12"
+description = "Setting up a comfortable indoor workspace for the cold months, from lighting to organization."
+tags = ["winter", "workspace", "productivity"]
+categories = ["seasonal"]
++++
+
+When the days are short and the weather keeps you inside, the quality of your workspace matters more than usual. Winter is the time to get the indoor environment right.
+
+## Lighting
+
+Natural light drops off sharply after the solstice. Compensate deliberately:
+
+- Position the desk near the largest window, perpendicular to it to avoid glare
+- Use a daylight-temperature desk lamp (5000K) for task lighting
+- Add a warm ambient light (2700K) behind the monitor to reduce eye strain
+- Avoid overhead fluorescents as the sole light source
+
+## Temperature and Air
+
+- Keep the room between 19 and 22 degrees Celsius -- cooler than most people expect for focused work
+- A small humidifier prevents the dry air problems that come with indoor heating
+- Open a window briefly each morning. Fresh air resets the room even in January.
+
+## Organization
+
+Winter projects tend to accumulate: half-read books, parts for repairs, notes for next year's garden. Contain the sprawl:
+
+- Designate one shelf or box as the active project zone
+- Everything else goes back to storage or gets discarded
+- A clear desk surface is not about aesthetics -- it reduces the cognitive load of choosing what to work on
+
+## Tools Within Reach
+
+Keep the essentials close:
+
+- Notebook and pen (faster than any app for capturing a passing thought)
+- Timer (25-minute blocks work, but only if the timer is visible)
+- Water and tea (dehydration is subtle indoors and kills focus)
+
+The goal is not a magazine-worthy setup. It is a space where sitting down to work feels like the path of least resistance.

--- a/almanac/content/search.md
+++ b/almanac/content/search.md
@@ -1,0 +1,4 @@
++++
+title = "Search"
+template = "search"
++++

--- a/almanac/static/css/style.css
+++ b/almanac/static/css/style.css
@@ -1,0 +1,768 @@
+/* =============================================================================
+   Almanac Theme - Calendar / Seasonal Content Blog
+   ============================================================================= */
+
+/* --- Reset & Base --- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-display: "Playfair Display", Georgia, serif;
+
+  /* Default: Spring */
+  --color-bg: #faf8f5;
+  --color-surface: #ffffff;
+  --color-text: #2c2c2c;
+  --color-text-muted: #6b6b6b;
+  --color-border: #e4e0db;
+  --color-accent: #c4697c;
+  --color-accent-light: #f5e6ea;
+  --color-today: #c4697c;
+  --color-event: #8b6f5e;
+  --color-season-label: #c4697c;
+}
+
+/* Season color overrides */
+[data-season="spring"] {
+  --color-accent: #c4697c;
+  --color-accent-light: #f5e6ea;
+  --color-today: #c4697c;
+  --color-season-label: #c4697c;
+}
+
+[data-season="summer"] {
+  --color-accent: #4a8c6f;
+  --color-accent-light: #e2f0e8;
+  --color-today: #4a8c6f;
+  --color-season-label: #4a8c6f;
+}
+
+[data-season="autumn"] {
+  --color-accent: #c17d3e;
+  --color-accent-light: #f5ece0;
+  --color-today: #c17d3e;
+  --color-season-label: #c17d3e;
+}
+
+[data-season="winter"] {
+  --color-accent: #5b7fa6;
+  --color-accent-light: #e4ecf4;
+  --color-today: #5b7fa6;
+  --color-season-label: #5b7fa6;
+}
+
+html {
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: var(--color-text);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* --- Layout --- */
+
+.wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header --- */
+
+.site-header {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.site-header .wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+}
+
+.site-brand:hover {
+  color: var(--color-accent);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.site-nav a:hover {
+  color: var(--color-accent);
+}
+
+/* --- Season Badge --- */
+
+.season-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-season-label);
+  border: 1px solid var(--color-season-label);
+  padding: 0.2rem 0.6rem;
+  border-radius: 2px;
+}
+
+/* --- Calendar Grid --- */
+
+.calendar-section {
+  padding: 2.5rem 0;
+}
+
+.calendar-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+.calendar-header h2 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.view-toggle button {
+  background: var(--color-surface);
+  border: none;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: var(--font-sans);
+}
+
+.view-toggle button.active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.view-toggle button:hover:not(.active) {
+  background: var(--color-accent-light);
+}
+
+/* Day-of-week labels */
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 2px;
+}
+
+.calendar-weekdays span {
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  padding: 0.5rem 0;
+}
+
+/* Grid */
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.calendar-day {
+  aspect-ratio: 1;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.calendar-day:hover {
+  border-color: var(--color-accent);
+}
+
+.calendar-day.empty {
+  background: transparent;
+  border-color: transparent;
+}
+
+.calendar-day.empty:hover {
+  border-color: transparent;
+}
+
+.calendar-day .day-number {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  margin-bottom: 0.25rem;
+}
+
+.calendar-day.today {
+  border-color: var(--color-today);
+  border-width: 2px;
+}
+
+.calendar-day.today .day-number {
+  color: var(--color-today);
+}
+
+.calendar-day .day-event {
+  font-size: 0.65rem;
+  color: var(--color-event);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.calendar-day .day-event a {
+  color: var(--color-event);
+}
+
+.calendar-day .day-event a:hover {
+  color: var(--color-accent);
+}
+
+/* --- List View --- */
+
+.list-view {
+  display: none;
+}
+
+.list-view.active {
+  display: block;
+}
+
+.calendar-grid-wrapper {
+  display: block;
+}
+
+.calendar-grid-wrapper.hidden {
+  display: none;
+}
+
+.list-month {
+  margin-bottom: 2.5rem;
+}
+
+.list-month h3 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.list-item {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.list-item:last-child {
+  border-bottom: none;
+}
+
+.list-date {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  min-width: 3rem;
+  flex-shrink: 0;
+}
+
+.list-title {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.list-title:hover {
+  color: var(--color-accent);
+}
+
+.list-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* --- Post Cards (Home) --- */
+
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.post-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
+.post-card .post-date {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.post-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  line-height: 1.3;
+}
+
+.post-card h3 a {
+  color: var(--color-text);
+}
+
+.post-card h3 a:hover {
+  color: var(--color-accent);
+}
+
+.post-card .post-excerpt {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.post-card .post-tags {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.post-card .post-tags a {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--color-accent);
+  background: var(--color-accent-light);
+  padding: 0.15rem 0.5rem;
+  border-radius: 2px;
+}
+
+/* --- Single Post --- */
+
+.post-single {
+  padding: 3rem 0;
+}
+
+.post-single header {
+  margin-bottom: 2rem;
+}
+
+.post-single .post-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin-bottom: 0.75rem;
+}
+
+.post-single .post-cover {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+
+.post-single .post-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.post-content {
+  max-width: 680px;
+  line-height: 1.8;
+}
+
+.post-content h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 2rem 0 1rem;
+}
+
+.post-content h3 {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.post-content p {
+  margin-bottom: 1.25rem;
+}
+
+.post-content ul,
+.post-content ol {
+  margin: 0 0 1.25rem 1.5rem;
+}
+
+.post-content li {
+  margin-bottom: 0.4rem;
+}
+
+.post-content blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding-left: 1rem;
+  margin: 1.5rem 0;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.post-content pre {
+  background: #f5f3f0;
+  padding: 1.25rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  border: 1px solid var(--color-border);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.post-content code {
+  font-size: 0.9em;
+  background: #f5f3f0;
+  padding: 0.15rem 0.35rem;
+  border-radius: 2px;
+}
+
+.post-content pre code {
+  background: none;
+  padding: 0;
+}
+
+.post-content img {
+  border: 1px solid var(--color-border);
+  margin: 1.5rem 0;
+}
+
+.post-tags-bottom {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.post-tags-bottom a {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-accent);
+  background: var(--color-accent-light);
+  padding: 0.25rem 0.6rem;
+  border-radius: 2px;
+}
+
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  gap: 2rem;
+}
+
+.post-nav a {
+  max-width: 48%;
+}
+
+.post-nav .nav-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.post-nav .nav-title {
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.nav-next {
+  text-align: right;
+  margin-left: auto;
+}
+
+/* --- Taxonomy --- */
+
+.taxonomy-list {
+  list-style: none;
+  padding: 2rem 0;
+}
+
+.taxonomy-list li {
+  margin-bottom: 0.5rem;
+}
+
+.taxonomy-list a {
+  font-weight: 500;
+}
+
+.taxonomy-posts {
+  list-style: none;
+  padding: 1rem 0;
+}
+
+.taxonomy-posts li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* --- Search --- */
+
+.search-container {
+  padding: 2rem 0;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: var(--font-sans);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.search-results {
+  list-style: none;
+  margin-top: 1rem;
+}
+
+.search-results li {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.search-results a {
+  font-weight: 500;
+}
+
+/* --- 404 --- */
+
+.error-404 {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.error-404 h1 {
+  font-family: var(--font-display);
+  font-size: 5rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  margin-bottom: 0.5rem;
+}
+
+.error-404 p {
+  color: var(--color-text-muted);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Footer --- */
+
+.site-footer {
+  margin-top: auto;
+  padding: 2rem 0;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.site-footer .wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.site-footer a {
+  color: var(--color-text-muted);
+}
+
+.site-footer a:hover {
+  color: var(--color-accent);
+}
+
+/* --- Page --- */
+
+.page-content {
+  padding: 3rem 0;
+}
+
+.page-content h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+/* --- Section --- */
+
+.section-content {
+  padding: 2.5rem 0;
+}
+
+.section-content h1 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 768px) {
+  .site-header .wrapper {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .calendar-grid {
+    gap: 1px;
+  }
+
+  .calendar-day {
+    padding: 0.3rem;
+    font-size: 0.7rem;
+  }
+
+  .calendar-day .day-number {
+    font-size: 0.75rem;
+  }
+
+  .calendar-day .day-event {
+    font-size: 0.55rem;
+  }
+
+  .post-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .post-single .post-title {
+    font-size: 1.5rem;
+  }
+
+  .list-item {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .list-desc {
+    margin-left: 0;
+  }
+
+  .post-nav {
+    flex-direction: column;
+  }
+
+  .post-nav a {
+    max-width: 100%;
+  }
+
+  .nav-next {
+    text-align: left;
+  }
+}
+
+@media (max-width: 480px) {
+  .calendar-weekdays span {
+    font-size: 0.6rem;
+  }
+
+  .calendar-day .day-event {
+    display: none;
+  }
+}

--- a/almanac/templates/404.html
+++ b/almanac/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <div class="error-404">
+      <h1>404</h1>
+      <p>The page you're looking for doesn't exist.</p>
+      <a href="{{ base_url }}/">Back to home</a>
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/almanac/templates/footer.html
+++ b/almanac/templates/footer.html
@@ -1,0 +1,28 @@
+  <footer class="site-footer">
+    <div class="wrapper">
+      <span>&copy; {{ current_year }} {{ site.title }}</span>
+      <span>Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></span>
+    </div>
+  </footer>
+
+  <script>
+    (function() {
+      var month = new Date().getMonth();
+      var season;
+      if (month >= 2 && month <= 4) season = 'spring';
+      else if (month >= 5 && month <= 7) season = 'summer';
+      else if (month >= 8 && month <= 10) season = 'autumn';
+      else season = 'winter';
+      document.body.setAttribute('data-season', season);
+
+      var badge = document.querySelector('.season-badge');
+      if (badge) {
+        var labels = { spring: 'Spring', summer: 'Summer', autumn: 'Autumn', winter: 'Winter' };
+        badge.textContent = labels[season];
+      }
+    })();
+  </script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/almanac/templates/header.html
+++ b/almanac/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-season="spring">
+
+  <header class="site-header">
+    <div class="wrapper">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/search/">Search</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>

--- a/almanac/templates/home.html
+++ b/almanac/templates/home.html
@@ -1,0 +1,138 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="calendar-section">
+      <div class="calendar-header">
+        <h2>
+          <span class="season-badge">Spring</span>
+          <span id="calendar-month-label"></span>
+        </h2>
+        <div class="view-toggle">
+          <button class="active" id="btn-grid" onclick="switchView('grid')">Grid</button>
+          <button id="btn-list" onclick="switchView('list')">List</button>
+        </div>
+      </div>
+
+      <div class="calendar-grid-wrapper" id="grid-view">
+        <div class="calendar-weekdays">
+          <span>Sun</span><span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span>
+        </div>
+        <div class="calendar-grid" id="calendar-grid"></div>
+      </div>
+
+      <div class="list-view" id="list-view">
+        <div class="list-month" id="list-content"></div>
+      </div>
+    </section>
+
+    <section class="calendar-section">
+      <h2 style="font-family: var(--font-display); font-size: 1.5rem; font-weight: 700; margin-bottom: 1.5rem;">Recent Posts</h2>
+      <div class="post-grid">
+        {% for item in site.pages %}
+        <article class="post-card">
+          <div class="post-date">
+            {% if item.date %}{{ item.date }}{% endif %}
+          </div>
+          <h3><a href="{{ item.url }}">{{ item.title }}</a></h3>
+          {% if item.description %}
+          <p class="post-excerpt">{{ item.description }}</p>
+          {% endif %}
+          {% if item.tags %}
+          <div class="post-tags">
+            {% for tag in item.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function() {
+      var events = {
+        '01-01': 'New Year',
+        '02-14': 'Valentine\'s Day',
+        '03-20': 'Vernal Equinox',
+        '04-22': 'Earth Day',
+        '05-01': 'May Day',
+        '06-21': 'Summer Solstice',
+        '07-04': 'Independence Day',
+        '09-22': 'Autumnal Equinox',
+        '10-31': 'Halloween',
+        '11-28': 'Thanksgiving',
+        '12-21': 'Winter Solstice',
+        '12-25': 'Christmas'
+      };
+
+      var now = new Date();
+      var year = now.getFullYear();
+      var month = now.getMonth();
+      var today = now.getDate();
+
+      var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December'];
+
+      document.getElementById('calendar-month-label').textContent = monthNames[month] + ' ' + year;
+
+      var firstDay = new Date(year, month, 1).getDay();
+      var daysInMonth = new Date(year, month + 1, 0).getDate();
+      var grid = document.getElementById('calendar-grid');
+      var listContent = document.getElementById('list-content');
+
+      var html = '';
+      var listHtml = '<h3>' + monthNames[month] + ' ' + year + '</h3>';
+
+      for (var i = 0; i < firstDay; i++) {
+        html += '<div class="calendar-day empty"></div>';
+      }
+
+      for (var d = 1; d <= daysInMonth; d++) {
+        var mm = String(month + 1).padStart(2, '0');
+        var dd = String(d).padStart(2, '0');
+        var key = mm + '-' + dd;
+        var isToday = d === today;
+        var evt = events[key] || '';
+
+        html += '<div class="calendar-day' + (isToday ? ' today' : '') + '">';
+        html += '<span class="day-number">' + d + '</span>';
+        if (evt) {
+          html += '<span class="day-event">' + evt + '</span>';
+        }
+        html += '</div>';
+
+        if (evt) {
+          listHtml += '<div class="list-item">';
+          listHtml += '<span class="list-date">' + mm + '/' + dd + '</span>';
+          listHtml += '<span class="list-title">' + evt + '</span>';
+          listHtml += '</div>';
+        }
+      }
+
+      grid.innerHTML = html;
+      listContent.innerHTML = listHtml;
+
+      window.switchView = function(view) {
+        var gridEl = document.getElementById('grid-view');
+        var listEl = document.getElementById('list-view');
+        var btnGrid = document.getElementById('btn-grid');
+        var btnList = document.getElementById('btn-list');
+
+        if (view === 'list') {
+          gridEl.classList.add('hidden');
+          listEl.classList.add('active');
+          btnGrid.classList.remove('active');
+          btnList.classList.add('active');
+        } else {
+          gridEl.classList.remove('hidden');
+          listEl.classList.remove('active');
+          btnGrid.classList.add('active');
+          btnList.classList.remove('active');
+        }
+      };
+    })();
+  </script>
+
+{% include "footer.html" %}

--- a/almanac/templates/page.html
+++ b/almanac/templates/page.html
@@ -1,0 +1,46 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <article class="post-single">
+      <header>
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta">
+          {% if page.date %}{{ page.date }}{% endif %}
+          {% if page.reading_time %} &middot; {{ page.reading_time }} min read{% endif %}
+        </div>
+      </header>
+
+      {% if page.image %}
+      <img class="post-cover" src="{{ page.image }}" alt="{{ page.title }}" loading="lazy">
+      {% endif %}
+
+      <div class="post-content">
+        {{ content }}
+      </div>
+
+      {% if page.tags %}
+      <div class="post-tags-bottom">
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <nav class="post-nav">
+        {% if page.higher %}
+        <a class="nav-prev" href="{{ page.higher.url }}">
+          <span class="nav-label">Newer</span>
+          <div class="nav-title">{{ page.higher.title }}</div>
+        </a>
+        {% endif %}
+        {% if page.lower %}
+        <a class="nav-next" href="{{ page.lower.url }}">
+          <span class="nav-label">Older</span>
+          <div class="nav-title">{{ page.lower.title }}</div>
+        </a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+
+{% include "footer.html" %}

--- a/almanac/templates/search.html
+++ b/almanac/templates/search.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="page-content">
+      <h1>{{ page.title }}</h1>
+
+      <div class="search-container">
+        <input type="text" id="search-input" class="search-input" placeholder="Search articles..." autofocus>
+        <ul id="search-results" class="search-results"></ul>
+      </div>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+  <script>
+    (function() {
+      var input = document.getElementById('search-input');
+      var resultsEl = document.getElementById('search-results');
+      var fuse;
+
+      function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+      }
+
+      fetch('{{ base_url }}/search.json')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          fuse = new Fuse(data, { keys: ['title', 'content'], threshold: 0.3 });
+        });
+
+      input.addEventListener('input', function() {
+        var query = input.value.trim();
+        if (!query || !fuse) { resultsEl.innerHTML = ''; return; }
+        var results = fuse.search(query).slice(0, 10);
+        resultsEl.innerHTML = results.map(function(r) {
+          return '<li><a href="' + escapeHtml(r.item.url) + '">' + escapeHtml(r.item.title) + '</a></li>';
+        }).join('');
+      });
+    })();
+  </script>
+
+{% include "footer.html" %}

--- a/almanac/templates/section.html
+++ b/almanac/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="section-content">
+      <h1>{{ page.title }}</h1>
+
+      {{ content }}
+
+      <div class="post-grid">
+        {% for item in section.pages %}
+        <article class="post-card">
+          <div class="post-date">
+            {% if item.date %}{{ item.date }}{% endif %}
+          </div>
+          <h3><a href="{{ item.url }}">{{ item.title }}</a></h3>
+          {% if item.description %}
+          <p class="post-excerpt">{{ item.description }}</p>
+          {% endif %}
+          {% if item.tags %}
+          <div class="post-tags">
+            {% for tag in item.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </article>
+        {% endfor %}
+      </div>
+
+      {{ pagination }}
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/almanac/templates/shortcodes/alert.html
+++ b/almanac/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/almanac/templates/taxonomy.html
+++ b/almanac/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="page-content">
+      <h1>{{ page.title }}</h1>
+      <ul class="taxonomy-list">
+        {{ content }}
+      </ul>
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/almanac/templates/taxonomy_term.html
+++ b/almanac/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+  <main class="wrapper">
+    <section class="page-content">
+      <h1>#{{ page.title }}</h1>
+      <ul class="taxonomy-posts">
+        {{ content }}
+      </ul>
+    </section>
+  </main>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3,6 +3,11 @@
     "light",
     "docs"
   ],
+  "almanac": [
+    "light",
+    "blog",
+    "calendar"
+  ],
   "airwave": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Add new `almanac` example site with calendar grid view and list view toggle
- Seasonal color palette that auto-detects the current season (spring pink, summer green, autumn orange, winter blue)
- Today's date highlighted on the calendar, event/holiday markers on date cells
- Light theme with desk-calendar aesthetic, Playfair Display + Inter typography
- 4 seasonal sample posts + welcome post + about page + search
- Update `tags.json` with `light`, `blog`, `calendar` tags

Closes #104

## Test plan
- [ ] `hwaro build` succeeds in `almanac/` directory
- [ ] `hwaro serve` renders calendar grid on homepage
- [ ] Grid/list view toggle works
- [ ] Season badge and color palette match the current season
- [ ] Posts display correctly in grid cards and single page view
- [ ] Search page returns results
- [ ] Responsive layout works on mobile widths