### PR TITLE
Add new example: habitat (real estate listing theme)

### DIFF
--- a/habitat/AGENTS.md
+++ b/habitat/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/habitat/config.toml
+++ b/habitat/config.toml
@@ -1,0 +1,49 @@
+title = "Habitat Realty"
+description = "Premium properties, expertly matched to your lifestyle"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 12
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["properties"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+[search]
+enabled = false

--- a/habitat/content/about.md
+++ b/habitat/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "About Habitat Realty"
+description = "Trusted real estate professionals helping you find the perfect home since 2015"
++++
+
+## Who We Are
+
+Habitat Realty was founded with a simple belief: finding a home should be a thoughtful, transparent experience. We are a team of licensed agents with deep knowledge of the local market, committed to matching people with properties that fit their lives.
+
+## Our Approach
+
+We don't just list properties. We listen to what matters to you &mdash; commute time, school districts, outdoor space, neighborhood character &mdash; and then curate options that genuinely make sense.
+
+Every listing on our site includes verified square footage, recent inspection notes, and honest neighborhood context. We believe informed buyers make confident decisions.
+
+## The Numbers
+
+Since 2015, we have closed over 1,200 transactions across the metro area. Our average listing sells within 28 days, and our client satisfaction rate stands at 97%.
+
+## Work With Us
+
+Whether you are buying your first apartment or selling a family home, we are here to guide you through every step. Reach out to schedule a consultation.
+
+**Habitat Realty**
+42 Prospect Lane, Suite 300
+Maplewood, MW 07040
+
+info@habitat-realty.com
++1 (555) 482-7100

--- a/habitat/content/index.md
+++ b/habitat/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+template = "home"
++++

--- a/habitat/content/properties/_index.md
+++ b/habitat/content/properties/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Properties"
+description = "Browse our curated selection of homes, apartments, and commercial spaces"
+sort_by = "weight"
++++

--- a/habitat/content/properties/birchwood-rental.md
+++ b/habitat/content/properties/birchwood-rental.md
@@ -1,0 +1,54 @@
++++
+title = "Birchwood Park Rental"
+description = "Bright 1-bedroom apartment in a well-managed building, close to parks and public transit."
+weight = 7
+tags = ["apartment", "rental", "city"]
+categories = ["For Rent"]
+
+[extra]
+price = "$1,850/mo"
+area = "720 sqft"
+bedrooms = "1"
+bathrooms = "1"
+location = "Birchwood Park, Eastside"
+type = "Apartment"
+status = "For Rent"
+year_built = "2015"
+lot_size = "N/A"
+garage = "N/A"
++++
+
+**$1,850/mo** | 720 sqft | Birchwood Park, Eastside
+
+---
+
+## Property Overview
+
+A well-kept one-bedroom apartment on the third floor of the Birchwood Park building. South-facing windows fill the living room with natural light throughout the day. The kitchen has been updated with white cabinetry, a gas range, and a dishwasher.
+
+The bedroom comfortably fits a queen bed and dresser, with a closet system that maximizes storage. Shared laundry facilities are located on each floor.
+
+## Key Features
+
+- **Layout:** Open living and kitchen area, separate bedroom, full bath
+- **Kitchen:** Gas range, dishwasher, microwave, updated cabinetry
+- **Sunlight:** South-facing exposure, large windows in living room and bedroom
+- **Building:** On-site management, laundry on every floor, bike room
+- **Lease:** 12-month minimum, pets allowed with deposit
+
+## Neighborhood
+
+Birchwood Park is a residential neighborhood with a large public park, a community garden, and a branch library. The Eastside metro station is a four-minute walk, providing direct access to downtown in under fifteen minutes. A grocery store and pharmacy are on the same block.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2015 |
+| Floor | 3rd of 5 |
+| Bedrooms | 1 |
+| Bathrooms | 1 |
+| Parking | Street (permit zone) |
+| Lease Term | 12-month minimum |
+| Pets | Allowed (deposit required) |
+| Available | April 1, 2026 |

--- a/habitat/content/properties/cedar-hollow-cottage.md
+++ b/habitat/content/properties/cedar-hollow-cottage.md
@@ -1,0 +1,54 @@
++++
+title = "Cedar Hollow Cottage"
+description = "Charming 3-bedroom cottage with original character, updated systems, and a wraparound porch."
+weight = 3
+tags = ["house", "cottage", "garden"]
+categories = ["For Sale"]
+
+[extra]
+price = "$520,000"
+area = "1,800 sqft"
+bedrooms = "3"
+bathrooms = "2"
+location = "Cedar Hollow, Westfield"
+type = "House"
+status = "For Sale"
+year_built = "1948"
+lot_size = "0.28 acres"
+garage = "Detached 1-car"
++++
+
+**$520,000** | 1,800 sqft | Cedar Hollow, Westfield
+
+---
+
+## Property Overview
+
+A 1948 cottage with the kind of character that newer builds simply cannot replicate. Original crown moldings, built-in bookshelves, and arched doorways have been carefully preserved through a series of thoughtful updates.
+
+The kitchen was fully modernized in 2020, with a farmhouse sink, butcher-block counters, and open shelving. The wraparound porch is the centerpiece of the home &mdash; wide enough for a table and chairs, shaded by a century-old oak.
+
+## Key Features
+
+- **Character:** Original hardwood floors, crown moldings, arched doorways
+- **Kitchen:** Renovated 2020, farmhouse style with modern appliances
+- **Porch:** Full wraparound, southern exposure, screened section
+- **Garden:** Perennial beds, raised vegetable garden, stone walkway
+- **Updates:** New roof (2021), rewired electrical, copper plumbing
+
+## Neighborhood
+
+Cedar Hollow is one of Westfield's most walkable neighborhoods. The Saturday farmers market is three blocks away, and the public library and community pool are within a ten-minute walk. Local shops line Cedar Street, including two bakeries and an independent bookstore.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 1948 |
+| Lot Size | 0.28 acres |
+| Bedrooms | 3 |
+| Bathrooms | 2 |
+| Garage | Detached 1-car |
+| Heating | Hot water baseboard |
+| Cooling | Window units (3) |
+| Taxes (annual) | $7,400 |

--- a/habitat/content/properties/elm-street-townhouse.md
+++ b/habitat/content/properties/elm-street-townhouse.md
@@ -1,0 +1,55 @@
++++
+title = "Elm Street Townhouse"
+description = "End-unit 3-bedroom townhouse with private garage, rooftop deck, and walkable location."
+weight = 5
+tags = ["townhouse", "modern", "family"]
+categories = ["For Sale"]
+
+[extra]
+price = "$575,000"
+area = "1,950 sqft"
+bedrooms = "3"
+bathrooms = "2.5"
+location = "Elm Street, Midtown"
+type = "Townhouse"
+status = "For Sale"
+year_built = "2017"
+lot_size = "0.05 acres"
+garage = "1-car attached"
++++
+
+**$575,000** | 1,950 sqft | Elm Street, Midtown
+
+---
+
+## Property Overview
+
+An end-unit townhouse in Midtown's sought-after Elm Street row, built in 2017. The three-level layout provides clear separation between living, sleeping, and entertaining spaces. The main level features an open kitchen and living area with 9-foot ceilings and wide-plank floors.
+
+The rooftop deck is a standout &mdash; 200 square feet of private outdoor space with built-in planters and skyline views to the west.
+
+## Key Features
+
+- **Layout:** Three levels with logical flow; living, sleeping, and rooftop entertaining
+- **Kitchen:** White quartz counters, soft-close cabinetry, gas range, pantry closet
+- **Rooftop:** Private 200 sqft deck with built-in planters and gas line for grill
+- **Garage:** Attached single-car with internal access and storage shelving
+- **Efficiency:** Spray foam insulation, LED lighting throughout, Energy Star appliances
+
+## Neighborhood
+
+Elm Street sits in the middle of Midtown's restaurant and boutique corridor. The weekend market, a public park, and the metro station are all within a five-minute walk. Several highly rated schools serve the area.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2017 |
+| Lot Size | 0.05 acres |
+| Bedrooms | 3 |
+| Bathrooms | 2.5 |
+| Garage | 1-car attached |
+| HOA Fee | $150/month |
+| Heating | Forced air, gas |
+| Cooling | Central air |
+| Taxes (annual) | $7,800 |

--- a/habitat/content/properties/linden-court-apartment.md
+++ b/habitat/content/properties/linden-court-apartment.md
@@ -1,0 +1,55 @@
++++
+title = "Linden Court Apartment"
+description = "Modern 2-bedroom apartment in a boutique building with rooftop terrace and in-unit laundry."
+weight = 2
+tags = ["apartment", "modern", "city"]
+categories = ["For Sale"]
+
+[extra]
+price = "$425,000"
+area = "1,100 sqft"
+bedrooms = "2"
+bathrooms = "2"
+location = "Linden Court, Downtown"
+type = "Apartment"
+status = "For Sale"
+year_built = "2019"
+lot_size = "N/A"
+garage = "1 assigned space"
++++
+
+**$425,000** | 1,100 sqft | Linden Court, Downtown
+
+---
+
+## Property Overview
+
+A sleek two-bedroom apartment on the fourth floor of the Linden Court building, completed in 2019. Floor-to-ceiling windows fill the living area with natural light, and the open kitchen features integrated European cabinetry and stone countertops.
+
+Both bedrooms are generously sized, with the primary offering an en-suite bath with a glass-enclosed shower. In-unit washer and dryer included.
+
+## Key Features
+
+- **Kitchen:** Integrated appliances, waterfall island, soft-close cabinetry
+- **Flooring:** Wide-plank engineered oak throughout
+- **Windows:** Floor-to-ceiling, double-glazed, south-facing exposure
+- **Building:** Secure lobby, package room, bicycle storage
+- **Rooftop:** Shared terrace with seating areas and city views
+
+## Neighborhood
+
+Downtown Linden Court puts you within walking distance of cafes, a farmers market, and the central transit hub. The riverfront park is two blocks east, and the business district is a ten-minute walk north.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2019 |
+| Floor | 4th of 6 |
+| Bedrooms | 2 |
+| Bathrooms | 2 |
+| Parking | 1 assigned space |
+| HOA Fee | $380/month |
+| Heating | In-floor radiant |
+| Cooling | Ductless mini-split |
+| Taxes (annual) | $5,100 |

--- a/habitat/content/properties/maple-ridge-house.md
+++ b/habitat/content/properties/maple-ridge-house.md
@@ -1,0 +1,54 @@
++++
+title = "Maple Ridge Family Home"
+description = "Spacious 4-bedroom colonial in a quiet, tree-lined neighborhood with excellent schools nearby."
+weight = 1
+tags = ["house", "family", "garden"]
+categories = ["For Sale"]
+
+[extra]
+price = "$685,000"
+area = "2,400 sqft"
+bedrooms = "4"
+bathrooms = "3"
+location = "Maple Ridge, Maplewood"
+type = "House"
+status = "For Sale"
+year_built = "2003"
+lot_size = "0.35 acres"
+garage = "2-car attached"
++++
+
+**$685,000** | 2,400 sqft | Maple Ridge, Maplewood
+
+---
+
+## Property Overview
+
+A well-maintained colonial on a quiet cul-de-sac in the heart of Maple Ridge. This four-bedroom home offers generous living space, a renovated kitchen with quartz countertops, and a private backyard with mature landscaping.
+
+The open floor plan connects the living room to a sun-filled dining area, making it ideal for everyday living and entertaining alike. Hardwood floors run throughout the main level.
+
+## Key Features
+
+- **Kitchen:** Fully renovated in 2021 with quartz counters, stainless steel appliances, and a breakfast island
+- **Primary suite:** Walk-in closet, en-suite bath with dual vanity and soaking tub
+- **Basement:** Finished, adds 800 sqft of flexible living space
+- **Outdoor:** Fenced backyard, flagstone patio, mature oak and maple trees
+- **Systems:** New HVAC (2022), updated electrical panel, tankless water heater
+
+## Neighborhood
+
+Maple Ridge is a family-friendly neighborhood with sidewalks, a community park, and direct access to the Greenway Trail. Maplewood Elementary (rated 9/10) is a five-minute walk. Downtown Maplewood, with its shops and restaurants, is a short drive away.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2003 |
+| Lot Size | 0.35 acres |
+| Bedrooms | 4 |
+| Bathrooms | 3 |
+| Garage | 2-car attached |
+| Heating | Forced air, gas |
+| Cooling | Central air |
+| Taxes (annual) | $9,200 |

--- a/habitat/content/properties/oakmont-commercial.md
+++ b/habitat/content/properties/oakmont-commercial.md
@@ -1,0 +1,54 @@
++++
+title = "Oakmont Commercial Space"
+description = "Ground-floor retail or office space on a high-traffic corner with excellent visibility and foot traffic."
+weight = 6
+tags = ["commercial", "retail", "investment"]
+categories = ["For Lease"]
+
+[extra]
+price = "$4,200/mo"
+area = "1,500 sqft"
+bedrooms = "N/A"
+bathrooms = "1"
+location = "Oakmont Ave, Commerce District"
+type = "Commercial"
+status = "For Lease"
+year_built = "2010"
+lot_size = "N/A"
+garage = "Street parking"
++++
+
+**$4,200/mo** | 1,500 sqft | Oakmont Ave, Commerce District
+
+---
+
+## Property Overview
+
+A ground-floor commercial space on the corner of Oakmont Avenue and Third Street, one of the Commerce District's highest-traffic intersections. The storefront features large plate-glass windows on two sides, providing maximum visibility for retail or professional use.
+
+The space is delivered as a warm shell with polished concrete floors, exposed ductwork, and a finished restroom. The previous tenant operated a design studio; the layout works equally well for retail, a cafe, or a professional office.
+
+## Key Features
+
+- **Frontage:** Corner unit with two-sided storefront windows
+- **Condition:** Warm shell with polished concrete, exposed ceiling, finished restroom
+- **Utilities:** Separate meter for electric, water, and gas; HVAC in place
+- **Access:** ADA-compliant entrance, rear delivery door
+- **Signage:** Approved for blade sign and window graphics
+
+## Neighborhood
+
+The Commerce District anchors the city's small-business corridor. Neighboring tenants include a coffee roaster, a bookshop, and a coworking space. Foot traffic peaks during lunch hours and weekend markets. A municipal parking garage is half a block south.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2010 |
+| Ceiling Height | 12 feet |
+| Frontage | 35 linear feet |
+| Restrooms | 1 (ADA-compliant) |
+| Parking | Street + nearby garage |
+| Lease Term | 3-year minimum |
+| NNN Estimate | $8/sqft annually |
+| Available | Immediately |

--- a/habitat/content/properties/riverstone-penthouse.md
+++ b/habitat/content/properties/riverstone-penthouse.md
@@ -1,0 +1,55 @@
++++
+title = "Riverstone Penthouse"
+description = "Luxury 3-bedroom penthouse with panoramic river views, private elevator access, and designer finishes."
+weight = 4
+tags = ["apartment", "luxury", "city"]
+categories = ["For Sale"]
+
+[extra]
+price = "$1,250,000"
+area = "2,800 sqft"
+bedrooms = "3"
+bathrooms = "3.5"
+location = "Riverstone Tower, Waterfront"
+type = "Penthouse"
+status = "For Sale"
+year_built = "2021"
+lot_size = "N/A"
+garage = "2 assigned spaces"
++++
+
+**$1,250,000** | 2,800 sqft | Riverstone Tower, Waterfront
+
+---
+
+## Property Overview
+
+The crown jewel of Riverstone Tower. This full-floor penthouse occupies the 18th level, with unobstructed views of the river and skyline from every room. A private elevator opens directly into a gallery foyer with 10-foot ceilings.
+
+The great room spans 40 feet, anchored by a linear gas fireplace and flanked by walls of glass. The chef's kitchen features a marble waterfall island, Wolf range, and Sub-Zero refrigeration.
+
+## Key Features
+
+- **Views:** 270-degree panorama of the river, bridge, and downtown skyline
+- **Kitchen:** Wolf, Sub-Zero, and Miele appliances, marble island, wine fridge
+- **Primary suite:** Walk-in dressing room, spa bath with freestanding tub and rain shower
+- **Terrace:** 400 sqft private terrace, plumbed for outdoor kitchen
+- **Building:** 24/7 concierge, fitness center, resident lounge, guest suite
+
+## Neighborhood
+
+The Waterfront district is the city's most dynamic neighborhood. The riverwalk, marina, and waterfront restaurants are at your doorstep. The performing arts center is a five-minute walk, and the financial district is accessible via the pedestrian bridge.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2021 |
+| Floor | 18th (top floor) |
+| Bedrooms | 3 |
+| Bathrooms | 3.5 |
+| Parking | 2 assigned spaces |
+| HOA Fee | $1,200/month |
+| Heating | Forced air, zoned |
+| Cooling | Central air, zoned |
+| Taxes (annual) | $18,500 |

--- a/habitat/content/properties/summit-view-estate.md
+++ b/habitat/content/properties/summit-view-estate.md
@@ -1,0 +1,55 @@
++++
+title = "Summit View Estate"
+description = "Expansive 5-bedroom estate on 2 acres with pool, guest house, and mountain views."
+weight = 8
+tags = ["house", "luxury", "garden"]
+categories = ["For Sale"]
+
+[extra]
+price = "$2,100,000"
+area = "4,500 sqft"
+bedrooms = "5"
+bathrooms = "4.5"
+location = "Summit Ridge, Highlands"
+type = "Estate"
+status = "For Sale"
+year_built = "2015"
+lot_size = "2.0 acres"
+garage = "3-car attached"
++++
+
+**$2,100,000** | 4,500 sqft | Summit Ridge, Highlands
+
+---
+
+## Property Overview
+
+Set on two acres at the top of Summit Ridge, this estate commands unobstructed views of the western mountain range. The main residence is a five-bedroom contemporary with clean lines, natural stone accents, and walls of glass designed to frame the landscape.
+
+A detached guest house with a full kitchen, bedroom, and bath provides space for visitors or rental income. The heated saltwater pool is surrounded by a bluestone terrace with an outdoor kitchen.
+
+## Key Features
+
+- **Views:** Western mountain panorama from living areas, primary suite, and terrace
+- **Guest house:** 600 sqft detached unit with kitchen, bedroom, and full bath
+- **Pool:** Heated saltwater, 40 ft lap lane, bluestone surround
+- **Kitchen:** Main house has a professional-grade kitchen with dual ovens and 48-inch range
+- **Land:** 2 acres, partially wooded, drip-irrigated landscaping
+
+## Neighborhood
+
+Summit Ridge is a private enclave of estate-sized lots in the Highlands. The area is known for its trails, equestrian facilities, and proximity to a state park. The village center, with restaurants, a winery, and an organic grocer, is a ten-minute drive.
+
+## Specifications
+
+| Detail | Value |
+|--------|-------|
+| Year Built | 2015 |
+| Lot Size | 2.0 acres |
+| Bedrooms | 5 (main) + 1 (guest) |
+| Bathrooms | 4.5 (main) + 1 (guest) |
+| Garage | 3-car attached |
+| Pool | Heated saltwater |
+| Heating | Geothermal |
+| Cooling | Central air, zoned |
+| Taxes (annual) | $24,000 |

--- a/habitat/static/css/style.css
+++ b/habitat/static/css/style.css
@@ -1,0 +1,1066 @@
+/* ============================================
+   Habitat Realty - Real Estate Listing Theme
+   ============================================ */
+
+:root {
+  --bg: #f8f9fa;
+  --bg-white: #ffffff;
+  --bg-subtle: #f1f3f5;
+  --text: #1a1a2e;
+  --text-secondary: #495057;
+  --text-muted: #868e96;
+  --accent: #2b4c7e;
+  --accent-hover: #1a365d;
+  --accent-light: #e8eef6;
+  --success: #2d6a4f;
+  --border: #dee2e6;
+  --border-light: #e9ecef;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.1);
+  --radius: 6px;
+  --font-display: "DM Serif Display", Georgia, serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  line-height: 1.7;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: var(--accent-hover);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ---- Buttons ---- */
+
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: var(--radius);
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.btn-outline:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ---- Header ---- */
+
+.site-header {
+  background: var(--bg-white);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.logo-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--accent);
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  border-radius: 4px;
+}
+
+.logo-text {
+  font-family: var(--font-display);
+  font-size: 1.375rem;
+  color: var(--text);
+}
+
+.site-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-nav a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  position: relative;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+
+.site-nav a:hover {
+  color: var(--text);
+}
+
+.site-nav a:hover::after {
+  width: 100%;
+}
+
+.header-cta {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  background: var(--accent);
+  color: #fff;
+  border-radius: var(--radius);
+  transition: background 0.2s ease;
+}
+
+.header-cta:hover {
+  background: var(--accent-hover);
+  color: #fff;
+}
+
+/* ---- Hero ---- */
+
+.hero {
+  padding: 6rem 2rem 5rem;
+  text-align: center;
+  background: var(--bg-white);
+  border-bottom: 1px solid var(--border);
+}
+
+.hero-inner {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.hero-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 1.25rem;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  font-weight: 400;
+  color: var(--text);
+  line-height: 1.15;
+  margin-bottom: 1.25rem;
+}
+
+.hero-desc {
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  line-height: 1.75;
+  margin-bottom: 2.25rem;
+  max-width: 540px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ---- Stats Bar ---- */
+
+.stats-bar {
+  background: var(--accent);
+  color: #fff;
+}
+
+.stats-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2.5rem 2rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
+  text-align: center;
+}
+
+.stat-number {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  opacity: 0.8;
+  letter-spacing: 0.02em;
+}
+
+/* ---- Section Headers ---- */
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  font-weight: 400;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
+.section-desc {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.section-footer {
+  text-align: center;
+  margin-top: 2.5rem;
+}
+
+/* ---- Featured Section ---- */
+
+.featured-section {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 5rem 2rem;
+}
+
+/* ---- Property Grid ---- */
+
+.property-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.property-grid--full {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.property-card {
+  display: block;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  overflow: hidden;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  position: relative;
+}
+
+.property-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+  color: var(--text);
+}
+
+.property-badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--success);
+  color: #fff;
+  border-radius: 3px;
+}
+
+.property-info {
+  padding: 1.5rem;
+}
+
+.property-type {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.property-name {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 400;
+  color: var(--text);
+  margin-bottom: 0.375rem;
+  line-height: 1.3;
+}
+
+.property-location {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.property-meta {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.property-meta span {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.property-excerpt {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 1rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.property-price {
+  font-family: var(--font-display);
+  font-size: 1.375rem;
+  color: var(--text);
+  margin: 0;
+}
+
+/* ---- Services Section ---- */
+
+.services-section {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 5rem 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+.service-card {
+  padding: 2rem;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+}
+
+.service-step {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.service-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.625rem;
+  color: var(--text);
+}
+
+.service-card p {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+}
+
+/* ---- CTA Section ---- */
+
+.cta-section {
+  border-top: 1px solid var(--border);
+  background: var(--bg-white);
+}
+
+.cta-inner {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.cta-inner h2 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 400;
+  margin-bottom: 0.75rem;
+}
+
+.cta-inner p {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+  line-height: 1.7;
+}
+
+/* ---- Listing Page ---- */
+
+.listing-main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 3rem 2rem 5rem;
+}
+
+.listing-header {
+  margin-bottom: 2.5rem;
+}
+
+.listing-title {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  font-weight: 400;
+  margin-bottom: 0.375rem;
+}
+
+.listing-desc {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.listing-count {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* ---- Detail Page ---- */
+
+.detail-main {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 3rem 2rem 5rem;
+}
+
+.detail-header {
+  margin-bottom: 2rem;
+}
+
+.detail-header-top {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.detail-badge {
+  display: inline-block;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--success);
+  color: #fff;
+  border-radius: 3px;
+}
+
+.detail-type {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.detail-title {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  font-weight: 400;
+  line-height: 1.2;
+  margin-bottom: 0.375rem;
+}
+
+.detail-location {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.detail-price {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  color: var(--text);
+}
+
+/* ---- Spec Bar ---- */
+
+.spec-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1px;
+  background: var(--border-light);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 2rem;
+}
+
+.spec-item {
+  padding: 1.25rem 1rem;
+  background: var(--bg-white);
+  text-align: center;
+}
+
+.spec-value {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+
+.spec-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+/* ---- Detail Tags ---- */
+
+.detail-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 0.3rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.tag:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ---- Detail Body ---- */
+
+.detail-body {
+  margin-bottom: 3rem;
+}
+
+.detail-body p {
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.detail-body strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.detail-body h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--text);
+}
+
+.detail-body ul {
+  margin-bottom: 1.25rem;
+  padding-left: 1.25rem;
+}
+
+.detail-body li {
+  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.detail-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 1.5rem 0;
+}
+
+.detail-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.detail-body th,
+.detail-body td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.9375rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.detail-body th {
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg-subtle);
+}
+
+.detail-body td {
+  color: var(--text-secondary);
+}
+
+.detail-body td:first-child {
+  font-weight: 500;
+  color: var(--text);
+}
+
+/* ---- Detail CTA ---- */
+
+.detail-cta {
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.detail-cta p {
+  font-weight: 600;
+  color: var(--text);
+  margin-right: 0.5rem;
+}
+
+/* ---- Page Main (About, etc.) ---- */
+
+.page-main {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 2rem 5rem;
+}
+
+.page-main h1 {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  font-weight: 400;
+  margin-bottom: 1.5rem;
+  line-height: 1.2;
+}
+
+.page-main h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--text);
+}
+
+.page-main p {
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.page-main strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---- Taxonomy ---- */
+
+.taxonomy-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 400;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.taxonomy-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.taxonomy-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-white);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text);
+  transition: border-color 0.2s;
+}
+
+.taxonomy-card:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.taxonomy-count {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* ---- Pagination ---- */
+
+nav.pagination {
+  margin-top: 2.5rem;
+  text-align: center;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+nav.pagination a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.875rem;
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  opacity: 0.4;
+}
+
+/* ---- Error Page ---- */
+
+.error-page {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.error-page h1 {
+  font-family: var(--font-display);
+  font-size: 6rem;
+  font-weight: 400;
+  color: var(--border);
+  margin-bottom: 0.5rem;
+}
+
+.error-page p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  margin-bottom: 2rem;
+}
+
+.error-page a {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 2px;
+}
+
+/* ---- Footer ---- */
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  background: var(--text);
+  color: #adb5bd;
+}
+
+.footer-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 3.5rem 2rem 2rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 3rem;
+  margin-bottom: 2.5rem;
+}
+
+.footer-logo {
+  font-family: var(--font-display);
+  font-size: 1.375rem;
+  color: #fff;
+  margin-bottom: 0.75rem;
+}
+
+.footer-desc {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #868e96;
+}
+
+.footer-links h4,
+.footer-contact h4 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #fff;
+  margin-bottom: 1rem;
+}
+
+.footer-links a {
+  display: block;
+  font-size: 0.875rem;
+  color: #868e96;
+  margin-bottom: 0.5rem;
+  transition: color 0.2s;
+}
+
+.footer-links a:hover {
+  color: #fff;
+}
+
+.footer-contact p {
+  font-size: 0.875rem;
+  color: #868e96;
+  margin-bottom: 0.25rem;
+  line-height: 1.6;
+}
+
+.footer-bottom {
+  padding-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+  font-size: 0.8125rem;
+  color: #495057;
+}
+
+.footer-bottom a {
+  color: #868e96;
+}
+
+.footer-bottom a:hover {
+  color: #fff;
+}
+
+/* ---- Responsive ---- */
+
+@media (max-width: 960px) {
+  .property-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .services-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+  }
+
+  .footer-brand {
+    grid-column: 1 / -1;
+  }
+
+  .stats-inner {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-inner {
+    padding: 0 1.25rem;
+  }
+
+  .header-cta {
+    display: none;
+  }
+
+  .hero {
+    padding: 4rem 1.5rem 3.5rem;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .hero-desc {
+    font-size: 1rem;
+  }
+
+  .featured-section,
+  .services-section {
+    padding: 3.5rem 1.5rem;
+  }
+
+  .listing-main,
+  .detail-main,
+  .page-main {
+    padding: 2rem 1.25rem 3rem;
+  }
+
+  .listing-title,
+  .detail-title {
+    font-size: 2rem;
+  }
+
+  .spec-bar {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .property-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .services-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .spec-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .stats-inner {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .detail-cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: 2rem;
+  }
+
+  .site-nav {
+    gap: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.8125rem;
+  }
+}

--- a/habitat/templates/404.html
+++ b/habitat/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="page-main">
+    <div class="error-page">
+      <h1>404</h1>
+      <p>This property listing could not be found. It may have been sold or removed.</p>
+      <a href="{{ base_url }}/properties/">Browse Available Properties</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/habitat/templates/footer.html
+++ b/habitat/templates/footer.html
@@ -1,0 +1,29 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <p class="footer-logo">Habitat Realty</p>
+          <p class="footer-desc">Premium properties, expertly matched to your lifestyle. Serving the metro area since 2015.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Quick Links</h4>
+          <a href="{{ base_url }}/properties/">All Properties</a>
+          <a href="{{ base_url }}/about/">About Us</a>
+          <a href="{{ base_url }}/tags/">Browse by Tag</a>
+        </div>
+        <div class="footer-contact">
+          <h4>Contact</h4>
+          <p>42 Prospect Lane, Suite 300</p>
+          <p>Maplewood, MW 07040</p>
+          <p>info@habitat-realty.com</p>
+          <p>+1 (555) 482-7100</p>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; {{ current_year }} Habitat Realty &middot; Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+      </div>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/habitat/templates/header.html
+++ b/habitat/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{% if page.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-mark">H</span>
+        <span class="logo-text">Habitat</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/properties/">Properties</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <a href="{{ base_url }}/about/" class="header-cta">Contact Us</a>
+    </div>
+  </header>

--- a/habitat/templates/home.html
+++ b/habitat/templates/home.html
@@ -1,0 +1,124 @@
+{% include "header.html" %}
+  <main>
+    <section class="hero">
+      <div class="hero-inner">
+        <p class="hero-label">Habitat Realty</p>
+        <h1 class="hero-title">Find the place<br>you belong</h1>
+        <p class="hero-desc">We connect people with homes, apartments, and commercial spaces across the metro area. Every listing is vetted, every detail verified.</p>
+        <div class="hero-actions">
+          <a href="{{ base_url }}/properties/" class="btn btn-primary">Browse Properties</a>
+          <a href="{{ base_url }}/about/" class="btn btn-outline">Learn More</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="stats-bar">
+      <div class="stats-inner">
+        <div class="stat">
+          <span class="stat-number">1,200+</span>
+          <span class="stat-label">Transactions Closed</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number">97%</span>
+          <span class="stat-label">Client Satisfaction</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number">28</span>
+          <span class="stat-label">Avg. Days on Market</span>
+        </div>
+        <div class="stat">
+          <span class="stat-number">10+</span>
+          <span class="stat-label">Years of Experience</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="featured-section">
+      <div class="section-header">
+        <h2 class="section-title">Featured Listings</h2>
+        <p class="section-desc">Hand-picked properties from our current portfolio</p>
+      </div>
+      <div class="property-grid">
+        <a href="{{ base_url }}/properties/maple-ridge-house/" class="property-card">
+          <div class="property-badge">For Sale</div>
+          <div class="property-info">
+            <h3 class="property-name">Maple Ridge Family Home</h3>
+            <p class="property-location">Maple Ridge, Maplewood</p>
+            <div class="property-meta">
+              <span>4 Bed</span>
+              <span>3 Bath</span>
+              <span>2,400 sqft</span>
+            </div>
+            <p class="property-price">$685,000</p>
+          </div>
+        </a>
+        <a href="{{ base_url }}/properties/linden-court-apartment/" class="property-card">
+          <div class="property-badge">For Sale</div>
+          <div class="property-info">
+            <h3 class="property-name">Linden Court Apartment</h3>
+            <p class="property-location">Linden Court, Downtown</p>
+            <div class="property-meta">
+              <span>2 Bed</span>
+              <span>2 Bath</span>
+              <span>1,100 sqft</span>
+            </div>
+            <p class="property-price">$425,000</p>
+          </div>
+        </a>
+        <a href="{{ base_url }}/properties/riverstone-penthouse/" class="property-card">
+          <div class="property-badge">For Sale</div>
+          <div class="property-info">
+            <h3 class="property-name">Riverstone Penthouse</h3>
+            <p class="property-location">Riverstone Tower, Waterfront</p>
+            <div class="property-meta">
+              <span>3 Bed</span>
+              <span>3.5 Bath</span>
+              <span>2,800 sqft</span>
+            </div>
+            <p class="property-price">$1,250,000</p>
+          </div>
+        </a>
+      </div>
+      <div class="section-footer">
+        <a href="{{ base_url }}/properties/" class="btn btn-outline">View All Properties</a>
+      </div>
+    </section>
+
+    <section class="services-section">
+      <div class="section-header">
+        <h2 class="section-title">How We Work</h2>
+        <p class="section-desc">A clear, straightforward process from first call to closing day</p>
+      </div>
+      <div class="services-grid">
+        <div class="service-card">
+          <span class="service-step">01</span>
+          <h3>Consultation</h3>
+          <p>We start with a conversation about your needs, timeline, and budget. No pressure, no jargon.</p>
+        </div>
+        <div class="service-card">
+          <span class="service-step">02</span>
+          <h3>Curated Search</h3>
+          <p>We narrow the market to a shortlist of properties that genuinely match your criteria.</p>
+        </div>
+        <div class="service-card">
+          <span class="service-step">03</span>
+          <h3>Guided Visits</h3>
+          <p>Tour each property with an agent who knows the building, the block, and the neighborhood.</p>
+        </div>
+        <div class="service-card">
+          <span class="service-step">04</span>
+          <h3>Close with Confidence</h3>
+          <p>We handle negotiations, inspections, and paperwork so you can focus on what comes next.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta-section">
+      <div class="cta-inner">
+        <h2>Ready to find your next home?</h2>
+        <p>Schedule a free consultation with one of our agents. We will listen first, then get to work.</p>
+        <a href="{{ base_url }}/about/" class="btn btn-primary">Get in Touch</a>
+      </div>
+    </section>
+  </main>
+{% include "footer.html" %}

--- a/habitat/templates/page.html
+++ b/habitat/templates/page.html
@@ -1,0 +1,82 @@
+{% include "header.html" %}
+  <main class="detail-main">
+    <article class="property-detail">
+      <div class="detail-header">
+        <div class="detail-header-top">
+          {% if page.extra.status %}
+          <span class="detail-badge">{{ page.extra.status }}</span>
+          {% endif %}
+          {% if page.extra.type %}
+          <span class="detail-type">{{ page.extra.type }}</span>
+          {% endif %}
+        </div>
+        <h1 class="detail-title">{{ page.title }}</h1>
+        {% if page.extra.location %}
+        <p class="detail-location">{{ page.extra.location }}</p>
+        {% endif %}
+        {% if page.extra.price %}
+        <p class="detail-price">{{ page.extra.price }}</p>
+        {% endif %}
+      </div>
+
+      {% if page.extra.bedrooms or page.extra.area %}
+      <div class="spec-bar">
+        {% if page.extra.bedrooms and page.extra.bedrooms != "N/A" %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.bedrooms }}</span>
+          <span class="spec-label">Bedrooms</span>
+        </div>
+        {% endif %}
+        {% if page.extra.bathrooms and page.extra.bathrooms != "N/A" %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.bathrooms }}</span>
+          <span class="spec-label">Bathrooms</span>
+        </div>
+        {% endif %}
+        {% if page.extra.area %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.area }}</span>
+          <span class="spec-label">Living Area</span>
+        </div>
+        {% endif %}
+        {% if page.extra.lot_size and page.extra.lot_size != "N/A" %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.lot_size }}</span>
+          <span class="spec-label">Lot Size</span>
+        </div>
+        {% endif %}
+        {% if page.extra.year_built %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.year_built }}</span>
+          <span class="spec-label">Year Built</span>
+        </div>
+        {% endif %}
+        {% if page.extra.garage and page.extra.garage != "N/A" %}
+        <div class="spec-item">
+          <span class="spec-value">{{ page.extra.garage }}</span>
+          <span class="spec-label">Parking</span>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+
+      {% if page.tags %}
+      <div class="detail-tags">
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <div class="detail-body">
+        {{ content | safe }}
+      </div>
+
+      <div class="detail-cta">
+        <p>Interested in this property?</p>
+        <a href="{{ base_url }}/about/" class="btn btn-primary">Schedule a Viewing</a>
+        <a href="{{ base_url }}/properties/" class="btn btn-outline">Back to Listings</a>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/habitat/templates/section.html
+++ b/habitat/templates/section.html
@@ -1,0 +1,48 @@
+{% include "header.html" %}
+  <main class="listing-main">
+    <div class="listing-header">
+      <h1 class="listing-title">{{ page.title }}</h1>
+      {% if page.description %}
+      <p class="listing-desc">{{ page.description }}</p>
+      {% endif %}
+      <div class="listing-count">{{ section.pages | length }} properties available</div>
+    </div>
+
+    <div class="property-grid property-grid--full">
+      {% for page in section.pages %}
+      <a href="{{ page.url }}" class="property-card">
+        {% if page.extra.status %}
+        <div class="property-badge">{{ page.extra.status }}</div>
+        {% endif %}
+        <div class="property-info">
+          {% if page.extra.type %}
+          <span class="property-type">{{ page.extra.type }}</span>
+          {% endif %}
+          <h3 class="property-name">{{ page.title }}</h3>
+          {% if page.extra.location %}
+          <p class="property-location">{{ page.extra.location }}</p>
+          {% endif %}
+          <div class="property-meta">
+            {% if page.extra.bedrooms and page.extra.bedrooms != "N/A" %}
+            <span>{{ page.extra.bedrooms }} Bed</span>
+            {% endif %}
+            {% if page.extra.bathrooms and page.extra.bathrooms != "N/A" %}
+            <span>{{ page.extra.bathrooms }} Bath</span>
+            {% endif %}
+            {% if page.extra.area %}
+            <span>{{ page.extra.area }}</span>
+            {% endif %}
+          </div>
+          {% if page.description %}
+          <p class="property-excerpt">{{ page.description }}</p>
+          {% endif %}
+          {% if page.extra.price %}
+          <p class="property-price">{{ page.extra.price }}</p>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/habitat/templates/taxonomy.html
+++ b/habitat/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="page-main">
+    <h1 class="taxonomy-title">{{ page.title }}</h1>
+    <div class="taxonomy-list">
+      {% for term in terms %}
+      <a href="{{ term.url }}" class="taxonomy-card">
+        {{ term.name }}
+        <span class="taxonomy-count">{{ term.pages | length }}</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/habitat/templates/taxonomy_term.html
+++ b/habitat/templates/taxonomy_term.html
@@ -1,0 +1,41 @@
+{% include "header.html" %}
+  <main class="listing-main">
+    <div class="listing-header">
+      <h1 class="listing-title">{{ page.title }}</h1>
+      <div class="listing-count">{{ pages | length }} properties</div>
+    </div>
+
+    <div class="property-grid property-grid--full">
+      {% for page in pages %}
+      <a href="{{ page.url }}" class="property-card">
+        {% if page.extra.status %}
+        <div class="property-badge">{{ page.extra.status }}</div>
+        {% endif %}
+        <div class="property-info">
+          {% if page.extra.type %}
+          <span class="property-type">{{ page.extra.type }}</span>
+          {% endif %}
+          <h3 class="property-name">{{ page.title }}</h3>
+          {% if page.extra.location %}
+          <p class="property-location">{{ page.extra.location }}</p>
+          {% endif %}
+          <div class="property-meta">
+            {% if page.extra.bedrooms and page.extra.bedrooms != "N/A" %}
+            <span>{{ page.extra.bedrooms }} Bed</span>
+            {% endif %}
+            {% if page.extra.bathrooms and page.extra.bathrooms != "N/A" %}
+            <span>{{ page.extra.bathrooms }} Bath</span>
+            {% endif %}
+            {% if page.extra.area %}
+            <span>{{ page.extra.area }}</span>
+            {% endif %}
+          </div>
+          {% if page.extra.price %}
+          <p class="property-price">{{ page.extra.price }}</p>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -147,6 +147,11 @@
     "dark",
     "blog"
   ],
+  "habitat": [
+    "light",
+    "landing",
+    "listing"
+  ],
   "hermit": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Add "habitat" example: a real estate / property listing themed Hwaro site
- Light theme with professional, trustworthy design using Inter + DM Serif Display fonts
- 8 property listings (houses, apartments, penthouse, townhouse, commercial, rental) with price, area, bedrooms, bathrooms, and location metadata
- Listing page with property cards, detail pages with spec bar and specifications table
- Landing page with stats bar, featured listings, and service process section
- Updated `tags.json` with `["light", "landing", "listing"]` tags

## Test plan
- [x] `hwaro build` succeeds (11 pages generated)
- [ ] Verify `hwaro serve` renders correctly in browser
- [ ] Check responsive layout at mobile/tablet breakpoints

Closes #112