### PR TITLE
Add new example: atlas (map / geography theme)

### DIFF
--- a/atlas/AGENTS.md
+++ b/atlas/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/atlas/config.toml
+++ b/atlas/config.toml
@@ -1,0 +1,131 @@
+title = "Atlas"
+description = "A cartographic journal of exploration and discovery"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 6
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["expeditions"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/atlas/content/about.md
+++ b/atlas/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
++++
+
+## About Atlas
+
+Atlas is a cartographic journal dedicated to the art of exploration. Each entry is a field report from the edges of the known world -- documenting terrain, coordinates, and the stories that maps alone cannot tell.
+
+The word *atlas* traces its origin to the Titan of Greek mythology who bore the weight of the heavens. In the 16th century, Gerardus Mercator named his collection of maps after this figure, and the term has since come to represent any systematic compilation of geographic knowledge.
+
+This journal follows that tradition. Rather than listing destinations, we chart the experience of moving through space: the texture of landscapes, the logic of cities, the silence of remote places.
+
+### Cartographic Notes
+
+- **Coordinates** are given in decimal degrees (WGS84 datum)
+- **Terrain classifications** follow standard geographic terminology
+- **Elevation** is measured in metres above mean sea level
+- **Dates** mark the period of field observation
+
+### Colophon
+
+Atlas is built with [Hwaro](https://hwaro.hahwul.com), a static site generator. Typography is set in Cormorant Garamond for headings and IBM Plex Sans for body text -- chosen to evoke the precision of cartographic lettering alongside the readability of modern field guides. The colour palette draws from vintage survey maps: parchment, khaki, and navy.

--- a/atlas/content/expeditions/2026-02-10-iceland-highlands.md
+++ b/atlas/content/expeditions/2026-02-10-iceland-highlands.md
@@ -1,0 +1,33 @@
++++
+title = "The Interior Highlands of Iceland"
+date = "2026-02-10"
+description = "Traversing the uninhabited interior between Askja caldera and Herdubreid, where the landscape reduces itself to its geological essentials."
+tags = ["Iceland", "Europe", "Volcanic"]
+categories = ["Europe"]
+region = "Subarctic Europe"
+coordinates = "65.0467 N, 16.7500 W"
+terrain = "Volcanic plateau"
+elevation = "1100m"
++++
+
+The Icelandic interior is one of the last uninhabited expanses in Europe. Between the Vatnajokull ice cap and the northern coastline lies a plateau of black sand, lava fields, and table mountains that has no permanent settlements and only a handful of seasonal tracks.
+
+<!-- more -->
+
+## Askja Caldera
+
+The approach to Askja follows Route F88, a track that crosses several unbridged rivers before arriving at the caldera rim. The caldera itself is roughly eight kilometres in diameter, formed by a series of eruptions that culminated in a catastrophic event in 1875. The resulting ashfall reached Scandinavia and contributed to a wave of Icelandic emigration.
+
+Within the main caldera sits Oskjuvatn, a lake formed after the 1875 eruption, with a measured depth of 220 metres -- the deepest lake in Iceland. Adjacent to it is Viti, a smaller geothermal crater lake whose name translates to "Hell." The water temperature in Viti hovers around 25 degrees Celsius, warm enough for bathing despite the surrounding terrain of ash and pumice.
+
+## Herdubreid: The Queen of Mountains
+
+Herdubreid stands alone on the highland plateau, a tuya -- a flat-topped volcano formed by eruption beneath a glacier. Its distinctive profile has earned it the title "Queen of Icelandic Mountains." The summit reaches 1682 metres and is capped by a flat plateau roughly 700 metres across.
+
+The mountain's isolation makes weather observation critical. Conditions shift within minutes, and the plateau offers no shelter from wind that accelerates unimpeded across hundreds of kilometres of flat terrain.
+
+## Practical Notes
+
+The highland roads are open only from late June through early September, depending on snow conditions. The Icelandic Road and Coastal Administration publishes daily updates on road openings. A modified four-wheel-drive vehicle is mandatory; river crossings require experience and careful assessment of water levels. No fuel, provisions, or communication infrastructure exists in the interior. The nearest services are at Myvatn to the north or Egilsstadir to the east.
+
+The landscape is classified as protected wilderness. All travel must remain on marked tracks. Vegetation, where it exists at all, consists of fragile moss that takes decades to recover from disturbance.

--- a/atlas/content/expeditions/2026-02-18-saharan-erg.md
+++ b/atlas/content/expeditions/2026-02-18-saharan-erg.md
@@ -1,0 +1,35 @@
++++
+title = "Crossing the Grand Erg Oriental"
+date = "2026-02-18"
+description = "A transit through the dune sea of southeastern Algeria, where navigation relies on sun angle and the memory of ancient caravan routes."
+tags = ["Algeria", "Africa", "Desert"]
+categories = ["Africa"]
+region = "North Africa"
+coordinates = "33.5000 N, 7.5000 E"
+terrain = "Sand dune sea (erg)"
+elevation = "80-300m"
++++
+
+The Grand Erg Oriental extends across approximately 100,000 square kilometres of southeastern Algeria and into Tunisia. Unlike the popular image of the Sahara as featureless sand, the erg is composed of enormous longitudinal dunes that can reach heights of 100 metres, separated by corridors of compacted sand and gravel.
+
+<!-- more -->
+
+## Reading the Dunes
+
+Sand dunes are not static. The erg's dune forms include barchan crescents, star dunes with multiple radiating arms, and linear seif dunes that extend for kilometres in parallel ridges. Each form reflects a particular wind regime. Star dunes indicate multidirectional winds and tend to grow vertically rather than migrating. Linear dunes align with the prevailing wind. Barchans advance downwind at measurable rates, sometimes several metres per year.
+
+The surface varies dramatically between the dune crests and the interdune corridors. Crests consist of loose, fine-grained sand that shifts underfoot. The corridors, called gassi, often have a surface of compacted sand or exposed reg -- a pavement of wind-polished gravel. It is along these corridors that vehicle travel is possible, though route-finding requires experience.
+
+## The Oasis of Ouargla
+
+At the northern edge of the erg lies Ouargla, one of the Sahara's historic trading oases. The town occupies a depression where groundwater reaches the surface, supporting date palms and small-scale agriculture. The ksar -- the old fortified quarter -- preserves architecture adapted to extreme heat: thick mudbrick walls, narrow alleys that remain in shadow for most of the day, and wind towers that channel airflow into interior rooms.
+
+The market in Ouargla still functions as a regional hub for the pastoral Tuareg and Mozabite communities. Dates, dried meat, and handwoven textiles are traded alongside fuel and machine parts for the vehicles that have replaced camel caravans on most routes.
+
+## Navigation and Conditions
+
+GPS coordinates serve as waypoints, but successful transit of the erg depends on understanding the terrain's logic. Corridors between dunes follow predictable patterns; soft sand traps occur at dune terminations; and the afternoon sun creates a glare that eliminates depth perception.
+
+Daytime temperatures in summer exceed 50 degrees Celsius. Winter days are more moderate, around 20 to 25 degrees, but nights can approach freezing. Sandstorms occur without warning, reducing visibility to zero and requiring immediate halt until conditions clear.
+
+Water consumption in the erg averages six to eight litres per person per day. There are no natural water sources between oases. The traditional caravan spacing of oases -- roughly one day's travel apart by camel -- reflects this constraint.

--- a/atlas/content/expeditions/2026-02-28-norwegian-fjords.md
+++ b/atlas/content/expeditions/2026-02-28-norwegian-fjords.md
@@ -1,0 +1,33 @@
++++
+title = "Surveying the Geirangerfjord"
+date = "2026-02-28"
+description = "Charting the vertical world of western Norway's fjord country, where cliffs rise directly from sea level to over a thousand metres."
+tags = ["Norway", "Europe", "Coastal"]
+categories = ["Europe"]
+region = "Western Scandinavia"
+coordinates = "62.1008 N, 7.0940 E"
+terrain = "Glacial fjord"
+elevation = "0-1500m"
++++
+
+The Geirangerfjord cuts fifteen kilometres inland from the Sunnylvsfjorden, its walls rising nearly vertically from water that reaches 260 metres in depth. The fjord is a textbook example of glacial erosion: a U-shaped valley carved by ice over successive glacial periods and subsequently flooded by the sea as ice retreated.
+
+<!-- more -->
+
+## The Geometry of Fjords
+
+A fjord is distinguished from other inlets by its depth relative to its width. Geirangerfjord is roughly one kilometre wide at the water surface and its walls rise to 1400 metres above sea level on either side. The depth-to-width ratio creates a corridor effect that channels wind and amplifies sound. A conversation at normal volume can sometimes be heard across the full width of the fjord.
+
+The waterfalls that mark the fjord walls -- Brudesloret, De Syv Sostrene, Suitor -- are seasonal features. In spring and early summer, snowmelt produces their maximum flow. By late summer, many reduce to thin streams or disappear entirely. Their presence or absence provides a reliable seasonal calendar for the region.
+
+## Abandoned Farms
+
+The fjord's most striking cultural feature is its abandoned mountain farms. Before road access in the 20th century, farms like Skagefla and Blomberg perched on narrow shelves hundreds of metres above the water, accessible only by precarious paths or by hauling supplies up the cliff face with ropes. Children were reportedly tethered to prevent falls during play.
+
+These farms were abandoned between 1900 and 1940 as the population migrated to coastal towns. The buildings remain, maintained now as cultural heritage sites. The farm at Skagefla, at 250 metres above sea level, offers a view that encompasses the entire inner fjord.
+
+## Practical Notes
+
+The fjord is accessible by ferry from Hellesylt to Geiranger, a one-hour crossing that serves as both transport and the best vantage point for the waterfalls. The road to Geiranger (County Road 63) includes the Ornesvingen eagle road with its hairpin bends, and is closed from November through May due to avalanche risk.
+
+The village of Geiranger has a permanent population of approximately 200, which increases dramatically during the cruise ship season from May to September. Kayak rental provides the quietest and most intimate way to experience the fjord's scale. The water temperature reaches about 12 degrees Celsius at the surface in summer.

--- a/atlas/content/expeditions/2026-03-08-altiplano-survey.md
+++ b/atlas/content/expeditions/2026-03-08-altiplano-survey.md
@@ -1,0 +1,35 @@
++++
+title = "The Altiplano Between Uyuni and Atacama"
+date = "2026-03-08"
+description = "Field notes from the high plateau connecting Bolivia's salt flats to Chile's driest desert, a landscape stripped to mineral and sky."
+tags = ["Bolivia", "South America", "Highland"]
+categories = ["South America"]
+region = "Central Andes"
+coordinates = "20.4637 S, 67.6262 W"
+terrain = "High-altitude salt flat and desert"
+elevation = "3650-4800m"
++++
+
+The Altiplano is a basin trapped between the Eastern and Western Cordilleras of the Andes, averaging 3750 metres in elevation across an area of roughly 100,000 square kilometres. At its centre lies the Salar de Uyuni, the world's largest salt flat at over 10,000 square kilometres.
+
+<!-- more -->
+
+## Salar de Uyuni
+
+The salar formed from the evaporation of prehistoric Lake Minchin, which covered the basin approximately 30,000 years ago. The resulting salt crust is several metres thick and contains an estimated 10 billion tonnes of salt, along with significant reserves of lithium -- perhaps 50 to 70 percent of the world's accessible deposits.
+
+During the dry season, the surface is a hard, white hexagonal mosaic of salt polygons. Each polygon is roughly one to two metres across, formed by the thermal expansion and contraction cycle of the crust. The flatness is extraordinary: over the entire 10,000-square-kilometre surface, the elevation varies by less than one metre. This property makes the salar a calibration site for satellite altimetry instruments.
+
+During the wet season (December to March), a thin layer of water transforms the salar into the world's largest natural mirror. The reflected sky eliminates the horizon line, creating a disorienting condition where ground and air become indistinguishable.
+
+## The Coloured Lagoons
+
+Southwest of Uyuni, the route to the Chilean border passes through a series of mineral-laden lagoons at elevations above 4000 metres. Laguna Colorada's red water derives from algae and suspended sediment. Laguna Verde, at the base of Volcan Licancabur, takes its colour from arsenic and copper compounds.
+
+These lagoons support colonies of three flamingo species -- James's, Andean, and Chilean -- each adapted to slightly different water chemistries. The flamingos feed on the extremophile organisms that thrive in conditions hostile to most life: high UV radiation, salinity levels several times that of seawater, and temperatures that can swing from minus 20 to plus 20 degrees Celsius within a single day.
+
+## Altitude and Observation
+
+Working at altitude demands methodical acclimatisation. The atmospheric pressure at 4000 metres is roughly 60 percent of sea level. Physical exertion produces disproportionate fatigue. Metal expands and contracts with the extreme temperature swings. Camera batteries discharge rapidly in the cold.
+
+The clarity of the air is the compensation. At this altitude, above most atmospheric moisture and particulate matter, visibility extends well beyond 100 kilometres. The night sky is correspondingly intense -- the Milky Way casts visible shadows on the white salt surface.

--- a/atlas/content/expeditions/2026-03-18-mekong-delta.md
+++ b/atlas/content/expeditions/2026-03-18-mekong-delta.md
@@ -1,0 +1,37 @@
++++
+title = "Mapping the Mekong Delta"
+date = "2026-03-18"
+description = "Navigating the distributary network where the Mekong dissolves into the South China Sea, a territory that is neither fully land nor fully water."
+tags = ["Vietnam", "Asia", "River"]
+categories = ["Asia"]
+region = "Southeast Asia"
+coordinates = "10.0341 N, 105.7206 E"
+terrain = "River delta and wetland"
+elevation = "0-5m"
++++
+
+The Mekong Delta begins south of Phnom Penh, where the river divides into the Tien Giang and Hau Giang branches. By the time it reaches the sea across a 200-kilometre front, it has split into nine major distributaries -- earning its Vietnamese name, Cuu Long, the Nine Dragons.
+
+<!-- more -->
+
+## Hydrology of a Living Delta
+
+The delta covers approximately 40,000 square kilometres and is one of the most productive agricultural regions on earth, contributing roughly half of Vietnam's rice output. Its existence is recent in geological terms: most of the delta formed within the last 6000 years as sediment accumulated at the river's mouth.
+
+The annual flood cycle defines the region. From June to November, the Mekong's flow increases tenfold, inundating vast areas. This flooding deposits fresh sediment, replenishes soil nutrients, and sustains the fisheries that provide protein for millions. The Tonle Sap in Cambodia reverses flow during this period, acting as a natural flood buffer -- a hydrological phenomenon unique among the world's major rivers.
+
+## Canal Networks
+
+The canal system of the delta is among the most extensive on earth. Beginning with natural distributaries and expanded over centuries of human engineering, the network totals several thousand kilometres of navigable waterways. The canals serve simultaneously as irrigation channels, transport corridors, drainage systems, and boundaries between land holdings.
+
+Travel by boat reveals a landscape organised around water rather than land. Houses stand on stilts or floating pontoons. Markets operate from boats. Orchards of mango, longan, and durian occupy islands between channels. The boundary between agriculture and aquaculture is often invisible -- rice paddies transition seamlessly into fish ponds.
+
+## Can Tho and the Floating Markets
+
+Can Tho, the delta's largest city, sits at the junction of the Hau River and the Can Tho River. The Cai Rang floating market, five kilometres downstream, is the region's primary wholesale market. Boats gather before dawn, each displaying their cargo on a tall pole -- pineapples, watermelons, sweet potatoes -- so buyers can identify offerings from a distance.
+
+The market's logic is efficient. Large wholesaler boats anchor in midstream. Smaller boats circulate, purchasing in bulk and redistributing to retail channels throughout the canal network. The entire transaction system operates on water, without docking or unloading to land.
+
+## Practical Notes
+
+The delta is best navigated by hiring a local boatman familiar with the tidal patterns and channel depths. Water levels fluctuate significantly with both tides and season. Channels that are navigable at high tide may become impassable mud banks six hours later. The wet season (June to November) offers the most dramatic flooding but also the most mosquitoes and the heaviest rain. The dry season (December to May) provides easier travel but reduced water levels in secondary channels.

--- a/atlas/content/expeditions/_index.md
+++ b/atlas/content/expeditions/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Expeditions"
+sort_by = "date"
+reverse = false
+paginate = 6
+template = "section"
+description = "Field reports from surveyed territories, ordered by date of observation."
+generate_feeds = true
++++

--- a/atlas/content/index.md
+++ b/atlas/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Atlas"
+template = "home"
++++

--- a/atlas/static/css/style.css
+++ b/atlas/static/css/style.css
@@ -1,0 +1,952 @@
+/* ==========================================================================
+   Atlas — Cartographic Journal Theme
+   Colors: parchment, khaki, navy. No gradients, no emoji.
+   ========================================================================== */
+
+:root {
+  --parchment: #f5f0e8;
+  --parchment-dark: #ede6d8;
+  --khaki: #8a7e6b;
+  --khaki-light: #b0a48e;
+  --navy: #1e2d3d;
+  --navy-light: #2c4158;
+  --navy-muted: #3d5a73;
+  --ink: #2a2520;
+  --ink-light: #5c5549;
+  --border: #cdc4b1;
+  --border-light: #ddd6c8;
+  --accent: #7a4430;
+  --content-width: 720px;
+  --wide-width: 960px;
+  --font-heading: "Cormorant Garamond", Georgia, serif;
+  --font-body: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+
+/* ---------- Reset & Base ---------- */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  line-height: 1.7;
+  color: var(--ink);
+  background-color: var(--parchment);
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: var(--navy);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  transition: border-color 0.2s;
+}
+
+a:hover {
+  border-bottom-color: var(--navy);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ---------- Header ---------- */
+
+.site-header {
+  border-bottom: 2px solid var(--navy);
+  background-color: var(--parchment);
+  position: relative;
+}
+
+.site-header::after {
+  content: "";
+  display: block;
+  height: 1px;
+  background-color: var(--navy);
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  right: 0;
+}
+
+.header-inner {
+  max-width: var(--wide-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-bottom: none;
+  color: var(--navy);
+}
+
+.site-logo:hover {
+  border-bottom: none;
+}
+
+.compass-icon {
+  color: var(--navy);
+}
+
+.site-title-text {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.75rem;
+}
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--khaki);
+  border-bottom: none;
+  padding-bottom: 2px;
+}
+
+.site-nav a:hover {
+  color: var(--navy);
+  border-bottom: 1px solid var(--navy);
+}
+
+/* ---------- Main ---------- */
+
+main {
+  max-width: var(--wide-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* ---------- Hero (Home) ---------- */
+
+.hero-section {
+  text-align: center;
+  padding: 4rem 0 3rem;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.hero-inner {
+  position: relative;
+}
+
+.hero-decoration {
+  margin-bottom: 1.5rem;
+  color: var(--khaki-light);
+}
+
+.hero-compass {
+  opacity: 0.6;
+}
+
+.hero-title {
+  font-family: var(--font-heading);
+  font-size: 3.5rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--navy);
+  margin: 0 0 0.5rem;
+}
+
+.hero-subtitle {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--khaki);
+  margin: 0;
+}
+
+.hero-rule {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.rule-line {
+  display: block;
+  width: 60px;
+  height: 1px;
+  background-color: var(--border);
+}
+
+.rule-diamond {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border: 1px solid var(--khaki);
+  transform: rotate(45deg);
+}
+
+/* ---------- Expeditions Section (Home) ---------- */
+
+.expeditions-section {
+  padding: 3rem 0;
+}
+
+.section-header {
+  margin-bottom: 2rem;
+}
+
+.section-header h2 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--navy);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0 0 0.75rem;
+}
+
+.contour-line {
+  height: 3px;
+  position: relative;
+}
+
+.contour-line::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 60px;
+  height: 1px;
+  background-color: var(--navy);
+}
+
+.contour-line::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 8px;
+  width: 45px;
+  height: 1px;
+  background-color: var(--khaki-light);
+}
+
+/* ---------- Expedition Grid ---------- */
+
+.expedition-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.expedition-card {
+  background-color: var(--parchment-dark);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.expedition-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background-color: var(--khaki-light);
+  transition: background-color 0.2s;
+}
+
+.expedition-card:hover {
+  border-color: var(--khaki);
+}
+
+.expedition-card:hover::before {
+  background-color: var(--navy);
+}
+
+.expedition-card.featured {
+  grid-column: 1 / -1;
+  border-color: var(--khaki);
+}
+
+.expedition-card.featured::before {
+  background-color: var(--navy);
+  width: 4px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.region-badge {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background-color: transparent;
+  border: 1px solid var(--accent);
+  padding: 0.15rem 0.5rem;
+}
+
+.card-date {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--khaki);
+}
+
+.card-title {
+  font-family: var(--font-heading);
+  font-size: 1.3rem;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0 0 0.5rem;
+}
+
+.card-title a {
+  color: var(--navy);
+  border-bottom: none;
+}
+
+.card-title a:hover {
+  color: var(--navy-light);
+}
+
+.card-coordinates {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--khaki);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.card-excerpt {
+  font-size: 0.9rem;
+  color: var(--ink-light);
+  line-height: 1.6;
+  margin: 0 0 1rem;
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.terrain-tag {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--khaki);
+}
+
+.reading-time {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--khaki);
+}
+
+/* ---------- Single Post ---------- */
+
+.post {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 2.5rem 0 3rem;
+}
+
+.post-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.post-header::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 1px;
+  background-color: var(--border-light);
+}
+
+.post-region {
+  display: inline-block;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0.2rem 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.post-title {
+  font-family: var(--font-heading);
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--navy);
+  margin: 0 0 0.75rem;
+}
+
+.post-description {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--khaki);
+  line-height: 1.5;
+  margin: 0 0 1.25rem;
+}
+
+.post-meta {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--khaki);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.meta-separator {
+  color: var(--border);
+}
+
+.meta-coordinates {
+  letter-spacing: 0.02em;
+}
+
+.post-field-data {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.field-item {
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--khaki);
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--border-light);
+}
+
+/* ---------- Post Content ---------- */
+
+.post-content {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: var(--ink);
+}
+
+.post-content > p:first-child::first-letter {
+  font-family: var(--font-heading);
+  font-size: 3.5rem;
+  float: left;
+  line-height: 0.8;
+  margin-right: 0.1em;
+  margin-top: 0.1em;
+  color: var(--navy);
+  font-weight: 700;
+}
+
+.post-content h2 {
+  font-family: var(--font-heading);
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--navy);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.post-content h3 {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--navy-light);
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-content p {
+  margin: 1.25em 0;
+}
+
+.post-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 3px solid var(--khaki);
+  background-color: var(--parchment-dark);
+  color: var(--ink-light);
+  font-style: italic;
+}
+
+.post-content blockquote p {
+  margin: 0.5em 0;
+}
+
+.post-content ul,
+.post-content ol {
+  padding-left: 1.5rem;
+  margin: 1.25em 0;
+}
+
+.post-content li {
+  margin-bottom: 0.5em;
+}
+
+.post-content code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background-color: var(--parchment-dark);
+  padding: 0.15em 0.4em;
+  border: 1px solid var(--border-light);
+}
+
+.post-content pre {
+  background-color: var(--parchment-dark);
+  border: 1px solid var(--border);
+  padding: 1.25rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  line-height: 1.5;
+}
+
+.post-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.post-content hr {
+  border: none;
+  height: 1px;
+  background-color: var(--border);
+  margin: 2.5rem 0;
+  position: relative;
+}
+
+.post-content hr::after {
+  content: "";
+  position: absolute;
+  top: -3px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--parchment);
+}
+
+/* ---------- Post Footer ---------- */
+
+.post-footer {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.post-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--khaki);
+  border: 1px solid var(--border);
+  padding: 0.2rem 0.6rem;
+  transition: all 0.2s;
+}
+
+.tag:hover {
+  color: var(--navy);
+  border-color: var(--navy);
+}
+
+/* ---------- Post Navigation ---------- */
+
+.post-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--navy);
+}
+
+.post-nav::before {
+  content: "";
+  position: absolute;
+}
+
+.nav-prev,
+.nav-next {
+  display: flex;
+  flex-direction: column;
+  border-bottom: none;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  transition: border-color 0.2s;
+}
+
+.nav-prev:hover,
+.nav-next:hover {
+  border-color: var(--navy);
+  border-bottom: 1px solid var(--navy);
+}
+
+.nav-next {
+  text-align: right;
+}
+
+.nav-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--khaki);
+  margin-bottom: 0.25rem;
+}
+
+.nav-title {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+/* ---------- Archive / Section ---------- */
+
+.archive {
+  padding: 2.5rem 0 3rem;
+}
+
+.archive-header {
+  margin-bottom: 2.5rem;
+}
+
+.archive-header h1 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--navy);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0 0 0.5rem;
+}
+
+.archive-description {
+  font-size: 0.95rem;
+  color: var(--khaki);
+  font-style: italic;
+  margin: 0 0 1rem;
+}
+
+/* ---------- Pagination ---------- */
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.page-link {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navy);
+  border: 1px solid var(--navy);
+  border-bottom: 1px solid var(--navy);
+  padding: 0.4rem 1rem;
+  transition: all 0.2s;
+}
+
+.page-link:hover {
+  background-color: var(--navy);
+  color: var(--parchment);
+  border-bottom: 1px solid var(--navy);
+}
+
+.page-info {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--khaki);
+}
+
+/* ---------- Taxonomy ---------- */
+
+.taxonomy-page,
+.taxonomy-term-page {
+  padding: 2.5rem 0 3rem;
+}
+
+.taxonomy-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.taxonomy-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background-color: var(--parchment-dark);
+  transition: all 0.2s;
+}
+
+.taxonomy-item:hover {
+  border-color: var(--navy);
+  border-bottom-color: var(--navy);
+}
+
+.taxonomy-name {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.taxonomy-count {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--khaki);
+  border: 1px solid var(--border-light);
+  padding: 0.1rem 0.4rem;
+  min-width: 1.5rem;
+  text-align: center;
+}
+
+/* ---------- 404 ---------- */
+
+.error-page {
+  padding: 5rem 0;
+  text-align: center;
+}
+
+.error-code {
+  font-family: var(--font-heading);
+  font-size: 6rem;
+  font-weight: 700;
+  color: var(--border);
+  line-height: 1;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.error-content h1 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--navy);
+  font-style: italic;
+  margin: 0 0 1rem;
+}
+
+.error-content p {
+  font-size: 0.95rem;
+  color: var(--khaki);
+  margin: 0 0 2rem;
+}
+
+.return-link {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navy);
+  border: 1px solid var(--navy);
+  padding: 0.5rem 1.25rem;
+}
+
+.return-link:hover {
+  background-color: var(--navy);
+  color: var(--parchment);
+}
+
+/* ---------- Footer ---------- */
+
+.site-footer {
+  border-top: 2px solid var(--navy);
+  margin-top: 3rem;
+  position: relative;
+}
+
+.site-footer::before {
+  content: "";
+  display: block;
+  height: 1px;
+  background-color: var(--navy);
+  position: absolute;
+  top: -5px;
+  left: 0;
+  right: 0;
+}
+
+.footer-inner {
+  max-width: var(--wide-width);
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer-tagline {
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  font-style: italic;
+  color: var(--khaki);
+}
+
+.footer-meta {
+  font-size: 0.8rem;
+  color: var(--khaki);
+}
+
+.footer-meta a {
+  color: var(--navy);
+}
+
+/* ---------- Alert Shortcode ---------- */
+
+.alert {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  border-left: 3px solid var(--khaki);
+  background-color: var(--parchment-dark);
+}
+
+.alert p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.alert-warning {
+  border-left-color: var(--accent);
+}
+
+.alert-info {
+  border-left-color: var(--navy-muted);
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 640px) {
+  .header-inner {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .site-nav {
+    gap: 1rem;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .hero-compass {
+    width: 80px;
+    height: 80px;
+  }
+
+  .expedition-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .expedition-card.featured {
+    grid-column: 1;
+  }
+
+  .post-title {
+    font-size: 1.75rem;
+  }
+
+  .post-meta {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .meta-separator {
+    display: none;
+  }
+
+  .post-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .post-field-data {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+  }
+
+  .taxonomy-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/atlas/templates/404.html
+++ b/atlas/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+<section class="error-page">
+  <div class="error-content">
+    <span class="error-code">404</span>
+    <h1>Terra Incognita</h1>
+    <p>This territory has not yet been charted. The expedition may have moved to a different coordinate.</p>
+    <a href="{{ base_url }}/" class="return-link">Return to base camp</a>
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/atlas/templates/footer.html
+++ b/atlas/templates/footer.html
@@ -1,0 +1,13 @@
+  </main>
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-coordinates">
+        <span class="footer-tagline">Charting the unknown, one expedition at a time.</span>
+      </div>
+      <div class="footer-meta">
+        <span>Powered by <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">Hwaro</a></span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/atlas/templates/header.html
+++ b/atlas/templates/header.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page_title and page_title != site_title %}{{ page_title }} - {{ site_title }}{% else %}{{ site_title }} - A Cartographic Journal{% endif %}</title>
+  <meta name="description" content="{{ page.description | default(site_description) }}">
+  {{ og_all_tags | safe }}
+  {{ canonical_tag | safe }}
+  {{ highlight_tags | safe }}
+  {{ auto_includes | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {% if site.feeds and site.feeds.enabled %}
+  <link rel="alternate" type="application/atom+xml" title="{{ site_title }}" href="{{ base_url }}/atom.xml">
+  {% endif %}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <div class="header-brand">
+        <a href="{{ base_url }}/" class="site-logo">
+          <svg class="compass-icon" viewBox="0 0 40 40" width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="1.5"/>
+            <circle cx="20" cy="20" r="2" fill="currentColor"/>
+            <line x1="20" y1="4" x2="20" y2="12" stroke="currentColor" stroke-width="1.5"/>
+            <line x1="20" y1="28" x2="20" y2="36" stroke="currentColor" stroke-width="1"/>
+            <line x1="4" y1="20" x2="12" y2="20" stroke="currentColor" stroke-width="1"/>
+            <line x1="28" y1="20" x2="36" y2="20" stroke="currentColor" stroke-width="1"/>
+            <polygon points="20,6 17,16 20,14 23,16" fill="currentColor"/>
+            <text x="20" y="3" text-anchor="middle" font-size="5" fill="currentColor" font-family="sans-serif" font-weight="600">N</text>
+          </svg>
+          <span class="site-title-text">Atlas</span>
+        </a>
+      </div>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Index</a>
+        <a href="{{ base_url }}/expeditions/">Expeditions</a>
+        <a href="{{ base_url }}/tags/">Regions</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>
+  <main>

--- a/atlas/templates/home.html
+++ b/atlas/templates/home.html
@@ -1,0 +1,65 @@
+{% include "header.html" %}
+
+<section class="hero-section">
+  <div class="hero-inner">
+    <div class="hero-decoration">
+      <svg class="hero-compass" viewBox="0 0 120 120" width="120" height="120" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="60" cy="60" r="56" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+        <circle cx="60" cy="60" r="44" stroke="currentColor" stroke-width="0.5"/>
+        <circle cx="60" cy="60" r="4" fill="currentColor"/>
+        <line x1="60" y1="8" x2="60" y2="30" stroke="currentColor" stroke-width="1.5"/>
+        <line x1="60" y1="90" x2="60" y2="112" stroke="currentColor" stroke-width="0.75"/>
+        <line x1="8" y1="60" x2="30" y2="60" stroke="currentColor" stroke-width="0.75"/>
+        <line x1="90" y1="60" x2="112" y2="60" stroke="currentColor" stroke-width="0.75"/>
+        <polygon points="60,10 55,30 60,26 65,30" fill="currentColor"/>
+        <text x="60" y="7" text-anchor="middle" font-size="8" fill="currentColor" font-weight="600">N</text>
+        <text x="113" y="63" text-anchor="start" font-size="7" fill="currentColor">E</text>
+        <text x="60" y="119" text-anchor="middle" font-size="7" fill="currentColor">S</text>
+        <text x="7" y="63" text-anchor="end" font-size="7" fill="currentColor">W</text>
+      </svg>
+    </div>
+    <h1 class="hero-title">Atlas</h1>
+    <p class="hero-subtitle">A cartographic journal of exploration and discovery</p>
+    <div class="hero-rule">
+      <span class="rule-line"></span>
+      <span class="rule-diamond"></span>
+      <span class="rule-line"></span>
+    </div>
+  </div>
+</section>
+
+<section class="expeditions-section">
+  <div class="section-header">
+    <h2>Recent Expeditions</h2>
+    <div class="contour-line"></div>
+  </div>
+  <div class="expedition-grid">
+    {% for post in site.pages | sort_by("date", reverse=true) %}
+    {% if post.section == "expeditions" %}
+    <article class="expedition-card {% if loop.first %}featured{% endif %}">
+      <div class="card-header">
+        {% if post.extra.region %}
+        <span class="region-badge">{{ post.extra.region }}</span>
+        {% endif %}
+        <time class="card-date" datetime="{{ post.date }}">{{ post.date | date("%d %b %Y") }}</time>
+      </div>
+      <h3 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h3>
+      {% if post.extra.coordinates %}
+      <div class="card-coordinates">{{ post.extra.coordinates }}</div>
+      {% endif %}
+      {% if post.summary %}
+      <p class="card-excerpt">{{ post.summary | strip_html | truncate_words(30) }}</p>
+      {% endif %}
+      <div class="card-footer">
+        {% if post.extra.terrain %}
+        <span class="terrain-tag">{{ post.extra.terrain }}</span>
+        {% endif %}
+        <span class="reading-time">{{ post.reading_time }} min read</span>
+      </div>
+    </article>
+    {% endif %}
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/atlas/templates/page.html
+++ b/atlas/templates/page.html
@@ -1,0 +1,65 @@
+{% include "header.html" %}
+
+<article class="post">
+  <header class="post-header">
+    {% if page.extra.region %}
+    <span class="post-region">{{ page.extra.region }}</span>
+    {% endif %}
+    <h1 class="post-title">{{ page.title }}</h1>
+    {% if page.description %}
+    <p class="post-description">{{ page.description }}</p>
+    {% endif %}
+    <div class="post-meta">
+      <time datetime="{{ page.date }}">{{ page.date | date("%d %B %Y") }}</time>
+      {% if page.extra.coordinates %}
+      <span class="meta-separator">|</span>
+      <span class="meta-coordinates">{{ page.extra.coordinates }}</span>
+      {% endif %}
+      <span class="meta-separator">|</span>
+      <span class="meta-reading-time">{{ page.reading_time }} min read</span>
+    </div>
+    {% if page.extra.terrain or page.extra.elevation %}
+    <div class="post-field-data">
+      {% if page.extra.terrain %}
+      <span class="field-item">Terrain: {{ page.extra.terrain }}</span>
+      {% endif %}
+      {% if page.extra.elevation %}
+      <span class="field-item">Elevation: {{ page.extra.elevation }}</span>
+      {% endif %}
+    </div>
+    {% endif %}
+  </header>
+
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.tags %}
+  <footer class="post-footer">
+    <div class="post-tags">
+      {% for tag in page.tags %}
+      <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+      {% endfor %}
+    </div>
+  </footer>
+  {% endif %}
+
+  <nav class="post-nav">
+    {% if page.lower %}
+    <a href="{{ page.lower.url }}" class="nav-prev">
+      <span class="nav-label">Previous Expedition</span>
+      <span class="nav-title">{{ page.lower.title }}</span>
+    </a>
+    {% else %}
+    <span></span>
+    {% endif %}
+    {% if page.higher %}
+    <a href="{{ page.higher.url }}" class="nav-next">
+      <span class="nav-label">Next Expedition</span>
+      <span class="nav-title">{{ page.higher.title }}</span>
+    </a>
+    {% endif %}
+  </nav>
+</article>
+
+{% include "footer.html" %}

--- a/atlas/templates/section.html
+++ b/atlas/templates/section.html
@@ -1,0 +1,51 @@
+{% include "header.html" %}
+
+<section class="archive">
+  <header class="archive-header">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}
+    <p class="archive-description">{{ section.description }}</p>
+    {% endif %}
+    <div class="contour-line"></div>
+  </header>
+
+  <div class="expedition-grid">
+    {% for post in section.pages %}
+    <article class="expedition-card">
+      <div class="card-header">
+        {% if post.extra.region %}
+        <span class="region-badge">{{ post.extra.region }}</span>
+        {% endif %}
+        <time class="card-date" datetime="{{ post.date }}">{{ post.date | date("%d %b %Y") }}</time>
+      </div>
+      <h3 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h3>
+      {% if post.extra.coordinates %}
+      <div class="card-coordinates">{{ post.extra.coordinates }}</div>
+      {% endif %}
+      {% if post.summary %}
+      <p class="card-excerpt">{{ post.summary | strip_html | truncate_words(30) }}</p>
+      {% endif %}
+      <div class="card-footer">
+        {% if post.extra.terrain %}
+        <span class="terrain-tag">{{ post.extra.terrain }}</span>
+        {% endif %}
+        <span class="reading-time">{{ post.reading_time }} min read</span>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+
+  {% if paginator %}
+  <nav class="pagination">
+    {% if paginator.previous_page %}
+    <a href="{{ paginator.previous_page }}" class="page-link prev">Previous</a>
+    {% endif %}
+    <span class="page-info">Page {{ paginator.current_page }} of {{ paginator.total_pages }}</span>
+    {% if paginator.next_page %}
+    <a href="{{ paginator.next_page }}" class="page-link next">Next</a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</section>
+
+{% include "footer.html" %}

--- a/atlas/templates/shortcodes/alert.html
+++ b/atlas/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <p>{{ message }}</p>
+</div>

--- a/atlas/templates/taxonomy.html
+++ b/atlas/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+<section class="taxonomy-page">
+  <header class="archive-header">
+    <h1>{{ taxonomy_name | default("Tags") }}</h1>
+    <div class="contour-line"></div>
+  </header>
+  <div class="taxonomy-list">
+    {% for term in taxonomy_terms %}
+    <a href="{{ base_url }}/{{ taxonomy_name | default("tags") | slugify }}/{{ term.name | slugify }}/" class="taxonomy-item">
+      <span class="taxonomy-name">{{ term.name }}</span>
+      <span class="taxonomy-count">{{ term.pages | length }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/atlas/templates/taxonomy_term.html
+++ b/atlas/templates/taxonomy_term.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<section class="taxonomy-term-page">
+  <header class="archive-header">
+    <h1>{{ taxonomy_term | default("Tag") }}</h1>
+    <p class="archive-description">{{ taxonomy_pages | length }} expeditions</p>
+    <div class="contour-line"></div>
+  </header>
+
+  <div class="expedition-grid">
+    {% for post in taxonomy_pages %}
+    <article class="expedition-card">
+      <div class="card-header">
+        {% if post.extra.region %}
+        <span class="region-badge">{{ post.extra.region }}</span>
+        {% endif %}
+        <time class="card-date" datetime="{{ post.date }}">{{ post.date | date("%d %b %Y") }}</time>
+      </div>
+      <h3 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h3>
+      {% if post.extra.coordinates %}
+      <div class="card-coordinates">{{ post.extra.coordinates }}</div>
+      {% endif %}
+      {% if post.summary %}
+      <p class="card-excerpt">{{ post.summary | strip_html | truncate_words(30) }}</p>
+      {% endif %}
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -8,6 +8,11 @@
     "blog",
     "podcast"
   ],
+  "atlas": [
+    "light",
+    "blog",
+    "geography"
+  ],
   "anubis": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- New "atlas" example site with a cartographic journal theme inspired by vintage survey maps
- Light theme with parchment, khaki, and navy color palette (no gradients, no emoji)
- Cartographic decorative elements: compass rose SVG, contour line dividers, coordinate metadata
- 5 exploration journal-style posts covering Iceland, Sahara, Norway, Bolivia, and Vietnam
- Tags: `light`, `blog`, `geography`

## Test plan
- [ ] `hwaro build` completes without errors or warnings
- [ ] Home page renders compass hero, expedition card grid with region badges and coordinates
- [ ] Individual post pages show region, coordinates, terrain, elevation metadata
- [ ] Section, taxonomy, and 404 pages render correctly
- [ ] Responsive layout works on mobile viewports

Closes #111