### PR TITLE
Add new example: telegraph (breaking news wire theme)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -293,6 +293,11 @@
     "blog",
     "traditional"
   ],
+  "telegraph": [
+    "light",
+    "blog",
+    "news"
+  ],
   "terminal": [
     "dark",
     "blog"

--- a/telegraph/AGENTS.md
+++ b/telegraph/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/telegraph/config.toml
+++ b/telegraph/config.toml
@@ -1,0 +1,129 @@
+title = "Telegraph Wire"
+description = "Breaking news wire service — real-time dispatches from the field"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 20
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 50
+path = "posts"
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/telegraph/content/about.md
+++ b/telegraph/content/about.md
@@ -1,0 +1,40 @@
++++
+title = "About Telegraph Wire"
+description = "About this news wire service theme"
++++
+
+## About
+
+**Telegraph Wire** is a breaking news and wire service theme for [Hwaro](https://github.com/hahwul/hwaro). It draws inspiration from professional news wire services like the Associated Press and Reuters, where speed, clarity, and scannability are paramount.
+
+## Design Principles
+
+- **Scannable list layout** — Headlines and one-line summaries arranged in a fast-scrolling feed, optimized for rapid scanning
+- **Timestamp-first metadata** — Every dispatch leads with a precise timestamp, wire-service style
+- **Breaking / Urgent badges** — Red and orange labels for high-priority stories, instantly visible in the feed
+- **Sans-serif typography** — Inter for body text, JetBrains Mono for timestamps and metadata, chosen for maximum legibility at speed
+- **Light, high-contrast palette** — White background with sharp black type and red accents, the visual language of professional newswires
+- **Minimal ornamentation** — No decorative elements. Every pixel serves the content
+
+## Customization
+
+Mark any post as breaking news by adding `breaking = true` under `[extra]` in the front matter. For urgent dispatches, use `urgent = true`.
+
+```toml
++++
+title = "Your Headline Here"
+date = "2026-03-22"
+description = "A concise one-line summary."
+tags = ["topic"]
+
+[extra]
+breaking = true
++++
+```
+
+## Setup
+
+1. Run `hwaro init telegraph` to scaffold the project
+2. Add dispatches under `content/posts/`
+3. Run `hwaro serve` to preview locally
+4. Run `hwaro build` for production output

--- a/telegraph/content/index.md
+++ b/telegraph/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Wire"
+template = "home"
++++
+
+**TELEGRAPH WIRE** is a real-time news dispatch service. All stories are filed by correspondents in the field and transmitted as they develop.
+
+Browse the [latest dispatches](/posts/) or filter by [topic](/tags/).
+
+---
+
+## How It Works
+
+Each dispatch follows wire service conventions: a dateline identifies the filing location, the lead paragraph carries the essential facts, and subsequent paragraphs provide context in descending order of importance. Stories marked **BREAKING** or **URGENT** indicate developing situations where details may change rapidly.
+
+This is a theme for [Hwaro](https://github.com/hahwul/hwaro), a static site generator. It is designed for news blogs, journalism portfolios, and anyone who values clarity and speed over decoration.

--- a/telegraph/content/posts/2026-03-19-mars-mission-water.md
+++ b/telegraph/content/posts/2026-03-19-mars-mission-water.md
@@ -1,0 +1,26 @@
++++
+title = "Mars Orbiter Confirms Liquid Water Reservoir Beneath Southern Polar Cap"
+date = "2026-03-19T20:00:00Z"
+description = "Radar data from the joint mission provides strongest evidence yet for a sustained subsurface water body on Mars."
+tags = ["science", "space"]
++++
+
+HOUSTON — Mission scientists have confirmed the detection of a sustained liquid water reservoir beneath the Martian south polar ice cap, based on eighteen months of radar sounding data collected by the joint international Mars orbiter.
+
+The reservoir, located approximately 1.5 kilometers below the surface, extends over an estimated 30 square kilometers. The water is believed to remain liquid due to a combination of dissolved salts and geothermal heating, conditions that lower the freezing point well below zero degrees Celsius.
+
+## Significance
+
+While previous observations had suggested the possibility of subsurface water, the new dataset provides the highest-resolution confirmation to date. The extended observation period allowed the team to rule out several alternative explanations, including certain types of ice and clay deposits that can produce similar radar signatures.
+
+The finding has immediate implications for the ongoing search for microbial life beyond Earth. Subsurface liquid water environments shielded from radiation represent one of the most plausible habitats for any extant Martian biology.
+
+## Next Steps
+
+The discovery is expected to influence site selection for future surface missions. Landing near the polar region presents significant engineering challenges, but several space agencies are understood to be evaluating whether a dedicated subsurface access mission is technically feasible within the next decade.
+
+Sample return planning, already underway for equatorial sites, may need to be expanded to include polar targets if the scientific community determines that the water reservoir represents a higher-priority astrobiology target.
+
+---
+
+*Filed from Houston.*

--- a/telegraph/content/posts/2026-03-19-supply-chain-transparency.md
+++ b/telegraph/content/posts/2026-03-19-supply-chain-transparency.md
@@ -1,0 +1,32 @@
++++
+title = "Major Cloud Providers Adopt Shared Supply Chain Transparency Standard"
+date = "2026-03-19T13:10:00Z"
+description = "The standard requires detailed provenance documentation for all hardware components in cloud infrastructure."
+tags = ["technology", "security", "infrastructure"]
++++
+
+SEATTLE — The five largest cloud infrastructure providers have jointly adopted a supply chain transparency standard that requires detailed provenance documentation for every hardware component deployed in their data centers.
+
+The standard, developed over fourteen months of private negotiation, mandates that component manufacturers provide verifiable records tracing each part from raw materials through fabrication, assembly, and delivery. The records will be stored in an append-only ledger system accessible to auditors and, in summarized form, to customers.
+
+## Motivation
+
+The initiative follows several high-profile incidents in which counterfeit or compromised components were discovered in enterprise hardware supply chains. While none of the participating providers have publicly disclosed finding compromised parts in their own infrastructure, industry sources indicate that the frequency of attempted supply chain infiltration has increased substantially.
+
+## Implementation
+
+Compliance will be phased in over three years:
+
+- **Year one**: Server processors, memory modules, and network interface cards
+- **Year two**: Storage devices, power supplies, and motherboards
+- **Year three**: All remaining components, including cables and passive infrastructure
+
+Suppliers that cannot meet the documentation requirements by the relevant deadline will be removed from approved vendor lists. The providers have committed to offering transition assistance to smaller suppliers.
+
+## Market Impact
+
+Hardware manufacturers have broadly accepted the new requirements, though several noted that compliance costs will be significant, particularly for companies with complex, multi-tier supply chains. Industry analysts expect the standard to become a de facto requirement across the enterprise hardware market, as suppliers invest in compliance infrastructure that benefits all customers.
+
+---
+
+*Filed from Seattle.*

--- a/telegraph/content/posts/2026-03-20-ai-regulation-framework.md
+++ b/telegraph/content/posts/2026-03-20-ai-regulation-framework.md
@@ -1,0 +1,31 @@
++++
+title = "International AI Governance Body Releases First Binding Regulatory Framework"
+date = "2026-03-20T16:00:00Z"
+description = "The framework establishes mandatory safety evaluations for AI systems above defined capability thresholds."
+tags = ["policy", "technology", "international"]
++++
+
+BRUSSELS — The Global AI Governance Council, established last year under a multilateral treaty, has released its first binding regulatory framework, requiring mandatory safety evaluations for AI systems that exceed defined capability thresholds.
+
+The framework, which takes effect in 180 days, applies to any organization developing or deploying general-purpose AI systems that meet at least two of six specified capability benchmarks. These include performance on standardized reasoning tests, autonomous task completion rates, and the ability to generate novel code or scientific hypotheses without human guidance.
+
+## Evaluation Requirements
+
+Under the new rules, qualifying systems must undergo independent safety evaluations before deployment. The evaluations cover four domains:
+
+- Propensity for generating harmful outputs under adversarial prompting
+- Robustness of internal safety mechanisms under sustained stress testing
+- Transparency of decision-making processes for high-stakes applications
+- Environmental impact assessments covering training and inference energy costs
+
+Organizations that fail to obtain clearance face escalating penalties, beginning with deployment restrictions and potentially culminating in development moratoriums for repeat violations.
+
+## Reactions
+
+The framework has drawn a mixed response. Proponents described it as a necessary step toward ensuring that AI development proceeds with adequate safeguards. Several leading AI laboratories issued statements affirming their intent to comply, noting that many of the required evaluations align with internal practices already in place.
+
+Critics argued that the capability thresholds are set too low and could impede beneficial research, particularly at academic institutions and smaller companies with fewer resources to navigate the compliance process.
+
+---
+
+*Filed from Brussels.*

--- a/telegraph/content/posts/2026-03-20-zero-day-exploit-chain.md
+++ b/telegraph/content/posts/2026-03-20-zero-day-exploit-chain.md
@@ -1,0 +1,30 @@
++++
+title = "Security Researchers Disclose Zero-Day Exploit Chain Affecting Billions of Mobile Devices"
+date = "2026-03-20T08:30:00Z"
+description = "Patches are being distributed, but the exploit was actively used in targeted surveillance campaigns for an estimated five months before discovery."
+tags = ["urgent", "security", "technology"]
++++
+
+SAN FRANCISCO — A coordinated disclosure by three independent security research groups has revealed a chain of zero-day vulnerabilities affecting the baseband processors used in an estimated 3.2 billion mobile devices worldwide.
+
+The exploit chain, which researchers have designated "SilentFrame," allows an attacker within radio range to achieve remote code execution on a target device without any user interaction. The attack leaves no persistent indicators visible to standard forensic tools.
+
+## Scope and Exploitation
+
+Researchers found evidence that the vulnerability chain had been actively exploited in targeted surveillance operations for approximately five months prior to discovery. Targets identified so far include journalists, legal professionals, and political figures in at least nine countries.
+
+The affected baseband chip, manufactured by a single supplier and integrated into devices from multiple major handset makers, processes cellular radio signals at a level below the main operating system. This architectural separation means that conventional mobile security software cannot detect or prevent exploitation.
+
+## Patch Status
+
+The chip manufacturer has released firmware updates that address all three vulnerabilities in the chain. Device manufacturers are distributing patches through their standard update channels, but researchers cautioned that the baseband update process varies significantly across devices and carriers.
+
+Devices that have not received updates remain vulnerable. Researchers recommend that high-risk individuals consider disabling cellular connectivity on affected devices until patches are confirmed installed.
+
+## Discovery Process
+
+The vulnerability was initially identified through anomalous radio traffic patterns detected by a university research lab studying cellular protocol behavior. The research team traced the anomalies to crafted signaling messages that triggered memory corruption in the baseband firmware.
+
+---
+
+*Filed from San Francisco. Technical advisories available through standard channels.*

--- a/telegraph/content/posts/2026-03-21-open-source-funding-bill.md
+++ b/telegraph/content/posts/2026-03-21-open-source-funding-bill.md
@@ -1,0 +1,28 @@
++++
+title = "Legislature Passes Landmark Open Source Security Funding Act"
+date = "2026-03-21T18:45:00Z"
+description = "The bill allocates $2.1 billion over five years to audit and maintain critical open source software used in government systems."
+tags = ["policy", "open-source", "security"]
++++
+
+WASHINGTON — The Senate voted 78-19 today to pass the Open Source Security Funding Act, a bipartisan bill that allocates $2.1 billion over five years to fund security audits, maintenance, and developer compensation for open source software projects deemed critical to national infrastructure.
+
+The legislation, which now awaits the President's signature, creates a new office within the Department of Commerce tasked with identifying and prioritizing open source projects that underpin federal systems. An estimated 97% of government software stacks contain open source components, many of which are maintained by unpaid volunteers.
+
+## Structure of Funding
+
+The bill divides funding into three primary channels:
+
+- **Direct maintenance grants** for maintainers of critical projects, modeled on academic research funding
+- **Security audit programs** run through partnerships with established code auditing firms
+- **A rapid response fund** for emergencies, such as newly disclosed vulnerabilities in widely deployed libraries
+
+## Industry Reaction
+
+The open source community has responded with cautious optimism. Several prominent maintainers noted that while the funding is welcome, the details of implementation will determine whether the program succeeds or creates new bureaucratic burdens.
+
+Major technology companies that depend heavily on open source have signaled willingness to match federal contributions through a parallel private sector fund, though details remain under negotiation.
+
+---
+
+*Filed from Washington.*

--- a/telegraph/content/posts/2026-03-21-undersea-cable-disruption.md
+++ b/telegraph/content/posts/2026-03-21-undersea-cable-disruption.md
@@ -1,0 +1,30 @@
++++
+title = "Subsea Cable Damage in North Atlantic Disrupts Transatlantic Data Traffic for Six Hours"
+date = "2026-03-21T09:20:00Z"
+description = "Redundant routing restored service, but investigators are examining whether the damage was accidental or deliberate."
+tags = ["breaking", "infrastructure", "international", "security"]
++++
+
+LONDON — A major subsea fiber optic cable connecting North America and Northern Europe suffered damage early this morning, causing widespread latency spikes and intermittent outages for transatlantic internet traffic lasting approximately six hours before redundant routing fully compensated.
+
+The cable, one of fewer than twenty that carry the bulk of data between the two continents, was severed at a point approximately 400 kilometers southwest of Ireland at a depth of roughly 3,200 meters.
+
+## Impact Assessment
+
+Financial markets experienced brief disruptions during the European opening as high-frequency trading systems, which depend on minimal latency between exchanges, were forced to reroute through longer paths. Several exchanges reported temporary increases in trade execution times of between 15 and 40 milliseconds.
+
+Cloud service providers activated disaster recovery protocols, shifting traffic to alternate cables. Most consumer-facing services experienced little noticeable impact beyond the initial hours.
+
+## Investigation
+
+Maritime authorities have dispatched a cable repair vessel to the site. Preliminary analysis of the break pattern has not yet determined whether the damage resulted from anchor drag, seismic activity, or deliberate interference.
+
+This is the fourth significant subsea cable incident in the North Atlantic in the past eighteen months, a frequency that infrastructure security analysts have described as statistically unusual. Previous incidents were attributed to fishing equipment and anchor strikes, though two remain formally unresolved.
+
+## Broader Context
+
+The incident has intensified calls from both governments and industry groups for enhanced monitoring of critical undersea cable routes and increased investment in cable redundancy, particularly in corridors where a small number of cables carry disproportionate traffic loads.
+
+---
+
+*Developing story. Filed from London.*

--- a/telegraph/content/posts/2026-03-22-global-cybersecurity-summit.md
+++ b/telegraph/content/posts/2026-03-22-global-cybersecurity-summit.md
@@ -1,0 +1,35 @@
++++
+title = "World Leaders Convene Emergency Cybersecurity Summit After Critical Infrastructure Attacks"
+date = "2026-03-22T14:30:00Z"
+description = "G20 nations agree to establish joint cyber defense framework following coordinated attacks on power grids across three continents."
+tags = ["breaking", "security", "policy", "international"]
++++
+
+GENEVA — Leaders from all G20 nations have agreed to establish a joint cyber defense coordination center following a series of coordinated attacks that disrupted power infrastructure in twelve countries over the past 72 hours.
+
+The agreement, reached after marathon overnight negotiations at the United Nations European headquarters, marks the first time major world powers have committed to real-time threat intelligence sharing across national boundaries.
+
+## Key Provisions
+
+The framework includes several first-of-their-kind measures:
+
+- A permanent cyber operations center staffed by personnel from all member nations, based in Singapore
+- Mandatory 30-minute disclosure windows for attacks targeting critical infrastructure
+- Shared vulnerability databases accessible to all signatories
+- Joint attribution protocols designed to reduce the time between attack detection and public attribution
+
+## Industry Response
+
+Private sector technology firms have broadly welcomed the agreement. Major cloud infrastructure providers issued a joint statement pledging full cooperation with the new framework, including expedited access to telemetry data during active incidents.
+
+> "This is the most significant multilateral security agreement of the decade. The threat landscape has made cooperation not just desirable but existential," said one senior diplomat who participated in the negotiations.
+
+## Implementation Timeline
+
+The coordination center is expected to reach initial operating capability within 90 days. Full operational status, including the automated threat sharing systems, is targeted for the end of 2026.
+
+Critics have noted that several nations with significant offensive cyber capabilities were notably reluctant during negotiations, agreeing to the framework only after key provisions around offensive operations were softened in the final draft.
+
+---
+
+*Reporting from Geneva. Additional dispatches to follow as details emerge.*

--- a/telegraph/content/posts/2026-03-22-quantum-computing-milestone.md
+++ b/telegraph/content/posts/2026-03-22-quantum-computing-milestone.md
@@ -1,0 +1,30 @@
++++
+title = "Research Lab Achieves 10,000-Qubit Quantum Processor, Surpassing Previous Record by Factor of Four"
+date = "2026-03-22T11:15:00Z"
+description = "The breakthrough raises immediate questions about the timeline for current encryption standards becoming vulnerable."
+tags = ["urgent", "technology", "science", "security"]
++++
+
+ZURICH — A European research consortium announced today that it has successfully demonstrated a 10,000-qubit quantum processor operating at error rates low enough for practical computation, a milestone that experts said could accelerate the timeline for quantum-relevant cryptographic threats.
+
+The processor, designated QR-10K, maintained coherence across all qubits for over 200 microseconds during benchmark tests, a figure that the research team described as sufficient for certain classes of optimization and simulation problems previously thought to be years away.
+
+## Implications for Cryptography
+
+The announcement has reignited debate among cryptographers about the urgency of transitioning to post-quantum encryption standards. While the QR-10K remains far from the estimated millions of logical qubits needed to break RSA-2048, the rate of progress has outpaced most projections published as recently as last year.
+
+Several national security agencies declined to comment on the record but are understood to be reassessing internal timelines for cryptographic migration.
+
+## Technical Details
+
+The consortium achieved the qubit count through a novel architecture that tiles smaller, independently calibrated modules into a unified computational fabric. This modular approach sidesteps many of the scaling challenges that have constrained previous superconducting designs.
+
+Error correction overhead, long considered the primary barrier to useful quantum computation, was reduced through a combination of hardware improvements and a new class of stabilizer codes developed specifically for the modular architecture.
+
+## What Comes Next
+
+The team has stated that their next target is demonstrating quantum advantage on a commercially relevant optimization problem, a goal they believe is achievable within 18 months using an upgraded version of the current architecture.
+
+---
+
+*Filed from Zurich. Updates to follow.*

--- a/telegraph/content/posts/_index.md
+++ b/telegraph/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Archive"
+sort_by = "date"
+reverse = true
+paginate_by = 20
+template = "section"
++++

--- a/telegraph/templates/404.html
+++ b/telegraph/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <div class="error-page">
+    <h1>404</h1>
+    <p>This dispatch could not be located in the wire archive.</p>
+    <a href="{{ base_url }}/">Return to Wire</a>
+  </div>
+{% include "footer.html" %}

--- a/telegraph/templates/footer.html
+++ b/telegraph/templates/footer.html
@@ -1,0 +1,9 @@
+  </main>
+  <footer class="site-footer">
+    <div class="site-footer-inner">
+      END TRANSMISSION &mdash; &copy; {{ current_year }} {{ site.title }} &mdash; Powered by Hwaro
+    </div>
+  </footer>
+  {{ highlight_js }}
+</body>
+</html>

--- a/telegraph/templates/header.html
+++ b/telegraph/templates/header.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% elif section %}{{ section.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #ffffff;
+      --bg-secondary: #f7f7f8;
+      --text: #111111;
+      --text-secondary: #555555;
+      --text-muted: #888888;
+      --border: #d0d0d0;
+      --border-light: #e5e5e5;
+      --accent: #c41e1e;
+      --accent-bg: #c41e1e;
+      --accent-text: #ffffff;
+      --urgent-bg: #b35900;
+      --tag-bg: #eaeaea;
+      --tag-text: #444444;
+      --mono: 'JetBrains Mono', monospace;
+      --sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+
+    body {
+      font-family: var(--sans);
+      font-size: 15px;
+      line-height: 1.6;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: var(--text); text-decoration: none; }
+    a:hover { color: var(--accent); }
+
+    .masthead {
+      border-bottom: 3px solid var(--text);
+      padding: 20px 0 16px;
+    }
+    .masthead-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+    .masthead-top {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .masthead h1 {
+      font-size: 28px;
+      font-weight: 800;
+      letter-spacing: -0.5px;
+      text-transform: uppercase;
+    }
+    .masthead h1 a { color: var(--text); }
+    .masthead h1 a:hover { color: var(--text); }
+    .wire-label {
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--text-muted);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .masthead-rule {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 12px 0 0;
+    }
+
+    .site-nav {
+      border-bottom: 1px solid var(--border-light);
+      background: var(--bg);
+    }
+    .site-nav-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+    .site-nav a {
+      display: block;
+      padding: 10px 0;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+      border-bottom: 2px solid transparent;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .site-nav a:hover {
+      color: var(--text);
+      border-bottom-color: var(--accent);
+    }
+
+    .ticker-bar {
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-light);
+      padding: 8px 0;
+    }
+    .ticker-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 12px;
+      color: var(--text-muted);
+      font-family: var(--mono);
+    }
+    .ticker-label {
+      background: var(--accent-bg);
+      color: var(--accent-text);
+      padding: 2px 8px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      flex-shrink: 0;
+    }
+
+    .site-main {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    .wire-feed { list-style: none; }
+    .wire-item {
+      border-bottom: 1px solid var(--border-light);
+      padding: 18px 0;
+    }
+    .wire-item:first-child { padding-top: 24px; }
+    .wire-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 6px;
+      flex-wrap: wrap;
+    }
+    .wire-timestamp {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-muted);
+      font-weight: 500;
+    }
+    .wire-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      padding: 1px 6px;
+      background: var(--tag-bg);
+      color: var(--tag-text);
+    }
+    .wire-badge--breaking {
+      background: var(--accent-bg);
+      color: var(--accent-text);
+    }
+    .wire-badge--urgent {
+      background: var(--urgent-bg);
+      color: #ffffff;
+    }
+    .wire-headline {
+      font-size: 18px;
+      font-weight: 700;
+      line-height: 1.3;
+      letter-spacing: -0.2px;
+      margin-bottom: 4px;
+    }
+    .wire-headline a { color: var(--text); }
+    .wire-headline a:hover { color: var(--accent); }
+    .wire-summary {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .article {
+      padding: 32px 0 48px;
+    }
+    .article-header {
+      margin-bottom: 28px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid var(--border-light);
+    }
+    .article-header h1 {
+      font-size: 28px;
+      font-weight: 800;
+      line-height: 1.2;
+      letter-spacing: -0.5px;
+      margin-bottom: 12px;
+    }
+    .article-dateline {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .article-tags {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .article-tags a {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 2px 8px;
+      background: var(--tag-bg);
+      color: var(--tag-text);
+    }
+    .article-tags a:hover {
+      background: var(--text);
+      color: var(--bg);
+    }
+
+    .prose { max-width: 640px; }
+    .prose p { margin-bottom: 16px; }
+    .prose h2 {
+      font-size: 20px;
+      font-weight: 700;
+      margin: 32px 0 12px;
+      letter-spacing: -0.2px;
+    }
+    .prose h3 {
+      font-size: 16px;
+      font-weight: 700;
+      margin: 24px 0 8px;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+    .prose ul, .prose ol {
+      margin: 0 0 16px 20px;
+    }
+    .prose li { margin-bottom: 4px; }
+    .prose blockquote {
+      border-left: 3px solid var(--accent);
+      margin: 20px 0;
+      padding: 12px 20px;
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+    .prose code {
+      font-family: var(--mono);
+      font-size: 13px;
+      background: var(--bg-secondary);
+      padding: 2px 5px;
+    }
+    .prose pre {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-light);
+      padding: 16px;
+      overflow-x: auto;
+      margin-bottom: 16px;
+    }
+    .prose pre code { background: none; padding: 0; }
+    .prose hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 28px 0;
+    }
+    .prose strong { font-weight: 700; }
+    .prose p:first-of-type {
+      font-size: 16px;
+      line-height: 1.55;
+    }
+
+    .pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 16px;
+      padding: 24px 0 48px;
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .pagination a {
+      color: var(--text-secondary);
+      padding: 6px 14px;
+      border: 1px solid var(--border);
+    }
+    .pagination a:hover {
+      background: var(--text);
+      color: var(--bg);
+      border-color: var(--text);
+    }
+    .pagination .current {
+      color: var(--text-muted);
+    }
+
+    .taxonomy-page { padding: 32px 0 48px; }
+    .taxonomy-page h1 {
+      font-size: 22px;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 24px;
+      padding-bottom: 12px;
+      border-bottom: 2px solid var(--text);
+    }
+    .taxonomy-list { list-style: none; }
+    .taxonomy-list li {
+      display: inline-block;
+      margin: 0 8px 8px 0;
+    }
+    .taxonomy-list a {
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 6px 14px;
+      border: 1px solid var(--border);
+      display: block;
+    }
+    .taxonomy-list a:hover {
+      background: var(--text);
+      color: var(--bg);
+      border-color: var(--text);
+    }
+
+    .site-footer {
+      border-top: 3px solid var(--text);
+      margin-top: 40px;
+      padding: 20px 0;
+      text-align: center;
+    }
+    .site-footer-inner {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 24px;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--text-muted);
+      letter-spacing: 0.5px;
+    }
+
+    .error-page {
+      text-align: center;
+      padding: 80px 24px;
+    }
+    .error-page h1 {
+      font-size: 48px;
+      font-weight: 800;
+      margin-bottom: 8px;
+    }
+    .error-page p {
+      color: var(--text-secondary);
+      margin-bottom: 24px;
+    }
+
+    @media (max-width: 600px) {
+      .masthead h1 { font-size: 22px; }
+      .masthead-top { flex-direction: column; gap: 4px; }
+      .site-nav-inner { gap: 16px; }
+      .wire-headline { font-size: 16px; }
+      .article-header h1 { font-size: 22px; }
+    }
+  </style>
+  {{ highlight_css }}
+</head>
+<body>
+  <header class="masthead">
+    <div class="masthead-inner">
+      <div class="masthead-top">
+        <h1><a href="{{ base_url }}/">Telegraph Wire</a></h1>
+        <span class="wire-label">Real-Time News Service</span>
+      </div>
+      <hr class="masthead-rule">
+    </div>
+  </header>
+  <nav class="site-nav">
+    <div class="site-nav-inner">
+      <a href="{{ base_url }}/">Wire</a>
+      <a href="{{ base_url }}/posts/">Archive</a>
+      <a href="{{ base_url }}/tags/">Topics</a>
+      <a href="{{ base_url }}/about/">About</a>
+    </div>
+  </nav>
+  <main class="site-main">

--- a/telegraph/templates/home.html
+++ b/telegraph/templates/home.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <div class="ticker-bar">
+    <div class="ticker-inner">
+      <span class="ticker-label">Live</span>
+      <span>Real-time dispatches from correspondents worldwide</span>
+    </div>
+  </div>
+  <article class="article">
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </article>
+{% include "footer.html" %}

--- a/telegraph/templates/page.html
+++ b/telegraph/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <article class="article">
+    <header class="article-header">
+      {% if page.date %}<div class="article-dateline">{{ page.date | date(format="%Y-%m-%d %H:%M") }} UTC</div>{% endif %}
+      <h1>{{ page.title }}</h1>
+      {% if page.tags | length > 0 %}
+      <div class="article-tags">
+        {% for tag in page.tags %}<a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>{% endfor %}
+      </div>
+      {% endif %}
+    </header>
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </article>
+{% include "footer.html" %}

--- a/telegraph/templates/section.html
+++ b/telegraph/templates/section.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+  <div class="ticker-bar">
+    <div class="ticker-inner">
+      <span class="ticker-label">Live</span>
+      <span>Dispatches updated as events develop — {{ section.pages_count }} stories on file</span>
+    </div>
+  </div>
+  <ul class="wire-feed">
+    {% for post in section.pages %}
+    <li class="wire-item">
+      <div class="wire-meta">
+        <span class="wire-timestamp">{{ post.date | date(format="%Y-%m-%d %H:%M") }}</span>
+        {% for tag in post.tags %}
+          {% if tag == "breaking" %}<span class="wire-badge wire-badge--breaking">{{ tag }}</span>
+          {% elif tag == "urgent" %}<span class="wire-badge wire-badge--urgent">{{ tag }}</span>
+          {% else %}<span class="wire-badge">{{ tag }}</span>
+          {% endif %}
+        {% endfor %}
+      </div>
+      <h2 class="wire-headline"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+      {% if post.description %}<p class="wire-summary">{{ post.description }}</p>{% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% if paginator %}
+  <div class="pagination">
+    {% if paginator.previous %}<a href="{{ paginator.previous }}">Previous</a>{% endif %}
+    <span class="current">Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+    {% if paginator.next %}<a href="{{ paginator.next }}">Next</a>{% endif %}
+  </div>
+  {% endif %}
+{% include "footer.html" %}

--- a/telegraph/templates/taxonomy.html
+++ b/telegraph/templates/taxonomy.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <div class="taxonomy-page">
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+  </div>
+{% include "footer.html" %}

--- a/telegraph/templates/taxonomy_term.html
+++ b/telegraph/templates/taxonomy_term.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <div class="taxonomy-page">
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+  </div>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Add `telegraph` example: a breaking news wire service theme inspired by AP/Reuters
- Light theme with scannable list layout, timestamp-first metadata, breaking/urgent red/orange badges via tags
- Sans-serif typography (Inter + JetBrains Mono), no gradients, no emojis
- 8 sample dispatches covering cybersecurity, quantum computing, policy, infrastructure, and science
- Registered in `tags.json` with tags: `light`, `blog`, `news`

Closes #113

## Test plan
- [ ] `hwaro build` passes with no warnings
- [ ] Homepage renders with ticker bar and intro text
- [ ] `/posts/` shows wire feed with timestamps, badges, and headlines
- [ ] Breaking/urgent tags render with colored badges
- [ ] Individual post pages display correctly with dateline and prose
- [ ] `/tags/` taxonomy page works
- [ ] Responsive layout on mobile