### PR TITLE
Add inkwell example: poetry/verse theme

### DIFF
--- a/inkwell/AGENTS.md
+++ b/inkwell/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/inkwell/config.toml
+++ b/inkwell/config.toml
@@ -1,0 +1,127 @@
+title = "Inkwell"
+description = "A poetry and verse journal"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 8
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+sections = ["poems"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/inkwell/content/about.md
+++ b/inkwell/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About"
++++
+
+Inkwell is a quiet space for verse. Born from the belief that poetry deserves room to breathe, this journal presents each poem with the care of a hand-set page.
+
+The design draws from the tradition of fine letterpress chapbooks -- generous margins, measured spacing, and nothing between the reader and the words but ink on paper.
+
+Here you will find poems that linger on small observations, on the weight of seasons, on silences between familiar things. Each piece is offered without commentary, trusting the reader to bring their own understanding.
+
+> A poem begins in delight and ends in wisdom.
+>
+> -- Robert Frost
+
+If you wish to submit your own work, or simply to say a kind word, you are welcome to reach out. This journal thrives on the quiet exchange between those who read and those who write.

--- a/inkwell/content/index.md
+++ b/inkwell/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+template = "home"
++++

--- a/inkwell/content/poems/_index.md
+++ b/inkwell/content/poems/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Poems"
+sort_by = "date"
+reverse = true
++++

--- a/inkwell/content/poems/kitchen-at-dusk.md
+++ b/inkwell/content/poems/kitchen-at-dusk.md
@@ -1,0 +1,26 @@
++++
+title = "Kitchen at Dusk"
+date = "2025-02-20"
+description = "The last light finds the copper pot and rests there..."
+tags = ["home", "stillness"]
++++
+
+The last light finds the copper pot
+and rests there, briefly,
+the way a hand rests on a shoulder
+before turning to leave.
+
+Onion skins curl on the board
+like the margins of old letters.
+Steam rises from the kettle's mouth,
+a small, forgivable confession.
+
+I stand at the window
+watching the street lamps wake,
+one by one, their amber stations
+marking the road from here to dark.
+
+The bread is cooling on the rack.
+The clock ticks its one syllable.
+And the kitchen gathers evening
+into its familiar arms.

--- a/inkwell/content/poems/letter-to-november.md
+++ b/inkwell/content/poems/letter-to-november.md
@@ -1,0 +1,26 @@
++++
+title = "Letter to November"
+date = "2024-11-10"
+description = "Dear month of bare branches and early dark..."
+tags = ["seasons", "solitude"]
++++
+
+Dear month of bare branches
+and early dark,
+I have come around again
+to your spare rehearsal.
+
+You who strip the ornament
+from every standing thing
+until the bones of elms
+show clear against the sky.
+
+I used to think you cruel.
+Now I see the kindness in it --
+this insistence on what's real
+beneath the excess green.
+
+Teach me your economy.
+Show me how to stand
+with nothing but the truth
+of what I am, uncovered.

--- a/inkwell/content/poems/morning-fugue.md
+++ b/inkwell/content/poems/morning-fugue.md
@@ -1,0 +1,26 @@
++++
+title = "Morning Fugue"
+date = "2024-10-05"
+description = "The coffee maker speaks first, its familiar argument of steam..."
+tags = ["home", "morning"]
++++
+
+The coffee maker speaks first,
+its familiar argument of steam
+and dark persuasion filling
+the kitchen's empty court.
+
+Then the radiator enters,
+knocking its slow percussion
+through the pipes, a rhythm
+older than the house.
+
+The cat contributes silence,
+which is also a voice,
+pressing her weight against
+the warm side of the morning.
+
+And I, the last to join,
+bring only this: the sound
+of a spoon against a cup,
+stirring the day to life.

--- a/inkwell/content/poems/on-reading-late.md
+++ b/inkwell/content/poems/on-reading-late.md
@@ -1,0 +1,26 @@
++++
+title = "On Reading Late"
+date = "2025-01-08"
+description = "The house has settled into itself, each room a closed eye..."
+tags = ["night", "solitude"]
++++
+
+The house has settled into itself,
+each room a closed eye.
+Only this lamp and I remain,
+conspirators against the hour.
+
+The pages smell of other years.
+I turn them carefully,
+aware that someone else's fingers
+pressed these very words.
+
+A sentence stops me cold --
+not for what it says
+but for the silence
+it has carried all this way.
+
+Outside, the town is dreaming.
+The book is almost done.
+I hold the last few pages
+like a letter I'm afraid to finish.

--- a/inkwell/content/poems/the-hour-before-rain.md
+++ b/inkwell/content/poems/the-hour-before-rain.md
@@ -1,0 +1,31 @@
++++
+title = "The Hour Before Rain"
+date = "2025-03-15"
+description = "The garden holds its breath, each leaf a cupped palm..."
+tags = ["nature", "seasons"]
++++
+
+The garden holds its breath,
+each leaf a cupped palm
+waiting for what the clouds
+have carried from the coast.
+
+A thrush adjusts its grip
+on the low wall, tilts
+its head as if to read
+the greying manuscript of sky.
+
+The air has thickened now,
+sweet with turned earth
+and the dust of stones
+remembering their river.
+
+Soon the first drop will arrive,
+tentative as a word
+spoken across a table
+to someone nearly loved.
+
+And the garden will answer,
+not with gratitude exactly,
+but with the slow exhale
+of a thing at last permitted.

--- a/inkwell/content/poems/what-the-river-knows.md
+++ b/inkwell/content/poems/what-the-river-knows.md
@@ -1,0 +1,26 @@
++++
+title = "What the River Knows"
+date = "2024-12-02"
+description = "It knows the underside of bridges, the way iron weeps in winter..."
+tags = ["nature", "memory"]
++++
+
+It knows the underside of bridges,
+the way iron weeps in winter,
+and the particular shade of green
+that only willows understand.
+
+It knows which stones will sing
+when the current finds them right,
+and which will hold their silence
+for another hundred years.
+
+It knows the heron's patience,
+standing in the shallows
+like a question no one thought
+to ask until this moment.
+
+It knows that moving forward
+is not the same as leaving.
+That carrying a thing downstream
+is its own form of keeping.

--- a/inkwell/templates/404.html
+++ b/inkwell/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="not-found">
+      <h1>Lost Page</h1>
+      <p>The verse you seek has not yet been written.</p>
+      <p><a href="{{ base_url }}/">Return home</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/inkwell/templates/footer.html
+++ b/inkwell/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer class="site-footer">
+      <p>Powered by <a href="https://hwaro.hahwul.com">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/inkwell/templates/header.html
+++ b/inkwell/templates/header.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500;1,600&family=EB+Garamond:ital,wght@0,400;0,500;1,400;1,500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #1a1a1a;
+      --ink-light: #4a4a4a;
+      --ink-faint: #8a8a8a;
+      --rule: #c8c0b8;
+      --rule-light: #e0dbd5;
+      --parchment: #faf8f5;
+      --parchment-warm: #f3efe9;
+      --serif: 'Cormorant Garamond', 'Georgia', serif;
+      --body-serif: 'EB Garamond', 'Georgia', serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--body-serif);
+      font-size: 18px;
+      line-height: 1.8;
+      color: var(--ink);
+      background: var(--parchment);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Layout */
+    .site-frame {
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    /* Header */
+    .site-header {
+      padding: 3rem 0 2rem;
+      text-align: center;
+      border-bottom: 1px solid var(--rule);
+    }
+
+    .site-title {
+      font-family: var(--serif);
+      font-size: 1.6rem;
+      font-weight: 300;
+      letter-spacing: 0.25em;
+      text-transform: uppercase;
+      color: var(--ink);
+      text-decoration: none;
+      display: block;
+    }
+
+    .site-title:hover {
+      color: var(--ink-light);
+    }
+
+    .site-nav {
+      margin-top: 1rem;
+      display: flex;
+      justify-content: center;
+      gap: 2rem;
+    }
+
+    .site-nav a {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      font-weight: 400;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--ink-faint);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .site-nav a:hover {
+      color: var(--ink);
+    }
+
+    /* Main */
+    .site-main {
+      min-height: 60vh;
+      padding: 3rem 0;
+    }
+
+    /* Footer */
+    .site-footer {
+      padding: 2rem 0;
+      border-top: 1px solid var(--rule);
+      text-align: center;
+      font-family: var(--serif);
+      font-size: 0.8rem;
+      letter-spacing: 0.1em;
+      color: var(--ink-faint);
+    }
+
+    .site-footer a {
+      color: var(--ink-faint);
+      text-decoration: none;
+    }
+
+    .site-footer a:hover {
+      color: var(--ink);
+    }
+
+    /* Typography */
+    h1 {
+      font-family: var(--serif);
+      font-weight: 300;
+      font-size: 2rem;
+      line-height: 1.3;
+      letter-spacing: 0.02em;
+      margin-bottom: 0.5em;
+    }
+
+    h2 {
+      font-family: var(--serif);
+      font-weight: 400;
+      font-size: 1.4rem;
+      line-height: 1.4;
+      margin-top: 2em;
+      margin-bottom: 0.5em;
+    }
+
+    p {
+      margin-bottom: 1.2em;
+    }
+
+    a {
+      color: var(--ink);
+      text-decoration-color: var(--rule);
+      text-underline-offset: 3px;
+      transition: text-decoration-color 0.2s;
+    }
+
+    a:hover {
+      text-decoration-color: var(--ink);
+    }
+
+    /* Home page */
+    .home-epigraph {
+      text-align: center;
+      padding: 6rem 0 4rem;
+    }
+
+    .home-epigraph .book-title {
+      font-family: var(--serif);
+      font-size: 2.8rem;
+      font-weight: 300;
+      letter-spacing: 0.08em;
+      color: var(--ink);
+      margin-bottom: 0.4em;
+    }
+
+    .home-epigraph .book-subtitle {
+      font-family: var(--serif);
+      font-style: italic;
+      font-size: 1.1rem;
+      font-weight: 300;
+      color: var(--ink-light);
+      letter-spacing: 0.05em;
+    }
+
+    .home-divider {
+      width: 60px;
+      border: none;
+      border-top: 1px solid var(--rule);
+      margin: 2.5rem auto;
+    }
+
+    /* Poem card list */
+    .poem-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    .poem-entry {
+      padding: 1.8rem 0;
+      border-bottom: 1px solid var(--rule-light);
+    }
+
+    .poem-entry:last-child {
+      border-bottom: none;
+    }
+
+    .poem-entry-title {
+      font-family: var(--serif);
+      font-size: 1.3rem;
+      font-weight: 400;
+      font-style: italic;
+      margin-bottom: 0.3em;
+    }
+
+    .poem-entry-title a {
+      color: var(--ink);
+      text-decoration: none;
+    }
+
+    .poem-entry-title a:hover {
+      text-decoration: underline;
+      text-decoration-color: var(--rule);
+    }
+
+    .poem-entry-excerpt {
+      font-family: var(--body-serif);
+      font-size: 0.95rem;
+      color: var(--ink-light);
+      line-height: 1.7;
+      font-style: italic;
+    }
+
+    .poem-entry-meta {
+      margin-top: 0.5em;
+      font-family: var(--serif);
+      font-size: 0.8rem;
+      letter-spacing: 0.08em;
+      color: var(--ink-faint);
+      text-transform: uppercase;
+    }
+
+    /* Poem page */
+    .poem-header {
+      text-align: center;
+      padding: 2rem 0 1.5rem;
+      border-bottom: 1px solid var(--rule-light);
+      margin-bottom: 2.5rem;
+    }
+
+    .poem-header h1 {
+      font-style: italic;
+      font-weight: 300;
+      font-size: 2.2rem;
+      margin-bottom: 0.3em;
+    }
+
+    .poem-header .poem-meta {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      letter-spacing: 0.1em;
+      color: var(--ink-faint);
+      text-transform: uppercase;
+    }
+
+    /* Poem body — the verse itself */
+    .poem-body {
+      max-width: 480px;
+      margin: 0 auto;
+      padding: 1rem 0 2rem;
+    }
+
+    .poem-body p {
+      text-align: center;
+      line-height: 2;
+      margin-bottom: 2em;
+      font-size: 1.05rem;
+    }
+
+    .poem-body p:last-child {
+      margin-bottom: 0;
+    }
+
+    .poem-end-mark {
+      text-align: center;
+      margin-top: 3rem;
+      font-family: var(--serif);
+      font-size: 0.9rem;
+      color: var(--rule);
+      letter-spacing: 0.5em;
+    }
+
+    .poem-footer-nav {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--rule-light);
+      text-align: center;
+    }
+
+    .poem-footer-nav a {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--ink-faint);
+      text-decoration: none;
+    }
+
+    .poem-footer-nav a:hover {
+      color: var(--ink);
+    }
+
+    /* About / prose page */
+    .prose {
+      max-width: 540px;
+      margin: 0 auto;
+    }
+
+    .prose h1 {
+      text-align: center;
+      margin-bottom: 1.5em;
+      padding-bottom: 1em;
+      border-bottom: 1px solid var(--rule-light);
+    }
+
+    .prose p {
+      text-indent: 1.5em;
+      margin-bottom: 0.8em;
+    }
+
+    .prose p:first-of-type {
+      text-indent: 0;
+    }
+
+    .prose blockquote {
+      margin: 2em 0;
+      padding-left: 1.5em;
+      border-left: 2px solid var(--rule);
+      font-style: italic;
+      color: var(--ink-light);
+    }
+
+    /* Section list */
+    .section-header {
+      text-align: center;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--rule-light);
+      margin-bottom: 1rem;
+    }
+
+    .section-header h1 {
+      font-style: italic;
+      letter-spacing: 0.05em;
+    }
+
+    ul.section-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    ul.section-list li {
+      padding: 1rem 0;
+      border-bottom: 1px solid var(--rule-light);
+    }
+
+    ul.section-list li:last-child {
+      border-bottom: none;
+    }
+
+    ul.section-list li a {
+      font-family: var(--serif);
+      font-style: italic;
+      font-size: 1.15rem;
+      color: var(--ink);
+      text-decoration: none;
+    }
+
+    ul.section-list li a:hover {
+      text-decoration: underline;
+      text-decoration-color: var(--rule);
+    }
+
+    /* Taxonomy */
+    .taxonomy-desc {
+      text-align: center;
+      font-style: italic;
+      color: var(--ink-light);
+      margin-bottom: 1.5rem;
+    }
+
+    /* Tags */
+    .tag-list {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.5em;
+    }
+
+    .tag-list a {
+      font-family: var(--serif);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-faint);
+      text-decoration: none;
+      padding: 0.2em 0.6em;
+      border: 1px solid var(--rule-light);
+    }
+
+    .tag-list a:hover {
+      color: var(--ink);
+      border-color: var(--rule);
+    }
+
+    /* Pagination */
+    nav.pagination {
+      margin-top: 2rem;
+      text-align: center;
+    }
+
+    nav.pagination .pagination-list {
+      list-style: none;
+      padding: 0;
+      display: flex;
+      justify-content: center;
+      gap: 0.3rem;
+      flex-wrap: wrap;
+    }
+
+    nav.pagination a {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      padding: 0.3em 0.6em;
+      color: var(--ink-faint);
+      text-decoration: none;
+    }
+
+    nav.pagination a:hover {
+      color: var(--ink);
+    }
+
+    .pagination-current span {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      padding: 0.3em 0.6em;
+      color: var(--ink);
+      border-bottom: 1px solid var(--ink);
+    }
+
+    .pagination-disabled span {
+      font-family: var(--serif);
+      font-size: 0.85rem;
+      padding: 0.3em 0.6em;
+      color: var(--rule);
+    }
+
+    /* 404 */
+    .not-found {
+      text-align: center;
+      padding: 4rem 0;
+    }
+
+    .not-found h1 {
+      font-style: italic;
+      font-weight: 300;
+    }
+
+    .not-found p {
+      color: var(--ink-light);
+      font-style: italic;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      body { font-size: 16px; }
+      .site-frame { padding: 0 1.2rem; }
+      .home-epigraph { padding: 3rem 0 2rem; }
+      .home-epigraph .book-title { font-size: 2rem; }
+      .poem-header h1 { font-size: 1.7rem; }
+      .poem-body { padding: 0.5rem 0 1.5rem; }
+      .site-nav { gap: 1.2rem; }
+    }
+  </style>
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-frame">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/poems/">Poems</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/inkwell/templates/home.html
+++ b/inkwell/templates/home.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="home-epigraph">
+      <div class="book-title">{{ site.title }}</div>
+      <div class="book-subtitle">{{ site.description }}</div>
+    </div>
+
+    <hr class="home-divider">
+
+    <ul class="poem-list">
+      {% for poem in site.pages %}
+      {% if poem.section == "poems" %}
+      <li class="poem-entry">
+        <div class="poem-entry-title"><a href="{{ base_url }}{{ poem.url }}">{{ poem.title }}</a></div>
+        {% if poem.description %}
+        <div class="poem-entry-excerpt">{{ poem.description }}</div>
+        {% endif %}
+        {% if poem.date %}
+        <div class="poem-entry-meta">{{ poem.date }}</div>
+        {% endif %}
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/inkwell/templates/page.html
+++ b/inkwell/templates/page.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.section == "poems" %}
+    <article>
+      <div class="poem-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="poem-meta">{{ page.date }}</div>
+        {% endif %}
+      </div>
+
+      <div class="poem-body">
+        {{ content }}
+      </div>
+
+      {% if page.tags %}
+      <div class="tag-list">
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | lower | replace(' ', '-') }}/">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <div class="poem-end-mark">* * *</div>
+
+      <div class="poem-footer-nav">
+        <a href="{{ base_url }}/poems/">Back to all poems</a>
+      </div>
+    </article>
+    {% else %}
+    <article class="prose">
+      <h1>{{ page.title }}</h1>
+      {{ content }}
+    </article>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/inkwell/templates/section.html
+++ b/inkwell/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/inkwell/templates/shortcodes/alert.html
+++ b/inkwell/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/inkwell/templates/taxonomy.html
+++ b/inkwell/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    <p class="taxonomy-desc">Browse all collections</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/inkwell/templates/taxonomy_term.html
+++ b/inkwell/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    <p class="taxonomy-desc">Poems in this collection</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -188,6 +188,11 @@
     "dark",
     "blog"
   ],
+  "inkwell": [
+    "light",
+    "blog",
+    "poetry"
+  ],
   "lab": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Add new `inkwell` example: a poetry/verse journal with whitespace-centered layout
- Elegant serif typography (Cormorant Garamond + EB Garamond), thin ink-line dividers
- Minimal book-cover style index page, centered verse with clear stanza separation
- 6 sample poems with tag taxonomy (nature, seasons, home, solitude, etc.)
- Light theme, no gradients, no emojis

## Test plan
- [ ] `hwaro build` succeeds without warnings
- [ ] Home page renders book-cover layout with poem list
- [ ] Individual poem pages show centered verse with stanza spacing
- [ ] About page renders prose layout with blockquote
- [ ] `/poems/` section list renders correctly
- [ ] Tags taxonomy pages work
- [ ] Responsive layout on mobile

Closes #124