### PR TITLE
Add curator example: museum / art exhibition theme

### DIFF
--- a/curator/AGENTS.md
+++ b/curator/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/curator/config.toml
+++ b/curator/config.toml
@@ -1,0 +1,130 @@
+title = "Curator"
+description = "Museum and art exhibition theme with white cube gallery aesthetics"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 20
+sections = ["works"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/curator/content/about.md
+++ b/curator/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About"
++++
+
+## The Gallery
+
+Curator is a space dedicated to the contemplation of contemporary art. Founded in 2020, the gallery maintains a focused program of exhibitions that prioritize depth over breadth.
+
+Our exhibition philosophy centers on creating intimate encounters between viewer and artwork. Each piece is given generous space -- room to breathe, room to be seen.
+
+## Visit
+
+The gallery is open Tuesday through Saturday, 10:00 to 18:00. Late opening until 21:00 on the first Thursday of each month.
+
+Admission is free.
+
+## Contact
+
+For press inquiries, exhibition proposals, and general information, please reach out through the contact channels listed on our institutional page.

--- a/curator/content/index.md
+++ b/curator/content/index.md
@@ -1,0 +1,14 @@
++++
+title = "Current Exhibition"
+template = "home"
++++
+
+## Traces of Light
+
+An exhibition exploring the intersection of form, space, and perception. Through six selected works spanning painting, sculpture, photography, and installation, this collection invites viewers to reconsider the boundaries between the visible and the felt.
+
+The works presented here examine how light shapes our understanding of materiality -- from the stillness of captured shadow to the quiet tension of suspended form.
+
+**On view:** January 15 -- April 30, 2026
+
+Gallery hours: Tuesday -- Saturday, 10:00 -- 18:00

--- a/curator/content/works/_index.md
+++ b/curator/content/works/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Works"
+sort_by = "weight"
+reverse = false
+template = "section"
++++

--- a/curator/content/works/erosion-study-no-7.md
+++ b/curator/content/works/erosion-study-no-7.md
@@ -1,0 +1,15 @@
++++
+title = "Erosion Study No. 7"
+weight = 5
+tags = ["sculpture", "ceramic"]
+artist = "Seo Jiwon"
+year = "2024"
+medium = "Stoneware, calcium oxide glaze"
+dimensions = "35 x 28 x 22 cm"
++++
+
+A compact, densely worked ceramic form, *Erosion Study No. 7* is part of Seo's extended investigation into the aesthetics of geological time. The surface has been repeatedly built up and carved away, fired and re-fired, producing a terrain of ridges, fissures, and smooth plateaus that suggests both landscape and body.
+
+The calcium oxide glaze pools in recesses and thins over ridges, creating a topographic map of the firing process itself. Seo embraces the kiln as collaborator, allowing thermal accident to complete what the hand began.
+
+Despite its modest scale, the work carries considerable visual weight. It asks to be circumnavigated, examined from above and below, its surface read like braille.

--- a/curator/content/works/resonance-field.md
+++ b/curator/content/works/resonance-field.md
@@ -1,0 +1,15 @@
++++
+title = "Resonance Field"
+weight = 4
+tags = ["installation", "sound"]
+artist = "Idriss Benhaddou"
+year = "2025"
+medium = "Speaker array, custom electronics, copper wire"
+dimensions = "Variable, approx. 400 x 600 cm"
++++
+
+*Resonance Field* is a site-responsive sound installation that transforms the gallery into an instrument. Sixteen speakers, suspended at varying heights, emit barely audible tones that shift in response to the movement of visitors within the space.
+
+Benhaddou's work operates at the threshold of perception. The tones are felt as much as heard -- low frequencies that resonate in the chest, high harmonics that seem to exist just at the edge of consciousness. The copper wire connecting the speakers creates a visible web that maps the sonic architecture of the room.
+
+The piece resists passive consumption. It demands presence, stillness, and attention. Stand in one spot and the sound stabilizes into a chord; move, and it dissolves into something new.

--- a/curator/content/works/still-life-with-absence.md
+++ b/curator/content/works/still-life-with-absence.md
@@ -1,0 +1,15 @@
++++
+title = "Still Life with Absence"
+weight = 2
+tags = ["painting", "oil"]
+artist = "Yuto Nakamura"
+year = "2023"
+medium = "Oil on linen"
+dimensions = "120 x 90 cm"
++++
+
+Nakamura's painting presents a table arranged with familiar domestic objects -- a ceramic bowl, a folded cloth, a glass half-filled with water -- yet the composition is governed by what is missing. A conspicuous gap at the center of the arrangement draws the eye more forcefully than any object present.
+
+The palette is restrained: muted earth tones and cool grays, punctuated by the translucence of the glass. Nakamura's brushwork oscillates between precise rendering and passages of deliberate ambiguity, where forms soften and bleed into the ground.
+
+This is still life as meditation on loss -- not dramatic or sentimental, but quiet, attentive, and deeply considered.

--- a/curator/content/works/suspended-geometry.md
+++ b/curator/content/works/suspended-geometry.md
@@ -1,0 +1,15 @@
++++
+title = "Suspended Geometry"
+weight = 1
+tags = ["sculpture", "installation"]
+artist = "Maren Solvik"
+year = "2024"
+medium = "Steel wire, brass, nylon thread"
+dimensions = "240 x 180 x 180 cm"
++++
+
+A lattice of intersecting lines held in tension, *Suspended Geometry* occupies the threshold between drawing and sculpture. Solvik's practice treats three-dimensional space as a canvas, using industrial materials to trace forms that shift with the viewer's position.
+
+The work rewards slow looking. From one angle, the wires converge into dense, almost opaque planes; from another, they dissolve into near-invisibility. The brass elements catch ambient light unpredictably, producing fleeting constellations that never repeat.
+
+Solvik has spoken of her interest in structures that exist "between presence and disappearance." This piece embodies that tension -- monumental in scale, yet so delicate it seems on the verge of vanishing.

--- a/curator/content/works/threshold-i.md
+++ b/curator/content/works/threshold-i.md
@@ -1,0 +1,15 @@
++++
+title = "Threshold I"
+weight = 3
+tags = ["photography", "silver-gelatin"]
+artist = "Clara Reinhardt"
+year = "2022"
+medium = "Silver gelatin print"
+dimensions = "60 x 45 cm"
++++
+
+*Threshold I* belongs to Reinhardt's ongoing series examining transitional architectural spaces -- doorways, corridors, stairwells -- photographed in conditions of extreme low light. The resulting image hovers between representation and abstraction: a vertical sliver of light bisects a field of near-total darkness.
+
+Reinhardt works exclusively with analogue processes, and the materiality of the silver gelatin print is essential to the work's effect. In reproduction, the image reads as a simple division of light and dark. In person, the surface reveals a complex tonal range -- deep, velvety blacks giving way to luminous mid-tones that seem to emanate from within the paper itself.
+
+The print invites the viewer to step closer, to peer into the darkness, to cross the threshold.

--- a/curator/content/works/window-condition.md
+++ b/curator/content/works/window-condition.md
@@ -1,0 +1,15 @@
++++
+title = "Window, Condition"
+weight = 6
+tags = ["painting", "mixed-media"]
+artist = "Lena Pavlova"
+year = "2023"
+medium = "Acrylic, graphite, and gesso on panel"
+dimensions = "150 x 110 cm"
++++
+
+Pavlova's large-scale panel painting layers translucent washes of acrylic over dense graphite drawing, producing a surface that shifts between opacity and transparency. The title references both the architectural element and the act of looking through -- a painting as aperture.
+
+The composition suggests a window frame, but the view beyond is indeterminate: pale fields of color overlap and recede, neither landscape nor abstraction but something in between. Graphite lines emerge and submerge beneath the paint, like thoughts not quite articulated.
+
+Pavlova has described her process as "building a surface that remembers." Each layer records a decision, a gesture, a revision. The final image is an archaeology of its own making.

--- a/curator/static/css/style.css
+++ b/curator/static/css/style.css
@@ -1,0 +1,557 @@
+/* =========================================================================
+   Curator — Museum / Art Exhibition Theme
+   ========================================================================= */
+
+/* --- Reset & Base --- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --color-black: #1a1a1a;
+  --color-dark: #333333;
+  --color-mid: #777777;
+  --color-light: #b0b0b0;
+  --color-border: #e0e0e0;
+  --color-bg: #fdfdfd;
+  --color-white: #ffffff;
+  --font-serif: "Cormorant Garamond", "Georgia", "Times New Roman", serif;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --max-width: 860px;
+  --spacing-xs: 0.5rem;
+  --spacing-sm: 1rem;
+  --spacing-md: 2rem;
+  --spacing-lg: 4rem;
+  --spacing-xl: 6rem;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--color-dark);
+  background-color: var(--color-bg);
+}
+
+/* --- Layout --- */
+.site-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--spacing-md);
+}
+
+/* --- Header --- */
+.site-header {
+  padding: var(--spacing-lg) 0 var(--spacing-md);
+  border-bottom: 1px solid var(--color-black);
+}
+
+.site-header-inner {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 400;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-black);
+  text-decoration: none;
+}
+
+.site-title:hover {
+  color: var(--color-mid);
+}
+
+.site-nav {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.site-nav a {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-mid);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.site-nav a:hover {
+  color: var(--color-black);
+}
+
+/* --- Main Content --- */
+.site-main {
+  min-height: calc(100vh - 280px);
+  padding: var(--spacing-xl) 0;
+}
+
+/* --- Typography --- */
+h1, h2, h3, h4 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  color: var(--color-black);
+  line-height: 1.3;
+}
+
+h1 {
+  font-size: 2.2rem;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--spacing-md);
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+h3 {
+  font-size: 1.15rem;
+  margin-top: var(--spacing-md);
+  margin-bottom: var(--spacing-xs);
+}
+
+p {
+  margin-bottom: var(--spacing-sm);
+  max-width: 65ch;
+}
+
+a {
+  color: var(--color-black);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--color-mid);
+}
+
+blockquote {
+  border-left: 2px solid var(--color-border);
+  padding-left: var(--spacing-md);
+  margin: var(--spacing-md) 0;
+  color: var(--color-mid);
+  font-style: italic;
+}
+
+strong {
+  font-weight: 600;
+  color: var(--color-black);
+}
+
+em {
+  font-style: italic;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-lg) 0;
+}
+
+/* --- Home / Exhibition Page --- */
+.exhibition-intro {
+  max-width: 580px;
+}
+
+.exhibition-intro h2 {
+  font-size: 2rem;
+  font-style: italic;
+  margin-top: 0;
+  margin-bottom: var(--spacing-md);
+}
+
+.exhibition-intro p {
+  color: var(--color-dark);
+  line-height: 1.8;
+}
+
+.exhibition-works-heading {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-light);
+  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* --- Works List (Home) --- */
+.works-list {
+  list-style: none;
+}
+
+.works-list li {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.works-list li:last-child {
+  border-bottom: none;
+}
+
+.work-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: var(--spacing-sm) 0;
+  text-decoration: none;
+  transition: padding-left 0.2s;
+}
+
+.work-link:hover {
+  padding-left: var(--spacing-sm);
+}
+
+.work-link:hover .work-title {
+  color: var(--color-black);
+}
+
+.work-title {
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  font-style: italic;
+  color: var(--color-dark);
+  transition: color 0.2s;
+}
+
+.work-artist {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  color: var(--color-light);
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  margin-left: var(--spacing-md);
+}
+
+/* --- Section (Works Gallery) --- */
+.section-header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.section-header h1 {
+  font-size: 1rem;
+  font-family: var(--font-sans);
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-light);
+}
+
+/* --- Artwork Page --- */
+.artwork-header {
+  margin-bottom: var(--spacing-lg);
+  padding-bottom: var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.artwork-title {
+  font-family: var(--font-serif);
+  font-size: 2.4rem;
+  font-style: italic;
+  font-weight: 400;
+  margin-bottom: var(--spacing-md);
+}
+
+/* --- Caption / Metadata (Museum Label Style) --- */
+.artwork-caption {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1.5rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  max-width: 400px;
+}
+
+.caption-label {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-light);
+  padding-top: 0.15rem;
+}
+
+.caption-value {
+  color: var(--color-dark);
+}
+
+/* --- Artwork Body --- */
+.artwork-body {
+  max-width: 600px;
+  padding: var(--spacing-lg) 0;
+}
+
+.artwork-body p {
+  margin-bottom: 1.2rem;
+  line-height: 1.85;
+}
+
+/* --- Prev / Next Navigation --- */
+.artwork-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  margin-top: var(--spacing-xl);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+  gap: var(--spacing-md);
+}
+
+.artwork-nav-item {
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-width: 45%;
+  transition: opacity 0.2s;
+}
+
+.artwork-nav-item:hover {
+  opacity: 0.6;
+}
+
+.artwork-nav-item--next {
+  text-align: right;
+  margin-left: auto;
+}
+
+.nav-direction {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-light);
+}
+
+.nav-title {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--color-dark);
+}
+
+/* --- Tags --- */
+.artwork-tags {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+}
+
+.tag {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-light);
+  border: 1px solid var(--color-border);
+  padding: 0.2rem 0.6rem;
+  text-decoration: none;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.tag:hover {
+  color: var(--color-dark);
+  border-color: var(--color-dark);
+}
+
+/* --- Taxonomy --- */
+.taxonomy-list {
+  list-style: none;
+  margin-top: var(--spacing-md);
+}
+
+.taxonomy-list li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.taxonomy-list a {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  font-style: italic;
+  text-decoration: none;
+  color: var(--color-dark);
+}
+
+.taxonomy-list a:hover {
+  color: var(--color-mid);
+}
+
+.taxonomy-heading {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-light);
+  margin-bottom: var(--spacing-sm);
+}
+
+/* --- Footer --- */
+.site-footer {
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-md) 0;
+  border-top: 1px solid var(--color-black);
+}
+
+.site-footer p {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--color-light);
+}
+
+.site-footer a {
+  color: var(--color-light);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  color: var(--color-dark);
+}
+
+/* --- 404 --- */
+.error-page {
+  text-align: center;
+  padding: var(--spacing-xl) 0;
+}
+
+.error-page h1 {
+  font-size: 5rem;
+  font-family: var(--font-serif);
+  font-weight: 300;
+  color: var(--color-border);
+  margin-bottom: var(--spacing-sm);
+}
+
+.error-page p {
+  color: var(--color-mid);
+  max-width: none;
+}
+
+.error-page a {
+  color: var(--color-dark);
+}
+
+/* --- Page (About, etc.) --- */
+.page-header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.page-header h1 {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-light);
+}
+
+.page-body {
+  max-width: 600px;
+}
+
+.page-body h2 {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-black);
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+.page-body p {
+  line-height: 1.85;
+  margin-bottom: 1.2rem;
+}
+
+/* --- Code --- */
+code {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.85em;
+  background: #f5f5f5;
+  padding: 0.15rem 0.4rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: #f5f5f5;
+  padding: var(--spacing-sm);
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  margin: var(--spacing-md) 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* --- Responsive --- */
+@media (max-width: 640px) {
+  :root {
+    --spacing-lg: 3rem;
+    --spacing-xl: 4rem;
+  }
+
+  .site-wrapper {
+    padding: 0 var(--spacing-sm);
+  }
+
+  .site-header-inner {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+
+  h1 {
+    font-size: 1.75rem;
+  }
+
+  .artwork-title {
+    font-size: 1.8rem;
+  }
+
+  .artwork-caption {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .caption-label {
+    margin-top: 0.5rem;
+  }
+
+  .work-link {
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .work-artist {
+    margin-left: 0;
+  }
+
+  .artwork-nav {
+    flex-direction: column;
+  }
+
+  .artwork-nav-item {
+    max-width: 100%;
+  }
+
+  .artwork-nav-item--next {
+    text-align: left;
+  }
+}

--- a/curator/templates/404.html
+++ b/curator/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <h1>404</h1>
+      <p>The work you are looking for is not on display.</p>
+      <p><a href="{{ base_url }}/">Return to the exhibition</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/curator/templates/footer.html
+++ b/curator/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>Powered by <a href="https://hwaro.hahwul.com">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/curator/templates/header.html
+++ b/curator/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <div class="site-header-inner">
+        <a href="{{ base_url }}/" class="site-title">Curator</a>
+        <nav class="site-nav">
+          <a href="{{ base_url }}/">Exhibition</a>
+          <a href="{{ base_url }}/works/">Works</a>
+          <a href="{{ base_url }}/about/">About</a>
+        </nav>
+      </div>
+    </header>

--- a/curator/templates/home.html
+++ b/curator/templates/home.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="exhibition-intro">
+      {{ content | safe }}
+    </div>
+
+    <p class="exhibition-works-heading">Works in this exhibition</p>
+    <ul class="works-list">
+      {% for work in site.pages | sort_by("weight") %}
+      {% if work.section == "works" %}
+      <li>
+        <a href="{{ work.url }}" class="work-link">
+          <span class="work-title">{{ work.title }}</span>
+          <span class="work-artist">{{ work.extra.artist }}</span>
+        </a>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/curator/templates/page.html
+++ b/curator/templates/page.html
@@ -1,0 +1,62 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.section == "works" %}
+      <article>
+        <div class="artwork-header">
+          <h1 class="artwork-title">{{ page.title }}</h1>
+          <div class="artwork-caption">
+            {% if page.extra.artist %}
+            <span class="caption-label">Artist</span>
+            <span class="caption-value">{{ page.extra.artist }}</span>
+            {% endif %}
+            {% if page.extra.year %}
+            <span class="caption-label">Year</span>
+            <span class="caption-value">{{ page.extra.year }}</span>
+            {% endif %}
+            {% if page.extra.medium %}
+            <span class="caption-label">Medium</span>
+            <span class="caption-value">{{ page.extra.medium }}</span>
+            {% endif %}
+            {% if page.extra.dimensions %}
+            <span class="caption-label">Dimensions</span>
+            <span class="caption-value">{{ page.extra.dimensions }}</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+          <div class="artwork-tags">
+            {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </div>
+
+        <div class="artwork-body">
+          {{ content | safe }}
+        </div>
+
+        <nav class="artwork-nav">
+          {% if page.lower %}
+          <a href="{{ page.lower.url }}" class="artwork-nav-item artwork-nav-item--prev">
+            <span class="nav-direction">Previous work</span>
+            <span class="nav-title">{{ page.lower.title }}</span>
+          </a>
+          {% endif %}
+          {% if page.higher %}
+          <a href="{{ page.higher.url }}" class="artwork-nav-item artwork-nav-item--next">
+            <span class="nav-direction">Next work</span>
+            <span class="nav-title">{{ page.higher.title }}</span>
+          </a>
+          {% endif %}
+        </nav>
+      </article>
+    {% else %}
+      <div class="page-header">
+        <h1>{{ page.title }}</h1>
+      </div>
+      <div class="page-body">
+        {{ content | safe }}
+      </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/curator/templates/section.html
+++ b/curator/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    {{ content | safe }}
+    <ul class="works-list">
+      {% for work in site.pages | sort_by("weight") %}
+      {% if work.section == "works" %}
+      <li>
+        <a href="{{ work.url }}" class="work-link">
+          <span class="work-title">{{ work.title }}</span>
+          <span class="work-artist">{{ work.extra.artist }}{% if work.extra.year %}, {{ work.extra.year }}{% endif %}</span>
+        </a>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/curator/templates/shortcodes/alert.html
+++ b/curator/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/curator/templates/taxonomy.html
+++ b/curator/templates/taxonomy.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <p class="taxonomy-heading">Browse by {{ taxonomy_name }}</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/curator/templates/taxonomy_term.html
+++ b/curator/templates/taxonomy_term.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <p class="taxonomy-heading">Works tagged "{{ taxonomy_term }}"</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -98,6 +98,11 @@
     "blog",
     "minimal"
   ],
+  "curator": [
+    "light",
+    "portfolio",
+    "exhibition"
+  ],
   "darkroom": [
     "dark",
     "portfolio",


### PR DESCRIPTION
## Summary
- Museum / art gallery white cube style example with minimal light design
- Exhibition caption-style metadata per artwork (artist, year, medium, dimensions)
- Previous/next artwork navigation between works
- 6 sample artworks across painting, sculpture, photography, installation
- Tags: `light`, `portfolio`, `exhibition`

Closes #118

## Test plan
- [ ] `hwaro build` succeeds without errors
- [ ] Home page lists all 6 works with artist names
- [ ] Individual work pages show caption metadata and prev/next navigation
- [ ] Works section page shows all works with artist and year
- [ ] About page renders correctly
- [ ] 404 page renders correctly
- [ ] Tags and taxonomy pages work