### PR TITLE
Add terrarium example: miniature showcase theme

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -492,6 +492,11 @@
     "docs",
     "wiki"
   ],
+  "terrarium": [
+    "light",
+    "portfolio",
+    "miniature"
+  ],
   "zen": [
     "light",
     "blog",

--- a/terrarium/AGENTS.md
+++ b/terrarium/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/terrarium/config.toml
+++ b/terrarium/config.toml
@@ -1,0 +1,131 @@
+title = "Terrarium"
+description = "A showcase of miniature worlds and tiny things — delicate craftsmanship in small scale."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[pagination]
+enabled = true
+per_page = 9
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 3
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["gallery", "process"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/terrarium/content/about.md
+++ b/terrarium/content/about.md
@@ -1,0 +1,29 @@
++++
+title = "About"
++++
+
+## About Terrarium
+
+Terrarium is a showcase of miniature craftsmanship — a place where small-scale creations are presented with the reverence they deserve. Each piece in our collection represents hours of careful, deliberate work at a scale most people overlook.
+
+## Our Philosophy
+
+We believe the smallest things deserve the closest attention. A 1:48 scale bookshelf tells a story not just about woodworking, but about patience, precision, and the quiet joy of creating something that fits in the palm of your hand.
+
+## What We Document
+
+- **Finished pieces** — Photographed in detail, with precise scale and material information
+- **Making processes** — Step-by-step documentation showing how miniatures come to life
+- **Techniques** — From sculpting and painting to weathering and lighting at tiny scales
+
+## Scale Reference
+
+All works in the collection include scale metadata so you can understand the true size of what you're seeing:
+
+| Scale | Common Use | 1cm Represents |
+|-------|-----------|---------------|
+| 1:12 | Dollhouse standard | 12cm |
+| 1:24 | Half scale | 24cm |
+| 1:48 | Quarter scale | 48cm |
+| 1:87 | HO model railroad | 87cm |
+| 1:144 | Micro scale | 144cm |

--- a/terrarium/content/gallery/_index.md
+++ b/terrarium/content/gallery/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Gallery"
+sort_by = "date"
+reverse = true
+description = "A curated collection of miniature works, each photographed to reveal the fine details invisible to the casual eye."
+template = "section"
++++

--- a/terrarium/content/gallery/bonsai-grove.md
+++ b/terrarium/content/gallery/bonsai-grove.md
@@ -1,0 +1,33 @@
++++
+title = "Bonsai Grove"
+date = "2026-02-20"
+description = "Three miniature wire-armature trees planted in a handmade ceramic tray, evoking a windswept coastal grove."
+tags = ["botanical", "sculpture", "wire"]
+scale = "1:48"
+actual_size = "10 x 6cm"
+materials = "Copper wire, static grass, clay, acrylic"
++++
+
+## Bonsai Grove
+
+A triptych of miniature trees arranged in a shallow ceramic dish, suggesting a grove shaped by decades of coastal wind. The tallest tree stands just over 4 centimeters.
+
+## Wire Armature Technique
+
+Each tree begins as a bundle of 30-gauge copper wires twisted together at the base to form the trunk. Individual wires are then separated and shaped to create primary branches, secondary branches, and finally the finest twig structure.
+
+### Trunk Treatment
+
+After shaping, the wire trunks are coated with a mixture of PVA glue and tissue paper, built up in thin layers and textured with a dental tool to simulate bark. The surface is painted in thin washes of acrylic — raw umber base with lighter dry-brushing to bring out the texture.
+
+### Foliage
+
+The canopy is made from static grass and fine foam flock, applied with an electrostatic applicator. The color transitions from dark green at the interior to a lighter, sun-bleached tone at the windward edges.
+
+## The Tray
+
+The ceramic dish was thrown on a miniature potter's wheel and bisque-fired. A thin ash glaze gives it a matte, stone-like surface. Three drainage holes are drilled in the base, though they serve only an aesthetic purpose in this display piece.
+
+## Arrangement
+
+The three trees are positioned according to classical bonsai grouping principles: the tallest on one side, the second offset behind, and the smallest creating a forward accent. The negative space between them is as carefully considered as the forms themselves.

--- a/terrarium/content/gallery/kitchen-shelf.md
+++ b/terrarium/content/gallery/kitchen-shelf.md
@@ -1,0 +1,42 @@
++++
+title = "Kitchen Shelf"
+date = "2026-02-10"
+description = "A 1:12 dollhouse-scale kitchen shelf stocked with handmade ceramic vessels, copper pots, and preserved food jars."
+tags = ["diorama", "interior", "ceramic"]
+scale = "1:12"
+actual_size = "12 x 3 x 8cm"
+materials = "Basswood, polymer clay, copper sheet, paper"
++++
+
+## Kitchen Shelf
+
+A single shelf unit from a dollhouse kitchen, presented as a standalone piece. Every item on it was made by hand at 1:12 scale — the standard for dollhouse miniatures.
+
+## The Shelf
+
+Built from basswood strips, joined with mortise-and-tenon joints (yes, even at this scale). The wood is stained with diluted walnut ink and finished with a thin coat of wax. Three shelves, each 12 centimeters wide.
+
+## Contents
+
+### Top Shelf — Ceramics
+
+Six vessels thrown from polymer clay on a pin vise:
+- Two stoneware crocks with lids
+- A pitcher with a pulled handle
+- Three small bowls stacked together
+
+Each piece was shaped, cured, sanded, and glazed with thinned acrylic. The stoneware texture comes from rolling the raw clay against fine sandpaper before shaping.
+
+### Middle Shelf — Copper Pots
+
+Four copper pots and pans made from 0.1mm copper sheet:
+- Cut to pattern with micro scissors
+- Shaped over wooden forms
+- Seams soldered under magnification
+- Handles riveted with 0.3mm brass pins
+
+The largest pot is 9 millimeters in diameter. The smallest saucepan is 5 millimeters.
+
+### Bottom Shelf — Preserved Foods
+
+Eight glass jars with preserved fruits and vegetables. The jars are cut from clear acrylic rod on a mini lathe, hollowed with a drill bit, and filled with tinted resin to simulate preserved contents. Lids are turned brass discs with paper labels.

--- a/terrarium/content/gallery/moss-jar.md
+++ b/terrarium/content/gallery/moss-jar.md
@@ -1,0 +1,29 @@
++++
+title = "The Moss Jar"
+date = "2026-03-20"
+description = "A self-sustaining ecosystem sealed inside a vintage apothecary jar, featuring live moss, tiny ferns, and a miniature stone path."
+tags = ["terrarium", "botanical", "sealed"]
+scale = "1:12"
+actual_size = "8cm tall"
+materials = "Glass jar, sphagnum moss, fittonia, pebbles"
++++
+
+## The Moss Jar
+
+A closed terrarium built inside a reclaimed apothecary jar from a Paris flea market. The vessel measures just 8 centimeters tall, yet contains a complete, self-cycling ecosystem.
+
+## Composition
+
+The layers follow classical terrarium construction: drainage pebbles at the base, followed by activated charcoal, a thin mesh barrier, and substrate. The planting arrangement creates a natural-looking forest floor with varying heights and textures.
+
+The stone path is made from individually shaped pieces of slate, each no larger than a grain of rice. They wind through the moss carpet toward a small clearing at the back of the jar.
+
+## Living Elements
+
+- **Sphagnum moss** — Forms the ground cover, maintaining humidity
+- **Fittonia** — A single nerve plant cutting, chosen for its fine leaf pattern
+- **Selaginella** — Miniature fern-like accent near the path edge
+
+## Technical Notes
+
+The seal was completed three months ago. Condensation cycles are visible on the glass walls each morning, indicating a healthy water cycle. No intervention has been needed since sealing.

--- a/terrarium/content/gallery/ocean-pendant.md
+++ b/terrarium/content/gallery/ocean-pendant.md
@@ -1,0 +1,32 @@
++++
+title = "Ocean Pendant"
+date = "2026-02-28"
+description = "A wearable resin pendant containing a sculpted ocean floor scene with coral, sand, and a tiny shipwreck."
+tags = ["resin", "jewelry", "ocean"]
+scale = "1:144"
+actual_size = "2.5cm diameter"
+materials = "UV resin, pigment, wire, sand"
++++
+
+## Ocean Pendant
+
+A micro-scale seascape encased in a dome of optically clear UV resin. The pendant measures 2.5 centimeters across — small enough to wear as a necklace, detailed enough to reward close inspection with a loupe.
+
+## Layered Construction
+
+The scene was built in six resin pours, each cured before the next layer was added. This creates genuine depth rather than a flat image:
+
+1. **Base layer** — Fine white sand mixed into resin for the ocean floor
+2. **Wreck layer** — A shipwreck frame bent from 0.1mm copper wire, positioned on the sand bed
+3. **Coral layer** — Branching coral structures sculpted from tinted resin, placed with tweezers
+4. **Water layer** — Lightly tinted blue resin filling the mid-depth
+5. **Surface layer** — Clear resin with a subtle ripple texture on the casting surface
+6. **Dome coat** — Final clear coat sanded and polished to optical clarity
+
+## The Shipwreck
+
+The hull frame consists of eleven ribs bent from copper wire, each approximately 3 millimeters long. They are arranged to suggest a vessel half-buried in sand, with the keel line still visible. A single mast stub rises from the center — 2 millimeters of wire with a thread-wrapped tip.
+
+## Finishing
+
+The pendant bezel is turned brass, polished and lacquered. A silver bail connects to a fine chain. Total weight: 4 grams.

--- a/terrarium/content/gallery/reading-nook.md
+++ b/terrarium/content/gallery/reading-nook.md
@@ -1,0 +1,36 @@
++++
+title = "The Reading Nook"
+date = "2026-03-15"
+description = "A 1:24 scale recreation of a cozy reading corner with handbound books, a working lamp, and upholstered armchair."
+tags = ["diorama", "interior", "furniture"]
+scale = "1:24"
+actual_size = "6 x 5 x 7cm"
+materials = "Basswood, paper, LED, fabric, brass wire"
++++
+
+## The Reading Nook
+
+This half-scale diorama captures a quiet evening reading corner. The entire scene fits within a box measuring 6 by 5 by 7 centimeters, yet every element is individually crafted.
+
+## Details
+
+The armchair was built from basswood and upholstered with a scrap of vintage linen. The cushion shows a slight depression — shaped while the glue was still setting to suggest the presence of an absent reader.
+
+### The Books
+
+Twelve miniature books line the shelf behind the chair. Each was individually bound:
+
+1. Pages cut from tissue paper and folded into signatures
+2. Spines glued with PVA and clamped under a weighted block
+3. Covers made from cardstock with printed textures
+4. Titles hand-lettered under a magnifying lamp
+
+The largest book measures 4 millimeters tall. The smallest is barely 2 millimeters — just visible without magnification.
+
+### The Lamp
+
+A functioning LED lamp sits on the side table. The shade is turned from a wooden dowel sanded to 0.3mm wall thickness, thin enough to glow warmly when lit. The brass wire stem runs through a drilled channel in the table leg to a hidden battery compartment below the diorama base.
+
+## Construction Time
+
+Approximately 40 hours across three weeks.

--- a/terrarium/content/gallery/winter-street.md
+++ b/terrarium/content/gallery/winter-street.md
@@ -1,0 +1,29 @@
++++
+title = "Winter Street"
+date = "2026-03-08"
+description = "A 1:87 HO-scale street scene depicting a quiet European lane after fresh snowfall, with lit shop windows."
+tags = ["diorama", "architectural", "seasonal"]
+scale = "1:87"
+actual_size = "15 x 8cm"
+materials = "Styrene, plaster, acrylic paint, fiber optics"
++++
+
+## Winter Street
+
+An HO-scale vignette of a cobblestone lane somewhere in northern Europe. Fresh snow blankets the rooftops and gathers in the crevices of the stone facades. Two shop windows glow with warm light from fiber optics routed through the building shells.
+
+## Buildings
+
+Three structures line the street, each scratch-built from styrene sheet:
+
+- **The bakery** — Half-timbered facade with individual timber strips. The window display holds a tray of bread rolls sculpted from epoxy putty, each one smaller than a peppercorn.
+- **The bookshop** — Stone facade scored and painted to simulate aged limestone. A hand-painted sign hangs from a bent wire bracket.
+- **The residence** — Rendered walls with a slate roof made from layered cardstock, individually cut and staggered.
+
+## Snow Effects
+
+The snow is a combination of baking soda (for fresh-fallen coverage) and white acrylic medium (for icy, compacted areas). Icicles hanging from the eaves are made from stretched clear sprue — heated and pulled to a hair-thin taper.
+
+## Lighting
+
+Warm white fiber optics illuminate the shop interiors. The light source is a single LED hidden beneath the base, with individual fibers routed up through drilled channels in the floor plates. The effect is visible only when ambient light is low, just like real shop windows at dusk.

--- a/terrarium/content/index.md
+++ b/terrarium/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Terrarium"
+template = "home"
++++

--- a/terrarium/content/process/_index.md
+++ b/terrarium/content/process/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Making Process"
+sort_by = "weight"
+reverse = false
+description = "Step-by-step documentation of how miniature worlds are built — from concept to completion."
+template = "section"
++++

--- a/terrarium/content/process/building-the-structure.md
+++ b/terrarium/content/process/building-the-structure.md
@@ -1,0 +1,45 @@
++++
+title = "Building the Structure"
+date = "2026-03-05"
+weight = 2
+description = "Constructing the physical framework — cutting, joining, and assembling the core structural elements."
+tags = ["process", "construction"]
+materials = "Basswood, styrene, adhesives"
+step = "2"
++++
+
+## From Flat to Form
+
+With plans in hand, construction begins. The structural phase transforms flat sheet material into three-dimensional forms that will carry the detail work to come.
+
+## Cutting
+
+Precision cutting is the foundation of clean miniature work. The primary tools:
+
+- **Steel ruler and fresh blade** — For straight cuts in sheet material. Blades are changed frequently; a dull edge tears rather than cuts at this scale.
+- **Micro saw** — For thicker stock. A jeweler's saw with a fine blade handles basswood strips cleanly.
+- **Laser cutter** — When available, produces the cleanest edges. Particularly useful for repetitive elements like roof tiles or floor planks.
+
+## Joining
+
+At miniature scale, joinery must be both strong and invisible:
+
+- **PVA glue** — The workhorse adhesive. Slow setting allows repositioning. Sands cleanly when dry.
+- **Cyanoacrylate (CA)** — For instant bonds on non-porous materials. Used sparingly — excess shows.
+- **Soldering** — For metal-to-metal joins on copper and brass elements.
+
+Where possible, mechanical joints are used even at small scale. A shelf bracket with a genuine mortise joint will look correct in ways that a butt-glued joint cannot match, because the eye reads the grain direction and shadow lines.
+
+## Assembly Order
+
+Structures are assembled inside-out:
+
+1. Interior walls and floors first
+2. Exterior shell fitted around the interior
+3. Roof structure last (allows access to interior during detailing)
+
+This order matters because many interior details — wiring for lights, surface textures on walls — must be completed before the space is enclosed.
+
+## Checking Scale
+
+Throughout construction, the piece is regularly checked against a scale ruler and reference photos. A common mistake is "scale creep" — unconsciously making elements slightly too large because they feel fragile. Trusting the measurements over instinct is essential.

--- a/terrarium/content/process/concept-and-planning.md
+++ b/terrarium/content/process/concept-and-planning.md
@@ -1,0 +1,44 @@
++++
+title = "Concept and Planning"
+date = "2026-03-01"
+weight = 1
+description = "Every miniature begins with research, reference gathering, and scale calculations before any material is touched."
+tags = ["process", "planning"]
+materials = "Paper, pencil, reference photos"
+step = "1"
++++
+
+## Starting Small Starts Big
+
+The paradox of miniature work is that the smallest projects demand the most planning. At 1:12 or 1:48 scale, there is no room for improvisation — every millimeter is committed.
+
+## Reference Gathering
+
+Before any material is cut, the process begins with research:
+
+- **Photographic reference** — Collecting images of the real-world subject from multiple angles
+- **Dimensional research** — Finding actual measurements to convert to the working scale
+- **Material study** — Understanding what the real surfaces look like at close range
+
+For architectural subjects, floor plans and elevation drawings are essential. For organic subjects like plants, macro photography reveals structures that are invisible at normal viewing distance.
+
+## Scale Drawings
+
+Working drawings are produced at the target scale, typically on graph paper with a fine mechanical pencil. Key measurements are noted in both real-world and scaled dimensions.
+
+A simple conversion table is kept on hand:
+
+| Real Size | 1:12 | 1:24 | 1:48 |
+|-----------|------|------|------|
+| 1 meter | 83mm | 42mm | 21mm |
+| 30cm | 25mm | 12.5mm | 6.3mm |
+| 10cm | 8.3mm | 4.2mm | 2.1mm |
+
+## Material Selection
+
+Materials are chosen not just for appearance but for workability at the target scale. Wood that carves well at full size may splinter at miniature dimensions. Paint that looks smooth on a wall may appear thick and textured on a 5mm surface.
+
+Common substitutions:
+- Basswood replaces hardwoods (finer grain at small scale)
+- Tissue paper replaces fabric (thinner drape)
+- Copper wire replaces steel (easier to bend without spring-back)

--- a/terrarium/content/process/detailing-and-finishing.md
+++ b/terrarium/content/process/detailing-and-finishing.md
@@ -1,0 +1,55 @@
++++
+title = "Detailing and Finishing"
+date = "2026-03-10"
+weight = 3
+description = "Adding the fine details, paint, weathering, and final touches that bring a miniature world to life."
+tags = ["process", "detailing", "painting"]
+materials = "Acrylic paint, pigments, varnish, micro tools"
+step = "3"
++++
+
+## Where the Magic Lives
+
+The structure is built. Now comes the phase that transforms a small object into a small world. Detailing is where miniature work earns its reputation for obsessiveness — and where the results justify it.
+
+## Surface Preparation
+
+Before any paint touches the surface:
+
+1. All joints are filled and sanded smooth
+2. Surfaces are cleaned of dust and finger oils
+3. A thin primer coat is applied (grey for most surfaces, white for light colors)
+
+Primer serves two purposes: it provides a uniform base for color, and it reveals surface imperfections that bare material hides. A second round of sanding often follows the first primer coat.
+
+## Painting
+
+Miniature painting follows different rules than full-scale work:
+
+- **Thin coats** — Multiple thin layers build depth without obscuring detail. A single thick coat will fill carved lines and round sharp edges.
+- **Wash technique** — Thinned paint flows into recesses, creating shadow and depth. Dark washes over a lighter base coat instantly add age and dimension.
+- **Dry brushing** — A nearly dry brush dragged across raised surfaces deposits paint only on the high points, simulating wear and highlighting texture.
+
+### Color at Scale
+
+Colors behave differently at miniature scale. Atmospheric perspective means that distant objects appear lighter and less saturated. Even in a diorama only 15 centimeters deep, this effect should be considered:
+
+- Foreground elements use full-strength color
+- Background elements are mixed with a small amount of the background color
+- This subtle shift creates convincing depth
+
+## Weathering
+
+New things look wrong in miniature. Real-world objects accumulate wear, dirt, and patina. Weathering techniques simulate this:
+
+- **Pigment powders** — Rubbed into surfaces to simulate dust and grime
+- **Chipping** — Sponge-applied paint in contrasting colors suggests worn edges
+- **Rust effects** — Orange and brown washes on metal surfaces
+
+The key is restraint. Over-weathering is as unconvincing as no weathering at all.
+
+## Final Assembly
+
+The last step brings all sub-assemblies together. Elements that were painted and detailed separately are now placed into the scene. Lighting is connected. Loose items — books on a shelf, leaves on a path — are positioned with tweezers and fixed with micro drops of adhesive.
+
+Then the piece is sealed and placed under glass, or framed, or mounted. And a world that fits in your hands is complete.

--- a/terrarium/templates/404.html
+++ b/terrarium/templates/404.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container">
+      <div class="not-found">
+        <h1>404</h1>
+        <p>This tiny world could not be found.</p>
+        <p style="margin-top: 1.5rem;"><a href="{{ base_url }}/">Return to the collection</a></p>
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terrarium/templates/footer.html
+++ b/terrarium/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <div class="container">
+        <p>Powered by Hwaro</p>
+      </div>
+    </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/terrarium/templates/header.html
+++ b/terrarium/templates/header.html
@@ -1,0 +1,519 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --font-serif: "Cormorant Garamond", Georgia, serif;
+      --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --color-ink: #2c2c2c;
+      --color-ink-light: #6b6b6b;
+      --color-ink-faint: #a0a0a0;
+      --color-surface: #faf9f7;
+      --color-surface-warm: #f3f1ed;
+      --color-surface-card: #ffffff;
+      --color-border: #e4e0da;
+      --color-border-light: #ece9e3;
+      --color-accent: #7a6e5d;
+      --color-accent-hover: #5c523f;
+      --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);
+      --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.06);
+      --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.08);
+      --radius: 3px;
+      --max-width: 1120px;
+      --content-width: 680px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--font-sans);
+      font-weight: 300;
+      font-size: 15px;
+      line-height: 1.7;
+      color: var(--color-ink);
+      background-color: var(--color-surface);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Layout */
+    .container { max-width: var(--max-width); margin: 0 auto; padding: 0 2rem; }
+    .content-narrow { max-width: var(--content-width); margin: 0 auto; }
+
+    /* Header */
+    .site-header {
+      padding: 1.75rem 0;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .site-header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .site-brand {
+      text-decoration: none;
+      color: var(--color-ink);
+    }
+    .site-brand .brand-name {
+      font-family: var(--font-serif);
+      font-size: 1.5rem;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+    }
+    .site-brand span {
+      display: block;
+      font-family: var(--font-sans);
+      font-size: 0.7rem;
+      font-weight: 300;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--color-ink-faint);
+      margin-top: 2px;
+    }
+    .site-nav {
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+    .site-nav a {
+      font-size: 0.8rem;
+      font-weight: 400;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-decoration: none;
+      color: var(--color-ink-light);
+      transition: color 0.2s ease;
+    }
+    .site-nav a:hover {
+      color: var(--color-ink);
+    }
+
+    /* Main */
+    .site-main {
+      min-height: calc(100vh - 200px);
+      padding: 3rem 0;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      font-family: var(--font-serif);
+      font-weight: 500;
+      line-height: 1.3;
+    }
+    h1 { font-size: 2rem; margin-bottom: 0.75rem; }
+    h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 0.5rem; }
+    h3 { font-size: 1.2rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+    p { margin: 0.75rem 0; }
+
+    a {
+      color: var(--color-accent);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    a:hover { color: var(--color-accent-hover); }
+
+    /* Hero Section (Home) */
+    .hero {
+      text-align: center;
+      padding: 4rem 0 3rem;
+    }
+    .hero h1 {
+      font-family: var(--font-serif);
+      font-size: 2.75rem;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      margin-bottom: 1rem;
+    }
+    .hero p {
+      font-size: 1rem;
+      color: var(--color-ink-light);
+      max-width: 520px;
+      margin: 0 auto;
+    }
+
+    /* Gallery Grid */
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.5rem;
+      margin: 2.5rem 0;
+    }
+    .gallery-card {
+      background: var(--color-surface-card);
+      border: 1px solid var(--color-border-light);
+      border-radius: var(--radius);
+      overflow: hidden;
+      text-decoration: none;
+      color: inherit;
+      transition: box-shadow 0.25s ease, transform 0.25s ease;
+    }
+    .gallery-card:hover {
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+      color: inherit;
+    }
+    .gallery-card-image {
+      aspect-ratio: 4 / 3;
+      background-color: var(--color-surface-warm);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      position: relative;
+    }
+    .gallery-card-image img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .gallery-card-image .placeholder-icon {
+      font-size: 2rem;
+      color: var(--color-ink-faint);
+      font-family: var(--font-serif);
+      font-style: italic;
+    }
+    .scale-badge {
+      position: absolute;
+      bottom: 8px;
+      right: 8px;
+      background: rgba(255, 255, 255, 0.92);
+      padding: 2px 8px;
+      font-size: 0.65rem;
+      font-weight: 500;
+      letter-spacing: 0.05em;
+      color: var(--color-ink-light);
+      border-radius: 2px;
+    }
+    .gallery-card-body {
+      padding: 1rem 1.25rem 1.25rem;
+    }
+    .gallery-card-body h3 {
+      font-family: var(--font-serif);
+      font-size: 1.1rem;
+      font-weight: 500;
+      margin: 0 0 0.25rem;
+    }
+    .gallery-card-body .card-meta {
+      font-size: 0.75rem;
+      color: var(--color-ink-faint);
+      letter-spacing: 0.03em;
+    }
+    .gallery-card-body .card-desc {
+      font-size: 0.85rem;
+      color: var(--color-ink-light);
+      margin-top: 0.5rem;
+      line-height: 1.5;
+    }
+
+    /* Process Steps */
+    .process-steps {
+      margin: 2rem 0;
+    }
+    .step-item {
+      display: flex;
+      gap: 1.5rem;
+      padding: 1.5rem 0;
+      border-bottom: 1px solid var(--color-border-light);
+    }
+    .step-item:last-child { border-bottom: none; }
+    .step-number {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      border: 1px solid var(--color-border);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-serif);
+      font-size: 0.9rem;
+      color: var(--color-ink-light);
+    }
+    .step-content h3 {
+      font-size: 1rem;
+      margin: 0 0 0.25rem;
+    }
+    .step-content p {
+      font-size: 0.85rem;
+      color: var(--color-ink-light);
+      margin: 0;
+    }
+
+    /* Section Header */
+    .section-header {
+      margin-bottom: 2rem;
+    }
+    .section-header h1 {
+      font-size: 2rem;
+      margin-bottom: 0.25rem;
+    }
+    .section-header p {
+      color: var(--color-ink-light);
+      font-size: 0.9rem;
+    }
+
+    /* Article / Post */
+    .article {
+      max-width: var(--content-width);
+      margin: 0 auto;
+    }
+    .article-header {
+      margin-bottom: 2rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--color-border-light);
+    }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 400;
+      margin-bottom: 0.75rem;
+    }
+    .article-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.25rem;
+      font-size: 0.8rem;
+      color: var(--color-ink-faint);
+    }
+    .article-meta .meta-item {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+    .article-meta .meta-label {
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 0.65rem;
+      color: var(--color-ink-faint);
+    }
+    .article-body {
+      font-size: 1rem;
+      line-height: 1.8;
+    }
+    .article-body h2 {
+      margin-top: 2.5rem;
+    }
+    .article-body img {
+      max-width: 100%;
+      border-radius: var(--radius);
+      margin: 1.5rem 0;
+    }
+    .article-body blockquote {
+      border-left: 2px solid var(--color-border);
+      padding-left: 1.25rem;
+      margin: 1.5rem 0;
+      color: var(--color-ink-light);
+      font-style: italic;
+    }
+    .article-body ul, .article-body ol {
+      padding-left: 1.5rem;
+      margin: 1rem 0;
+    }
+    .article-body li {
+      margin-bottom: 0.35rem;
+    }
+    .article-body code {
+      background: var(--color-surface-warm);
+      padding: 0.1rem 0.35rem;
+      border-radius: 2px;
+      font-size: 0.85em;
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+    .article-body pre {
+      background: var(--color-surface-warm);
+      border: 1px solid var(--color-border-light);
+      padding: 1rem 1.25rem;
+      border-radius: var(--radius);
+      overflow-x: auto;
+      margin: 1.5rem 0;
+    }
+    .article-body pre code {
+      background: none;
+      padding: 0;
+    }
+
+    /* Tags */
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 1rem 0;
+    }
+    .tag {
+      font-size: 0.7rem;
+      font-weight: 400;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 0.25rem 0.65rem;
+      background: var(--color-surface-warm);
+      border: 1px solid var(--color-border-light);
+      border-radius: 2px;
+      color: var(--color-ink-light);
+      text-decoration: none;
+      transition: border-color 0.2s ease;
+    }
+    .tag:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+    }
+
+    /* Taxonomy */
+    .taxonomy-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1rem;
+      margin: 1.5rem 0;
+    }
+    .taxonomy-item {
+      padding: 1rem 1.25rem;
+      background: var(--color-surface-card);
+      border: 1px solid var(--color-border-light);
+      border-radius: var(--radius);
+      text-decoration: none;
+      color: var(--color-ink);
+      transition: box-shadow 0.2s ease;
+    }
+    .taxonomy-item:hover {
+      box-shadow: var(--shadow-sm);
+      color: var(--color-ink);
+    }
+    .taxonomy-item .term-name {
+      font-family: var(--font-serif);
+      font-size: 1.05rem;
+    }
+    .taxonomy-item .term-count {
+      font-size: 0.75rem;
+      color: var(--color-ink-faint);
+    }
+
+    /* Post List (for taxonomy term pages) */
+    .post-list {
+      list-style: none;
+      margin: 1.5rem 0;
+    }
+    .post-list li {
+      padding: 0.75rem 0;
+      border-bottom: 1px solid var(--color-border-light);
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+    .post-list li:last-child { border-bottom: none; }
+    .post-list a {
+      font-family: var(--font-serif);
+      font-size: 1.05rem;
+    }
+    .post-list .post-date {
+      font-size: 0.75rem;
+      color: var(--color-ink-faint);
+      flex-shrink: 0;
+      margin-left: 1rem;
+    }
+
+    /* Pagination */
+    nav.pagination { margin: 2.5rem 0; }
+    nav.pagination .pagination-list {
+      list-style: none;
+      display: flex;
+      gap: 0.35rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    nav.pagination a {
+      display: inline-block;
+      padding: 0.35rem 0.7rem;
+      border: 1px solid var(--color-border);
+      border-radius: 2px;
+      font-size: 0.8rem;
+      color: var(--color-ink-light);
+      text-decoration: none;
+      transition: all 0.2s ease;
+    }
+    nav.pagination a:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+    }
+    .pagination-current span {
+      display: inline-block;
+      padding: 0.35rem 0.7rem;
+      border: 1px solid var(--color-accent);
+      border-radius: 2px;
+      font-size: 0.8rem;
+      background: var(--color-surface-warm);
+    }
+    .pagination-disabled span {
+      display: inline-block;
+      padding: 0.35rem 0.7rem;
+      border: 1px solid var(--color-border-light);
+      border-radius: 2px;
+      font-size: 0.8rem;
+      color: var(--color-ink-faint);
+      opacity: 0.5;
+    }
+
+    /* 404 */
+    .not-found {
+      text-align: center;
+      padding: 5rem 0;
+    }
+    .not-found h1 {
+      font-size: 4rem;
+      font-weight: 400;
+      color: var(--color-ink-faint);
+    }
+    .not-found p {
+      color: var(--color-ink-light);
+    }
+
+    /* Footer */
+    .site-footer {
+      padding: 2rem 0;
+      border-top: 1px solid var(--color-border);
+      text-align: center;
+      font-size: 0.75rem;
+      color: var(--color-ink-faint);
+      letter-spacing: 0.04em;
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .gallery-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+      .hero h1 { font-size: 2rem; }
+      .container { padding: 0 1.25rem; }
+      .site-nav { gap: 1.25rem; }
+      .site-nav a { font-size: 0.7rem; }
+    }
+    @media (max-width: 480px) {
+      .gallery-grid { grid-template-columns: 1fr; }
+      .site-header .container { flex-direction: column; gap: 0.75rem; align-items: flex-start; }
+      .step-item { flex-direction: column; gap: 0.75rem; }
+      .post-list li { flex-direction: column; gap: 0.25rem; }
+      .post-list .post-date { margin-left: 0; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <a href="{{ base_url }}/" class="site-brand">
+        <span class="brand-name">Terrarium</span>
+        <span>Miniature Worlds</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/gallery/">Gallery</a>
+        <a href="{{ base_url }}/process/">Process</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </div>
+  </header>

--- a/terrarium/templates/home.html
+++ b/terrarium/templates/home.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container">
+      <div class="hero">
+        <h1>Small Worlds, Grand Details</h1>
+        <p>A curated collection of miniature creations — terrariums, dioramas, and tiny handcrafted worlds where every millimeter tells a story.</p>
+      </div>
+
+      <div class="section-header">
+        <h2>Featured Works</h2>
+        <p>Recent additions to the collection</p>
+      </div>
+      <div class="gallery-grid">
+        {% for item in site.pages %}
+          {% if item.section == "gallery" %}
+          <a href="{{ item.url }}" class="gallery-card">
+            <div class="gallery-card-image">
+              <span class="placeholder-icon">{{ item.title | truncate(length=1, end="") }}</span>
+              {% if item.extra.scale %}
+              <span class="scale-badge">{{ item.extra.scale }}</span>
+              {% endif %}
+            </div>
+            <div class="gallery-card-body">
+              <h3>{{ item.title }}</h3>
+              <div class="card-meta">
+                {% if item.extra.actual_size %}{{ item.extra.actual_size }}{% if item.date %} / {% endif %}{% endif %}{% if item.date %}{{ item.date | date("%b %Y") }}{% endif %}
+              </div>
+              {% if item.description %}
+              <div class="card-desc">{{ item.description }}</div>
+              {% endif %}
+            </div>
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+
+      <div class="section-header" style="margin-top: 3rem;">
+        <h2>Making Process</h2>
+        <p>Step-by-step documentation of creation</p>
+      </div>
+      <div class="process-steps">
+        {% for item in site.pages %}
+          {% if item.section == "process" %}
+          <a href="{{ item.url }}" class="step-item" style="text-decoration: none; color: inherit;">
+            <div class="step-number">{{ item.extra.step }}</div>
+            <div class="step-content">
+              <h3>{{ item.title }}</h3>
+              <p>{{ item.description }}</p>
+            </div>
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terrarium/templates/page.html
+++ b/terrarium/templates/page.html
@@ -1,0 +1,55 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container">
+      <article class="article">
+        <div class="article-header">
+          <h1>{{ page.title }}</h1>
+          {% if page.section == "gallery" or page.section == "process" %}
+          <div class="article-meta">
+            {% if page.date | date("%Y-%m-%d") %}
+            <div class="meta-item">
+              <span class="meta-label">Date</span>
+              {{ page.date | date("%B %d, %Y") }}
+            </div>
+            {% endif %}
+            {% if page.extra.scale %}
+            <div class="meta-item">
+              <span class="meta-label">Scale</span>
+              {{ page.extra.scale }}
+            </div>
+            {% endif %}
+            {% if page.extra.actual_size %}
+            <div class="meta-item">
+              <span class="meta-label">Actual Size</span>
+              {{ page.extra.actual_size }}
+            </div>
+            {% endif %}
+            {% if page.extra.materials %}
+            <div class="meta-item">
+              <span class="meta-label">Materials</span>
+              {{ page.extra.materials }}
+            </div>
+            {% endif %}
+            {% if page.reading_time %}
+            <div class="meta-item">
+              <span class="meta-label">Read</span>
+              {{ page.reading_time }} min
+            </div>
+            {% endif %}
+          </div>
+          {% endif %}
+        </div>
+        <div class="article-body">
+          {{ content | safe }}
+        </div>
+        {% if page.tags | length > 0 %}
+        <div class="tag-list" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--color-border-light);">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </article>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terrarium/templates/section.html
+++ b/terrarium/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container">
+      <div class="section-header">
+        <h1>{{ section.title }}</h1>
+        {% if section.description %}
+        <p>{{ section.description }}</p>
+        {% endif %}
+      </div>
+      {{ content | safe }}
+      {% if section.pages | length > 0 %}
+      <div class="gallery-grid">
+        {% for item in section.pages %}
+        <a href="{{ item.url }}" class="gallery-card">
+          <div class="gallery-card-image">
+            <span class="placeholder-icon">{{ item.title | truncate(length=1, end="") }}</span>
+            {% if item.extra.scale %}
+            <span class="scale-badge">{{ item.extra.scale }}</span>
+            {% endif %}
+          </div>
+          <div class="gallery-card-body">
+            <h3>{{ item.title }}</h3>
+            <div class="card-meta">
+              {% if item.extra.actual_size %}{{ item.extra.actual_size }}{% if item.date %} / {% endif %}{% endif %}{% if item.date %}{{ item.date | date("%b %Y") }}{% endif %}
+            </div>
+            {% if item.description %}
+            <div class="card-desc">{{ item.description }}</div>
+            {% endif %}
+          </div>
+        </a>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terrarium/templates/shortcodes/alert.html
+++ b/terrarium/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/terrarium/templates/taxonomy.html
+++ b/terrarium/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container content-narrow">
+      <div class="section-header">
+        <h1>{{ page.title }}</h1>
+        <p>Browse all terms</p>
+      </div>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/terrarium/templates/taxonomy_term.html
+++ b/terrarium/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="container content-narrow">
+      <div class="section-header">
+        <h1>{{ page.title }}</h1>
+        <p>All items tagged with this term</p>
+      </div>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- New `terrarium` example: light theme portfolio site for miniature/tiny things showcase
- Gallery layout with scale metadata badges (1:12, 1:24, 1:48, 1:87, 1:144) and actual size information
- Step-by-step making process section documenting concept, construction, and detailing phases
- 6 gallery items (moss jar, reading nook, winter street, ocean pendant, bonsai grove, kitchen shelf) and 3 process posts
- Clean, warm aesthetic using Cormorant Garamond + Inter fonts on a light background
- Tags: `light`, `portfolio`, `miniature`

Closes #150

## Test plan
- [ ] Verify `hwaro build` completes successfully in the terrarium directory
- [ ] Check homepage renders gallery grid and process steps
- [ ] Confirm scale badges and actual size metadata display on gallery cards
- [ ] Verify individual gallery/process pages show full article metadata
- [ ] Confirm about page renders cleanly without empty meta sections
- [ ] Test responsive layout at mobile breakpoints