### PR TITLE
feat: add atelier example theme

### DIFF
--- a/atelier/config.toml
+++ b/atelier/config.toml
@@ -1,0 +1,9 @@
+title = "Atelier"
+description = "Design Studio & Creative Agency"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]

--- a/atelier/content/about.md
+++ b/atelier/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About Atelier"
+description = "About our design studio"
++++
+
+We are a creative agency specializing in digital experiences and brand identities.
+
+Our approach centers on clarity, structure, and bold typography. We do not use gradients or emojis. Our aesthetic is deeply rooted in modernism, prioritizing an asymmetrical grid and a light theme to showcase our portfolio case studies effectively.

--- a/atelier/content/index.md
+++ b/atelier/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Selected Works"
+description = "A creative design studio showcasing work"
+template = "index"
++++
+Our portfolio spans digital, print, and branding.

--- a/atelier/content/projects/_index.md
+++ b/atelier/content/projects/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Projects"
+template = "section"
++++
+
+Here are some selected projects.

--- a/atelier/content/projects/acme-rebrand.md
+++ b/atelier/content/projects/acme-rebrand.md
@@ -1,0 +1,12 @@
++++
+title = "Acme Corp Rebrand"
+description = "A complete overhaul of the Acme Corp visual identity, focusing on modern typography and a clean, asymmetrical layout."
+template = "project"
+date = "2026-03-01"
+[extra]
+client = "Acme Corp"
+role = "Branding & Web Design"
+duration = "3 months"
++++
+
+This project involved extensive research into the brand's history, resulting in a minimalist yet powerful visual identity that resonates with their target audience.

--- a/atelier/content/projects/globex-launch.md
+++ b/atelier/content/projects/globex-launch.md
@@ -1,0 +1,12 @@
++++
+title = "Globex Launch"
+description = "Strategic digital campaign combining large-scale imagery with concise, impactful copy."
+template = "project"
+date = "2026-03-15"
+[extra]
+client = "Globex"
+role = "Digital Campaign"
+duration = "1 month"
++++
+
+The Globex launch campaign needed to make a bold statement. By utilizing stark contrasts and a strict, grid-based layout, we created an unforgettable digital experience.

--- a/atelier/static/css/style.css
+++ b/atelier/static/css/style.css
@@ -1,0 +1,172 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #111111;
+  --meta-color: #666666;
+  --border-color: #eeeeee;
+  --accent-color: #000000;
+  --font-sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-serif: "Georgia", serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.site-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px;
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 60px;
+}
+
+@media (max-width: 768px) {
+  .site-wrapper {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+}
+
+.site-header {
+  margin-bottom: 40px;
+}
+
+.site-title {
+  font-size: 2rem;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--text-color);
+  display: block;
+  margin-bottom: 10px;
+  letter-spacing: -0.05em;
+}
+
+.site-tagline {
+  color: var(--meta-color);
+  font-size: 0.9rem;
+  margin-bottom: 30px;
+}
+
+.site-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: var(--meta-color);
+  font-weight: 500;
+  transition: color 0.3s;
+}
+
+.site-nav a:hover {
+  color: var(--text-color);
+}
+
+.site-main {
+  min-height: 60vh;
+}
+
+.page-header h1 {
+  font-size: 4rem;
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  margin-top: 0;
+  margin-bottom: 40px;
+  line-height: 1.1;
+}
+
+@media (max-width: 768px) {
+  .page-header h1 {
+    font-size: 2.5rem;
+  }
+}
+
+.site-footer {
+  grid-column: 1 / -1;
+  margin-top: 80px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-color);
+  color: var(--meta-color);
+  font-size: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+.site-footer a {
+  color: var(--text-color);
+  text-decoration: none;
+}
+
+/* Projects Grid */
+.projects-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 100px;
+  margin-top: 60px;
+}
+
+.project-card {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 40px;
+  align-items: start;
+}
+
+@media (max-width: 768px) {
+  .project-card {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}
+
+.project-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  font-size: 0.85rem;
+  color: var(--meta-color);
+  padding-top: 10px;
+  border-top: 1px solid var(--border-color);
+}
+
+.project-meta span {
+  display: block;
+}
+
+.project-content {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.img-placeholder {
+  width: 100%;
+  height: 400px;
+  background-color: var(--border-color);
+}
+
+.project-desc h3 {
+  font-size: 2rem;
+  margin-top: 0;
+  margin-bottom: 15px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.project-desc p {
+  font-size: 1.1rem;
+  color: var(--meta-color);
+  max-width: 600px;
+}

--- a/atelier/templates/footer.html
+++ b/atelier/templates/footer.html
@@ -1,0 +1,10 @@
+    <footer class="site-footer">
+      <p>
+        built with <a href="https://github.com/hahwul/hwaro">Hwaro</a> &middot;
+        hosted on <a href="https://pages.github.com/">GitHub Pages</a>
+      </p>
+      <p>&copy; {{ site.title }}</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/atelier/templates/header.html
+++ b/atelier/templates/header.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} | {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <aside class="site-sidebar">
+      <header class="site-header">
+        <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+        <p class="site-tagline">{{ site.description }}</p>
+      </header>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Work</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </aside>

--- a/atelier/templates/index.html
+++ b/atelier/templates/index.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="page-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    <div class="page-content">
+      {{ content }}
+    </div>
+
+    <div class="projects-grid">
+      <article class="project-card">
+        <div class="project-meta">
+          <span class="client">Client: Acme Corp</span>
+          <span class="role">Role: Branding & Web Design</span>
+          <span class="duration">Duration: 3 months</span>
+        </div>
+        <div class="project-content">
+          <div class="img-placeholder"></div>
+          <div class="project-desc">
+            <h3><a href="{{ base_url }}/projects/acme-rebrand/">Acme Corp Rebrand</a></h3>
+            <p>A complete overhaul of the Acme Corp visual identity, focusing on modern typography and a clean, asymmetrical layout.</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="project-card">
+        <div class="project-meta">
+          <span class="client">Client: Globex</span>
+          <span class="role">Role: Digital Campaign</span>
+          <span class="duration">Duration: 1 month</span>
+        </div>
+        <div class="project-content">
+          <div class="img-placeholder"></div>
+          <div class="project-desc">
+            <h3><a href="{{ base_url }}/projects/globex-launch/">Globex Launch</a></h3>
+            <p>Strategic digital campaign combining large-scale imagery with concise, impactful copy.</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/atelier/templates/page.html
+++ b/atelier/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="page-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/atelier/templates/project.html
+++ b/atelier/templates/project.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main project-single">
+    <div class="page-header">
+      <h1>{{ page.title }}</h1>
+    </div>
+
+    <div class="project-card">
+      <div class="project-meta">
+        <span class="client">Client: {{ page.extra.client }}</span>
+        <span class="role">Role: {{ page.extra.role }}</span>
+        <span class="duration">Duration: {{ page.extra.duration }}</span>
+      </div>
+      <div class="project-content">
+        {{ content }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/atelier/templates/section.html
+++ b/atelier/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="page-header">
+      <h1>{{ section.title }}</h1>
+    </div>
+    {{ content }}
+    <div class="projects-grid">
+      {% for page in section.pages %}
+        <article class="project-card">
+          <div class="project-meta">
+            <span class="client">Client: {{ page.extra.client }}</span>
+            <span class="role">Role: {{ page.extra.role }}</span>
+            <span class="duration">Duration: {{ page.extra.duration }}</span>
+          </div>
+          <div class="project-content">
+            {% if page.image %}
+              <img src="{{ page.image }}" alt="{{ page.title }}" class="project-img">
+            {% else %}
+              <div class="img-placeholder"></div>
+            {% endif %}
+            <div class="project-desc">
+              <h3><a href="{{ page.url }}">{{ page.title }}</a></h3>
+              <p>{{ page.description }}</p>
+            </div>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -506,5 +506,10 @@
     "light",
     "blog",
     "zen"
+  ],
+  "atelier": [
+    "light",
+    "portfolio",
+    "agency"
   ]
 }


### PR DESCRIPTION
Added a new 'atelier' example site demonstrating a clean, modern design agency portfolio template. The design utilizes a light theme and an asymmetrical grid, strictly avoiding the use of gradients and emojis as requested.

Fixes #145