### PR TITLE
feat: Add tavern example (RPG guild theme)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -506,5 +506,10 @@
     "light",
     "blog",
     "zen"
+  ],
+  "tavern": [
+    "dark",
+    "blog",
+    "rpg"
   ]
 }

--- a/tavern/config.toml
+++ b/tavern/config.toml
@@ -1,0 +1,41 @@
+title = "Tavern"
+description = "RPG community / game guild theme"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/tavern/content/index.md
+++ b/tavern/content/index.md
@@ -1,0 +1,35 @@
++++
+title = "Welcome to the Obsidian Hearth"
+description = "A haven for adventurers, mercenaries, and seekers of truth."
++++
+
+<div style="text-align: center; margin-bottom: 40px; border-bottom: 2px solid var(--border-color); padding-bottom: 20px;">
+  <p style="font-size: 1.2rem; color: #a8947b; font-style: italic;">
+    "Pull up a chair by the hearth, traveler. The ale is warm, but the tales are cold with truth."
+  </p>
+</div>
+
+The **Obsidian Hearth** is a sanctuary for those who walk the shadowed paths. Whether you are a hardened sellsword, a weaver of arcane mysteries, or a scout who has seen too much, you will find kinship and work here.
+
+### The Notice Board
+
+Our guild's lifeblood flows through the Notice Board. Here, patrons from across the realm post their pleas for aid, bounties, and expeditions.
+
+- **[View the Notice Board](/posts/)** to find your next contract.
+- Seek out the Guild Master to post a new bounty.
+- Respect the sanctuary of the Hearth; blades drawn inside will be answered tenfold.
+
+### Guild Roster
+
+Our members are as varied as the stars, bound only by their skill and the guild's charter. We seek those who can survive the deep woods, the forgotten ruins, and the treacherous politics of the capital.
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 20px;">
+  <div style="flex: 1; min-width: 200px; background-color: var(--card-bg); padding: 15px; border: 1px solid var(--border-color);">
+    <h3 style="margin-top: 0; color: #cda434; font-family: var(--font-heading);">Fighters & Knights</h3>
+    <p style="font-size: 0.9rem; color: #a8947b;">The bulwark against the darkness. Always in high demand for caravan escort and ruin clearing.</p>
+  </div>
+  <div style="flex: 1; min-width: 200px; background-color: var(--card-bg); padding: 15px; border: 1px solid var(--border-color);">
+    <h3 style="margin-top: 0; color: #cda434; font-family: var(--font-heading);">Mages & Scholars</h3>
+    <p style="font-size: 0.9rem; color: #a8947b;">Keepers of lore and wielders of the arcane. Essential for interpreting ancient seals.</p>
+  </div>
+</div>

--- a/tavern/content/posts/_index.md
+++ b/tavern/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Notice Board"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = true
++++

--- a/tavern/content/posts/ancient-ruins.md
+++ b/tavern/content/posts/ancient-ruins.md
@@ -1,0 +1,29 @@
++++
+title = "Expedition: The Sunken Library of Aethelgard"
+date = "2026-03-24"
+description = "Seeking scholars and guards to explore newly uncovered ruins beneath the lake."
+tags = ["expedition", "lore", "dungeon"]
+[extra]
+author = "Archmage Veylus"
+class = "Mage/Scholar"
+level = "8+"
+avatar = "A"
++++
+
+Recent seismic activity has drained a portion of Lake Mir, revealing the entrance to the long-lost Sunken Library of Aethelgard. I am organizing an expedition to retrieve the intact tomes before the water returns or looters arrive.
+
+<!-- more -->
+
+### The Expedition
+
+This is an academic endeavor, but the ruins of Aethelgard are notoriously well-defended by ancient automatons and magical traps.
+
+* **Primary Objective:** Secure the central archive and retrieve the *Codex of Infinite Tides*.
+* **Secondary Objective:** Map the first three levels of the ruins.
+* **Reward:** 1000 gold pieces, a share of any mundane treasure found, and access to the Archmage's personal library for one month.
+
+### Requirements
+
+I require at least two competent arcane scholars to help decipher the warding runes, and a robust vanguard to deal with any physical threats. The environment is likely to be damp, dark, and highly unstable.
+
+We depart at the next dawn. Meet at the eastern docks.

--- a/tavern/content/posts/first-quest.md
+++ b/tavern/content/posts/first-quest.md
@@ -1,0 +1,29 @@
++++
+title = "Bounty: The Crimson Wolf of the Weeping Woods"
+date = "2026-03-22"
+description = "A massive wolf with fur the color of blood has been terrorizing the northern caravans."
+tags = ["bounty", "combat", "woods"]
+[extra]
+author = "Merchant Guild of Oakhaven"
+class = "Fighter/Ranger"
+level = "5+"
+avatar = "W"
++++
+
+A massive wolf with fur the color of blood has been terrorizing the northern caravans. It strikes only during the new moon and seems unnaturally intelligent. The local militia has failed to track it down.
+
+<!-- more -->
+
+### The Contract
+
+The beast must be slain and its pelt brought back as proof. The creature is known as the **Crimson Wolf**, though some locals whisper it is a skinwalker or a demon bound to the forest.
+
+* **Target:** The Crimson Wolf
+* **Location:** The Weeping Woods, north of Oakhaven
+* **Reward:** 500 gold pieces and a minor enchanted ring from the Merchant Guild's vaults.
+
+### Known Information
+
+Survivors report the wolf is larger than a horse and moves without a sound until it is too late. It is often accompanied by a pack of normal timber wolves, though they seem completely subjugated to its will.
+
+*Bring your sharpest steel and do not wander from the path.*

--- a/tavern/static/css/style.css
+++ b/tavern/static/css/style.css
@@ -1,0 +1,276 @@
+:root {
+  --bg-color: #1a120b; /* Very dark brown, like shadowed tavern wood */
+  --text-color: #e5d3b3; /* Pale tan, parchment-like */
+  --accent-color: #8b0000; /* Deep red, like aged wine */
+  --card-bg: #2d2116; /* Lighter wood for cards/boards */
+  --border-color: #5c4033; /* Dark brown for borders */
+  --font-main: 'MedievalSharp', 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
+  --font-heading: 'Cinzel', 'Times New Roman', Times, serif;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-main);
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: #cda434; /* Gold-like color for links */
+  text-decoration: none;
+  border-bottom: 1px dashed var(--border-color);
+  transition: color 0.3s;
+}
+
+a:hover {
+  color: var(--accent-color);
+  border-bottom: 1px solid var(--accent-color);
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  border-bottom: 4px double var(--border-color);
+  padding: 40px 0;
+  text-align: center;
+  margin-bottom: 40px;
+  background-color: #110c08; /* Slightly darker top bar */
+}
+
+header h1 {
+  font-family: var(--font-heading);
+  font-size: 3rem;
+  margin: 0;
+  color: #cda434;
+  text-shadow: 2px 2px 4px #000;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+header p {
+  font-size: 1.2rem;
+  color: #a8947b;
+  font-style: italic;
+}
+
+nav {
+  margin-top: 20px;
+}
+
+nav a {
+  margin: 0 15px;
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  color: var(--text-color);
+  border: none;
+}
+
+nav a:hover {
+  color: #cda434;
+  border: none;
+}
+
+/* Quest Board (Post List) */
+.quest-board {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.quest-card {
+  background-color: var(--card-bg);
+  border: 2px solid var(--border-color);
+  padding: 20px;
+  box-shadow: 5px 5px 0px #0b0805;
+  transition: transform 0.2s;
+  position: relative;
+}
+
+.quest-card:hover {
+  transform: translateY(-2px);
+  border-color: #cda434;
+}
+
+/* Pinned paper effect on card corners */
+.quest-card::before, .quest-card::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background-color: #0b0805; /* Represents a dark iron nail */
+  border-radius: 50%;
+}
+.quest-card::before { top: 10px; left: 10px; }
+.quest-card::after { top: 10px; right: 10px; }
+
+.quest-title {
+  font-family: var(--font-heading);
+  font-size: 1.8rem;
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.quest-title a {
+  color: var(--text-color);
+  border: none;
+}
+.quest-title a:hover {
+  color: #cda434;
+}
+
+.quest-meta {
+  font-size: 0.9rem;
+  color: #a8947b;
+  margin-bottom: 15px;
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: var(--border-color);
+  color: #cda434;
+  font-family: var(--font-heading);
+  font-size: 0.8rem;
+  border: 1px solid #cda434;
+  text-transform: uppercase;
+}
+
+.badge-class { background-color: #2b1d14; border-color: #a8947b; color: #e5d3b3; }
+.badge-level { background-color: #4a0e0e; border-color: #ff6b6b; color: #ffcccc; }
+
+.quest-summary {
+  margin-bottom: 0;
+}
+
+/* Character Profile Sidebar/Info */
+.character-profile {
+  background-color: #110c08;
+  border: 1px solid var(--border-color);
+  padding: 15px;
+  margin-bottom: 30px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.profile-avatar {
+  width: 80px;
+  height: 80px;
+  background-color: var(--card-bg);
+  border: 2px solid #cda434;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  color: #cda434;
+}
+
+.profile-stats {
+  flex-grow: 1;
+}
+
+.profile-name {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  margin: 0 0 5px 0;
+  color: #cda434;
+}
+
+.profile-details {
+  font-size: 0.9rem;
+  color: #a8947b;
+}
+
+/* Post Content */
+.post-content h1, .post-content h2, .post-content h3 {
+  font-family: var(--font-heading);
+  color: #cda434;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 5px;
+  margin-top: 40px;
+}
+
+.post-content blockquote {
+  border-left: 4px solid var(--accent-color);
+  margin: 0;
+  padding-left: 20px;
+  font-style: italic;
+  color: #a8947b;
+  background-color: var(--card-bg);
+  padding: 15px;
+}
+
+.post-content pre {
+  background-color: #0b0805;
+  padding: 15px;
+  border: 1px solid var(--border-color);
+  overflow-x: auto;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.post-content code {
+  background-color: #0b0805;
+  padding: 2px 5px;
+  color: #cda434;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+/* Tags */
+.tags {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.tag {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  padding: 5px 10px;
+  font-size: 0.8rem;
+  color: var(--text-color);
+}
+.tag:hover {
+  background-color: var(--border-color);
+  border-color: #cda434;
+  color: #cda434;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 40px;
+  border-top: 1px solid var(--border-color);
+  padding-top: 20px;
+}
+
+.pagination a {
+  border: 1px solid var(--border-color);
+  padding: 5px 15px;
+  font-family: var(--font-heading);
+  background-color: var(--card-bg);
+}
+.pagination a:hover {
+  background-color: var(--border-color);
+  border-color: #cda434;
+}
+
+footer {
+  text-align: center;
+  padding: 40px 0;
+  margin-top: 60px;
+  border-top: 4px double var(--border-color);
+  color: #a8947b;
+  font-size: 0.9rem;
+}

--- a/tavern/templates/404.html
+++ b/tavern/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<div style="text-align: center; margin-top: 50px;">
+  <h1 style="font-family: var(--font-heading); font-size: 5rem; color: #8b0000; margin: 0;">404</h1>
+  <p style="font-size: 1.5rem; color: #cda434;">You have wandered too far into the dark woods.</p>
+  <p>The path you seek is no longer here.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 20px; padding: 10px 20px; background-color: var(--card-bg); border: 1px solid #cda434; color: #cda434; font-family: var(--font-heading);">Return to the Tavern</a>
+</div>
+
+{% include "footer.html" %}

--- a/tavern/templates/footer.html
+++ b/tavern/templates/footer.html
@@ -1,0 +1,10 @@
+  </main>
+  <footer>
+    <div class="container">
+      &copy; {{ current_year }} {{ site.title }}. All rights reserved.
+      <br>
+      Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/tavern/templates/header.html
+++ b/tavern/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=MedievalSharp&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1><a href="{{ base_url }}/" style="border: none; color: inherit;">{{ site.title }}</a></h1>
+      <p>{{ site.description }}</p>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Quests</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">

--- a/tavern/templates/page.html
+++ b/tavern/templates/page.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+
+<article class="post-content">
+  <div class="character-profile">
+    <div class="profile-avatar">
+      {% if page.extra.avatar %}
+        {{ page.extra.avatar }}
+      {% else %}
+        P
+      {% endif %}
+    </div>
+    <div class="profile-stats">
+      <h2 class="profile-name">{{ page.extra.author | default("Guild Master") }}</h2>
+      <div class="profile-details">
+        {% if page.extra.class %}
+          <span class="badge badge-class">{{ page.extra.class }}</span>
+        {% endif %}
+        {% if page.extra.level %}
+          <span class="badge badge-level">Lv. {{ page.extra.level }}</span>
+        {% endif %}
+        <span style="margin-left: 10px;">Posted on {{ page.date | date("%B %d, %Y") }}</span>
+      </div>
+    </div>
+  </div>
+
+  <h1 class="quest-title">{{ page.title }}</h1>
+
+  {{ content | safe }}
+
+  {% if page.tags %}
+  <div class="tags">
+    <span>Tags:</span>
+    {% for tag in page.tags %}
+      <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/tavern/templates/section.html
+++ b/tavern/templates/section.html
@@ -1,0 +1,46 @@
+{% include "header.html" %}
+
+<h1 style="font-family: var(--font-heading); color: #cda434; text-align: center; margin-bottom: 30px;">
+  {{ page_title | default("Quest Board") }}
+</h1>
+
+<div class="quest-board">
+  {% for post in section.pages %}
+    <div class="quest-card">
+      <h2 class="quest-title"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
+      <div class="quest-meta">
+        <span>{{ post.date | date("%Y-%m-%d") }}</span>
+        {% if post.extra.class %}
+          <span class="badge badge-class">{{ post.extra.class }}</span>
+        {% endif %}
+        {% if post.extra.level %}
+          <span class="badge badge-level">Lv. {{ post.extra.level }}</span>
+        {% endif %}
+      </div>
+      <p class="quest-summary">
+        {% if post.summary %}
+          {{ post.summary | strip_html | truncate_words(30) }}
+        {% else %}
+          {{ post.description }}
+        {% endif %}
+      </p>
+    </div>
+  {% endfor %}
+</div>
+
+{% if section.pages_count > 0 and section.pages[0].lower %}
+  <div class="pagination">
+    <div>
+      {% if section.pages[0].higher %}
+        <a href="{{ section.pages[0].higher.url }}">&larr; Previous Quests</a>
+      {% endif %}
+    </div>
+    <div>
+      {% if section.pages[0].lower %}
+        <a href="{{ section.pages[0].lower.url }}">Next Quests &rarr;</a>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
+{% include "footer.html" %}

--- a/tavern/templates/taxonomy.html
+++ b/tavern/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+
+<h1 style="font-family: var(--font-heading); color: #cda434; text-align: center;">Tavern Tags</h1>
+
+<div style="display: flex; flex-wrap: wrap; gap: 15px; justify-content: center; margin-top: 40px;">
+  {% for term in taxonomy_terms %}
+    <a href="{{ term.url }}" class="tag" style="font-size: 1.2rem; padding: 10px 20px;">
+      {{ term.name }} ({{ term.pages | length }})
+    </a>
+  {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/tavern/templates/taxonomy_term.html
+++ b/tavern/templates/taxonomy_term.html
@@ -1,0 +1,31 @@
+{% include "header.html" %}
+
+<h1 style="font-family: var(--font-heading); color: #cda434; text-align: center; margin-bottom: 30px;">
+  Quests tagged: {{ taxonomy_term.name }}
+</h1>
+
+<div class="quest-board">
+  {% for post in taxonomy_term.pages %}
+    <div class="quest-card">
+      <h2 class="quest-title"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
+      <div class="quest-meta">
+        <span>{{ post.date | date("%Y-%m-%d") }}</span>
+        {% if post.extra.class %}
+          <span class="badge badge-class">{{ post.extra.class }}</span>
+        {% endif %}
+        {% if post.extra.level %}
+          <span class="badge badge-level">Lv. {{ post.extra.level }}</span>
+        {% endif %}
+      </div>
+      <p class="quest-summary">
+        {% if post.summary %}
+          {{ post.summary | strip_html | truncate_words(30) }}
+        {% else %}
+          {{ post.description }}
+        {% endif %}
+      </p>
+    </div>
+  {% endfor %}
+</div>
+
+{% include "footer.html" %}


### PR DESCRIPTION
Resolves: https://github.com/hahwul/hwaro-examples/issues/144

Added a new Hwaro example site called `tavern` focusing on an RPG community and game guild theme.
- Configured tags `dark`, `blog`, `rpg` in `tags.json`
- Designed a dark, wood and parchment styled CSS (`static/css/style.css`)
- Added custom RPG-themed layouts for quests and character profiles (`templates/`)
- Created sample content including an index page and two sample bounty/expedition quests (`content/`)
- Adhered strictly to design constraints: no gradients and no emojis used in the code or content.