### PR TITLE
feat: add podcast-fm example site

### DIFF
--- a/podcast-fm/config.toml
+++ b/podcast-fm/config.toml
@@ -1,0 +1,41 @@
+title = "Podcast FM"
+description = "A warm, dark-toned podcast show and episode listing"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["episodes"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/podcast-fm/content/episodes/_index.md
+++ b/podcast-fm/content/episodes/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Episodes"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = true
+transparent = false
++++
+
+Browse all our past and recent episodes. Dive deep into conversations that resonate in the quiet of the night.

--- a/podcast-fm/content/episodes/ep-01-quiet-ambience.md
+++ b/podcast-fm/content/episodes/ep-01-quiet-ambience.md
@@ -1,0 +1,27 @@
++++
+title = "Ep 01: The Quiet Ambience"
+date = "2023-10-01"
+description = "Exploring the sounds of the city when everyone else is asleep."
+tags = ["ambience", "city", "night"]
+categories = ["audioscapes"]
+template = "page"
+
+[extra]
+duration = "45:30"
+audio_url = "#"
+artwork = "https://images.unsplash.com/photo-1519681393784-d120267933ba?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
++++
+
+In our inaugural episode, we walk through the quiet streets of the city. We discuss how the absence of daylight alters our perception of sound and space.
+
+### Show Notes
+* 00:00 - Intro & Ambience
+* 10:15 - The hum of the streetlights
+* 25:30 - Interview with a night shift worker
+* 40:00 - Outro and reflections
+
+### Transcript
+
+**Host:** Welcome to The Night Owl Frequency. It's 3 AM, and the city is finally quiet...
+
+*Transcript continues here...*

--- a/podcast-fm/content/episodes/ep-02-midnight-creativity.md
+++ b/podcast-fm/content/episodes/ep-02-midnight-creativity.md
@@ -1,0 +1,27 @@
++++
+title = "Ep 02: Midnight Creativity"
+date = "2023-10-15"
+description = "Why do some of us work best in the dark?"
+tags = ["creativity", "focus", "night"]
+categories = ["interviews"]
+template = "page"
+
+[extra]
+duration = "52:10"
+audio_url = "#"
+artwork = "https://images.unsplash.com/photo-1498623116890-37e912163d5d?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
++++
+
+In this episode, we sit down with artists and developers who thrive during the midnight hours. We explore the psychology of focus without interruptions.
+
+### Show Notes
+* 00:00 - Introduction to nocturnal productivity
+* 08:30 - Discussion on flow states
+* 22:45 - The artist's perspective
+* 45:10 - Tips for healthy night work
+
+### Transcript
+
+**Host:** Many of us have felt it. The burst of energy right when we should be sleeping...
+
+*Transcript continues here...*

--- a/podcast-fm/content/index.md
+++ b/podcast-fm/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "The Night Owl Frequency"
+description = "A podcast exploring the warm, dark tones of late night creativity and storytelling."
+template = "index"
++++
+
+Welcome to **The Night Owl Frequency**, a show dedicated to those who find inspiration when the world goes quiet. Tune in for deep conversations, immersive audioscapes, and stories from the dark.

--- a/podcast-fm/static/css/style.css
+++ b/podcast-fm/static/css/style.css
@@ -1,0 +1,348 @@
+/* podcast-fm CSS
+   Dark theme with warm dark tones, dark charcoal background. No gradients, no emojis.
+*/
+
+:root {
+    --bg-color: #121212;
+    --bg-secondary: #1e1e1e;
+    --bg-tertiary: #2a2a2a;
+    --text-main: #f0f0f0;
+    --text-muted: #a0a0a0;
+    --accent: #d4a373; /* Warm tone accent */
+    --accent-hover: #faedcd;
+    --border-color: #333333;
+
+    --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+a:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 1rem;
+    width: 100%;
+}
+
+.text-center { text-align: center; }
+.mt-4 { margin-top: 1.5rem; }
+.mb-4 { margin-bottom: 1.5rem; }
+
+/* Header */
+.site-header {
+    background-color: var(--bg-secondary);
+    padding: 1.5rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.site-header .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.site-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+}
+
+.site-title a {
+    color: var(--text-main);
+    text-decoration: none;
+}
+
+.site-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+}
+
+.site-nav a {
+    color: var(--text-main);
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+}
+
+.site-nav a:hover {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+/* Main */
+.site-main {
+    flex: 1;
+    padding: 3rem 1rem;
+}
+
+/* Typography & Content */
+h1, h2, h3, h4, h5, h6 {
+    color: var(--text-main);
+    margin-bottom: 1rem;
+    line-height: 1.3;
+}
+
+.page-header {
+    margin-bottom: 3rem;
+}
+
+.page-title {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.lead {
+    font-size: 1.25rem;
+    color: var(--text-muted);
+}
+
+.content {
+    font-size: 1.1rem;
+}
+
+.content p { margin-bottom: 1.5rem; }
+.content ul, .content ol { margin-bottom: 1.5rem; padding-left: 2rem; }
+.content li { margin-bottom: 0.5rem; }
+
+/* Buttons & Links */
+.btn {
+    display: inline-block;
+    background-color: var(--accent);
+    color: var(--bg-color);
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    font-weight: 600;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.btn:hover {
+    background-color: var(--accent-hover);
+    color: var(--bg-color);
+    text-decoration: none;
+}
+
+/* Episode List */
+.episode-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.episode-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+@media (min-width: 600px) {
+    .episode-card {
+        flex-direction: row;
+    }
+}
+
+.card-artwork {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    background-color: var(--bg-tertiary);
+}
+
+@media (min-width: 600px) {
+    .card-artwork {
+        width: 250px;
+        flex-shrink: 0;
+    }
+}
+
+.card-artwork img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.card-content {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.card-content h3 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.episode-meta {
+    display: flex;
+    gap: 1rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+    align-items: center;
+}
+
+.play-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    margin-top: auto;
+    padding-top: 1rem;
+}
+
+/* Episode Detail */
+.episode-detail .episode-header {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+@media (min-width: 768px) {
+    .episode-detail .episode-header {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+}
+
+.episode-artwork {
+    width: 100%;
+    max-width: 300px;
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: var(--bg-tertiary);
+    margin: 0 auto;
+}
+
+.episode-artwork img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.episode-info {
+    flex: 1;
+}
+
+.player-controls {
+    margin: 1.5rem 0;
+}
+
+.play-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: var(--accent);
+    color: var(--bg-color);
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.play-btn:hover {
+    background-color: var(--accent-hover);
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.tag {
+    background-color: var(--bg-tertiary);
+    color: var(--text-main);
+    padding: 0.25rem 0.75rem;
+    border-radius: 99px;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.tag:hover {
+    background-color: var(--accent);
+    color: var(--bg-color);
+    text-decoration: none;
+}
+
+/* Taxonomies */
+.taxonomy-list {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.taxonomy-list li a {
+    display: flex;
+    justify-content: space-between;
+    background-color: var(--bg-secondary);
+    padding: 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    color: var(--text-main);
+}
+
+.taxonomy-list li a:hover {
+    border-color: var(--accent);
+    text-decoration: none;
+}
+
+.term-count {
+    background-color: var(--bg-tertiary);
+    padding: 0.1rem 0.5rem;
+    border-radius: 99px;
+    font-size: 0.85rem;
+}
+
+/* Footer */
+.site-footer {
+    background-color: var(--bg-secondary);
+    padding: 2rem 0;
+    text-align: center;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+}

--- a/podcast-fm/templates/404.html
+++ b/podcast-fm/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<div class="not-found text-center">
+    <h1 class="page-title">404 - Static Interference</h1>
+    <p>We couldn't tune into the page you were looking for.</p>
+    <a href="{{ base_url }}/" class="btn mt-4">Return Home</a>
+</div>
+
+{% include "footer.html" %}

--- a/podcast-fm/templates/footer.html
+++ b/podcast-fm/templates/footer.html
@@ -1,0 +1,8 @@
+    </main>
+    <footer class="site-footer">
+        <div class="container">
+            <p>&copy; {{ current_year }} {{ site.title }}. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/podcast-fm/templates/header.html
+++ b/podcast-fm/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <h1 class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+            <nav class="site-nav">
+                <ul>
+                    <li><a href="{{ base_url }}/">Home</a></li>
+                    <li><a href="{{ base_url }}/episodes/">Episodes</a></li>
+                    <li><a href="{{ base_url }}/tags/">Tags</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main class="site-main container">

--- a/podcast-fm/templates/index.html
+++ b/podcast-fm/templates/index.html
@@ -1,0 +1,53 @@
+{% include "header.html" %}
+
+<div class="index-layout">
+    <header class="page-header text-center">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.description %}
+        <p class="lead">{{ page.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="content page-content intro-content">
+        {{ content | safe }}
+    </div>
+
+    <section class="latest-episodes">
+        <h2>Latest Episodes</h2>
+        {% set recent_episodes = site.pages | where("section", "episodes") | sort_by("date") | reverse %}
+        <div class="episode-list">
+            {% for episode in recent_episodes | slice(end=3) %}
+            <article class="episode-card">
+                {% if episode.extra.artwork %}
+                <div class="card-artwork">
+                    <img src="{{ episode.extra.artwork }}" alt="Artwork for {{ episode.title }}" loading="lazy">
+                </div>
+                {% endif %}
+                <div class="card-content">
+                    <h3><a href="{{ episode.url }}">{{ episode.title }}</a></h3>
+                    <div class="episode-meta">
+                        {% if episode.date %}
+                        <time datetime="{{ episode.date | date("%Y-%m-%d") }}">{{ episode.date | date("%B %d, %Y") }}</time>
+                        {% endif %}
+                        {% if episode.extra.duration %}
+                        <span class="duration">{{ episode.extra.duration }}</span>
+                        {% endif %}
+                    </div>
+                    <p>{{ episode.description }}</p>
+                    <a href="{{ episode.url }}" class="play-link" aria-label="Play {{ episode.title }}">
+                        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <polygon points="5 3 19 12 5 21 5 3" fill="currentColor"></polygon>
+                        </svg>
+                        Play Episode
+                    </a>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+        <div class="text-center mt-4">
+            <a href="{{ base_url }}/episodes/" class="btn">All Episodes</a>
+        </div>
+    </section>
+</div>
+
+{% include "footer.html" %}

--- a/podcast-fm/templates/page.html
+++ b/podcast-fm/templates/page.html
@@ -1,0 +1,48 @@
+{% include "header.html" %}
+
+<article class="episode-detail">
+    <header class="episode-header">
+        {% if page.extra.artwork %}
+        <div class="episode-artwork">
+            <img src="{{ page.extra.artwork }}" alt="{{ page.title }} artwork" loading="lazy">
+        </div>
+        {% endif %}
+        <div class="episode-info">
+            <h1 class="page-title">{{ page.title }}</h1>
+            <div class="episode-meta">
+                {% if page.date %}
+                <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%B %d, %Y") }}</time>
+                {% endif %}
+                {% if page.extra.duration %}
+                <span class="duration">{{ page.extra.duration }}</span>
+                {% endif %}
+            </div>
+
+            {% if page.extra.audio_url %}
+            <div class="player-controls">
+                <button class="play-btn" aria-label="Play Episode">
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <polygon points="10 8 16 12 10 16 10 8" fill="currentColor"></polygon>
+                    </svg>
+                    Listen Now
+                </button>
+            </div>
+            {% endif %}
+
+            {% if page.tags %}
+            <div class="tags">
+                {% for tag in page.tags %}
+                <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </header>
+
+    <div class="content page-content">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/podcast-fm/templates/section.html
+++ b/podcast-fm/templates/section.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+
+<header class="page-header text-center">
+    <h1 class="page-title">{{ section.title | default("Episodes") }}</h1>
+    {% if section.description %}
+    <p class="lead">{{ section.description }}</p>
+    {% endif %}
+</header>
+
+<div class="content page-content mb-4 text-center">
+    {{ content | safe }}
+</div>
+
+<div class="episode-list">
+    {% for episode in section.pages %}
+    <article class="episode-card">
+        {% if episode.extra.artwork %}
+        <div class="card-artwork">
+            <img src="{{ episode.extra.artwork }}" alt="Artwork for {{ episode.title }}" loading="lazy">
+        </div>
+        {% endif %}
+        <div class="card-content">
+            <h3><a href="{{ episode.url }}">{{ episode.title }}</a></h3>
+            <div class="episode-meta">
+                {% if episode.date %}
+                <time datetime="{{ episode.date | date("%Y-%m-%d") }}">{{ episode.date | date("%B %d, %Y") }}</time>
+                {% endif %}
+                {% if episode.extra.duration %}
+                <span class="duration">{{ episode.extra.duration }}</span>
+                {% endif %}
+            </div>
+            <p>{{ episode.description }}</p>
+            <a href="{{ episode.url }}" class="play-link" aria-label="Play {{ episode.title }}">
+                <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <polygon points="5 3 19 12 5 21 5 3" fill="currentColor"></polygon>
+                </svg>
+                Play Episode
+            </a>
+        </div>
+    </article>
+    {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/podcast-fm/templates/taxonomy.html
+++ b/podcast-fm/templates/taxonomy.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+<header class="page-header text-center">
+    <h1 class="page-title">{{ taxonomy_name | title }}</h1>
+</header>
+
+<ul class="taxonomy-list">
+    {% for term in taxonomy_terms %}
+    <li>
+        <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/">
+            <span class="term-name">{{ term.name }}</span>
+            <span class="term-count">{{ term.pages | length }}</span>
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/podcast-fm/templates/taxonomy_term.html
+++ b/podcast-fm/templates/taxonomy_term.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+
+<header class="page-header text-center">
+    <h1 class="page-title">{{ taxonomy_name | title }}: {{ taxonomy_term.name }}</h1>
+</header>
+
+<div class="episode-list">
+    {% for episode in taxonomy_pages %}
+    <article class="episode-card">
+        {% if episode.extra.artwork %}
+        <div class="card-artwork">
+            <img src="{{ episode.extra.artwork }}" alt="Artwork for {{ episode.title }}" loading="lazy">
+        </div>
+        {% endif %}
+        <div class="card-content">
+            <h3><a href="{{ episode.url }}">{{ episode.title }}</a></h3>
+            <div class="episode-meta">
+                {% if episode.date %}
+                <time datetime="{{ episode.date | date("%Y-%m-%d") }}">{{ episode.date | date("%B %d, %Y") }}</time>
+                {% endif %}
+                {% if episode.extra.duration %}
+                <span class="duration">{{ episode.extra.duration }}</span>
+                {% endif %}
+            </div>
+            <p>{{ episode.description }}</p>
+            <a href="{{ episode.url }}" class="play-link" aria-label="Play {{ episode.title }}">
+                <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <polygon points="5 3 19 12 5 21 5 3" fill="currentColor"></polygon>
+                </svg>
+                Play Episode
+            </a>
+        </div>
+    </article>
+    {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -558,4 +558,10 @@
     "landing",
     "telemetry"
   ]
+,
+  "podcast-fm": [
+    "dark",
+    "media",
+    "podcast"
+  ]
 }


### PR DESCRIPTION
Added a new 'podcast-fm' Hwaro example site featuring a dark, audio-focused media design with warm dark tones, strictly without gradients or emojis.

---
*PR created automatically by Jules for task [13394661727279402405](https://jules.google.com/task/13394661727279402405) started by @hahwul*