### PR TITLE
feat: Add new 'diary' example site

### DIFF
--- a/diary/config.toml
+++ b/diary/config.toml
@@ -1,0 +1,36 @@
+title = "Diary"
+description = "A personal journal and daily log"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = [""]
+
+[markdown]
+safe = true
+lazy_loading = true

--- a/diary/content/_index.md
+++ b/diary/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "My Diary"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = true
++++

--- a/diary/content/baking-bread.md
+++ b/diary/content/baking-bread.md
@@ -1,0 +1,13 @@
++++
+title = "Baking Bread"
+date = "2024-05-18"
+description = "The slow process of making sourdough."
+tags = ["baking", "home", "slow-living"]
++++
+There is magic in flour, water, and salt.
+
+I spent most of the day in the kitchen, tending to a loaf of sourdough. It’s a slow process. You can't rush it. You have to wait for the yeast to do its work, for the dough to rise and fall and rise again.
+
+The house smells incredible now. A deep, earthy, toasted scent that wraps around you the moment you walk through the door.
+
+We ate the first slice while it was still too warm to cut properly, the butter melting instantly into the crumb. It wasn't perfect—the crust was a little too dark on one side—but it tasted like home. There is a deep satisfaction in making something from scratch, in working with your hands and seeing the tangible result of your patience.

--- a/diary/content/quiet-morning.md
+++ b/diary/content/quiet-morning.md
@@ -1,0 +1,13 @@
++++
+title = "A Quiet Morning"
+date = "2024-05-12"
+description = "Starting the day with coffee and thoughts."
+tags = ["morning", "coffee", "thoughts"]
++++
+The morning sun is spilling over the edge of the kitchen table, painting long shadows across the wooden floor. I’ve just brewed a fresh pot of coffee, and the smell is lingering in the air.
+
+It’s quiet today. The kind of quiet that feels like a thick, warm blanket.
+
+I spent an hour just looking out the window, watching the birds flutter between the branches of the old oak tree. No rushing, no notifications demanding my attention. Just the slow, steady rhythm of the morning unfolding.
+
+Sometimes I forget how important these small moments are. It's easy to get swept up in the current of the day, but sitting here, cup in hand, everything feels grounded and simple. I want to remember this feeling.

--- a/diary/content/thoughts-on-walking.md
+++ b/diary/content/thoughts-on-walking.md
@@ -1,0 +1,13 @@
++++
+title = "Thoughts on Walking"
+date = "2024-05-14"
+description = "A late afternoon stroll through the neighborhood."
+tags = ["walking", "thoughts", "neighborhood"]
++++
+I took a long walk this afternoon. The air is starting to carry that slight crispness that hints at the change of seasons.
+
+Walking has always been my way of untangling the knot of thoughts in my head. There is something about the rhythm of footsteps against the pavement that shakes loose the things I didn't realize I was holding onto.
+
+I passed by the old bookstore on the corner. It's been closed for months, but the sign is still hanging there, slightly faded by the sun. It made me think about permanence and how fleeting some things are, even the things that feel like they'll be there forever.
+
+When I got home, my legs were tired, but my mind felt clearer. A good trade, I think.

--- a/diary/templates/404.html
+++ b/diary/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<article class="post" style="text-align: center;">
+    <h1>Page Not Found</h1>
+    <p>The entry you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to diary</a></p>
+</article>
+
+{% include "footer.html" %}

--- a/diary/templates/footer.html
+++ b/diary/templates/footer.html
@@ -1,0 +1,7 @@
+        </main>
+        <footer class="site-footer">
+            <p>&copy; {{ current_year }} {{ site.title }}. All rights reserved.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/diary/templates/header.html
+++ b/diary/templates/header.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(site.title) }}</title>
+    <meta name="description" content="{{ page.description | default(site.description) }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-color: #fcfbf8; /* soft cream background */
+            --text-color: #3b3530; /* warm dark brown/grey */
+            --link-color: #8c6b5d; /* warm muted brown for links */
+            --meta-color: #9c928a; /* soft grey for dates/meta */
+            --border-color: #e8e3dc;
+        }
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: 'Lora', serif;
+            line-height: 1.8;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Caveat', cursive;
+            font-weight: 500;
+            color: var(--text-color);
+            margin-top: 2rem;
+            margin-bottom: 0.5rem;
+            line-height: 1.2;
+        }
+        h1 {
+            font-size: 3rem;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+        h2 {
+            font-size: 2.2rem;
+        }
+        a {
+            color: var(--link-color);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        a:hover {
+            border-bottom: 1px solid var(--link-color);
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+            flex: 1;
+            width: 100%;
+            box-sizing: border-box;
+        }
+        header.site-header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+        .site-title {
+            font-size: 4rem;
+            margin: 0;
+            border: none;
+        }
+        .site-title a {
+            color: var(--text-color);
+            border: none;
+        }
+        .site-nav {
+            margin-top: 1rem;
+            font-size: 1.1rem;
+            font-style: italic;
+        }
+        .site-nav a {
+            margin: 0 0.5rem;
+        }
+        p {
+            margin-bottom: 1.2rem;
+        }
+        .post-meta {
+            color: var(--meta-color);
+            font-size: 0.95rem;
+            font-style: italic;
+            margin-bottom: 1.5rem;
+        }
+        .post-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .post-list li {
+            margin-bottom: 3rem;
+        }
+        .post-list h2 {
+            margin-bottom: 0.2rem;
+            margin-top: 0;
+        }
+        .post-summary {
+            margin-top: 1rem;
+        }
+        .read-more {
+            font-style: italic;
+            font-size: 0.95rem;
+            color: var(--meta-color);
+        }
+        .tags {
+            margin-top: 1rem;
+            font-size: 0.9rem;
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+        .tags a {
+            color: var(--meta-color);
+            border-bottom: 1px dotted var(--meta-color);
+        }
+        .tags a:hover {
+            color: var(--text-color);
+            border-bottom-color: var(--text-color);
+        }
+        footer.site-footer {
+            text-align: center;
+            padding: 2rem 0;
+            color: var(--meta-color);
+            font-size: 0.9rem;
+            font-style: italic;
+            border-top: 1px solid var(--border-color);
+            margin-top: 4rem;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 4px;
+        }
+        code {
+            font-family: monospace;
+            background-color: var(--border-color);
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        pre {
+            background-color: #f0ebe1;
+            padding: 1rem;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+        pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+        blockquote {
+            border-left: 3px solid var(--border-color);
+            margin-left: 0;
+            padding-left: 1rem;
+            font-style: italic;
+            color: #6a6159;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header class="site-header">
+            <h1 class="site-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+            <div class="site-nav">
+                <a href="{{ base_url }}/">Entries</a>
+                <a href="{{ base_url }}/tags/">Tags</a>
+            </div>
+        </header>
+        <main>

--- a/diary/templates/page.html
+++ b/diary/templates/page.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<article class="post">
+    <h1>{{ page.title }}</h1>
+    <div class="post-meta">
+        {{ page.date | date("%B %d, %Y") }}
+        {% if page.taxonomies and page.taxonomies.tags %}
+            <div class="tags">
+                {% for tag in page.taxonomies.tags %}
+                    <a href="{{ base_url }}/tags/{{ tag | slugify }}/">#{{ tag }}</a>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+
+    <div class="post-content">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/diary/templates/section.html
+++ b/diary/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+{% if section.title and section.title != site.title %}
+    <h1>{{ section.title }}</h1>
+{% endif %}
+
+{% if section.content %}
+    <div class="section-content">
+        {{ section.content | safe }}
+    </div>
+{% endif %}
+
+<ul class="post-list">
+    {% for post in section.pages %}
+        <li>
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
+            {% if post.summary %}
+                <div class="post-summary">{{ post.summary | safe }}</div>
+                <a href="{{ post.url }}" class="read-more">Read entry...</a>
+            {% else %}
+                <div class="post-summary">{{ post.content | strip_html | truncate_words(40) }}</div>
+                <a href="{{ post.url }}" class="read-more">Read entry...</a>
+            {% endif %}
+        </li>
+    {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/diary/templates/taxonomy.html
+++ b/diary/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<h1>{{ taxonomy_name | capitalize }}</h1>
+
+<ul class="post-list">
+    {% for term in taxonomy_terms %}
+        <li>
+            <h2><a href="{{ base_url }}/{{ taxonomy_name }}/{{ term.name | slugify }}/">#{{ term.name }}</a></h2>
+            <div class="post-meta">{{ term.pages | length }} entries</div>
+        </li>
+    {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/diary/templates/taxonomy_term.html
+++ b/diary/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+
+<h1>Entries tagged "#{{ taxonomy_term.name }}"</h1>
+
+<ul class="post-list">
+    {% for post in taxonomy_pages %}
+        <li>
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
+            {% if post.summary %}
+                <div class="post-summary">{{ post.summary | safe }}</div>
+                <a href="{{ post.url }}" class="read-more">Read entry...</a>
+            {% else %}
+                <div class="post-summary">{{ post.content | strip_html | truncate_words(40) }}</div>
+                <a href="{{ post.url }}" class="read-more">Read entry...</a>
+            {% endif %}
+        </li>
+    {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -558,4 +558,11 @@
     "landing",
     "telemetry"
   ]
+,
+  "diary": [
+    "light",
+    "blog",
+    "personal",
+    "journal"
+  ]
 }


### PR DESCRIPTION
Creates a new example site called 'diary' as requested. The site features a light theme with soft cream background, intimate spacing, handwriting-inspired serif font (Caveat) for titles, single-column layout, and follows all design constraints (no gradients, no emojis).

---
*PR created automatically by Jules for task [7467939952547306197](https://jules.google.com/task/7467939952547306197) started by @hahwul*