### PR TITLE
Add clocktower example: countdown timer & event timeline

### DIFF
--- a/clocktower/AGENTS.md
+++ b/clocktower/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/clocktower/config.toml
+++ b/clocktower/config.toml
@@ -1,0 +1,131 @@
+title = "Clocktower"
+description = "Countdown timer & event timeline theme with a digital scoreboard aesthetic"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["events"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/clocktower/content/about.md
+++ b/clocktower/content/about.md
@@ -1,0 +1,23 @@
++++
+title = "About Clocktower"
+description = "About this countdown timer and event timeline"
++++
+
+## What is Clocktower?
+
+Clocktower is a countdown timer and event timeline built with Hwaro. It tracks upcoming events with precise countdowns and maintains an archive of past milestones.
+
+## Features
+
+- **Live Countdown** -- Real-time digital countdown to the next event
+- **Event Timeline** -- Visual timeline of upcoming events sorted by date
+- **Past Archive** -- Browse completed events and milestones
+- **Dark Interface** -- Digital scoreboard aesthetic optimized for readability
+
+## How It Works
+
+Events are managed as simple Markdown files with date metadata. The countdown timer automatically targets the nearest upcoming event and updates in real time. Once an event's date passes, it moves to the archive section.
+
+## Built With
+
+This site is powered by [Hwaro](https://github.com/hahwul/hwaro), a fast static site generator written in Crystal.

--- a/clocktower/content/events/_index.md
+++ b/clocktower/content/events/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Events"
+sort_by = "date"
+reverse = false
+template = "section"
++++

--- a/clocktower/content/events/annual-review.md
+++ b/clocktower/content/events/annual-review.md
@@ -1,0 +1,18 @@
++++
+title = "Annual Review 2025"
+date = "2025-12-15"
+description = "Year-end review and retrospective of project milestones"
+tags = ["review", "milestone"]
+[extra]
+location = "Hybrid"
+status = "past"
++++
+
+The annual review covered all major milestones achieved during 2025, including three major releases, two successful conferences, and significant community growth.
+
+## Highlights
+
+- 3 major releases shipped on schedule
+- Community grew from 2,000 to 8,500 members
+- 12 new contributors onboarded
+- Documentation coverage increased to 95%

--- a/clocktower/content/events/beta-release.md
+++ b/clocktower/content/events/beta-release.md
@@ -1,0 +1,18 @@
++++
+title = "Beta Release v1.8"
+date = "2025-11-20"
+description = "Public beta release with new API endpoints and dashboard"
+tags = ["release", "beta"]
+[extra]
+location = "Virtual Event"
+status = "past"
++++
+
+The v1.8 beta introduced new API endpoints, a redesigned dashboard, and improved developer documentation. Over 500 users participated in the beta program.
+
+## Key Metrics
+
+- 500+ beta testers enrolled
+- 127 bug reports submitted
+- 45 feature requests collected
+- 98% satisfaction rating from participants

--- a/clocktower/content/events/developer-summit.md
+++ b/clocktower/content/events/developer-summit.md
@@ -1,0 +1,21 @@
++++
+title = "Developer Summit 2026"
+date = "2026-09-20"
+description = "Annual developer conference featuring talks, workshops, and networking"
+tags = ["conference", "developer"]
+[extra]
+location = "Seoul, Korea"
+status = "upcoming"
++++
+
+Our annual developer summit returns with three days of talks, hands-on workshops, and networking opportunities. This year's theme focuses on building resilient systems.
+
+## Schedule Highlights
+
+- Day 1: Keynotes and architecture talks
+- Day 2: Hands-on workshops and labs
+- Day 3: Lightning talks and community showcase
+
+## Registration
+
+Early bird registration opens soon. Stay tuned for ticket information.

--- a/clocktower/content/events/hackathon-spring.md
+++ b/clocktower/content/events/hackathon-spring.md
@@ -1,0 +1,21 @@
++++
+title = "Spring Hackathon 2026"
+date = "2026-04-25"
+description = "48-hour hackathon focused on open source contributions"
+tags = ["hackathon", "opensource"]
+[extra]
+location = "Online"
+status = "upcoming"
++++
+
+A 48-hour online hackathon dedicated to contributing to open source projects. Teams of up to four members compete to build the most impactful contribution.
+
+## Tracks
+
+- **Infrastructure** -- Build tools, CI/CD, deployment
+- **Developer Experience** -- Documentation, SDKs, CLIs
+- **Security** -- Vulnerability scanning, hardening, auditing
+
+## Prizes
+
+Top three teams receive recognition and exclusive contributor badges.

--- a/clocktower/content/events/product-launch.md
+++ b/clocktower/content/events/product-launch.md
@@ -1,0 +1,18 @@
++++
+title = "Product Launch v2.0"
+date = "2026-06-15"
+description = "Major product release with new features and redesigned interface"
+tags = ["launch", "product"]
+[extra]
+location = "Virtual Event"
+status = "upcoming"
++++
+
+The next major release brings a completely redesigned interface, improved performance, and several highly requested features. Join us for the live launch event.
+
+## What to Expect
+
+- Live product demo
+- Q&A session with the engineering team
+- Early access for attendees
+- Technical deep dive into new architecture

--- a/clocktower/content/events/security-audit.md
+++ b/clocktower/content/events/security-audit.md
@@ -1,0 +1,19 @@
++++
+title = "Security Audit Completion"
+date = "2026-08-01"
+description = "Third-party security audit and penetration testing results"
+tags = ["security", "audit"]
+[extra]
+location = "Internal"
+status = "upcoming"
++++
+
+Scheduled third-party security audit covering the entire platform. The audit includes automated scanning, manual penetration testing, and code review.
+
+## Scope
+
+- API endpoint security review
+- Authentication and authorization flows
+- Data encryption at rest and in transit
+- Dependency vulnerability assessment
+- Infrastructure configuration audit

--- a/clocktower/content/events/system-migration.md
+++ b/clocktower/content/events/system-migration.md
@@ -1,0 +1,18 @@
++++
+title = "System Migration Complete"
+date = "2026-01-10"
+description = "Infrastructure migration to new cloud platform completed successfully"
+tags = ["infrastructure", "migration"]
+[extra]
+location = "Internal"
+status = "past"
++++
+
+Successfully migrated all production services to the new cloud platform. Zero downtime achieved during the transition window.
+
+## Results
+
+- 40% reduction in infrastructure costs
+- 2x improvement in response latency
+- 99.99% uptime maintained during migration
+- All services verified and monitoring confirmed

--- a/clocktower/content/index.md
+++ b/clocktower/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Clocktower"
+template = "home"
+description = "Countdown timer & event timeline"
++++

--- a/clocktower/static/css/style.css
+++ b/clocktower/static/css/style.css
@@ -1,0 +1,721 @@
+:root {
+  --bg: #0a0a0f;
+  --bg-card: #12121a;
+  --bg-elevated: #1a1a25;
+  --border: #2a2a3a;
+  --border-accent: #3d5afe;
+  --text: #e0e0e8;
+  --text-secondary: #8888a0;
+  --text-dim: #555568;
+  --accent: #3d5afe;
+  --accent-bright: #536dfe;
+  --success: #2e7d4f;
+  --font-mono: "Share Tech Mono", "SF Mono", "Fira Code", monospace;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--text);
+}
+
+/* Layout */
+
+.site-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-main {
+  flex: 1;
+}
+
+/* Header */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2.5rem;
+}
+
+.site-logo {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+}
+
+.site-logo:hover {
+  color: var(--accent-bright);
+}
+
+.logo-bracket {
+  color: var(--accent);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  transition: color 0.15s;
+}
+
+.site-nav a:hover {
+  color: var(--text);
+}
+
+/* Footer */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--border);
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer-brand {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  letter-spacing: 0.05em;
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+}
+
+/* Hero Countdown */
+
+.hero-countdown {
+  text-align: center;
+  padding: 3rem 0 4rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 3rem;
+}
+
+.hero-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+}
+
+.hero-event-name {
+  font-family: var(--font-sans);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2rem;
+}
+
+.countdown-display {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0;
+  margin-bottom: 1.5rem;
+}
+
+.countdown-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 5rem;
+}
+
+.countdown-value {
+  font-family: var(--font-mono);
+  font-size: 4rem;
+  font-weight: 400;
+  color: var(--text);
+  line-height: 1;
+  letter-spacing: 0.05em;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  min-width: 5rem;
+  text-align: center;
+}
+
+.countdown-sep {
+  font-family: var(--font-mono);
+  font-size: 3rem;
+  color: var(--text-dim);
+  padding: 0.5rem 0.25rem 0;
+  line-height: 1;
+}
+
+.countdown-label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  margin-top: 0.5rem;
+}
+
+.hero-date {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.05em;
+}
+
+/* Section Titles */
+
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.page-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+/* Timeline */
+
+.timeline-section {
+  margin-bottom: 3rem;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 2rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 0.4rem;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+
+.timeline-item {
+  position: relative;
+  display: block;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+
+.timeline-item:hover {
+  border-color: var(--accent);
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -1.85rem;
+  top: 1.35rem;
+  width: 9px;
+  height: 9px;
+  background: var(--accent);
+  border-radius: 50%;
+  border: 2px solid var(--bg);
+}
+
+.timeline-date {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+}
+
+.timeline-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0.25rem 0;
+}
+
+.timeline-location {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.timeline-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Archive */
+
+.archive-section {
+  margin-bottom: 3rem;
+}
+
+.archive-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.archive-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 0;
+  border-bottom: 1px solid var(--border);
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.archive-item:hover {
+  background: var(--bg-card);
+}
+
+.archive-date {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  min-width: 6rem;
+}
+
+.archive-title {
+  font-size: 0.95rem;
+  color: var(--text);
+  flex: 1;
+}
+
+.archive-badge {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--success);
+  border: 1px solid var(--success);
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* Event Detail */
+
+.event-detail {
+  max-width: 720px;
+}
+
+.event-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.event-date {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.event-title {
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+.event-location {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.event-status {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.event-status--upcoming {
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.event-status--past {
+  color: var(--text-dim);
+  border: 1px solid var(--text-dim);
+}
+
+/* Inline Countdown (Event Detail) */
+
+.inline-countdown {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  margin: 1.5rem 0 2rem;
+  padding: 1.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.inline-cd-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 3.5rem;
+}
+
+.inline-cd-value {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  color: var(--text);
+  line-height: 1;
+  letter-spacing: 0.05em;
+}
+
+.inline-cd-sep {
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  color: var(--text-dim);
+  padding: 0 0.15rem;
+  line-height: 1;
+}
+
+.inline-cd-label {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  margin-top: 0.35rem;
+}
+
+/* Event Content */
+
+.event-content {
+  line-height: 1.7;
+}
+
+.event-content h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 2rem 0 0.75rem;
+}
+
+.event-content h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.event-content p {
+  margin: 0.75rem 0;
+  color: var(--text);
+}
+
+.event-content ul,
+.event-content ol {
+  margin: 0.75rem 0;
+  padding-left: 1.25rem;
+}
+
+.event-content li {
+  margin-bottom: 0.35rem;
+}
+
+.event-content strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.event-content code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg-elevated);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
+
+.event-content pre {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.event-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* Event Tags */
+
+.event-tags {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag-badge {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  padding: 0.2rem 0.6rem;
+  border-radius: 3px;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.tag-badge:hover {
+  color: var(--accent-bright);
+  border-color: var(--accent);
+}
+
+/* Event Navigation */
+
+.event-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.nav-link {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.nav-link:hover {
+  color: var(--accent-bright);
+}
+
+/* Event List (Section) */
+
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.event-card {
+  display: block;
+  padding: 1.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+
+.event-card:hover {
+  border-color: var(--accent);
+}
+
+.event-card-date {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+}
+
+.event-card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0.25rem 0;
+}
+
+.event-card-location {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.event-card-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Taxonomy */
+
+.taxonomy-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+/* Error Page */
+
+.error-page {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-code {
+  font-family: var(--font-mono);
+  font-size: 5rem;
+  color: var(--text-dim);
+  line-height: 1;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.error-page h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.error-page p {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.error-link {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--accent-bright);
+  border: 1px solid var(--accent);
+  padding: 0.4rem 1rem;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.error-link:hover {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  .site-header {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .site-wrapper {
+    padding: 0 1rem;
+  }
+
+  .countdown-value {
+    font-size: 2.5rem;
+    min-width: 3.5rem;
+    padding: 0.4rem 0.5rem;
+  }
+
+  .countdown-unit {
+    min-width: 3.5rem;
+  }
+
+  .countdown-sep {
+    font-size: 2rem;
+  }
+
+  .hero-event-name {
+    font-size: 1.2rem;
+  }
+
+  .event-title {
+    font-size: 1.5rem;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: center;
+  }
+
+  .archive-item {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .archive-date {
+    min-width: auto;
+  }
+
+  .inline-countdown {
+    padding: 1rem;
+  }
+
+  .inline-cd-value {
+    font-size: 1.5rem;
+  }
+
+  .inline-cd-unit {
+    min-width: 2.5rem;
+  }
+}

--- a/clocktower/templates/404.html
+++ b/clocktower/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <span class="error-code">404</span>
+      <h1>Event Not Found</h1>
+      <p>The page you are looking for does not exist or has been archived.</p>
+      <a href="{{ base_url }}/" class="error-link">Return to Home</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/clocktower/templates/footer.html
+++ b/clocktower/templates/footer.html
@@ -1,0 +1,10 @@
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <p class="footer-brand">[Clocktower]</p>
+        <p class="footer-powered">Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+</body>
+</html>

--- a/clocktower/templates/header.html
+++ b/clocktower/templates/header.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-bracket">[</span>Clocktower<span class="logo-bracket">]</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/events/">Events</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/clocktower/templates/home.html
+++ b/clocktower/templates/home.html
@@ -1,0 +1,129 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <section class="hero-countdown">
+      <p class="hero-label">Next Event</p>
+      <h2 class="hero-event-name" id="next-event-name">--</h2>
+      <div class="countdown-display" id="countdown">
+        <div class="countdown-unit">
+          <span class="countdown-value" id="cd-days">--</span>
+          <span class="countdown-label">Days</span>
+        </div>
+        <div class="countdown-sep">:</div>
+        <div class="countdown-unit">
+          <span class="countdown-value" id="cd-hours">--</span>
+          <span class="countdown-label">Hours</span>
+        </div>
+        <div class="countdown-sep">:</div>
+        <div class="countdown-unit">
+          <span class="countdown-value" id="cd-minutes">--</span>
+          <span class="countdown-label">Min</span>
+        </div>
+        <div class="countdown-sep">:</div>
+        <div class="countdown-unit">
+          <span class="countdown-value" id="cd-seconds">--</span>
+          <span class="countdown-label">Sec</span>
+        </div>
+      </div>
+      <p class="hero-date" id="next-event-date">--</p>
+    </section>
+
+    <section class="timeline-section">
+      <h2 class="section-title">Upcoming Events</h2>
+      <div class="timeline">
+        {% for item in site.pages %}
+          {% if item.extra.status == "upcoming" %}
+          <a href="{{ item.url }}" class="timeline-item" data-date="{{ item.date }}">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <time class="timeline-date">{{ item.date | date("%Y-%m-%d") }}</time>
+              <h3 class="timeline-title">{{ item.title }}</h3>
+              <p class="timeline-location">{{ item.extra.location }}</p>
+              {% if item.description %}<p class="timeline-desc">{{ item.description }}</p>{% endif %}
+            </div>
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </section>
+
+    <section class="archive-section">
+      <h2 class="section-title">Past Events</h2>
+      <div class="archive-list">
+        {% for item in site.pages %}
+          {% if item.extra.status == "past" %}
+          <a href="{{ item.url }}" class="archive-item">
+            <time class="archive-date">{{ item.date | date("%Y-%m-%d") }}</time>
+            <span class="archive-title">{{ item.title }}</span>
+            <span class="archive-badge">Completed</span>
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </section>
+  </main>
+
+  <script>
+  (function() {
+    var events = [];
+    {% for item in site.pages %}
+      {% if item.extra.status == "upcoming" %}
+      events.push({
+        title: "{{ item.title }}",
+        date: "{{ item.date | date("%Y-%m-%d") }}",
+        url: "{{ item.url }}"
+      });
+      {% endif %}
+    {% endfor %}
+
+    events.sort(function(a, b) {
+      return new Date(a.date) - new Date(b.date);
+    });
+
+    var now = new Date();
+    var next = null;
+    for (var i = 0; i < events.length; i++) {
+      if (new Date(events[i].date) > now) {
+        next = events[i];
+        break;
+      }
+    }
+
+    if (!next && events.length > 0) {
+      next = events[0];
+    }
+
+    if (next) {
+      document.getElementById("next-event-name").textContent = next.title;
+      document.getElementById("next-event-date").textContent = next.date;
+
+      var target = new Date(next.date + "T00:00:00").getTime();
+
+      function pad(n) {
+        return n < 10 ? "0" + n : String(n);
+      }
+
+      function tick() {
+        var remaining = target - Date.now();
+        if (remaining <= 0) {
+          document.getElementById("cd-days").textContent = "00";
+          document.getElementById("cd-hours").textContent = "00";
+          document.getElementById("cd-minutes").textContent = "00";
+          document.getElementById("cd-seconds").textContent = "00";
+          return;
+        }
+        var d = Math.floor(remaining / 86400000);
+        var h = Math.floor((remaining % 86400000) / 3600000);
+        var m = Math.floor((remaining % 3600000) / 60000);
+        var s = Math.floor((remaining % 60000) / 1000);
+        document.getElementById("cd-days").textContent = pad(d);
+        document.getElementById("cd-hours").textContent = pad(h);
+        document.getElementById("cd-minutes").textContent = pad(m);
+        document.getElementById("cd-seconds").textContent = pad(s);
+      }
+
+      tick();
+      setInterval(tick, 1000);
+    }
+  })();
+  </script>
+{% include "footer.html" %}

--- a/clocktower/templates/page.html
+++ b/clocktower/templates/page.html
@@ -1,0 +1,85 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="event-detail">
+      <header class="event-header">
+        {% if page.date %}
+        <time class="event-date">{{ page.date | date("%Y-%m-%d") }}</time>
+        {% endif %}
+        <h1 class="event-title">{{ page.title }}</h1>
+        {% if page.extra.location %}
+        <p class="event-location">{{ page.extra.location }}</p>
+        {% endif %}
+        {% if page.extra.status %}
+        <span class="event-status event-status--{{ page.extra.status }}">{{ page.extra.status }}</span>
+        {% endif %}
+      </header>
+
+      {% if page.extra.status == "upcoming" and page.date %}
+      <div class="inline-countdown" data-target="{{ page.date | date("%Y-%m-%d") }}">
+        <div class="inline-cd-unit">
+          <span class="inline-cd-value" data-unit="days">--</span>
+          <span class="inline-cd-label">Days</span>
+        </div>
+        <div class="inline-cd-sep">:</div>
+        <div class="inline-cd-unit">
+          <span class="inline-cd-value" data-unit="hours">--</span>
+          <span class="inline-cd-label">Hours</span>
+        </div>
+        <div class="inline-cd-sep">:</div>
+        <div class="inline-cd-unit">
+          <span class="inline-cd-value" data-unit="minutes">--</span>
+          <span class="inline-cd-label">Min</span>
+        </div>
+        <div class="inline-cd-sep">:</div>
+        <div class="inline-cd-unit">
+          <span class="inline-cd-value" data-unit="seconds">--</span>
+          <span class="inline-cd-label">Sec</span>
+        </div>
+      </div>
+      {% endif %}
+
+      <div class="event-content">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags %}
+      <div class="event-tags">
+        {% for tag in page.tags %}
+        <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-badge">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <nav class="event-nav">
+        {% if page.higher %}<a href="{{ page.higher.url }}" class="nav-link nav-prev">Previous Event</a>{% endif %}
+        {% if page.lower %}<a href="{{ page.lower.url }}" class="nav-link nav-next">Next Event</a>{% endif %}
+      </nav>
+    </article>
+  </main>
+
+  <script>
+  (function() {
+    var el = document.querySelector(".inline-countdown");
+    if (!el) return;
+    var target = new Date(el.dataset.target + "T00:00:00").getTime();
+    function pad(n) { return n < 10 ? "0" + n : String(n); }
+    function tick() {
+      var remaining = target - Date.now();
+      if (remaining <= 0) {
+        el.querySelectorAll(".inline-cd-value").forEach(function(v) { v.textContent = "00"; });
+        return;
+      }
+      var d = Math.floor(remaining / 86400000);
+      var h = Math.floor((remaining % 86400000) / 3600000);
+      var m = Math.floor((remaining % 3600000) / 60000);
+      var s = Math.floor((remaining % 60000) / 1000);
+      el.querySelector('[data-unit="days"]').textContent = pad(d);
+      el.querySelector('[data-unit="hours"]').textContent = pad(h);
+      el.querySelector('[data-unit="minutes"]').textContent = pad(m);
+      el.querySelector('[data-unit="seconds"]').textContent = pad(s);
+    }
+    tick();
+    setInterval(tick, 1000);
+  })();
+  </script>
+{% include "footer.html" %}

--- a/clocktower/templates/section.html
+++ b/clocktower/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1 class="page-title">{{ page.title }}</h1>
+    {{ content | safe }}
+    <div class="event-list">
+      {% for item in section.pages %}
+      <a href="{{ item.url }}" class="event-card">
+        <time class="event-card-date">{{ item.date | date("%Y-%m-%d") }}</time>
+        <h3 class="event-card-title">{{ item.title }}</h3>
+        {% if item.extra.location %}
+        <p class="event-card-location">{{ item.extra.location }}</p>
+        {% endif %}
+        {% if item.description %}
+        <p class="event-card-desc">{{ item.description }}</p>
+        {% endif %}
+        {% if item.extra.status %}
+        <span class="event-status event-status--{{ item.extra.status }}">{{ item.extra.status }}</span>
+        {% endif %}
+      </a>
+      {% endfor %}
+    </div>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/clocktower/templates/shortcodes/alert.html
+++ b/clocktower/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/clocktower/templates/taxonomy.html
+++ b/clocktower/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1 class="page-title">{{ page.title }}</h1>
+    <p class="taxonomy-desc">Browse all terms:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/clocktower/templates/taxonomy_term.html
+++ b/clocktower/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1 class="page-title">{{ page.title }}</h1>
+    <p class="taxonomy-desc">Events tagged with this term:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -695,5 +695,10 @@
     "light",
     "landing",
     "app"
+  ],
+  "clocktower": [
+    "dark",
+    "landing",
+    "countdown"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new `clocktower` example: a dark-themed countdown timer & event timeline site with digital scoreboard aesthetic
- Features live countdown to the next upcoming event, vertical timeline for upcoming events, and an archive section for past events
- Includes flip-clock style monospace digit display, per-event detail page with inline countdown, and responsive mobile layout

## Test plan
- [ ] Verify `hwaro build` succeeds in the `clocktower/` directory
- [ ] Verify countdown timer updates in real time on the home page
- [ ] Verify event detail pages show inline countdown for upcoming events
- [ ] Verify past events appear in the archive section
- [ ] Verify responsive layout on mobile viewports

Closes #151