### PR TITLE
Add easel example: art tutorial / how-to-draw theme

### DIFF
--- a/easel/AGENTS.md
+++ b/easel/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/easel/config.toml
+++ b/easel/config.toml
@@ -1,0 +1,133 @@
+title = "Easel"
+description = "Art tutorials and step-by-step drawing lessons for every skill level."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["tutorials"]
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/easel/content/index.md
+++ b/easel/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Easel -- Art Tutorials"
+template = "home"
+description = "Step-by-step art tutorials and drawing lessons for every skill level."
++++
+
+Welcome to Easel, your studio companion for learning to draw and paint. Each lesson walks you through the process from blank page to finished work, with clear steps you can follow at your own pace.

--- a/easel/content/techniques/_index.md
+++ b/easel/content/techniques/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Techniques"
+description = "Foundational art techniques and principles for improving your work."
+template = "section"
+weight = 2
++++
+
+Master the fundamental techniques that underpin all visual art. These references cover shading, color theory, and composition -- the building blocks every artist needs.

--- a/easel/content/techniques/color-theory.md
+++ b/easel/content/techniques/color-theory.md
@@ -1,0 +1,44 @@
++++
+title = "Color Theory Basics"
+date = "2026-03-08"
+description = "Essential color theory for painters: the color wheel, mixing, temperature, and harmony."
+tags = ["watercolor", "fundamentals", "beginner"]
+categories = ["technique"]
+
+[extra]
+difficulty = "Beginner"
+duration = "25 minutes"
+tools = ["Watercolor Set", "Palette", "Watercolor Paper"]
++++
+
+Color theory provides a framework for making intentional choices about the colors in your work. Rather than relying on instinct alone, understanding these principles gives you control.
+
+## The Color Wheel
+
+The traditional color wheel arranges twelve hues in a circle. Three primaries (red, yellow, blue) combine to form three secondaries (orange, green, violet), and the six tertiaries fill the gaps between them.
+
+In practice, no single set of three paint tubes can mix every possible color. Professional palettes include a warm and a cool version of each primary to extend the mixing range.
+
+## Color Temperature
+
+Every color leans warm (toward yellow-orange) or cool (toward blue). Cadmium red is warm; alizarin crimson is cool. This distinction matters enormously in landscape painting, where cool colors recede and warm colors advance.
+
+Shadows are generally cooler than the surfaces they fall on. Sunlit areas tend warm. Painting these temperature shifts, even subtly, adds depth that value alone cannot achieve.
+
+## Color Harmony
+
+Harmonious color schemes share a structural relationship on the wheel.
+
+**Complementary** -- Colors opposite each other (blue and orange, red and green). High contrast, vibrant when placed side by side, neutral when mixed.
+
+**Analogous** -- Three to five colors adjacent on the wheel (yellow, yellow-green, green). Naturally harmonious, low contrast.
+
+**Triadic** -- Three colors equally spaced (red, yellow, blue). Balanced and colorful, but requires careful management of proportions.
+
+## Mixing Without Mud
+
+Muddy color results from mixing too many pigments or combining colors far apart on the wheel without intention. To keep mixtures clean, limit each mixture to two or three pigments. When you need a neutral gray or brown, mix specific complementaries rather than adding black.
+
+## Practice Exercise
+
+Create a simple color chart: mix each primary with every other color in your palette. Document the results. This reference sheet will save you time and frustration in every future painting session.

--- a/easel/content/techniques/composition-rules.md
+++ b/easel/content/techniques/composition-rules.md
@@ -1,0 +1,40 @@
++++
+title = "Composition Rules"
+date = "2026-03-12"
+description = "Principles of visual composition: arranging elements for balance, movement, and focal points."
+tags = ["fundamentals", "intermediate"]
+categories = ["technique"]
+
+[extra]
+difficulty = "Intermediate"
+duration = "20 minutes"
+tools = ["Sketchbook", "Any Drawing Tool"]
++++
+
+Composition is the arrangement of visual elements within the picture plane. A drawing with masterful rendering but poor composition will always feel wrong. Conversely, a loose sketch with strong composition holds attention immediately.
+
+## Rule of Thirds
+
+Divide the frame into a three-by-three grid. Placing key elements along these lines, or at their intersections, creates a dynamic balance. Centering the subject works for formal symmetry, but the rule of thirds produces more energetic compositions.
+
+## Leading Lines
+
+Lines within the image -- roads, rivers, edges of buildings, even the direction of a gaze -- guide the viewer's eye. Arrange them to point toward your focal point. Avoid lines that lead the eye out of the frame.
+
+## Foreground, Middle Ground, Background
+
+Depth in a two-dimensional image comes from layering spatial planes. A strong foreground element anchors the viewer, the middle ground holds the subject, and the background provides context and atmosphere. Overlapping these planes strengthens the illusion of space.
+
+## Value Structure
+
+Before committing to a full drawing, create small thumbnail sketches (roughly five centimeters across) that reduce the scene to three or four values. If the composition does not read clearly at this scale, it will not work at full size.
+
+Strong compositions typically have a dominant value -- either mostly light, mostly dark, or mostly mid-tone -- with a smaller area of contrasting value that draws attention.
+
+## Negative Space
+
+The space around and between subjects is as important as the subjects themselves. A portrait with too little space above the head feels cramped. A landscape with an empty, featureless sky wastes half the canvas. Learn to see and shape the negative space as consciously as you shape the positive forms.
+
+## Practice Exercise
+
+Take a finished drawing or painting and crop it in multiple ways using two L-shaped pieces of card. Notice how each crop changes the energy and focus of the image. This exercise trains your eye to evaluate composition before you commit to a final format.

--- a/easel/content/techniques/shading-fundamentals.md
+++ b/easel/content/techniques/shading-fundamentals.md
@@ -1,0 +1,40 @@
++++
+title = "Shading Fundamentals"
+date = "2026-03-05"
+description = "Understanding light, shadow, and the five elements of shading to create convincing three-dimensional form."
+tags = ["pencil", "fundamentals", "beginner"]
+categories = ["technique"]
+
+[extra]
+difficulty = "Beginner"
+duration = "30 minutes"
+tools = ["HB Pencil", "2B Pencil", "6B Pencil", "Blending Stump", "Drawing Paper"]
++++
+
+Shading transforms flat shapes into three-dimensional forms. Understanding how light interacts with objects is the single most important skill in representational drawing.
+
+## The Five Elements of Shading
+
+Every lit object displays five distinct value zones. Learning to see and render them is the foundation of realistic drawing.
+
+**Highlight** -- The brightest point where light hits the surface most directly. On a sphere, this is a small, intense spot. On matte surfaces, the highlight is softer and more diffused.
+
+**Light** -- The broad area receiving direct illumination. This is lighter than mid-tone but lacks the intensity of the highlight.
+
+**Mid-tone** -- The transition zone between light and shadow. This represents the actual local color of the object, unaffected by strong light or shadow.
+
+**Core Shadow** -- The darkest band on the object itself, found where the surface turns away from the light source. This is not the darkest dark in the scene -- that distinction belongs to the cast shadow at contact points.
+
+**Reflected Light** -- A subtle lightening within the shadow side, caused by light bouncing off nearby surfaces. This is always darker than any area on the light side. Beginners often make reflected light too bright, which flattens the form.
+
+## The Cast Shadow
+
+Separate from the object's own shading, the cast shadow falls on surrounding surfaces. It is darkest and sharpest where the object contacts the surface, becoming lighter and softer as it extends away.
+
+## Practice Exercise
+
+Draw a sphere using only an HB and 4B pencil. Start with a circle, identify your light source direction, then work through each of the five value zones. Spend at least fifteen minutes refining the transitions between zones until they appear seamless.
+
+## Common Mistakes
+
+Drawing outlines around shadow shapes instead of letting value transitions define edges. Shading with uniform pressure instead of varying stroke weight. Ignoring reflected light, or making it too prominent. These errors all point to the same underlying issue: drawing what you think you know rather than what you actually see.

--- a/easel/content/tutorials/_index.md
+++ b/easel/content/tutorials/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Tutorials"
+description = "Step-by-step art tutorials covering drawing, painting, and mixed media."
+template = "section"
+weight = 1
++++
+
+Browse our collection of art tutorials. Each lesson includes tool recommendations, difficulty ratings, and a clear step-by-step process.

--- a/easel/content/tutorials/drawing-a-rose.md
+++ b/easel/content/tutorials/drawing-a-rose.md
@@ -1,0 +1,56 @@
++++
+title = "Drawing a Rose"
+date = "2026-03-10"
+description = "Learn to draw a realistic rose using graphite pencils, from basic shapes to refined petals."
+tags = ["pencil", "botanical", "beginner"]
+categories = ["drawing"]
+
+[extra]
+difficulty = "Beginner"
+duration = "45 minutes"
+tools = ["HB Pencil", "2B Pencil", "4B Pencil", "Kneaded Eraser", "Drawing Paper"]
++++
+
+A rose is one of the most rewarding subjects for a beginning artist. Its layered petals teach you to see overlapping forms, and the soft curves build confidence with your pencil.
+
+## Reference
+
+Before you begin, study the subject. Notice how petals spiral outward from a tight center, each one curving slightly differently. Pay attention to where shadows collect between layers.
+
+## Step 1 -- Basic Shape
+
+Start with a small oval near the center of your page. This will be the bud core. Using your HB pencil, draw lightly -- these are construction lines you will erase later.
+
+Around the oval, sketch a loose cup shape. Think of it as a wine glass silhouette. This establishes the overall volume of the bloom.
+
+## Step 2 -- Inner Petals
+
+From the top of the oval, draw two or three small curved lines that overlap each other. These are the innermost petals, still tightly wrapped. Keep the lines soft and slightly uneven -- perfection looks unnatural.
+
+## Step 3 -- Middle Petals
+
+Working outward, add larger petals that begin to open. Each petal should originate from behind the one in front of it. Vary the widths: some petals appear narrow from this angle, others wide and full.
+
+Switch to your 2B pencil for the lines that will remain visible. Let the petals drape slightly at their edges -- roses are not rigid.
+
+## Step 4 -- Outer Petals
+
+The outermost petals are the largest and most open. Some may curl backward at the tips. Draw three to five large petals that frame the entire bloom. These petals often have subtle folds or creases.
+
+## Step 5 -- Stem and Leaves
+
+Draw two gently curving lines downward for the stem. Add a pair of leaves with serrated edges. The central vein of each leaf should follow the leaf's curve, not run perfectly straight.
+
+## Step 6 -- Shading
+
+Using your 4B pencil, begin adding shadows. The deepest darks are where petals overlap and in the center of the bloom. Work in one direction with your strokes, following the curve of each petal.
+
+Use your kneaded eraser to lift highlights on the tops of petals where light hits directly. The contrast between light edges and shadowed folds is what gives the rose its dimension.
+
+## Step 7 -- Refinement
+
+Step back and compare your drawing to the reference. Darken any shadows that need more depth. Soften hard edges by gently blending with your finger or a blending stump. Clean up any remaining construction lines.
+
+## Finished Work
+
+Your completed rose should have a clear sense of depth, with petals that appear to wrap around each other in space. The tonal range from bright highlights to deep shadows gives the drawing its realism.

--- a/easel/content/tutorials/portrait-sketching.md
+++ b/easel/content/tutorials/portrait-sketching.md
@@ -1,0 +1,64 @@
++++
+title = "Portrait Sketching"
+date = "2026-03-20"
+description = "Master the fundamentals of portrait drawing with charcoal, focusing on proportions and value structure."
+tags = ["charcoal", "portrait", "advanced"]
+categories = ["drawing"]
+
+[extra]
+difficulty = "Advanced"
+duration = "120 minutes"
+tools = ["Vine Charcoal", "Compressed Charcoal", "White Charcoal Pencil", "Chamois", "Kneaded Eraser", "Toned Paper"]
++++
+
+The human face is the most demanding and rewarding subject an artist can tackle. Every viewer is an expert at reading faces, which means even small errors are immediately noticed. Precision matters, but so does the confidence of your marks.
+
+## Reference
+
+Work from a photograph with clear, directional lighting -- a single light source from above and to one side. This creates the strong shadow patterns that give a portrait its structure. Avoid flat, even lighting.
+
+## Step 1 -- Head Proportions
+
+Using vine charcoal on toned paper, draw an egg shape for the head. Divide it with a vertical center line and a horizontal line at the midpoint. This halfway line is where the eyes sit -- a fact that surprises most beginners, who place the eyes too high.
+
+Mark the bottom of the nose halfway between the eye line and the chin. The mouth sits one-third of the distance from nose to chin.
+
+## Step 2 -- Placing the Features
+
+On the eye line, divide the width into five equal segments. The eyes occupy the second and fourth segments, each one eye-width apart. The width of the nose aligns with the inner corners of the eyes.
+
+Sketch the ears between the eye line and the nose line. Lightly indicate the hairline, which typically sits about one-third of the way down from the top of the head.
+
+## Step 3 -- Shadow Mapping
+
+Before refining any features, map the large shadow shapes. Squint at your reference to simplify what you see into two values: light and shadow. Using the side of your vine charcoal, block in all shadow areas as one connected shape.
+
+This shadow map is the skeleton of the portrait. If it reads correctly when you squint, the likeness is already emerging.
+
+## Step 4 -- Eyes and Brows
+
+The eyes are spheres set into sockets. Draw the upper lid as a more curved line than the lower. The iris is partially hidden by both lids -- never draw it as a complete circle. Add the crease above the eye and the subtle shadow beneath the lower lid.
+
+Eyebrows follow the brow ridge. They are thicker at the inner corner and taper outward. Avoid drawing individual hairs at this stage.
+
+## Step 5 -- Nose and Mouth
+
+The nose is defined primarily by the shadows it casts, not by outlines. Draw the cast shadow under the nose, the shadow along one side, and the small highlights on the tip and bridge. Resist the urge to outline the nostrils.
+
+For the mouth, the line where the lips meet is the most important mark. The upper lip is usually in shadow; the lower lip catches the light. The corners of the mouth are soft, not sharply defined.
+
+## Step 6 -- Building Values
+
+Switch to compressed charcoal for the darkest darks: the pupils, the shadow under the nose, the depth of the ear canal. Use your chamois to smooth transitions in the larger shadow areas.
+
+With the white charcoal pencil, establish the brightest highlights: the bridge of the nose, the forehead, the lower lip. Working on toned paper means your mid-tones are already present.
+
+## Step 7 -- Hair and Edges
+
+Treat hair as large masses of value, not individual strands. Block in the overall shape and shadow pattern. Add a few flyaway strands at the edges for a natural look.
+
+Examine the edges throughout the portrait. Some edges are sharp (the side of the nose against a lit cheek), others are soft (the jaw fading into the neck shadow). This variety of edges is what makes a portrait feel alive rather than cut out.
+
+## Finished Work
+
+Stand back and compare the drawing to the reference from a distance. Check the overall proportions and the big value relationships. A strong portrait reads clearly from across the room. The details -- eyelashes, skin texture, individual hairs -- are secondary to the large shapes and values that define the likeness.

--- a/easel/content/tutorials/watercolor-landscape.md
+++ b/easel/content/tutorials/watercolor-landscape.md
@@ -1,0 +1,62 @@
++++
+title = "Watercolor Landscape"
+date = "2026-03-15"
+description = "Paint a serene mountain landscape with watercolors, learning wet-on-wet and layering techniques."
+tags = ["watercolor", "landscape", "intermediate"]
+categories = ["painting"]
+
+[extra]
+difficulty = "Intermediate"
+duration = "90 minutes"
+tools = ["Watercolor Set", "Round Brush #8", "Round Brush #4", "Flat Wash Brush", "Watercolor Paper 300gsm", "Palette", "Water Containers"]
++++
+
+Watercolor landscapes teach restraint. The medium rewards those who let the paint move, who leave white space for light, and who build depth through transparent layers rather than heavy application.
+
+## Reference
+
+Study the scene: distant mountains, a middle-ground tree line, and a foreground meadow. Notice how colors become cooler and lighter as they recede. The sky is the lightest element; the foreground holds the darkest values.
+
+## Step 1 -- Sketching the Composition
+
+With a light pencil line, divide your paper into three horizontal zones. The sky occupies the upper third. Mountains and tree line sit in the middle. The foreground meadow fills the lower third.
+
+Keep the sketch minimal. Watercolor is transparent -- heavy pencil marks will show through the paint.
+
+## Step 2 -- The Sky Wash
+
+Wet the entire sky area with clean water using your flat wash brush. While the paper glistens, load your brush with a pale blue mixed from ultramarine and plenty of water. Apply it in broad horizontal strokes from the top, letting gravity pull the pigment downward.
+
+Leave a few areas untouched for clouds. The dry paper will repel the wash, creating soft white shapes. Let this dry completely before proceeding.
+
+## Step 3 -- Distant Mountains
+
+Mix a cool violet-gray: ultramarine blue with a touch of burnt sienna. Dilute it well. Paint the mountain silhouettes with your round brush, keeping the edges soft. Mountains in the distance should be pale and slightly blue.
+
+For the nearer range, use a slightly stronger mix. Allow the bases of the mountains to blur into the paper by painting into a slightly damp surface.
+
+## Step 4 -- Tree Line
+
+Let the mountains dry. Mix a muted green from sap green and a little burnt umber. Using your round brush, paint the tree line as a continuous irregular shape along the base of the mountains. Vary the height -- some trees are taller, creating a natural silhouette.
+
+While still wet, drop in darker green at the base of the trees. The pigment will bloom upward, creating a sense of shadow and density.
+
+## Step 5 -- Foreground Meadow
+
+This is where you use the most color. Wet the foreground area and apply a warm yellow-green wash. While wet, add strokes of deeper green, touches of ochre, and hints of warm brown.
+
+Let the colors mingle on the paper. Do not over-mix -- the beauty of watercolor is in its unpredictable blending.
+
+## Step 6 -- Details and Texture
+
+Once dry, add fine details with your small round brush. A few individual tree shapes in the middle ground. Thin dark lines suggesting grass blades in the foreground. A path or stream, if the composition calls for it.
+
+Use a dry brush technique for texture: load the brush, blot it on a paper towel, then drag it across the surface. The paint catches only the raised grain of the paper.
+
+## Step 7 -- Final Adjustments
+
+Assess the overall tonal balance. The painting should read clearly in three planes: pale sky, medium-value middle ground, and rich foreground. Darken any areas that compete with the foreground, or lift color with a damp brush if something is too heavy.
+
+## Finished Work
+
+A successful landscape in watercolor feels luminous. Light comes from the white of the paper shining through transparent layers. The loose, flowing quality of the medium should remain visible -- do not overwork it.

--- a/easel/static/css/style.css
+++ b/easel/static/css/style.css
@@ -1,0 +1,753 @@
+/* === Easel: Art Tutorial Theme === */
+/* Canvas-textured, light, art classroom aesthetic */
+
+:root {
+  --color-bg: #f5f0e8;
+  --color-bg-paper: #faf7f2;
+  --color-text: #2c2418;
+  --color-text-secondary: #6b5e4f;
+  --color-text-muted: #9a8d7e;
+  --color-border: #d4cbc0;
+  --color-border-light: #e8e0d5;
+  --color-accent: #8b4513;
+  --color-accent-hover: #6d360f;
+  --color-link: #5a3a1a;
+  --color-link-hover: #8b4513;
+  --color-beginner: #3a6b35;
+  --color-intermediate: #7a5c1f;
+  --color-advanced: #8b2500;
+  --color-tag-bg: #eee7db;
+  --color-tag-border: #d4cbc0;
+  --color-card-shadow: rgba(44, 36, 24, 0.06);
+  --font-body: "Georgia", "Times New Roman", serif;
+  --font-heading: "Georgia", "Times New Roman", serif;
+  --font-mono: "Menlo", "Consolas", monospace;
+  --font-ui: -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --max-width: 1120px;
+  --content-width: 720px;
+}
+
+/* === Reset & Base === */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  background-image:
+    url("data:image/svg+xml,%3Csvg width='100' height='100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100' height='100' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+  line-height: 1.7;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* === Header === */
+
+.site-header {
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-bg-paper);
+}
+
+.header-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0.9rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.site-logo {
+  font-family: var(--font-heading);
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: 0.02em;
+  text-decoration: none;
+}
+
+.site-logo:hover {
+  color: var(--color-accent);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+}
+
+.site-nav a {
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  padding: 0.2rem 0;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.site-nav a:hover {
+  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
+}
+
+.search-trigger {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.search-trigger:hover {
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-secondary);
+}
+
+/* === Search Overlay === */
+
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 36, 24, 0.4);
+  z-index: 100;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  background: var(--color-bg-paper);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 560px;
+  box-shadow: 0 8px 32px rgba(44, 36, 24, 0.12);
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.search-input-wrap svg {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  background: none;
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+  color: var(--color-text);
+  outline: none;
+}
+
+.search-input-wrap input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.search-input-wrap kbd {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.search-results {
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.search-result-item:hover {
+  background: var(--color-tag-bg);
+}
+
+.search-result-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  font-family: var(--font-ui);
+  margin-bottom: 0.15rem;
+}
+
+.search-result-snippet {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  font-family: var(--font-ui);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-result-snippet mark {
+  background: rgba(139, 69, 19, 0.12);
+  color: var(--color-accent);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-no-results {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-family: var(--font-ui);
+}
+
+/* === Hero === */
+
+.hero {
+  background-color: var(--color-bg-paper);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.hero-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 1rem;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  color: var(--color-text-secondary);
+  max-width: 560px;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.65rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-primary {
+  background-color: var(--color-accent);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: var(--color-accent-hover);
+  color: #fff;
+}
+
+.btn-secondary {
+  background-color: transparent;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-accent);
+  color: #fff;
+}
+
+/* === Featured Sections === */
+
+.featured-section {
+  padding: 3rem 0;
+}
+
+.featured-section + .featured-section {
+  border-top: 1px solid var(--color-border-light);
+}
+
+.section-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.featured-section h2 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 1.5rem;
+}
+
+/* === Card Grid === */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.tutorial-card {
+  background: var(--color-bg-paper);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 1.5rem;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.tutorial-card:hover {
+  box-shadow: 0 4px 16px var(--color-card-shadow);
+  border-color: var(--color-text-muted);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+}
+
+.tutorial-card h3 {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  line-height: 1.3;
+}
+
+.tutorial-card h3 a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.tutorial-card h3 a:hover {
+  color: var(--color-accent);
+}
+
+.tutorial-card > p {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+  margin-bottom: 1rem;
+}
+
+/* === Difficulty Badges === */
+
+.difficulty {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 3px;
+}
+
+.difficulty-beginner {
+  color: var(--color-beginner);
+  background: rgba(58, 107, 53, 0.1);
+  border: 1px solid rgba(58, 107, 53, 0.2);
+}
+
+.difficulty-intermediate {
+  color: var(--color-intermediate);
+  background: rgba(122, 92, 31, 0.1);
+  border: 1px solid rgba(122, 92, 31, 0.2);
+}
+
+.difficulty-advanced {
+  color: var(--color-advanced);
+  background: rgba(139, 37, 0, 0.1);
+  border: 1px solid rgba(139, 37, 0, 0.2);
+}
+
+/* === Duration === */
+
+.duration {
+  color: var(--color-text-muted);
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+}
+
+/* === Tool Tags === */
+
+.tool-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tool-tag {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  background: var(--color-tag-bg);
+  border: 1px solid var(--color-tag-border);
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+}
+
+/* === Section Page === */
+
+.section-main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.section-hero {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 2rem;
+}
+
+.section-hero h1 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.section-hero p {
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+  max-width: 560px;
+}
+
+/* === Lesson Article === */
+
+.page-main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.lesson-article {
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+
+.lesson-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.lesson-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+}
+
+.lesson-meta time {
+  color: var(--color-text-muted);
+}
+
+.lesson-header h1 {
+  font-family: var(--font-heading);
+  font-size: 2.2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 0.75rem;
+}
+
+.lesson-description {
+  font-size: 1.05rem;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.tools-required {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+}
+
+.tools-required strong {
+  display: block;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.6rem;
+}
+
+/* === Lesson Content (Prose) === */
+
+.lesson-content h2 {
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 2.5rem 0 0.75rem;
+  color: var(--color-text);
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-light);
+}
+
+.lesson-content h2:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.lesson-content h3 {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 2rem 0 0.5rem;
+}
+
+.lesson-content p {
+  margin-bottom: 1rem;
+  line-height: 1.75;
+}
+
+.lesson-content strong {
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.lesson-content ul,
+.lesson-content ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.lesson-content li {
+  margin-bottom: 0.35rem;
+  line-height: 1.65;
+}
+
+.lesson-content blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding: 0.5rem 1rem;
+  margin: 1.5rem 0;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.lesson-content code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--color-tag-bg);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+
+.lesson-content pre {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.lesson-content pre code {
+  background: none;
+  padding: 0;
+}
+
+.lesson-content img {
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  margin: 1.5rem 0;
+}
+
+/* === Lesson Footer === */
+
+.lesson-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+}
+
+.lesson-footer a {
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.lesson-footer a:hover {
+  color: var(--color-accent);
+}
+
+/* === Error Page === */
+
+.error-main {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 6rem 1.5rem;
+  text-align: center;
+}
+
+.error-main h1 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.error-main p {
+  color: var(--color-text-secondary);
+}
+
+/* === Footer === */
+
+.site-footer {
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-paper);
+  margin-top: auto;
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1.5rem;
+  text-align: center;
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.footer-inner a {
+  color: var(--color-text-secondary);
+}
+
+/* === Responsive === */
+
+@media (max-width: 768px) {
+  html {
+    font-size: 16px;
+  }
+
+  .header-inner {
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+
+  .site-nav {
+    gap: 1rem;
+    font-size: 0.8rem;
+  }
+
+  .hero-inner {
+    padding: 3rem 1rem;
+  }
+
+  .hero h1 {
+    font-size: 2rem;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-hero,
+  .section-inner,
+  .page-main {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .lesson-header h1 {
+    font-size: 1.7rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero h1 {
+    font-size: 1.7rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .search-trigger span {
+    display: none;
+  }
+}

--- a/easel/static/js/search.js
+++ b/easel/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/easel/templates/404.html
+++ b/easel/templates/404.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+  </div>
+</header>
+<main class="error-main">
+  <h1>Page Not Found</h1>
+  <p>The page you are looking for does not exist. Perhaps you would like to browse our <a href="{{ base_url }}/tutorials/">tutorials</a> instead.</p>
+</main>
+{% include "footer.html" %}

--- a/easel/templates/footer.html
+++ b/easel/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p>Powered by <a href="https://hwaro.hahwul.com">Hwaro</a></p>
+    </div>
+  </footer>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/easel/templates/header.html
+++ b/easel/templates/header.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} -- {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>

--- a/easel/templates/home.html
+++ b/easel/templates/home.html
@@ -1,0 +1,80 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      Search
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search tutorials and techniques..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<main class="home-main">
+  <section class="hero">
+    <div class="hero-inner">
+      <h1>Learn to Draw and Paint</h1>
+      <p class="hero-subtitle">Step-by-step art tutorials for every skill level. From pencil sketches to watercolor paintings, build your skills with guided lessons.</p>
+      <div class="hero-actions">
+        <a href="{{ base_url }}/tutorials/" class="btn btn-primary">Browse Tutorials</a>
+        <a href="{{ base_url }}/techniques/" class="btn btn-secondary">Study Techniques</a>
+      </div>
+    </div>
+  </section>
+
+  {% set tutorials_section = get_section(path="tutorials/_index.md") %}
+  <section class="featured-section">
+    <div class="section-inner">
+      <h2>Latest Tutorials</h2>
+      <div class="card-grid">
+        {% for tutorial in tutorials_section.pages | sort(attribute="date") | reverse %}
+        <article class="tutorial-card">
+          <div class="card-header">
+            <span class="difficulty difficulty-{{ tutorial.extra.difficulty | lower }}">{{ tutorial.extra.difficulty }}</span>
+            <span class="duration">{{ tutorial.extra.duration }}</span>
+          </div>
+          <h3><a href="{{ tutorial.url }}">{{ tutorial.title }}</a></h3>
+          <p>{{ tutorial.description }}</p>
+          <div class="tool-tags">
+            {% for tool in tutorial.extra.tools %}
+            <span class="tool-tag">{{ tool }}</span>
+            {% endfor %}
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  {% set techniques_section = get_section(path="techniques/_index.md") %}
+  <section class="featured-section">
+    <div class="section-inner">
+      <h2>Technique References</h2>
+      <div class="card-grid">
+        {% for technique in techniques_section.pages | sort(attribute="date") | reverse %}
+        <article class="tutorial-card">
+          <div class="card-header">
+            <span class="difficulty difficulty-{{ technique.extra.difficulty | lower }}">{{ technique.extra.difficulty }}</span>
+            <span class="duration">{{ technique.extra.duration }}</span>
+          </div>
+          <h3><a href="{{ technique.url }}">{{ technique.title }}</a></h3>
+          <p>{{ technique.description }}</p>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/easel/templates/page.html
+++ b/easel/templates/page.html
@@ -1,0 +1,62 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      Search
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search tutorials and techniques..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<main class="page-main">
+  <article class="lesson-article">
+    <header class="lesson-header">
+      <div class="lesson-meta">
+        {% if page.extra.difficulty %}
+        <span class="difficulty difficulty-{{ page.extra.difficulty | lower }}">{{ page.extra.difficulty }}</span>
+        {% endif %}
+        {% if page.extra.duration %}
+        <span class="duration">{{ page.extra.duration }}</span>
+        {% endif %}
+        {% if page.date %}
+        <time>{{ page.date | date("%B %d, %Y") }}</time>
+        {% endif %}
+      </div>
+      <h1>{{ page.title }}</h1>
+      {% if page.description %}
+      <p class="lesson-description">{{ page.description }}</p>
+      {% endif %}
+      {% if page.extra.tools %}
+      <div class="tools-required">
+        <strong>Tools Required</strong>
+        <div class="tool-tags">
+          {% for tool in page.extra.tools %}
+          <span class="tool-tag">{{ tool }}</span>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </header>
+    <div class="lesson-content">
+      {{ content | safe }}
+    </div>
+    <footer class="lesson-footer">
+      <a href="{{ base_url }}/{{ page.section }}/">&larr; Back to {{ page.section | capitalize }}</a>
+    </footer>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/easel/templates/section.html
+++ b/easel/templates/section.html
@@ -1,0 +1,56 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      Search
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search tutorials and techniques..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<main class="section-main">
+  <div class="section-hero">
+    <h1>{{ section.title }}</h1>
+    <p>{{ section.description }}</p>
+  </div>
+  <div class="section-inner">
+    <div class="card-grid">
+      {% for page in section.pages | sort(attribute="date") | reverse %}
+      <article class="tutorial-card">
+        <div class="card-header">
+          {% if page.extra.difficulty %}
+          <span class="difficulty difficulty-{{ page.extra.difficulty | lower }}">{{ page.extra.difficulty }}</span>
+          {% endif %}
+          {% if page.extra.duration %}
+          <span class="duration">{{ page.extra.duration }}</span>
+          {% endif %}
+        </div>
+        <h3><a href="{{ page.url }}">{{ page.title }}</a></h3>
+        <p>{{ page.description }}</p>
+        {% if page.extra.tools %}
+        <div class="tool-tags">
+          {% for tool in page.extra.tools %}
+          <span class="tool-tag">{{ tool }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</main>
+{% include "footer.html" %}

--- a/easel/templates/taxonomy.html
+++ b/easel/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+  </div>
+</header>
+<main class="section-main">
+  <div class="section-hero">
+    <h1>{{ page.title }}</h1>
+  </div>
+  <div class="section-inner">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/easel/templates/taxonomy_term.html
+++ b/easel/templates/taxonomy_term.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">Easel</a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/tutorials/">Tutorials</a>
+      <a href="{{ base_url }}/techniques/">Techniques</a>
+    </nav>
+  </div>
+</header>
+<main class="section-main">
+  <div class="section-hero">
+    <h1>{{ page.title }}</h1>
+  </div>
+  <div class="section-inner">
+    {{ content | safe }}
+  </div>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -167,6 +167,11 @@
     "blog",
     "sunset"
   ],
+  "easel": [
+    "light",
+    "docs",
+    "art"
+  ],
   "emerald": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Art tutorial themed example site with light, canvas-textured design
- Step-by-step drawing lessons with tool tags (pencil, watercolor, charcoal) and difficulty indicators (Beginner/Intermediate/Advanced)
- 3 tutorials (Drawing a Rose, Watercolor Landscape, Portrait Sketching) and 3 technique references (Shading, Color Theory, Composition)
- Serif typography with warm earth-tone palette for an art classroom aesthetic

## Test plan
- [x] `hwaro build` succeeds with 9 pages, no errors
- [x] `hwaro doctor --fix` passes
- [x] `tags.json` updated with `["light", "docs", "art"]`
- [ ] Verify rendered pages display correctly in browser

Closes #148