### PR TITLE
Add 'Built with Hwaro' ribbon banner to deployed sites

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,18 @@ jobs:
             fi
           done
 
+      - name: Inject ribbon banner into built sites
+        run: |
+          OUTPUT_DIR="${GITHUB_WORKSPACE}/_site"
+          RIBBON='<!-- Hwaro GitHub Ribbon --><a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener" style="position:fixed;top:0;right:0;z-index:9999;display:block;width:150px;height:150px;overflow:hidden;text-decoration:none;" aria-label="Built with Hwaro - View on GitHub"><span style="display:block;position:absolute;top:28px;right:-40px;width:220px;padding:6px 0;background:#24292e;color:#fff;font-size:13px;font-weight:600;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;text-align:center;transform:rotate(45deg);box-shadow:0 2px 8px rgba(0,0,0,0.3);letter-spacing:0.5px;line-height:1.4;">Built with Hwaro</span></a>'
+
+          find "${OUTPUT_DIR}" -name "*.html" -not -path "${OUTPUT_DIR}/index.html" | while read -r f; do
+            if grep -q '<body' "$f"; then
+              sed -i "s|<body\([^>]*\)>|<body\1>${RIBBON}|" "$f"
+            fi
+          done
+          echo "Ribbon injected into all built HTML files"
+
       - name: Generate index page
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
## Summary
- 배포 파이프라인에 "Built with Hwaro" 리본 배너 주입 단계 추가
- 빌드된 HTML의 `<body>` 태그에 우측 상단 고정 리본을 삽입 (GitHub 링크 포함)
- 소스 템플릿은 수정하지 않아 외부 사용자가 scaffold로 가져갈 때 리본이 포함되지 않음

## Test plan
- [ ] deploy workflow 실행 후 example 사이트에 리본 배너가 표시되는지 확인
- [ ] 메인 index 페이지에는 리본이 삽입되지 않는지 확인
- [ ] 리본 클릭 시 hwaro GitHub 리포로 이동하는지 확인