### PR TITLE
Fix permission denied in ribbon banner injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,8 @@ jobs:
           OUTPUT_DIR="${GITHUB_WORKSPACE}/_site"
           RIBBON='<!-- Hwaro GitHub Ribbon --><a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener" style="position:fixed;top:0;right:0;z-index:9999;display:block;width:150px;height:150px;overflow:hidden;text-decoration:none;" aria-label="Built with Hwaro - View on GitHub"><span style="display:block;position:absolute;top:28px;right:-40px;width:220px;padding:6px 0;background:#24292e;color:#fff;font-size:13px;font-weight:600;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;text-align:center;transform:rotate(45deg);box-shadow:0 2px 8px rgba(0,0,0,0.3);letter-spacing:0.5px;line-height:1.4;">Built with Hwaro</span></a>'
 
+          chmod -R u+w "${OUTPUT_DIR}"
+
           find "${OUTPUT_DIR}" -name "*.html" -not -path "${OUTPUT_DIR}/index.html" | while read -r f; do
             if grep -q '<body' "$f"; then
               sed -i "s|<body\([^>]*\)>|<body\1>${RIBBON}|" "$f"


### PR DESCRIPTION
## Summary
- `sed -i`가 `_site` 디렉토리 내에 임시 파일을 생성할 때 쓰기 권한이 없어 `Permission denied` 오류 발생
- ribbon injection 전에 `chmod -R u+w`를 추가하여 해결

Fixes the build failure introduced in f2ec91d.

## Test plan
- [ ] deploy workflow가 정상적으로 통과하는지 확인