### PR TITLE
Add almanac-docs and cartograph examples

### DIFF
--- a/almanac-docs/config.toml
+++ b/almanac-docs/config.toml
@@ -1,0 +1,217 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Almanac"
+description = "Release planning and product roadmap documentation"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = false
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+
+# =============================================================================
+# SEO
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+# =============================================================================
+# Search
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/almanac-docs/content/about.md
+++ b/almanac-docs/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About Almanac release planning documentation"
++++
+
+# About Almanac
+
+Almanac is the central hub for release planning and product roadmap documentation. It provides a structured view of past releases, current development efforts, and future plans.
+
+## Purpose
+
+This documentation site serves as the single source of truth for:
+
+- **Release History** -- Detailed changelogs and notes for every shipped version
+- **Roadmap Planning** -- Quarterly milestones with feature breakdowns and status tracking
+- **Version Comparison** -- Side-by-side feature matrices across releases
+
+## Built With
+
+This documentation site is built using the Hwaro static site generator.

--- a/almanac-docs/content/docs/releases/_index.md
+++ b/almanac-docs/content/docs/releases/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Releases"
+sort_by = "weight"
+page_template = "doc"
+description = "Release history and version changelogs"
++++
+
+Browse all release notes organized by version. Each release includes a detailed changelog, breaking changes, and migration guides.

--- a/almanac-docs/content/docs/releases/v3-1-0.md
+++ b/almanac-docs/content/docs/releases/v3-1-0.md
@@ -1,0 +1,46 @@
++++
+title = "v3.1.0"
+description = "Plugin system foundation, improved error reporting, and new starter templates"
+weight = 2
+tags = ["release", "stable"]
+
+[extra]
+status = "released"
+version = "v3.1.0"
+target_date = "2025-10-01"
++++
+
+## Overview
+
+Version 3.1.0 lays the groundwork for the plugin system and significantly improves error reporting across the build pipeline. Three new starter templates are included.
+
+## Changelog
+
+### New Features
+
+- **Plugin loader** -- Initial plugin system with markdown processor hooks
+- **Error context** -- Build errors now include file path, line number, and suggested fixes
+- **Starter templates** -- Added `blog`, `docs`, and `portfolio` scaffolds to `hwaro init`
+- **Draft preview** -- `hwaro serve --drafts` now shows draft content with a visible banner
+
+### Improvements
+
+- Template compilation errors include source line preview
+- Front matter validation warns about unknown fields
+- Taxonomy pages support custom sorting
+- Sitemap generation respects `draft` and `noindex` flags
+
+### Bug Fixes
+
+- Fixed incorrect page ordering when weight and date are both specified
+- Resolved template cache invalidation issue causing stale renders
+- Corrected canonical URL generation for paginated sections
+- Fixed shortcode parsing when content contains triple backticks
+
+## Compatibility
+
+| Component | Required Version |
+|-----------|-----------------|
+| Crystal | >= 1.10.0 |
+| Node.js (optional) | >= 16.0.0 |
+| Docker image | ghcr.io/hahwul/hwaro:3.1.0 |

--- a/almanac-docs/content/docs/releases/v3-2-0.md
+++ b/almanac-docs/content/docs/releases/v3-2-0.md
@@ -1,0 +1,72 @@
++++
+title = "v3.2.0"
+description = "Search overhaul, performance improvements, and accessibility updates"
+weight = 1
+tags = ["release", "stable"]
+
+[extra]
+status = "released"
+version = "v3.2.0"
+target_date = "2026-01-15"
++++
+
+## Overview
+
+Version 3.2.0 delivers a complete search overhaul, significant performance improvements, and comprehensive accessibility updates. This release focused on developer experience and operational reliability.
+
+## Changelog
+
+### New Features
+
+- **Full-text search engine** -- Replaced basic keyword matching with a proper search engine supporting fuzzy matching, phrase queries, and field-specific search
+- **Search result highlighting** -- Query terms are highlighted in search results with configurable context windows
+- **Performance dashboard** -- New admin panel showing build times, cache hit rates, and memory usage
+
+### Improvements
+
+- Reduced build times by 40% through parallel template compilation
+- Image processing pipeline now supports WebP and AVIF output formats
+- RSS feed generation is 3x faster with streaming XML writer
+- CLI output uses structured logging with configurable verbosity levels
+
+### Bug Fixes
+
+- Fixed memory leak in file watcher during long-running serve sessions
+- Resolved race condition in concurrent taxonomy page generation
+- Corrected date parsing for ISO 8601 dates with timezone offsets
+- Fixed broken relative links in nested section pages
+
+### Breaking Changes
+
+| Change | Migration |
+|--------|-----------|
+| Search config format changed | Update `[search]` section in config.toml. See migration guide below |
+| Minimum Crystal version is now 1.11 | Update Crystal toolchain |
+| Deprecated `page.content` removed | Use `content` filter instead |
+
+## Migration Guide
+
+### Search Configuration
+
+The search configuration has been restructured for clarity:
+
+```toml
+# Before (v3.1.x)
+[search]
+enabled = true
+type = "fuse"
+
+# After (v3.2.0)
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## Compatibility
+
+| Component | Required Version |
+|-----------|-----------------|
+| Crystal | >= 1.11.0 |
+| Node.js (optional) | >= 18.0.0 |
+| Docker image | ghcr.io/hahwul/hwaro:3.2.0 |

--- a/almanac-docs/content/docs/roadmap/_index.md
+++ b/almanac-docs/content/docs/roadmap/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Roadmap"
+sort_by = "weight"
+page_template = "doc"
+description = "Upcoming features and quarterly milestones"
++++
+
+Product roadmap organized by quarter. Each milestone includes planned features, target dates, and current development status.

--- a/almanac-docs/content/docs/roadmap/q2-2026.md
+++ b/almanac-docs/content/docs/roadmap/q2-2026.md
@@ -1,0 +1,51 @@
++++
+title = "Q2 2026"
+description = "Plugin ecosystem, webhook integration, and developer tooling improvements"
+weight = 1
+tags = ["roadmap", "q2-2026"]
+
+[extra]
+status = "in-progress"
+version = "v3.3.0"
+target_date = "Q2 2026"
++++
+
+## Milestone Overview
+
+Q2 2026 focuses on extending the plugin ecosystem, adding webhook support for CI/CD integration, and improving developer tooling.
+
+## Planned Features
+
+### Plugin Ecosystem
+
+| Feature | Priority | Status |
+|---------|----------|--------|
+| Plugin registry API | High | In Development |
+| Template hook system | High | In Development |
+| Asset pipeline plugins | Medium | Planned |
+| Custom shortcode plugins | Medium | Planned |
+| Plugin dependency resolution | Low | Planned |
+
+### Webhook Integration
+
+- **Build webhooks** -- Trigger external services on build completion or failure
+- **Content webhooks** -- Notify when content files change in watch mode
+- **Deploy webhooks** -- Integration with GitHub, GitLab, and Netlify deploy pipelines
+
+### Developer Tooling
+
+- **LSP support** -- Language server for template files with autocomplete and diagnostics
+- **Debug mode** -- Verbose template rendering with variable inspection
+- **Benchmark suite** -- Automated performance regression testing
+
+## Timeline
+
+| Month | Focus Area | Deliverable |
+|-------|-----------|-------------|
+| April | Plugin core | Registry API, hook system prototype |
+| May | Webhooks | Build and content webhook handlers |
+| June | Polish | LSP beta, documentation, release candidate |
+
+## Dependencies
+
+This milestone depends on the completion of the plugin loader from v3.1.0 and the search infrastructure from v3.2.0.

--- a/almanac-docs/content/docs/roadmap/q3-2026.md
+++ b/almanac-docs/content/docs/roadmap/q3-2026.md
@@ -1,0 +1,57 @@
++++
+title = "Q3 2026"
+description = "Architecture redesign, multi-tenant support, and enterprise features"
+weight = 2
+tags = ["roadmap", "q3-2026"]
+
+[extra]
+status = "planned"
+version = "v4.0.0"
+target_date = "Q3 2026"
++++
+
+## Milestone Overview
+
+Q3 2026 is a major release targeting architecture modernization, multi-tenant support, and enterprise-grade features. This version introduces breaking changes to support long-term scalability.
+
+## Planned Features
+
+### Architecture Redesign
+
+| Component | Change | Rationale |
+|-----------|--------|-----------|
+| Build pipeline | Parallel task graph | 2-4x faster builds on multi-core systems |
+| Template engine | Incremental compilation | Only recompile changed templates |
+| Content store | Indexed database | Sub-millisecond content queries |
+| Asset pipeline | Streaming processor | Lower memory usage for large sites |
+
+### Multi-Tenant Support
+
+- **Workspace isolation** -- Multiple independent sites sharing a single installation
+- **Shared template library** -- Cross-workspace template inheritance
+- **Per-workspace config** -- Override global settings at workspace level
+- **Unified search** -- Optional cross-workspace search index
+
+### Enterprise Features
+
+- **Audit logging** -- Track all content changes with author attribution
+- **Role-based access** -- Content editor, reviewer, and publisher roles
+- **Approval workflows** -- Require review before content publication
+- **SSO integration** -- SAML 2.0 and OpenID Connect support
+
+## Migration Considerations
+
+Version 4.0 will include breaking changes. A migration tool will be provided:
+
+```bash
+hwaro migrate --from 3.x --to 4.0
+```
+
+Key breaking changes under consideration:
+
+| Area | Proposed Change |
+|------|----------------|
+| Config format | Move to structured config with workspace support |
+| Template syntax | Stricter whitespace handling |
+| Front matter | Required `schema` field for content validation |
+| CLI | Restructured subcommands |

--- a/almanac-docs/content/index.md
+++ b/almanac-docs/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Home"
++++
+
+# Almanac
+
+Release planning and product roadmap documentation. Track upcoming features, milestones, and version history across all product lines.
+
+## Navigation
+
+- [Release History](/docs/releases/) -- Browse all release notes and changelogs
+- [Roadmap](/docs/roadmap/) -- View upcoming quarters and planned features
+
+## Current Quarter Overview
+
+| Version | Target | Status | Highlights |
+|---------|--------|--------|------------|
+| v3.2.0 | Q1 2026 | Released | Search overhaul, performance improvements |
+| v3.3.0 | Q2 2026 | In Progress | Plugin system, webhook support |
+| v4.0.0 | Q3 2026 | Planned | Architecture redesign, multi-tenant support |

--- a/almanac-docs/static/js/mobile-menu.js
+++ b/almanac-docs/static/js/mobile-menu.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('mobile-menu-btn');
+  const menu = document.getElementById('mobile-menu');
+  let isMenuOpen = false;
+
+  if (btn && menu) {
+    btn.addEventListener('click', () => {
+      isMenuOpen = !isMenuOpen;
+      if (isMenuOpen) {
+        menu.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          menu.classList.remove('opacity-0');
+          menu.classList.remove('pointer-events-none');
+        });
+        document.body.style.overflow = 'hidden';
+      } else {
+        menu.classList.add('opacity-0');
+        menu.classList.add('pointer-events-none');
+        setTimeout(() => {
+          menu.classList.add('hidden');
+        }, 300);
+        document.body.style.overflow = '';
+      }
+    });
+  }
+});

--- a/almanac-docs/templates/404.html
+++ b/almanac-docs/templates/404.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 flex flex-col items-center justify-center text-center">
+    <div class="relative z-10">
+      <h1 class="text-[10rem] font-black text-text/5 leading-none select-none">404</h1>
+      <div class="absolute inset-0 flex items-center justify-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-text">Page Not Found</h2>
+      </div>
+    </div>
+
+    <p class="text-muted text-lg mb-8 max-w-md mx-auto mt-4">The page you are looking for does not exist, has been removed, or is temporarily unavailable.</p>
+
+    <a href="{{ base_url }}/" class="inline-flex items-center gap-2 px-8 py-3 bg-primary text-white rounded-full font-bold text-sm hover:bg-primary-dark transition-all duration-300 transform hover:-translate-y-0.5">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
+      Back to Home
+    </a>
+  </main>
+{% include "footer.html" %}

--- a/almanac-docs/templates/doc.html
+++ b/almanac-docs/templates/doc.html
@@ -1,0 +1,125 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-12 grid grid-cols-1 md:grid-cols-[250px_1fr] gap-12">
+    <!-- Mobile Sidebar Toggle -->
+    <div class="md:hidden">
+      <details class="group border border-border rounded-lg bg-surface">
+        <summary class="flex items-center justify-between p-4 cursor-pointer list-none text-text font-medium focus:outline-none select-none">
+          <span>{{ section.title }} Navigation</span>
+          <svg class="w-5 h-5 text-muted transition-transform duration-300 group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="p-4 border-t border-border bg-white">
+           {% if section.pages %}
+           <ul class="space-y-1">
+             {% for doc in section.pages %}
+             <li>
+               <a href="{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-accent bg-accent/5 border-l-accent font-medium{% else %}text-muted border-l-transparent hover:text-text hover:bg-surface hover:border-l-primary/30{% endif %}">
+                 {{ doc.title }}
+               </a>
+             </li>
+             {% endfor %}
+           </ul>
+           {% endif %}
+        </div>
+      </details>
+    </div>
+
+    <!-- Sidebar -->
+    <aside class="hidden md:block sticky top-24 h-[calc(100vh-120px)] overflow-y-auto pr-6 border-r border-border">
+      {% if section.pages %}
+      <nav class="space-y-8">
+        <div>
+          <h3 class="text-xs uppercase tracking-widest text-muted/60 font-bold mb-4 px-3">{{ section.title }}</h3>
+          <ul class="space-y-1">
+            {% for doc in section.pages %}
+            <li>
+              <a href="{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-accent bg-accent/5 border-l-accent font-medium{% else %}text-muted border-l-transparent hover:text-text hover:bg-surface hover:border-l-primary/30{% endif %}">
+                {{ doc.title }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </nav>
+      {% endif %}
+    </aside>
+
+    <article class="min-w-0 pb-16">
+      <!-- Breadcrumbs -->
+      <div class="flex items-center text-sm text-muted mb-6 overflow-x-auto whitespace-nowrap">
+        <a href="{{ base_url }}/" class="hover:text-text transition-colors">Home</a>
+        <svg class="w-4 h-4 mx-2 text-border" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <a href="{{ section.url }}" class="hover:text-text transition-colors">{{ section.title }}</a>
+        <svg class="w-4 h-4 mx-2 text-border" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <span class="text-accent font-medium">{{ page.title }}</span>
+      </div>
+
+      <header class="mb-10 border-b border-border pb-10">
+        <h1 class="text-4xl font-bold text-text tracking-tight mb-4">{{ page.title }}</h1>
+        {% if page.extra.status %}
+        <div class="flex items-center gap-4 mt-4">
+          {% if page.extra.status == "released" %}
+            <span class="badge-released">Released</span>
+          {% elif page.extra.status == "in-progress" %}
+            <span class="badge-in-progress">In Progress</span>
+          {% elif page.extra.status == "planned" %}
+            <span class="badge-planned">Planned</span>
+          {% elif page.extra.status == "deferred" %}
+            <span class="badge-deferred">Deferred</span>
+          {% endif %}
+          {% if page.extra.version %}
+            <span class="text-sm text-muted font-mono">{{ page.extra.version }}</span>
+          {% endif %}
+          {% if page.extra.target_date %}
+            <span class="text-sm text-muted">{{ page.extra.target_date }}</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.description %}
+          <p class="text-lg text-muted leading-relaxed max-w-3xl mt-4">{{ page.description }}</p>
+        {% endif %}
+      </header>
+
+      <div class="grid grid-cols-1 {% if page.toc %}lg:grid-cols-[1fr_200px]{% endif %} gap-10 items-start">
+        <!-- Content -->
+        <div class="prose prose-lg max-w-none">
+          {{ content }}
+        </div>
+
+        <!-- TOC (Desktop) -->
+        {% if page.toc %}
+        <aside class="hidden lg:block sticky top-24">
+          <div class="border-l border-border pl-4 py-1">
+            <h4 class="text-xs uppercase tracking-widest text-muted/60 font-bold mb-3">On this page</h4>
+            <div class="toc text-sm text-muted">
+              {{ page.toc }}
+            </div>
+          </div>
+        </aside>
+        {% endif %}
+      </div>
+
+      <!-- Navigation -->
+      <nav class="grid grid-cols-2 gap-6 mt-16 pt-8 border-t border-border">
+        {% if page.lower %}
+        <a href="{{ page.lower.url }}" class="group flex flex-col p-4 rounded-xl border border-border hover:border-accent/30 hover:bg-surface transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-accent transition-colors">Previous</span>
+          <span class="text-lg font-semibold text-text group-hover:text-accent transition-colors">
+            &larr; {{ page.lower.title }}
+          </span>
+        </a>
+        {% else %}<div></div>{% endif %}
+
+        {% if page.higher %}
+        <a href="{{ page.higher.url }}" class="group flex flex-col items-end text-right p-4 rounded-xl border border-border hover:border-accent/30 hover:bg-surface transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-accent transition-colors">Next</span>
+          <span class="text-lg font-semibold text-text group-hover:text-accent transition-colors">
+            {{ page.higher.title }} &rarr;
+          </span>
+        </a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/almanac-docs/templates/footer.html
+++ b/almanac-docs/templates/footer.html
@@ -1,0 +1,14 @@
+  </div>
+  <footer class="mt-20 py-12 border-t border-border text-center">
+    <div class="max-w-6xl mx-auto px-6 flex flex-col items-center justify-center gap-4">
+      <div class="flex items-center gap-2 text-muted">
+        <span class="text-sm">Powered by</span>
+        <a href="https://github.com/hahwul/hwaro" class="text-primary hover:text-accent transition-colors font-medium">Hwaro</a>
+      </div>
+      <p class="text-xs text-muted/50">2026 Almanac Product Team. All rights reserved.</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/almanac-docs/templates/header.html
+++ b/almanac-docs/templates/header.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+
+  <!-- Google Fonts: Inter -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#3b82f6',
+            'primary-light': '#60a5fa',
+            'primary-dark': '#2563eb',
+            accent: '#3b82f6',
+            released: '#16a34a',
+            'in-progress': '#3b82f6',
+            planned: '#64748b',
+            deferred: '#d97706',
+            background: '#ffffff',
+            surface: '#f8fafc',
+            'surface-alt': '#f1f5f9',
+            border: '#e2e8f0',
+            muted: '#64748b',
+            text: '#0f172a',
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+          },
+        },
+      },
+    }
+  </script>
+
+  <style type="text/tailwindcss">
+    /* Prose: markdown rendered content */
+    .prose { @apply text-text/80; }
+    .prose h1, .prose h2, .prose h3 { @apply font-semibold leading-tight text-text; }
+    .prose h1 { @apply text-3xl mt-0 mb-6; }
+    .prose h2 { @apply text-2xl mt-10 mb-4 border-b border-border pb-2; }
+    .prose h3 { @apply text-xl mt-8 mb-3 text-text/90; }
+    .prose p { @apply my-5 leading-relaxed text-muted; }
+    .prose a { @apply text-accent hover:text-blue-700 hover:underline underline-offset-4 decoration-2 decoration-accent/30 transition-all; }
+    .prose strong { @apply text-text font-semibold; }
+    .prose code {
+      @apply bg-surface-alt px-1.5 py-0.5 rounded text-sm font-mono text-primary-dark border border-border;
+    }
+    .prose pre {
+      @apply bg-surface p-5 rounded-xl overflow-x-auto border border-border my-6;
+    }
+    .prose pre code { @apply bg-transparent p-0 border-0 text-text/80; }
+    .prose blockquote {
+      @apply my-6 py-3 px-5 border-l-4 border-accent bg-accent/5 text-muted italic rounded-r-lg;
+    }
+    .prose blockquote p { @apply my-2; }
+    .prose ul, .prose ol { @apply my-4 ml-6 text-muted; }
+    .prose li { @apply my-1.5 pl-1; }
+    .prose ul li { @apply list-disc marker:text-primary; }
+    .prose ol li { @apply list-decimal marker:text-primary; }
+    .prose img { @apply max-w-full rounded-xl border border-border shadow-sm; }
+    .prose table { @apply w-full border-collapse my-8 rounded-lg overflow-hidden; }
+    .prose thead { @apply bg-surface-alt text-text; }
+    .prose th, .prose td { @apply px-4 py-3 border-b border-border text-left text-sm text-muted; }
+    .prose tbody tr:last-child td { @apply border-b-0; }
+    .prose tbody tr:hover { @apply bg-surface; }
+
+    /* Pagination */
+    nav.pagination { @apply my-8; }
+    nav.pagination .pagination-list {
+      @apply list-none p-0 m-0 flex gap-2 flex-wrap items-center;
+    }
+    nav.pagination a {
+      @apply inline-block px-3 py-1.5 rounded-md border border-border text-muted no-underline text-sm
+             hover:text-text hover:border-primary hover:bg-surface transition-all;
+    }
+    .pagination-current span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-primary bg-primary/10 text-text text-sm font-medium;
+    }
+    .pagination-disabled span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-border text-muted opacity-30 text-sm;
+    }
+
+    /* Section list */
+    ul.section-list { @apply list-none p-0 my-6 space-y-3; }
+    ul.section-list li {
+      @apply p-4 bg-surface rounded-xl border border-border hover:border-primary/50 transition-colors;
+    }
+    ul.section-list li a { @apply font-medium text-accent hover:text-blue-700; }
+
+    /* TOC */
+    .toc ul { @apply ml-4 my-0 space-y-1; }
+    .toc li { @apply relative; }
+    .toc a { @apply text-muted no-underline text-sm hover:text-accent transition-colors block py-0.5; }
+    .toc .active > a { @apply text-accent font-medium; }
+
+    /* Status badges */
+    .badge-released { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-released/10 text-released border border-released/20; }
+    .badge-in-progress { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-in-progress/10 text-in-progress border border-in-progress/20; }
+    .badge-planned { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-planned/10 text-planned border border-planned/20; }
+    .badge-deferred { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-deferred/10 text-deferred border border-deferred/20; }
+  </style>
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body class="font-sans text-text bg-background leading-relaxed selection:bg-accent/20 selection:text-text" data-section="{{ page.section }}">
+  <div class="sticky top-0 z-50 bg-white/80 backdrop-blur-xl border-b border-border">
+    <header class="flex items-center justify-between px-6 py-4 max-w-7xl mx-auto">
+      <div class="flex items-center gap-8">
+        <a href="{{ base_url }}/" class="group flex items-center gap-2.5 font-bold text-xl text-text no-underline transition-colors z-50 relative">
+          <div class="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+            <span class="text-white text-sm font-bold">A</span>
+          </div>
+          <span class="text-text">{{ site.title }}</span>
+        </a>
+        <nav class="hidden md:flex gap-1 items-center">
+          <a href="{{ base_url }}/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Home</a>
+          <a href="{{ base_url }}/docs/releases/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Releases</a>
+          <a href="{{ base_url }}/docs/roadmap/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Roadmap</a>
+          <a href="{{ base_url }}/about/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">About</a>
+        </nav>
+      </div>
+
+      <div class="flex items-center gap-4 z-50 relative">
+        <div class="relative group hidden sm:block">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-muted group-hover:text-accent transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input type="text" placeholder="Search releases..." class="bg-surface border border-border text-sm rounded-full py-1.5 pl-9 pr-4 w-48 md:w-64 focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/50 transition-all text-text placeholder-muted hover:border-primary/30">
+        </div>
+        <!-- Mobile Menu Button -->
+        <button id="mobile-menu-btn" class="md:hidden p-2 text-muted hover:text-text transition-colors focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <!-- Mobile Menu Overlay -->
+    <div id="mobile-menu" class="hidden fixed inset-0 z-40 bg-white/95 backdrop-blur-xl pt-24 px-6 md:hidden transition-opacity duration-300 opacity-0 pointer-events-none">
+      <nav class="flex flex-col gap-4 text-lg font-medium">
+        <a href="{{ base_url }}/" class="text-muted hover:text-text py-2 border-b border-border">Home</a>
+        <a href="{{ base_url }}/docs/releases/" class="text-muted hover:text-text py-2 border-b border-border">Releases</a>
+        <a href="{{ base_url }}/docs/roadmap/" class="text-muted hover:text-text py-2 border-b border-border">Roadmap</a>
+        <a href="{{ base_url }}/about/" class="text-muted hover:text-text py-2 border-b border-border">About</a>
+        <!-- Mobile Search -->
+        <div class="relative mt-4">
+           <input type="text" placeholder="Search releases..." class="w-full bg-surface border border-border text-sm rounded-lg py-3 pl-4 pr-4 focus:outline-none focus:ring-2 focus:ring-accent/30 text-text placeholder-muted">
+        </div>
+      </nav>
+    </div>
+  </div>
+  <div class="max-w-7xl mx-auto px-6">
+
+  <script src="{{ base_url }}/js/mobile-menu.js"></script>

--- a/almanac-docs/templates/page.html
+++ b/almanac-docs/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <article class="prose prose-lg max-w-none">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/almanac-docs/templates/section.html
+++ b/almanac-docs/templates/section.html
@@ -1,0 +1,46 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 max-w-6xl mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-16">
+      <h1 class="text-5xl font-extrabold text-text tracking-tight mb-6">{{ page.title }}</h1>
+      <div class="prose prose-lg mx-auto text-muted">{{ content }}</div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {% for doc in section.pages %}
+      <a href="{{ doc.url }}" class="group relative block p-8 rounded-2xl bg-surface border border-border overflow-hidden transition-all duration-300 hover:border-accent/40 hover:-translate-y-1 hover:shadow-lg hover:shadow-accent/5">
+        <!-- Decoration -->
+        <div class="absolute top-0 right-0 p-6 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+           <svg class="w-6 h-6 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
+        </div>
+
+        {% if doc.extra.status %}
+        <div class="mb-3">
+          {% if doc.extra.status == "released" %}
+            <span class="badge-released">Released</span>
+          {% elif doc.extra.status == "in-progress" %}
+            <span class="badge-in-progress">In Progress</span>
+          {% elif doc.extra.status == "planned" %}
+            <span class="badge-planned">Planned</span>
+          {% elif doc.extra.status == "deferred" %}
+            <span class="badge-deferred">Deferred</span>
+          {% endif %}
+        </div>
+        {% endif %}
+
+        {% if doc.extra.version %}
+        <span class="text-xs font-mono text-muted/60 mb-1 block">{{ doc.extra.version }}</span>
+        {% endif %}
+
+        <h3 class="text-xl font-bold text-text mb-3 group-hover:text-accent transition-colors">{{ doc.title }}</h3>
+        {% if doc.description %}
+        <p class="text-muted text-sm leading-relaxed mb-0 group-hover:text-text/70 transition-colors">{{ doc.description }}</p>
+        {% endif %}
+
+        {% if doc.extra.target_date %}
+        <span class="text-xs text-muted/50 mt-4 block">{{ doc.extra.target_date }}</span>
+        {% endif %}
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/almanac-docs/templates/taxonomy.html
+++ b/almanac-docs/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-accent/10 text-accent text-xs font-bold uppercase tracking-wider mb-4 border border-accent/20">Taxonomy</span>
+      <h1 class="text-4xl md:text-5xl font-extrabold text-text tracking-tight mb-4">{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Browse all terms in this taxonomy.</p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/almanac-docs/templates/taxonomy_term.html
+++ b/almanac-docs/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-accent/10 text-accent text-xs font-bold uppercase tracking-wider mb-4 border border-accent/20">Tag</span>
+      <h1 class="text-4xl md:text-5xl font-extrabold text-text tracking-tight mb-4">#{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Records tagged with <span class="text-text font-medium">{{ page.title }}</span></p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/config.toml
+++ b/cartograph/config.toml
@@ -1,0 +1,217 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Cartograph"
+description = "System map and infrastructure topology documentation"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Pagination
+# =============================================================================
+
+[pagination]
+enabled = false
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+
+# =============================================================================
+# SEO
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+# =============================================================================
+# Search
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/cartograph/content/about.md
+++ b/cartograph/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About Cartograph infrastructure documentation"
++++
+
+# About Cartograph
+
+Cartograph is the infrastructure topology documentation hub. It provides a structured view of all deployment regions, services, and their interconnections.
+
+## Purpose
+
+This documentation serves as the reference for:
+
+- **Regional Topology** -- Availability zones, network layout, and capacity planning
+- **Service Catalog** -- Service specifications, dependencies, and SLA targets
+- **Incident Context** -- Quick reference during incidents for service ownership and architecture
+
+## Built With
+
+This documentation site is built using the Hwaro static site generator.

--- a/cartograph/content/docs/regions/_index.md
+++ b/cartograph/content/docs/regions/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Regions"
+sort_by = "weight"
+page_template = "doc"
+description = "Infrastructure regions and availability zones"
++++
+
+Browse infrastructure organized by geographic region. Each region page includes zone details, deployed services, and network specifications.

--- a/cartograph/content/docs/regions/ap-southeast.md
+++ b/cartograph/content/docs/regions/ap-southeast.md
@@ -1,0 +1,41 @@
++++
+title = "AP Southeast"
+description = "Asia-Pacific region for low-latency APAC access"
+weight = 3
+tags = ["region", "gcp", "production"]
+
+[extra]
+status = "degraded"
+region = "asia-southeast1"
+provider = "GCP"
++++
+
+## Region Overview
+
+AP Southeast provides low-latency access for Asia-Pacific customers. Currently operating in degraded state due to ongoing capacity expansion.
+
+## Availability Zones
+
+| Zone | CIDR Block | Instances | Role |
+|------|-----------|-----------|------|
+| asia-southeast1-a | 10.2.0.0/18 | 68 | Primary |
+| asia-southeast1-b | 10.2.64.0/18 | 52 | Secondary |
+
+## Current Issues
+
+> **Degraded Performance** -- The region is experiencing increased latency on the search-service due to ongoing index migration. Expected resolution by end of Q2 2026.
+
+| Issue | Impact | ETA |
+|-------|--------|-----|
+| Search index migration | +200ms latency on search queries | Q2 2026 |
+| Zone C provisioning | Limited DR capacity | Q3 2026 |
+
+## Deployed Services
+
+| Service | Instances | CPU | Memory | Health |
+|---------|-----------|-----|--------|--------|
+| api-gateway | 3 | 4 vCPU | 16 GB | Healthy |
+| auth-service | 2 | 2 vCPU | 8 GB | Healthy |
+| user-service | 2 | 2 vCPU | 8 GB | Healthy |
+| search-service | 2 | 8 vCPU | 32 GB | Degraded |
+| cache-service | 2 | 4 vCPU | 16 GB | Healthy |

--- a/cartograph/content/docs/regions/eu-west.md
+++ b/cartograph/content/docs/regions/eu-west.md
@@ -1,0 +1,52 @@
++++
+title = "EU West"
+description = "European production region for GDPR-compliant workloads"
+weight = 2
+tags = ["region", "aws", "production"]
+
+[extra]
+status = "healthy"
+region = "eu-west-1"
+provider = "AWS"
++++
+
+## Region Overview
+
+EU West serves European customers and hosts all GDPR-regulated data processing. Three availability zones provide high availability with data residency compliance.
+
+## Availability Zones
+
+| Zone | CIDR Block | Instances | Role |
+|------|-----------|-----------|------|
+| eu-west-1a | 10.1.0.0/18 | 112 | Primary |
+| eu-west-1b | 10.1.64.0/18 | 98 | Secondary |
+| eu-west-1c | 10.1.128.0/18 | 64 | Standby |
+
+## Compliance
+
+| Requirement | Implementation |
+|-------------|---------------|
+| GDPR Data Residency | All PII stored in eu-west-1 only |
+| Encryption at Rest | AES-256 via AWS KMS (eu-west key) |
+| Encryption in Transit | TLS 1.3 enforced |
+| Audit Logging | CloudTrail with 90-day retention |
+| Access Control | IAM with MFA required |
+
+## Deployed Services
+
+| Service | Instances | CPU | Memory | Health |
+|---------|-----------|-----|--------|--------|
+| api-gateway | 4 | 4 vCPU | 16 GB | Healthy |
+| auth-service | 3 | 2 vCPU | 8 GB | Healthy |
+| user-service | 3 | 2 vCPU | 8 GB | Healthy |
+| gdpr-service | 2 | 2 vCPU | 4 GB | Healthy |
+| data-pipeline | 4 | 8 vCPU | 32 GB | Healthy |
+
+## Network Topology
+
+### Peering Connections
+
+| Destination | Type | Bandwidth | Purpose |
+|------------|------|-----------|---------|
+| US East | VPC Peering | 10 Gbps | API sync, non-PII data |
+| EU Central (DR) | Transit Gateway | 5 Gbps | Disaster recovery |

--- a/cartograph/content/docs/regions/us-east.md
+++ b/cartograph/content/docs/regions/us-east.md
@@ -1,0 +1,70 @@
++++
+title = "US East"
+description = "Primary production region with three availability zones"
+weight = 1
+tags = ["region", "aws", "production"]
+
+[extra]
+status = "healthy"
+region = "us-east-1"
+provider = "AWS"
++++
+
+## Region Overview
+
+US East is the primary production region hosting core platform services. It operates across three availability zones with full redundancy.
+
+## Availability Zones
+
+| Zone | CIDR Block | Instances | Role |
+|------|-----------|-----------|------|
+| us-east-1a | 10.0.0.0/18 | 156 | Primary |
+| us-east-1b | 10.0.64.0/18 | 142 | Secondary |
+| us-east-1c | 10.0.128.0/18 | 98 | Disaster Recovery |
+
+## Network Topology
+
+### VPC Configuration
+
+```
+VPC: 10.0.0.0/16
+├── Public Subnets (10.0.0.0/20 per AZ)
+│   ├── Load Balancers
+│   ├── NAT Gateways
+│   └── Bastion Hosts
+├── Private Subnets (10.0.16.0/20 per AZ)
+│   ├── Application Servers
+│   └── Worker Nodes
+└── Data Subnets (10.0.32.0/20 per AZ)
+    ├── RDS Instances
+    ├── ElastiCache Clusters
+    └── OpenSearch Domains
+```
+
+### Cross-Region Connectivity
+
+| Destination | Type | Bandwidth | Latency |
+|------------|------|-----------|---------|
+| EU West | VPC Peering | 10 Gbps | 78ms |
+| AP Southeast | Transit Gateway | 5 Gbps | 195ms |
+| US West (DR) | VPC Peering | 10 Gbps | 62ms |
+
+## Deployed Services
+
+| Service | Instances | CPU | Memory | Health |
+|---------|-----------|-----|--------|--------|
+| api-gateway | 6 | 4 vCPU | 16 GB | Healthy |
+| auth-service | 4 | 2 vCPU | 8 GB | Healthy |
+| user-service | 4 | 2 vCPU | 8 GB | Healthy |
+| order-service | 6 | 4 vCPU | 16 GB | Healthy |
+| notification-service | 3 | 2 vCPU | 4 GB | Healthy |
+| search-service | 3 | 8 vCPU | 32 GB | Healthy |
+
+## Capacity
+
+| Resource | Allocated | Used | Available |
+|----------|-----------|------|-----------|
+| vCPUs | 512 | 348 | 164 |
+| Memory | 2048 GB | 1420 GB | 628 GB |
+| Storage (EBS) | 50 TB | 32 TB | 18 TB |
+| Elastic IPs | 20 | 14 | 6 |

--- a/cartograph/content/docs/services/_index.md
+++ b/cartograph/content/docs/services/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Services"
+sort_by = "weight"
+page_template = "doc"
+description = "Service catalog and dependency documentation"
++++
+
+Service catalog listing all platform services with specifications, dependencies, and operational details.

--- a/cartograph/content/docs/services/api-gateway.md
+++ b/cartograph/content/docs/services/api-gateway.md
@@ -1,0 +1,85 @@
++++
+title = "API Gateway"
+description = "Edge reverse proxy handling request routing, rate limiting, and TLS termination"
+weight = 1
+tags = ["service", "edge", "critical"]
+
+[extra]
+status = "healthy"
+region = "Global"
+provider = "Internal"
++++
+
+## Service Overview
+
+The API Gateway is the edge entry point for all client traffic. It handles TLS termination, request routing, rate limiting, and authentication token validation.
+
+## Specifications
+
+| Property | Value |
+|----------|-------|
+| Language | Go 1.22 |
+| Repository | platform/api-gateway |
+| Port | 443 (external), 8080 (internal) |
+| Protocol | HTTP/2, gRPC |
+| SLA Target | 99.99% |
+| Owner | Platform Team |
+
+## Dependencies
+
+| Service | Type | Criticality | Fallback |
+|---------|------|-------------|----------|
+| auth-service | Sync (gRPC) | Critical | Token cache (5min TTL) |
+| user-service | Sync (gRPC) | High | Cached user profiles |
+| rate-limiter | Sync (Redis) | Medium | Allow-all on failure |
+| config-service | Async (polling) | Low | Local config cache |
+
+## Request Flow
+
+```
+Client Request
+  ├── TLS Termination
+  ├── Rate Limit Check
+  ├── Auth Token Validation
+  ├── Request Routing
+  │   ├── /api/v2/users/* → user-service
+  │   ├── /api/v2/orders/* → order-service
+  │   └── /api/v2/search/* → search-service
+  ├── Response Transformation
+  └── Access Logging
+```
+
+## Configuration
+
+```yaml
+server:
+  listen: ":8080"
+  tls:
+    cert: /etc/tls/server.crt
+    key: /etc/tls/server.key
+
+routes:
+  - path: /api/v2/users
+    upstream: user-service:8080
+    timeout: 5s
+    retries: 2
+    circuit_breaker:
+      threshold: 5
+      timeout: 30s
+
+rate_limit:
+  default:
+    requests: 1000
+    window: 60s
+  authenticated:
+    requests: 5000
+    window: 60s
+```
+
+## Deployment
+
+| Region | Instances | Version | Last Deploy |
+|--------|-----------|---------|-------------|
+| US East | 6 | v2.4.1 | 2026-03-15 |
+| EU West | 4 | v2.4.1 | 2026-03-15 |
+| AP Southeast | 3 | v2.4.0 | 2026-03-10 |

--- a/cartograph/content/docs/services/auth-service.md
+++ b/cartograph/content/docs/services/auth-service.md
@@ -1,0 +1,72 @@
++++
+title = "Auth Service"
+description = "Authentication and authorization service handling JWT issuance and validation"
+weight = 2
+tags = ["service", "security", "critical"]
+
+[extra]
+status = "healthy"
+region = "Global"
+provider = "Internal"
++++
+
+## Service Overview
+
+The Auth Service manages user authentication, JWT token issuance, and authorization policy evaluation. It integrates with external identity providers via OIDC.
+
+## Specifications
+
+| Property | Value |
+|----------|-------|
+| Language | Rust |
+| Repository | platform/auth-service |
+| Port | 8081 (gRPC), 8082 (metrics) |
+| Protocol | gRPC with mTLS |
+| SLA Target | 99.99% |
+| Owner | Security Team |
+
+## Authentication Flows
+
+### Token Issuance
+
+```
+Login Request (credentials)
+  ├── Validate credentials against user-service
+  ├── Check MFA requirement
+  │   ├── TOTP verification
+  │   └── WebAuthn challenge
+  ├── Generate JWT (RS256, 15min expiry)
+  ├── Issue refresh token (opaque, 7d expiry)
+  └── Return token pair
+```
+
+### Token Validation
+
+| Check | Description | Failure Action |
+|-------|-------------|----------------|
+| Signature | RS256 verification | 401 Unauthorized |
+| Expiration | Token not expired | 401 Unauthorized |
+| Issuer | Matches expected issuer | 401 Unauthorized |
+| Audience | Matches service audience | 403 Forbidden |
+| Revocation | Not in revocation list | 401 Unauthorized |
+
+## Dependencies
+
+| Service | Type | Criticality | Fallback |
+|---------|------|-------------|----------|
+| user-service | Sync (gRPC) | Critical | None (hard dependency) |
+| Redis | Sync | Critical | Local LRU cache (readonly) |
+| PostgreSQL | Sync | Critical | Read replica |
+| OIDC providers | Async | Medium | Cached JWKS (24h) |
+
+## Key Rotation
+
+Keys are rotated on a 90-day cycle. The JWKS endpoint always exposes the current and previous key to allow for graceful rotation.
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | RS256 |
+| Key size | 4096 bit |
+| Rotation period | 90 days |
+| Overlap period | 7 days |
+| JWKS endpoint | /.well-known/jwks.json |

--- a/cartograph/content/docs/services/search-service.md
+++ b/cartograph/content/docs/services/search-service.md
@@ -1,0 +1,55 @@
++++
+title = "Search Service"
+description = "Full-text search service powered by OpenSearch with multi-tenant index management"
+weight = 3
+tags = ["service", "data", "high"]
+
+[extra]
+status = "degraded"
+region = "Global"
+provider = "Internal"
++++
+
+## Service Overview
+
+The Search Service provides full-text search capabilities across all platform data. It manages index lifecycle, query routing, and relevance tuning.
+
+## Specifications
+
+| Property | Value |
+|----------|-------|
+| Language | Java 21 |
+| Repository | platform/search-service |
+| Port | 9200 (API), 9300 (cluster) |
+| Protocol | HTTP/REST |
+| SLA Target | 99.95% |
+| Owner | Data Team |
+
+## Current Status
+
+> **Degraded** -- AP Southeast region experiencing elevated search latency due to ongoing index migration from OpenSearch 2.x to 2.11. US East and EU West operating normally.
+
+| Metric | US East | EU West | AP Southeast |
+|--------|---------|---------|--------------|
+| p50 latency | 12ms | 15ms | 210ms |
+| p99 latency | 85ms | 92ms | 1.2s |
+| Error rate | 0.01% | 0.02% | 0.15% |
+
+## Index Architecture
+
+```
+Platform Indices
+  ├── users-v3 (3 primary, 1 replica per AZ)
+  ├── orders-v5 (5 primary, 1 replica per AZ)
+  ├── products-v2 (3 primary, 1 replica per AZ)
+  └── audit-logs-{date} (daily rollover, 90d retention)
+```
+
+## Dependencies
+
+| Service | Type | Criticality | Fallback |
+|---------|------|-------------|----------|
+| OpenSearch cluster | Sync | Critical | Read replicas |
+| Redis (cache) | Sync | Medium | Direct query to OpenSearch |
+| Kafka (indexing) | Async | High | Retry queue with 24h buffer |
+| config-service | Async | Low | Local config cache |

--- a/cartograph/content/index.md
+++ b/cartograph/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Home"
++++
+
+# Cartograph
+
+System map and infrastructure topology documentation. Monitor regions, services, and network topology across all deployment zones.
+
+## Navigation
+
+- [Regions](/docs/regions/) -- Browse infrastructure by geographic region and availability zone
+- [Services](/docs/services/) -- View service catalog with dependencies and health status
+
+## Infrastructure Overview
+
+| Region | Provider | Zones | Services | Status |
+|--------|----------|-------|----------|--------|
+| US East | AWS | 3 | 24 | Healthy |
+| EU West | AWS | 3 | 18 | Healthy |
+| AP Southeast | GCP | 2 | 12 | Degraded |

--- a/cartograph/static/js/mobile-menu.js
+++ b/cartograph/static/js/mobile-menu.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('mobile-menu-btn');
+  const menu = document.getElementById('mobile-menu');
+  let isMenuOpen = false;
+
+  if (btn && menu) {
+    btn.addEventListener('click', () => {
+      isMenuOpen = !isMenuOpen;
+      if (isMenuOpen) {
+        menu.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          menu.classList.remove('opacity-0');
+          menu.classList.remove('pointer-events-none');
+        });
+        document.body.style.overflow = 'hidden';
+      } else {
+        menu.classList.add('opacity-0');
+        menu.classList.add('pointer-events-none');
+        setTimeout(() => {
+          menu.classList.add('hidden');
+        }, 300);
+        document.body.style.overflow = '';
+      }
+    });
+  }
+});

--- a/cartograph/templates/404.html
+++ b/cartograph/templates/404.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 flex flex-col items-center justify-center text-center">
+    <div class="relative z-10">
+      <h1 class="text-[10rem] font-black text-text/5 leading-none select-none">404</h1>
+      <div class="absolute inset-0 flex items-center justify-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-text">Page Not Found</h2>
+      </div>
+    </div>
+
+    <p class="text-muted text-lg mb-8 max-w-md mx-auto mt-4">The page you are looking for does not exist, has been removed, or is temporarily unavailable.</p>
+
+    <a href="{{ base_url }}/" class="inline-flex items-center gap-2 px-8 py-3 bg-primary text-white rounded-full font-bold text-sm hover:bg-primary-dark transition-all duration-300 transform hover:-translate-y-0.5">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
+      Back to Home
+    </a>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/templates/doc.html
+++ b/cartograph/templates/doc.html
@@ -1,0 +1,123 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-12 grid grid-cols-1 md:grid-cols-[250px_1fr] gap-12">
+    <!-- Mobile Sidebar Toggle -->
+    <div class="md:hidden">
+      <details class="group border border-border rounded-lg bg-surface">
+        <summary class="flex items-center justify-between p-4 cursor-pointer list-none text-text font-medium focus:outline-none select-none">
+          <span>{{ section.title }} Navigation</span>
+          <svg class="w-5 h-5 text-muted transition-transform duration-300 group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="p-4 border-t border-border bg-surface-alt">
+           {% if section.pages %}
+           <ul class="space-y-1">
+             {% for doc in section.pages %}
+             <li>
+               <a href="{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-primary bg-primary/5 border-l-primary font-medium{% else %}text-muted border-l-transparent hover:text-text hover:bg-surface hover:border-l-primary/30{% endif %}">
+                 {{ doc.title }}
+               </a>
+             </li>
+             {% endfor %}
+           </ul>
+           {% endif %}
+        </div>
+      </details>
+    </div>
+
+    <!-- Sidebar -->
+    <aside class="hidden md:block sticky top-24 h-[calc(100vh-120px)] overflow-y-auto pr-6 border-r border-border">
+      {% if section.pages %}
+      <nav class="space-y-8">
+        <div>
+          <h3 class="text-xs uppercase tracking-widest text-muted/60 font-bold mb-4 px-3">{{ section.title }}</h3>
+          <ul class="space-y-1">
+            {% for doc in section.pages %}
+            <li>
+              <a href="{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-primary bg-primary/5 border-l-primary font-medium{% else %}text-muted border-l-transparent hover:text-text hover:bg-surface hover:border-l-primary/30{% endif %}">
+                {{ doc.title }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </nav>
+      {% endif %}
+    </aside>
+
+    <article class="min-w-0 pb-16">
+      <!-- Breadcrumbs -->
+      <div class="flex items-center text-sm text-muted mb-6 overflow-x-auto whitespace-nowrap">
+        <a href="{{ base_url }}/" class="hover:text-text transition-colors">Home</a>
+        <svg class="w-4 h-4 mx-2 text-border" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <a href="{{ section.url }}" class="hover:text-text transition-colors">{{ section.title }}</a>
+        <svg class="w-4 h-4 mx-2 text-border" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <span class="text-primary font-medium">{{ page.title }}</span>
+      </div>
+
+      <header class="mb-10 border-b border-border pb-10">
+        <h1 class="text-4xl font-bold text-text tracking-tight mb-4">{{ page.title }}</h1>
+        {% if page.extra.status %}
+        <div class="flex items-center gap-4 mt-4">
+          {% if page.extra.status == "healthy" %}
+            <span class="badge-healthy">Healthy</span>
+          {% elif page.extra.status == "degraded" %}
+            <span class="badge-degraded">Degraded</span>
+          {% elif page.extra.status == "down" %}
+            <span class="badge-down">Down</span>
+          {% endif %}
+          {% if page.extra.region %}
+            <span class="text-sm text-muted font-mono">{{ page.extra.region }}</span>
+          {% endif %}
+          {% if page.extra.provider %}
+            <span class="text-sm text-muted">{{ page.extra.provider }}</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.description %}
+          <p class="text-lg text-muted leading-relaxed max-w-3xl mt-4">{{ page.description }}</p>
+        {% endif %}
+      </header>
+
+      <div class="grid grid-cols-1 {% if page.toc %}lg:grid-cols-[1fr_200px]{% endif %} gap-10 items-start">
+        <!-- Content -->
+        <div class="prose prose-lg max-w-none">
+          {{ content }}
+        </div>
+
+        <!-- TOC (Desktop) -->
+        {% if page.toc %}
+        <aside class="hidden lg:block sticky top-24">
+          <div class="border-l border-border pl-4 py-1">
+            <h4 class="text-xs uppercase tracking-widest text-muted/60 font-bold mb-3">On this page</h4>
+            <div class="toc text-sm text-muted">
+              {{ page.toc }}
+            </div>
+          </div>
+        </aside>
+        {% endif %}
+      </div>
+
+      <!-- Navigation -->
+      <nav class="grid grid-cols-2 gap-6 mt-16 pt-8 border-t border-border">
+        {% if page.lower %}
+        <a href="{{ page.lower.url }}" class="group flex flex-col p-4 rounded-xl border border-border hover:border-primary/30 hover:bg-surface transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-primary transition-colors">Previous</span>
+          <span class="text-lg font-semibold text-text group-hover:text-primary transition-colors">
+            &larr; {{ page.lower.title }}
+          </span>
+        </a>
+        {% else %}<div></div>{% endif %}
+
+        {% if page.higher %}
+        <a href="{{ page.higher.url }}" class="group flex flex-col items-end text-right p-4 rounded-xl border border-border hover:border-primary/30 hover:bg-surface transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-primary transition-colors">Next</span>
+          <span class="text-lg font-semibold text-text group-hover:text-primary transition-colors">
+            {{ page.higher.title }} &rarr;
+          </span>
+        </a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/templates/footer.html
+++ b/cartograph/templates/footer.html
@@ -1,0 +1,14 @@
+  </div>
+  <footer class="mt-20 py-12 border-t border-border text-center">
+    <div class="max-w-6xl mx-auto px-6 flex flex-col items-center justify-center gap-4">
+      <div class="flex items-center gap-2 text-muted">
+        <span class="text-sm">Powered by</span>
+        <a href="https://github.com/hahwul/hwaro" class="text-primary hover:text-primary-light transition-colors font-medium">Hwaro</a>
+      </div>
+      <p class="text-xs text-muted/50">2026 Cartograph Infrastructure Team. All rights reserved.</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cartograph/templates/header.html
+++ b/cartograph/templates/header.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+
+  <!-- Google Fonts: Inter -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#06b6d4',
+            'primary-light': '#22d3ee',
+            'primary-dark': '#0891b2',
+            accent: '#f97316',
+            background: '#0f1117',
+            surface: '#1a1d27',
+            'surface-alt': '#242836',
+            border: '#2e3345',
+            muted: '#8b95a5',
+            text: '#e8ecf1',
+            healthy: '#22c55e',
+            degraded: '#eab308',
+            down: '#ef4444',
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+          },
+        },
+      },
+    }
+  </script>
+
+  <style type="text/tailwindcss">
+    /* Scrollbar styling for dark theme */
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-track { background: #0f1117; }
+    ::-webkit-scrollbar-thumb { background: #2e3345; border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: #3e4355; }
+
+    /* Prose: markdown rendered content */
+    .prose { @apply text-text/80; }
+    .prose h1, .prose h2, .prose h3 { @apply font-semibold leading-tight text-text; }
+    .prose h1 { @apply text-3xl mt-0 mb-6; }
+    .prose h2 { @apply text-2xl mt-10 mb-4 border-b border-border pb-2; }
+    .prose h3 { @apply text-xl mt-8 mb-3 text-text/90; }
+    .prose p { @apply my-5 leading-relaxed text-muted; }
+    .prose a { @apply text-primary hover:text-primary-light hover:underline underline-offset-4 decoration-2 decoration-primary/30 transition-all; }
+    .prose strong { @apply text-text font-semibold; }
+    .prose code {
+      @apply bg-surface-alt px-1.5 py-0.5 rounded text-sm font-mono text-primary-light border border-border;
+    }
+    .prose pre {
+      @apply bg-surface p-5 rounded-xl overflow-x-auto border border-border my-6;
+    }
+    .prose pre code { @apply bg-transparent p-0 border-0 text-text/80; }
+    .prose blockquote {
+      @apply my-6 py-3 px-5 border-l-4 border-accent bg-accent/5 text-muted italic rounded-r-lg;
+    }
+    .prose blockquote p { @apply my-2; }
+    .prose ul, .prose ol { @apply my-4 ml-6 text-muted; }
+    .prose li { @apply my-1.5 pl-1; }
+    .prose ul li { @apply list-disc marker:text-primary; }
+    .prose ol li { @apply list-decimal marker:text-primary; }
+    .prose img { @apply max-w-full rounded-xl border border-border shadow-sm; }
+    .prose table { @apply w-full border-collapse my-8 rounded-lg overflow-hidden; }
+    .prose thead { @apply bg-surface-alt text-text; }
+    .prose th, .prose td { @apply px-4 py-3 border-b border-border text-left text-sm text-muted; }
+    .prose tbody tr:last-child td { @apply border-b-0; }
+    .prose tbody tr:hover { @apply bg-surface; }
+
+    /* Pagination */
+    nav.pagination { @apply my-8; }
+    nav.pagination .pagination-list {
+      @apply list-none p-0 m-0 flex gap-2 flex-wrap items-center;
+    }
+    nav.pagination a {
+      @apply inline-block px-3 py-1.5 rounded-md border border-border text-muted no-underline text-sm
+             hover:text-text hover:border-primary hover:bg-surface transition-all;
+    }
+    .pagination-current span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-primary bg-primary/10 text-text text-sm font-medium;
+    }
+    .pagination-disabled span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-border text-muted opacity-30 text-sm;
+    }
+
+    /* Section list */
+    ul.section-list { @apply list-none p-0 my-6 space-y-3; }
+    ul.section-list li {
+      @apply p-4 bg-surface rounded-xl border border-border hover:border-primary/50 transition-colors;
+    }
+    ul.section-list li a { @apply font-medium text-primary hover:text-primary-light; }
+
+    /* TOC */
+    .toc ul { @apply ml-4 my-0 space-y-1; }
+    .toc li { @apply relative; }
+    .toc a { @apply text-muted no-underline text-sm hover:text-primary transition-colors block py-0.5; }
+    .toc .active > a { @apply text-primary font-medium; }
+
+    /* Status badges */
+    .badge-healthy { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-healthy/10 text-healthy border border-healthy/20; }
+    .badge-degraded { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-degraded/10 text-degraded border border-degraded/20; }
+    .badge-down { @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-down/10 text-down border border-down/20; }
+  </style>
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body class="font-sans text-text bg-background leading-relaxed selection:bg-primary/20 selection:text-text" data-section="{{ page.section }}">
+  <div class="sticky top-0 z-50 bg-[#0f1117]/80 backdrop-blur-xl border-b border-border">
+    <header class="flex items-center justify-between px-6 py-4 max-w-7xl mx-auto">
+      <div class="flex items-center gap-8">
+        <a href="{{ base_url }}/" class="group flex items-center gap-2.5 font-bold text-xl text-text no-underline transition-colors z-50 relative">
+          <div class="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+            <span class="text-white text-sm font-bold">C</span>
+          </div>
+          <span class="text-text">{{ site.title }}</span>
+        </a>
+        <nav class="hidden md:flex gap-1 items-center">
+          <a href="{{ base_url }}/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Home</a>
+          <a href="{{ base_url }}/docs/regions/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Regions</a>
+          <a href="{{ base_url }}/docs/services/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">Services</a>
+          <a href="{{ base_url }}/about/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-text hover:bg-surface transition-all">About</a>
+        </nav>
+      </div>
+
+      <div class="flex items-center gap-4 z-50 relative">
+        <div class="relative group hidden sm:block">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-muted group-hover:text-primary transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input type="text" placeholder="Search infrastructure..." class="bg-surface border border-border text-sm rounded-full py-1.5 pl-9 pr-4 w-48 md:w-64 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-all text-text placeholder-muted hover:border-primary/30">
+        </div>
+        <!-- Mobile Menu Button -->
+        <button id="mobile-menu-btn" class="md:hidden p-2 text-muted hover:text-text transition-colors focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <!-- Mobile Menu Overlay -->
+    <div id="mobile-menu" class="hidden fixed inset-0 z-40 bg-[#0f1117]/95 backdrop-blur-xl pt-24 px-6 md:hidden transition-opacity duration-300 opacity-0 pointer-events-none">
+      <nav class="flex flex-col gap-4 text-lg font-medium">
+        <a href="{{ base_url }}/" class="text-muted hover:text-text py-2 border-b border-border">Home</a>
+        <a href="{{ base_url }}/docs/regions/" class="text-muted hover:text-text py-2 border-b border-border">Regions</a>
+        <a href="{{ base_url }}/docs/services/" class="text-muted hover:text-text py-2 border-b border-border">Services</a>
+        <a href="{{ base_url }}/about/" class="text-muted hover:text-text py-2 border-b border-border">About</a>
+        <!-- Mobile Search -->
+        <div class="relative mt-4">
+           <input type="text" placeholder="Search infrastructure..." class="w-full bg-surface border border-border text-sm rounded-lg py-3 pl-4 pr-4 focus:outline-none focus:ring-2 focus:ring-primary/30 text-text placeholder-muted">
+        </div>
+      </nav>
+    </div>
+  </div>
+  <div class="max-w-7xl mx-auto px-6">
+
+  <script src="{{ base_url }}/js/mobile-menu.js"></script>

--- a/cartograph/templates/page.html
+++ b/cartograph/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <article class="prose prose-lg max-w-none">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/templates/section.html
+++ b/cartograph/templates/section.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 max-w-6xl mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-16">
+      <h1 class="text-5xl font-extrabold text-text tracking-tight mb-6">{{ page.title }}</h1>
+      <div class="prose prose-lg mx-auto text-muted">{{ content }}</div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {% for doc in section.pages %}
+      <a href="{{ doc.url }}" class="group relative block p-8 rounded-2xl bg-surface border border-border overflow-hidden transition-all duration-300 hover:border-primary/40 hover:-translate-y-1 hover:shadow-lg hover:shadow-primary/5">
+        <!-- Decoration -->
+        <div class="absolute top-0 right-0 p-6 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+           <svg class="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
+        </div>
+
+        {% if doc.extra.status %}
+        <div class="mb-3">
+          {% if doc.extra.status == "healthy" %}
+            <span class="badge-healthy">Healthy</span>
+          {% elif doc.extra.status == "degraded" %}
+            <span class="badge-degraded">Degraded</span>
+          {% elif doc.extra.status == "down" %}
+            <span class="badge-down">Down</span>
+          {% endif %}
+        </div>
+        {% endif %}
+
+        {% if doc.extra.region %}
+        <span class="text-xs font-mono text-muted/60 mb-1 block">{{ doc.extra.region }}</span>
+        {% endif %}
+
+        <h3 class="text-xl font-bold text-text mb-3 group-hover:text-primary transition-colors">{{ doc.title }}</h3>
+        {% if doc.description %}
+        <p class="text-muted text-sm leading-relaxed mb-0 group-hover:text-text/70 transition-colors">{{ doc.description }}</p>
+        {% endif %}
+
+        {% if doc.extra.provider %}
+        <span class="text-xs text-muted/50 mt-4 block">{{ doc.extra.provider }}</span>
+        {% endif %}
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/templates/taxonomy.html
+++ b/cartograph/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-bold uppercase tracking-wider mb-4 border border-primary/20">Taxonomy</span>
+      <h1 class="text-4xl md:text-5xl font-extrabold text-text tracking-tight mb-4">{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Browse all terms in this taxonomy.</p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cartograph/templates/taxonomy_term.html
+++ b/cartograph/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-bold uppercase tracking-wider mb-4 border border-primary/20">Tag</span>
+      <h1 class="text-4xl md:text-5xl font-extrabold text-text tracking-tight mb-4">#{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Records tagged with <span class="text-text font-medium">{{ page.title }}</span></p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -19,6 +19,11 @@
     "blog",
     "calendar"
   ],
+  "almanac-docs": [
+    "light",
+    "docs",
+    "roadmap"
+  ],
   "analytics": [
     "light",
     "dashboard",
@@ -168,6 +173,11 @@
     "light",
     "blog",
     "outdoor"
+  ],
+  "cartograph": [
+    "dark",
+    "docs",
+    "infrastructure"
   ],
   "cathedral": [
     "light",


### PR DESCRIPTION
## Summary
- **almanac-docs** (#349): Release planning/roadmap documentation site with blue/gray/white light theme. Includes release history, quarterly roadmaps, milestone tracking with status badges, and version comparison tables.
- **cartograph** (#350): Infrastructure topology documentation site with gray/cyan/orange dark theme. Includes region topology, service catalog, network specs, capacity planning, and health status indicators.

Both examples follow the established docs pattern (keystone/nexus style) with Tailwind CDN, Inter font, sidebar navigation, breadcrumbs, and responsive design.

Closes #349
Closes #350

## Test plan
- [ ] `hwaro build` succeeds for both sites (verified locally)
- [ ] tags.json entries added alphabetically
- [ ] No emojis or gradients used
- [ ] Templates follow existing patterns (keystone reference)