### PR TITLE
Add new example: sextant

### DIFF
--- a/sextant/AGENTS.md
+++ b/sextant/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/sextant/config.toml
+++ b/sextant/config.toml
@@ -1,0 +1,183 @@
+title = "Sextant"
+description = "Metrics, KPI definitions, and SLO reference for data-driven teams."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[markdown]
+safe = false
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/sextant/content/dashboards/_index.md
+++ b/sextant/content/dashboards/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Dashboards"
+description = "Guidelines for building and maintaining BI dashboards."
+weight = 2
++++
+
+This section covers dashboard construction standards, widget types, and layout best practices. All dashboards should follow these guidelines to ensure consistency across teams.

--- a/sextant/content/dashboards/layout-guidelines.md
+++ b/sextant/content/dashboards/layout-guidelines.md
@@ -1,0 +1,67 @@
++++
+title = "Layout Guidelines"
+description = "Best practices for arranging widgets and structuring dashboards."
+weight = 2
++++
+
+## Grid System
+
+Dashboards use a 12-column grid. Widgets snap to column boundaries to ensure alignment across rows.
+
+| Widget Size | Columns | Use Case |
+|-------------|---------|----------|
+| Small | 3 | Scorecards |
+| Medium | 6 | Charts, small tables |
+| Large | 12 | Full-width tables, heatmaps |
+
+## Layout Pattern
+
+Follow a top-down information hierarchy. Place the most critical information at the top of the dashboard and progressive detail below.
+
+### Row 1: Headline Scorecards
+
+Place 3--4 scorecard widgets across the top row. These should represent the primary KPIs that the audience checks first.
+
+### Row 2: Trend Charts
+
+Use 1--2 time series widgets to show how the headline numbers are trending. Each chart should directly relate to a scorecard above it.
+
+### Row 3: Breakdown Tables
+
+Display supporting detail in tables or bar charts. This row answers "why" the headline numbers moved.
+
+### Row 4: Diagnostics (Optional)
+
+For operational dashboards, include lower-priority signals such as queue depth, cache hit rates, or per-service breakdowns.
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Dashboard | `[Team] Domain -- Audience` | `[Growth] Revenue -- Executive` |
+| Widget Title | Metric name, no abbreviations | `Monthly Recurring Revenue` |
+| Filter Label | Dimension: readable name | `Region: North America` |
+
+## Refresh Strategy
+
+Not all widgets need the same refresh interval. Configure each widget based on the data's natural update frequency.
+
+| Data Cadence | Refresh Interval | Examples |
+|-------------|-----------------|----------|
+| Real-time | 1--5 min | Error rate, request latency |
+| Hourly batches | 15--60 min | DAU, session counts |
+| Daily ETL | 6 hours | Revenue, cohort retention |
+| Weekly snapshots | 24 hours | DORA metrics, NPS |
+
+## Access Control
+
+Each dashboard has an owner and a visibility level.
+
+| Level | Who Can View | Who Can Edit |
+|-------|-------------|-------------|
+| Private | Owner only | Owner only |
+| Team | Team members | Owner and editors |
+| Organization | All employees | Owner and editors |
+| Public | Anyone with link | Owner only |
+
+Set the narrowest visibility that serves the audience. Executive dashboards should be Organization-level. Team operational dashboards should be Team-level.

--- a/sextant/content/dashboards/widget-configuration.md
+++ b/sextant/content/dashboards/widget-configuration.md
@@ -1,0 +1,105 @@
++++
+title = "Widget Configuration"
+description = "Reference for dashboard widget types and their configuration options."
+weight = 1
++++
+
+## Widget Types
+
+Every dashboard is composed of widgets. Select the widget type that best fits the data being displayed.
+
+| Widget | Best For | Refresh Interval |
+|--------|----------|-----------------|
+| Scorecard | Single KPI with trend | 5 min |
+| Time Series | Metric over time | 5 min |
+| Bar Chart | Categorical comparison | 15 min |
+| Table | Detailed breakdowns | 15 min |
+| Heatmap | Correlation or density | 1 hour |
+| Funnel | Conversion sequences | 1 hour |
+
+## Scorecard Widget
+
+Scorecards display a single headline number with optional comparison to a previous period. Use them for the most important KPIs at the top of a dashboard.
+
+### Configuration
+
+```yaml
+widget: scorecard
+metric: mrr
+aggregation: sum
+comparison: previous_period
+period: month
+format: currency_usd
+thresholds:
+  warning: -5%
+  critical: -10%
+```
+
+### Rules
+
+- Always include a comparison period so viewers can judge direction
+- Use `currency_usd` or `currency_eur` format for financial metrics
+- Use `percentage` format for rates and ratios
+- Set thresholds to match the alert levels defined in the SLO reference
+
+## Time Series Widget
+
+Time series charts plot a metric over a configurable time window. They support multiple series for comparison.
+
+### Configuration
+
+```yaml
+widget: time_series
+metrics:
+  - name: dau
+    aggregation: count_distinct
+    field: user_id
+  - name: wau
+    aggregation: count_distinct
+    field: user_id
+    window: 7d
+time_range: 30d
+granularity: day
+y_axis:
+  label: "Users"
+  min: 0
+```
+
+### Rules
+
+- Default time range is 30 days; adjust based on the metric's natural cadence
+- Always set `y_axis.min` to 0 unless the data is narrowly distributed
+- Limit to 4 series per chart to maintain readability
+- Use consistent colors: blue for primary, gray for comparison
+
+## Table Widget
+
+Tables are appropriate when users need to drill into specific rows or when the data has more than two dimensions.
+
+### Configuration
+
+```yaml
+widget: table
+source: analytics.feature_usage
+columns:
+  - field: feature_name
+    label: "Feature"
+    sortable: true
+  - field: adoption_rate
+    label: "Adoption %"
+    format: percentage
+    sortable: true
+  - field: owner_team
+    label: "Owner"
+sort:
+  field: adoption_rate
+  direction: desc
+row_limit: 25
+```
+
+### Rules
+
+- Always define an explicit sort order
+- Cap row display at 25; provide a "View All" link for longer datasets
+- Right-align numeric columns
+- Include the `sortable` flag on columns users are likely to filter by

--- a/sextant/content/index.md
+++ b/sextant/content/index.md
@@ -1,0 +1,29 @@
++++
+title = "Sextant"
+description = "Metrics, KPI definitions, and SLO reference for data-driven teams."
+template = "page"
++++
+
+Sextant is the single source of truth for metric definitions, KPI ownership, dashboard configuration, and service-level objectives across the organization.
+
+## Getting Started
+
+Use the sidebar to navigate between the three main sections of this reference.
+
+- [Metrics](metrics/) -- Canonical definitions for revenue, engagement, and operational KPIs. Each metric entry includes its formula, data source, and accountable owner.
+- [Dashboards](dashboards/) -- Guidelines for building and maintaining BI dashboards, including widget types, layout patterns, and refresh strategies.
+- [SLO Reference](slo/) -- Service Level Objective, Indicator, and Agreement definitions with approved threshold tables.
+
+## How to Use This Reference
+
+Every metric documented here follows a standard card format:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Human-readable metric name |
+| **Formula** | Calculation logic or SQL expression |
+| **Data Source** | Warehouse table or upstream system |
+| **Owner** | Team or individual accountable for accuracy |
+| **Status** | Active, Draft, or Deprecated |
+
+If you find a metric that is missing or incorrect, open a pull request against the `metrics/` directory.

--- a/sextant/content/metrics/_index.md
+++ b/sextant/content/metrics/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Metrics"
+description = "Canonical metric definitions organized by domain."
+weight = 1
++++
+
+This section contains the official metric catalog. Each metric is documented with its formula, data source, owner, and current status.
+
+Metrics are grouped into three domains:
+
+- **Revenue** -- Financial KPIs that measure business growth and monetization
+- **Engagement** -- User behavior metrics that track product adoption and retention
+- **Operational** -- Infrastructure and process metrics that reflect system health

--- a/sextant/content/metrics/engagement.md
+++ b/sextant/content/metrics/engagement.md
@@ -1,0 +1,102 @@
++++
+title = "Engagement Metrics"
+description = "User behavior metrics for tracking product adoption and retention."
+weight = 2
++++
+
+## Daily Active Users (DAU)
+
+<div class="metric-card">
+<h4>DAU</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(DISTINCT user_id) WHERE event_date = CURRENT_DATE</code></dd>
+<dt>Data Source</dt>
+<dd><code>analytics.events</code></dd>
+<dt>Owner</dt>
+<dd>Product Analytics</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+A user is considered "active" if they triggered at least one qualifying event during the calendar day (UTC). Bot traffic and internal accounts are excluded via the `is_human` flag.
+
+### DAU/MAU Ratio
+
+The DAU/MAU ratio (also called "stickiness") measures what fraction of monthly users return on any given day. A ratio above 0.25 is considered healthy for a B2B SaaS product.
+
+| Benchmark | Range | Interpretation |
+|-----------|-------|---------------|
+| Low | Below 0.10 | Users visit infrequently; investigate onboarding |
+| Moderate | 0.10 -- 0.25 | Typical for workflow tools with weekly cadence |
+| High | Above 0.25 | Strong daily habit formation |
+
+---
+
+## Retention Rate (Day N)
+
+<div class="metric-card">
+<h4>Day-N Retention</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(DISTINCT user_id active on day N) / COUNT(DISTINCT user_id in cohort)</code></dd>
+<dt>Data Source</dt>
+<dd><code>analytics.cohorts</code></dd>
+<dt>Owner</dt>
+<dd>Product Analytics</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+Retention is measured at standard intervals: Day 1, Day 7, Day 14, and Day 30. Cohorts are defined by signup date. The metric is reported both as an unbounded rate (any activity on day N) and a bounded rate (activity within a 24-hour window centered on day N).
+
+### Target Retention Curve
+
+| Interval | Target | Alert Threshold |
+|----------|--------|----------------|
+| Day 1 | 60% | Below 50% |
+| Day 7 | 40% | Below 30% |
+| Day 14 | 30% | Below 22% |
+| Day 30 | 25% | Below 18% |
+
+---
+
+## Feature Adoption Rate
+
+<div class="metric-card">
+<h4>Feature Adoption</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(DISTINCT users_using_feature) / DAU</code></dd>
+<dt>Data Source</dt>
+<dd><code>analytics.feature_usage</code></dd>
+<dt>Owner</dt>
+<dd>Product Team</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+Tracks the percentage of daily active users who interact with a specific feature. This is computed per-feature and reported on the Feature Health dashboard. Features with adoption below 5% after 90 days post-launch are flagged for review.
+
+---
+
+## Session Duration
+
+<div class="metric-card">
+<h4>Median Session Duration</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY session_seconds)</code></dd>
+<dt>Data Source</dt>
+<dd><code>analytics.sessions</code></dd>
+<dt>Owner</dt>
+<dd>Product Analytics</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--deprecated">Deprecated</span></dd>
+</dl>
+</div>
+
+> This metric has been deprecated in favor of Task Completion Rate, which better captures whether users are achieving their goals. Session duration is still computed for backward compatibility but is no longer included in executive reporting.

--- a/sextant/content/metrics/operational.md
+++ b/sextant/content/metrics/operational.md
@@ -1,0 +1,98 @@
++++
+title = "Operational Metrics"
+description = "Infrastructure and process metrics reflecting system health."
+weight = 3
++++
+
+## Request Latency (p50 / p95 / p99)
+
+<div class="metric-card">
+<h4>Request Latency</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_ms)</code></dd>
+<dt>Data Source</dt>
+<dd><code>monitoring.http_requests</code></dd>
+<dt>Owner</dt>
+<dd>Platform Engineering</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+Latency is measured at the load balancer. The primary reporting percentile is p95; p50 and p99 are tracked for context. Measurements exclude health-check endpoints and internal service-to-service calls.
+
+| Percentile | Target | Alert |
+|-----------|--------|-------|
+| p50 | Below 120ms | Above 200ms |
+| p95 | Below 500ms | Above 800ms |
+| p99 | Below 1500ms | Above 2500ms |
+
+---
+
+## Error Rate
+
+<div class="metric-card">
+<h4>Error Rate</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(status >= 500) / COUNT(*) * 100</code></dd>
+<dt>Data Source</dt>
+<dd><code>monitoring.http_requests</code></dd>
+<dt>Owner</dt>
+<dd>Platform Engineering</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+The error rate captures server-side failures as a percentage of total requests. Client errors (4xx) are tracked separately. A sustained error rate above 1% triggers an automatic incident via PagerDuty.
+
+---
+
+## Deployment Frequency
+
+<div class="metric-card">
+<h4>Deployment Frequency</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(deployments) per calendar week</code></dd>
+<dt>Data Source</dt>
+<dd><code>cicd.deployments</code></dd>
+<dt>Owner</dt>
+<dd>Developer Experience</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+Counts successful production deployments per week. Rollbacks are counted as separate deployments. This is one of the four DORA metrics tracked by the engineering organization.
+
+### DORA Metrics Summary
+
+| Metric | Current | Target | Elite Benchmark |
+|--------|---------|--------|----------------|
+| Deployment Frequency | 12/week | 15/week | On-demand |
+| Lead Time for Changes | 2.1 days | 1 day | Less than 1 hour |
+| Change Failure Rate | 8% | 5% | 0--15% |
+| Time to Restore | 45 min | 30 min | Less than 1 hour |
+
+---
+
+## Queue Depth
+
+<div class="metric-card">
+<h4>Queue Depth</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>COUNT(messages) WHERE state = 'pending'</code></dd>
+<dt>Data Source</dt>
+<dd><code>monitoring.message_queues</code></dd>
+<dt>Owner</dt>
+<dd>Platform Engineering</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--draft">Draft</span></dd>
+</dl>
+</div>
+
+Measures the number of unprocessed messages across all production queues. A rising queue depth with flat consumer throughput indicates a capacity bottleneck. This metric is in draft status while the team standardizes queue naming conventions across services.

--- a/sextant/content/metrics/revenue.md
+++ b/sextant/content/metrics/revenue.md
@@ -1,0 +1,93 @@
++++
+title = "Revenue Metrics"
+description = "Financial KPIs for tracking business growth and monetization."
+weight = 1
++++
+
+## Monthly Recurring Revenue (MRR)
+
+<div class="metric-card">
+<h4>MRR</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>SUM(subscription_amount) WHERE status = 'active'</code></dd>
+<dt>Data Source</dt>
+<dd><code>billing.subscriptions</code></dd>
+<dt>Owner</dt>
+<dd>Finance Team</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+MRR represents the normalized monthly revenue from all active subscriptions. It excludes one-time charges, usage overages, and credits. MRR is calculated on the first calendar day of each month using end-of-previous-month snapshots.
+
+### Variants
+
+| Variant | Definition |
+|---------|-----------|
+| New MRR | Revenue from customers who subscribed in the current period |
+| Expansion MRR | Additional revenue from existing customers who upgraded |
+| Contraction MRR | Lost revenue from existing customers who downgraded |
+| Churned MRR | Revenue lost from customers who cancelled entirely |
+| Net New MRR | New + Expansion - Contraction - Churned |
+
+---
+
+## Average Revenue Per Account (ARPA)
+
+<div class="metric-card">
+<h4>ARPA</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>MRR / COUNT(DISTINCT account_id) WHERE status = 'active'</code></dd>
+<dt>Data Source</dt>
+<dd><code>billing.subscriptions</code>, <code>core.accounts</code></dd>
+<dt>Owner</dt>
+<dd>Finance Team</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+ARPA measures the average monthly revenue generated per paying account. Use this to track pricing efficiency and segment health over time.
+
+---
+
+## Customer Lifetime Value (LTV)
+
+<div class="metric-card">
+<h4>LTV</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>ARPA / monthly_churn_rate</code></dd>
+<dt>Data Source</dt>
+<dd>Derived from ARPA and Churn Rate metrics</dd>
+<dt>Owner</dt>
+<dd>Growth Analytics</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--active">Active</span></dd>
+</dl>
+</div>
+
+LTV estimates the total revenue a customer will generate over their relationship with the company. The simplified formula above assumes constant churn; the data team also maintains a cohort-based LTV model for quarterly board reporting.
+
+---
+
+## Annual Contract Value (ACV)
+
+<div class="metric-card">
+<h4>ACV</h4>
+<dl>
+<dt>Formula</dt>
+<dd><code>SUM(contract_value) / contract_term_years</code></dd>
+<dt>Data Source</dt>
+<dd><code>sales.contracts</code></dd>
+<dt>Owner</dt>
+<dd>Revenue Operations</dd>
+<dt>Status</dt>
+<dd><span class="status-badge status-badge--draft">Draft</span></dd>
+</dl>
+</div>
+
+ACV normalizes multi-year contracts to an annual figure. This metric is currently in draft while the team finalizes how to handle mid-term amendments and early terminations.

--- a/sextant/content/slo/_index.md
+++ b/sextant/content/slo/_index.md
@@ -1,0 +1,7 @@
++++
+title = "SLO Reference"
+description = "Service Level Objectives, Indicators, and Agreement definitions."
+weight = 3
++++
+
+This section defines the service level framework used across the organization. It covers the terminology (SLI, SLO, SLA), currently approved objectives, and the threshold tables that drive alerting.

--- a/sextant/content/slo/definitions.md
+++ b/sextant/content/slo/definitions.md
@@ -1,0 +1,62 @@
++++
+title = "Definitions"
+description = "Formal definitions for SLI, SLO, and SLA."
+weight = 1
++++
+
+## Terminology
+
+| Term | Full Name | Definition |
+|------|-----------|-----------|
+| **SLI** | Service Level Indicator | A quantitative measure of a specific aspect of service quality |
+| **SLO** | Service Level Objective | A target value or range for an SLI, measured over a rolling window |
+| **SLA** | Service Level Agreement | A contractual commitment that includes consequences for missing SLOs |
+
+## How They Relate
+
+An **SLI** is what you measure. An **SLO** is the target you set for that measurement. An **SLA** is the promise you make to customers, backed by the SLO.
+
+For example:
+
+- SLI: The proportion of HTTP requests that return a 2xx status code
+- SLO: 99.9% of requests succeed over a 30-day rolling window
+- SLA: If monthly availability drops below 99.5%, affected customers receive a 10% service credit
+
+## Error Budgets
+
+Each SLO implies an error budget: the amount of unreliability you can tolerate before violating the objective.
+
+| SLO Target | Error Budget (30 days) | Equivalent Downtime |
+|-----------|----------------------|-------------------|
+| 99% | 1% | 7 hours 12 minutes |
+| 99.5% | 0.5% | 3 hours 36 minutes |
+| 99.9% | 0.1% | 43 minutes 12 seconds |
+| 99.95% | 0.05% | 21 minutes 36 seconds |
+| 99.99% | 0.01% | 4 minutes 19 seconds |
+
+When the remaining error budget for a service drops below 25%, the on-call team should prioritize reliability work over feature development.
+
+## SLI Specification vs. SLI Implementation
+
+### Specification
+
+The SLI specification describes *what* you want to measure in abstract terms. It is technology-agnostic.
+
+> The proportion of valid requests served successfully.
+
+### Implementation
+
+The SLI implementation describes *how* you measure it using your specific infrastructure.
+
+> `COUNT(status < 500) / COUNT(*)` computed from load balancer access logs over a 5-minute window.
+
+Always document both. The specification stays stable even if the implementation changes (for example, when migrating from load balancer logs to distributed tracing).
+
+## Choosing SLOs
+
+Use the following principles when setting SLO targets:
+
+1. **Start with user expectations.** What performance would make users satisfied? Set the SLO there, not at the current system performance.
+2. **Use data to calibrate.** Review 90 days of historical SLI data before choosing a target. If the system already meets 99.95%, setting an SLO at 99% wastes the signal.
+3. **Fewer is better.** Each service should have 2--4 SLOs. More than that dilutes focus.
+4. **Review quarterly.** Targets should evolve as the product and user base change.

--- a/sextant/content/slo/thresholds.md
+++ b/sextant/content/slo/thresholds.md
@@ -1,0 +1,73 @@
++++
+title = "Thresholds"
+description = "Approved SLO threshold tables for production services."
+weight = 2
++++
+
+## API Gateway
+
+| SLI | SLO Target | Warning | Critical | Window |
+|-----|-----------|---------|----------|--------|
+| Availability | 99.95% | Below 99.97% | Below 99.95% | 30 days |
+| Latency (p95) | 400ms | Above 350ms | Above 400ms | 1 hour |
+| Latency (p99) | 1200ms | Above 1000ms | Above 1200ms | 1 hour |
+| Error Rate | 0.1% | Above 0.08% | Above 0.1% | 15 min |
+
+## Authentication Service
+
+| SLI | SLO Target | Warning | Critical | Window |
+|-----|-----------|---------|----------|--------|
+| Availability | 99.99% | Below 99.995% | Below 99.99% | 30 days |
+| Login Latency (p95) | 300ms | Above 250ms | Above 300ms | 1 hour |
+| Token Validation (p95) | 50ms | Above 40ms | Above 50ms | 1 hour |
+| Error Rate | 0.05% | Above 0.03% | Above 0.05% | 15 min |
+
+## Data Pipeline
+
+| SLI | SLO Target | Warning | Critical | Window |
+|-----|-----------|---------|----------|--------|
+| Freshness | 15 min lag | Above 10 min | Above 15 min | Rolling |
+| Completeness | 99.9% | Below 99.95% | Below 99.9% | 24 hours |
+| Correctness | 99.99% | Below 99.995% | Below 99.99% | 7 days |
+| Throughput | 10k events/sec | Below 12k/sec | Below 10k/sec | 5 min |
+
+## Search Service
+
+| SLI | SLO Target | Warning | Critical | Window |
+|-----|-----------|---------|----------|--------|
+| Availability | 99.9% | Below 99.95% | Below 99.9% | 30 days |
+| Query Latency (p95) | 200ms | Above 180ms | Above 200ms | 1 hour |
+| Index Freshness | 5 min lag | Above 3 min | Above 5 min | Rolling |
+| Relevance (NDCG@10) | 0.75 | Below 0.78 | Below 0.75 | 7 days |
+
+## Notification Service
+
+| SLI | SLO Target | Warning | Critical | Window |
+|-----|-----------|---------|----------|--------|
+| Delivery Rate | 99.5% | Below 99.7% | Below 99.5% | 24 hours |
+| Delivery Latency (p95) | 30 sec | Above 20 sec | Above 30 sec | 1 hour |
+| Duplicate Rate | 0.01% | Above 0.008% | Above 0.01% | 24 hours |
+
+## Alerting Rules
+
+Thresholds are evaluated at two severity levels:
+
+### Warning
+
+A warning alert fires when the SLI approaches the SLO boundary. It is informational and does not page on-call. Warnings appear in Slack and on the team dashboard.
+
+### Critical
+
+A critical alert fires when the SLI violates the SLO target. It pages the on-call engineer and opens an incident ticket automatically.
+
+### Burn Rate Windows
+
+For availability SLOs, alerts use a multi-window burn rate strategy:
+
+| Alert Type | Short Window | Long Window | Burn Rate |
+|-----------|-------------|-------------|-----------|
+| Page (fast burn) | 5 min | 1 hour | 14.4x |
+| Page (slow burn) | 30 min | 6 hours | 6x |
+| Ticket | 2 hours | 3 days | 1x |
+
+A "14.4x burn rate" means the service is consuming its 30-day error budget 14.4 times faster than expected. At this rate, the entire budget would be exhausted in roughly 2 days.

--- a/sextant/static/css/style.css
+++ b/sextant/static/css/style.css
@@ -1,0 +1,662 @@
+:root {
+  --blue-700: #1d4ed8;
+  --blue-600: #2563eb;
+  --blue-500: #3b82f6;
+  --blue-100: #dbeafe;
+  --blue-50: #eff6ff;
+  --slate-900: #0f172a;
+  --slate-800: #1e293b;
+  --slate-700: #334155;
+  --slate-600: #475569;
+  --slate-500: #64748b;
+  --slate-400: #94a3b8;
+  --slate-300: #cbd5e1;
+  --slate-200: #e2e8f0;
+  --slate-100: #f1f5f9;
+  --slate-50: #f8fafc;
+  --white: #ffffff;
+  --header-h: 56px;
+  --sidebar-w: 260px;
+  --content-max-w: 800px;
+  --radius: 8px;
+  --radius-sm: 5px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--slate-800);
+  background: var(--white);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ------------------------------------------------------------------ Header */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: saturate(180%) blur(16px);
+  -webkit-backdrop-filter: saturate(180%) blur(16px);
+  border-bottom: 1px solid var(--slate-200);
+  display: flex;
+  align-items: center;
+  padding: 0 1.75rem;
+  z-index: 100;
+}
+
+.site-header .logo {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--slate-900);
+  text-decoration: none;
+  margin-right: 2.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.logo-mark {
+  width: 22px;
+  height: 22px;
+  background: var(--blue-600);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo-mark svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: var(--white);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.site-header nav {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.site-header nav a {
+  color: var(--slate-500);
+  text-decoration: none;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s, background 0.15s;
+}
+
+.site-header nav a:hover {
+  color: var(--slate-900);
+  background: var(--slate-100);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* ---------------------------------------------------------------- Search */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--slate-200);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  color: var(--slate-400);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.search-trigger:hover {
+  border-color: var(--slate-300);
+  color: var(--slate-600);
+}
+
+.search-trigger kbd {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--slate-200);
+  border-radius: 3px;
+  background: var(--slate-50);
+  color: var(--slate-400);
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 200;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 540px;
+  max-width: 90vw;
+  max-height: 70vh;
+  background: var(--white);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--slate-200);
+}
+
+.search-input-wrap svg {
+  flex-shrink: 0;
+  color: var(--slate-400);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--slate-900);
+  background: transparent;
+}
+
+.search-input-wrap input::placeholder {
+  color: var(--slate-400);
+}
+
+.search-input-wrap kbd {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--slate-200);
+  border-radius: 3px;
+  background: var(--slate-50);
+  color: var(--slate-400);
+  font-family: inherit;
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.search-results {
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--slate-800);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.search-result-item:hover,
+.search-result-item.active {
+  background: var(--slate-50);
+  text-decoration: none;
+}
+
+.search-result-item .search-result-title {
+  font-weight: 500;
+  font-size: 0.9rem;
+  margin-bottom: 0.1rem;
+}
+
+.search-result-item .search-result-snippet {
+  font-size: 0.8rem;
+  color: var(--slate-500);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-result-item .search-result-snippet mark {
+  background: var(--blue-100);
+  color: var(--blue-700);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-no-results {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--slate-400);
+  font-size: 0.9rem;
+}
+
+/* ---------------------------------------------------------------- Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+}
+
+/* --------------------------------------------------------------- Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: var(--slate-50);
+  border-right: 1px solid var(--slate-200);
+  padding: 1.5rem 0.75rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.docs-sidebar::-webkit-scrollbar {
+  width: 4px;
+}
+
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--slate-300);
+  border-radius: 2px;
+}
+
+.sidebar-section {
+  margin-bottom: 1.75rem;
+}
+
+.sidebar-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--slate-400);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.06em;
+  padding-left: 0.75rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  margin-bottom: 1px;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.3rem 0.75rem;
+  color: var(--slate-600);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  transition: all 0.15s;
+  line-height: 1.4;
+  border-left: 2px solid transparent;
+}
+
+.sidebar-links a:hover {
+  background: var(--white);
+  color: var(--slate-900);
+  border-left-color: var(--slate-300);
+}
+
+.sidebar-links a.active {
+  background: var(--blue-50);
+  color: var(--blue-700);
+  font-weight: 600;
+  border-left-color: var(--blue-600);
+}
+
+/* -------------------------------------------------------------- Content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 2.5rem 3rem 4rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w) + 6rem);
+}
+
+.docs-main h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  color: var(--slate-900);
+}
+
+.docs-main h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 2.5rem 0 0.75rem 0;
+  letter-spacing: -0.015em;
+  color: var(--slate-900);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--slate-200);
+}
+
+.docs-main h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 2rem 0 0.5rem 0;
+  color: var(--slate-800);
+}
+
+.docs-main h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem 0;
+  color: var(--slate-700);
+}
+
+.docs-main p {
+  margin-bottom: 1rem;
+  line-height: 1.7;
+  color: var(--slate-700);
+}
+
+.docs-main ul,
+.docs-main ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+  color: var(--slate-700);
+}
+
+.docs-main li {
+  margin-bottom: 0.35rem;
+  line-height: 1.6;
+}
+
+/* ---------------------------------------------------------------- Links */
+a {
+  color: var(--blue-600);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* ----------------------------------------------------------------- Code */
+code {
+  background: var(--slate-100);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  color: var(--blue-700);
+}
+
+pre {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  border: 1px solid var(--slate-200);
+  background: var(--slate-50);
+  margin: 1rem 0 1.5rem 0;
+  line-height: 1.5;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.82rem;
+  color: var(--slate-800);
+}
+
+/* --------------------------------------------------------------- Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+th {
+  text-align: left;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 2px solid var(--slate-300);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--slate-500);
+  background: var(--slate-50);
+}
+
+td {
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid var(--slate-200);
+  vertical-align: top;
+  color: var(--slate-700);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+/* ----------------------------------------------------------- Blockquote */
+blockquote {
+  border-left: 3px solid var(--blue-500);
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  background: var(--blue-50);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--slate-600);
+}
+
+blockquote p {
+  margin-bottom: 0;
+}
+
+/* --------------------------------------------------------- Metric Cards */
+.metric-card {
+  border: 1px solid var(--slate-200);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  margin: 1rem 0;
+  background: var(--white);
+  transition: border-color 0.15s;
+}
+
+.metric-card:hover {
+  border-color: var(--blue-300, #93c5fd);
+}
+
+.metric-card h4 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--slate-900);
+}
+
+.metric-card dl {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.metric-card dt {
+  font-weight: 600;
+  color: var(--slate-500);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  padding-top: 0.15rem;
+}
+
+.metric-card dd {
+  color: var(--slate-700);
+  margin: 0;
+}
+
+.metric-card dd code {
+  font-size: 0.8rem;
+}
+
+/* ---------------------------------------------------- Status indicators */
+.status-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 3px;
+}
+
+.status-badge--active {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge--draft {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-badge--deprecated {
+  background: var(--slate-100);
+  color: var(--slate-500);
+}
+
+/* --------------------------------------------------------- Section list */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--slate-50);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--slate-200);
+  transition: border-color 0.15s;
+}
+
+ul.section-list li:hover {
+  border-color: var(--slate-300);
+}
+
+ul.section-list li a {
+  font-weight: 500;
+  color: var(--blue-600);
+}
+
+/* ----------------------------------------------------------- Pagination */
+nav.pagination {
+  margin: 1.5rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--slate-200);
+  color: var(--slate-500);
+  text-decoration: none;
+}
+
+nav.pagination a:hover {
+  color: var(--blue-600);
+  border-color: var(--blue-600);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--blue-600);
+  background: var(--blue-50);
+  color: var(--blue-700);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--slate-200);
+  color: var(--slate-400);
+  opacity: 0.5;
+}
+
+/* --------------------------------------------------------------- Footer */
+.docs-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--slate-200);
+  color: var(--slate-400);
+  font-size: 0.8rem;
+}
+
+.docs-footer a {
+  color: var(--slate-400);
+}
+
+.docs-footer a:hover {
+  color: var(--blue-600);
+}
+
+/* ----------------------------------------------------------- Responsive */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 1.5rem 1rem;
+  }
+  .site-header nav {
+    display: none;
+  }
+  .metric-card dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/sextant/static/js/search.js
+++ b/sextant/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/sextant/templates/404.html
+++ b/sextant/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+<div style="display: flex; align-items: center; justify-content: center; min-height: calc(100vh - 56px); text-align: center; padding: 2rem;">
+  <div>
+    <h1 style="font-size: 4rem; font-weight: 700; color: #0f172a; margin-bottom: 0.5rem;">404</h1>
+    <p style="font-size: 1.1rem; color: #64748b; margin-bottom: 1.5rem;">The page you are looking for does not exist.</p>
+    <a href="{{ base_url }}/" style="color: #2563eb; font-weight: 500;">Return to Home</a>
+  </div>
+</div>
+{{ highlight_js }}
+{{ auto_includes_js }}
+</body>
+</html>

--- a/sextant/templates/footer.html
+++ b/sextant/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/sextant/templates/header.html
+++ b/sextant/templates/header.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">

--- a/sextant/templates/page.html
+++ b/sextant/templates/page.html
@@ -1,0 +1,63 @@
+{% include "header.html" %}
+<header class="site-header">
+  <a href="{{ base_url }}/" class="logo">
+    <span class="logo-mark">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
+    </span>
+    Sextant
+  </a>
+  <nav>
+    <a href="{{ base_url }}/metrics/">Metrics</a>
+    <a href="{{ base_url }}/dashboards/">Dashboards</a>
+    <a href="{{ base_url }}/slo/">SLO Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Metrics</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/metrics/">Overview</a></li>
+        <li><a href="{{ base_url }}/metrics/revenue/">Revenue</a></li>
+        <li><a href="{{ base_url }}/metrics/engagement/">Engagement</a></li>
+        <li><a href="{{ base_url }}/metrics/operational/">Operational</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Dashboards</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/dashboards/">Overview</a></li>
+        <li><a href="{{ base_url }}/dashboards/widget-configuration/">Widget Configuration</a></li>
+        <li><a href="{{ base_url }}/dashboards/layout-guidelines/">Layout Guidelines</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">SLO Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/slo/">Overview</a></li>
+        <li><a href="{{ base_url }}/slo/definitions/">Definitions</a></li>
+        <li><a href="{{ base_url }}/slo/thresholds/">Thresholds</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+{% include "footer.html" %}

--- a/sextant/templates/section.html
+++ b/sextant/templates/section.html
@@ -1,0 +1,69 @@
+{% include "header.html" %}
+<header class="site-header">
+  <a href="{{ base_url }}/" class="logo">
+    <span class="logo-mark">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
+    </span>
+    Sextant
+  </a>
+  <nav>
+    <a href="{{ base_url }}/metrics/">Metrics</a>
+    <a href="{{ base_url }}/dashboards/">Dashboards</a>
+    <a href="{{ base_url }}/slo/">SLO Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Metrics</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/metrics/">Overview</a></li>
+        <li><a href="{{ base_url }}/metrics/revenue/">Revenue</a></li>
+        <li><a href="{{ base_url }}/metrics/engagement/">Engagement</a></li>
+        <li><a href="{{ base_url }}/metrics/operational/">Operational</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Dashboards</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/dashboards/">Overview</a></li>
+        <li><a href="{{ base_url }}/dashboards/widget-configuration/">Widget Configuration</a></li>
+        <li><a href="{{ base_url }}/dashboards/layout-guidelines/">Layout Guidelines</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">SLO Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/slo/">Overview</a></li>
+        <li><a href="{{ base_url }}/slo/definitions/">Definitions</a></li>
+        <li><a href="{{ base_url }}/slo/thresholds/">Thresholds</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+
+    <h2>In This Section</h2>
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+{% include "footer.html" %}

--- a/sextant/templates/shortcodes/alert.html
+++ b/sextant/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 0.75rem 1rem; border: 1px solid #e2e8f0; background-color: #f8fafc; border-left: 3px solid #2563eb; margin: 1rem 0; border-radius: 0 5px 5px 0; font-size: 0.9rem; color: #334155;">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/sextant/templates/taxonomy.html
+++ b/sextant/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/sextant/templates/taxonomy_term.html
+++ b/sextant/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1235,5 +1235,10 @@
     "light",
     "blog",
     "zen"
+  ],
+  "sextant": [
+    "light",
+    "docs",
+    "metrics"
   ]
 }


### PR DESCRIPTION
## Summary
- Add sextant example site: a metrics/KPI definition docs site with blue/white/light-gray color palette and BI report aesthetic
- Three content sections: Metrics (revenue, engagement, operational), Dashboards (widget config, layout guidelines), SLO Reference (definitions, thresholds)
- Metric cards with formula, data source, owner, and status badge
- SLO/SLI/SLA definitions and per-service threshold tables
- Tags: `light`, `docs`, `metrics`

Closes #383

## Test plan
- [ ] Verify `hwaro build` succeeds in `sextant/` directory
- [ ] Check all sidebar navigation links resolve correctly
- [ ] Confirm light theme with no gradients or emoji
- [ ] Verify metric cards, status badges, and threshold tables render properly
- [ ] Confirm tags.json includes sextant entry