### PR TITLE
Add 3 new docs-style example sites

### DIFF
--- a/meridian-docs/AGENTS.md
+++ b/meridian-docs/AGENTS.md
@@ -1,0 +1,63 @@
+# Meridian Docs
+
+A timezone and scheduling API documentation site built with Hwaro.
+
+## Theme
+
+Light theme using a blue/white/gold color palette. Solid colors only, no gradients. Fonts: IBM Plex Sans (body) and IBM Plex Mono (code).
+
+## Colors
+
+- Primary blue: #2563eb
+- Gold accent: #b8860b / #d4a017
+- White backgrounds with slate/gray text
+- Blue-50 for hover and active states
+
+## Structure
+
+```
+meridian-docs/
+  config.toml              # Site configuration
+  AGENTS.md                # This file
+  content/
+    index.md               # Homepage
+    about.md               # About page
+    docs/
+      timezones/
+        _index.md          # Section index (sort_by weight, page_template doc)
+        timezone-database.md   # World timezone mapping table
+        dst-handling.md        # DST processing and edge cases
+        utc-conversion.md      # UTC conversion API reference
+      scheduling/
+        _index.md          # Section index
+        cron-expressions.md    # Cron expression syntax guide
+        recurring-jobs.md      # Recurring job management
+        error-handling.md      # Error handling and retry strategies
+  templates/
+    header.html            # Sticky nav, Tailwind config, search input
+    footer.html            # Footer with Hwaro attribution
+    doc.html               # Sidebar + content + TOC layout
+    page.html              # Simple centered content layout
+    section.html           # Card grid for section pages
+    taxonomy.html          # Taxonomy listing
+    taxonomy_term.html     # Taxonomy term listing
+    404.html               # Error page
+    shortcodes/
+      alert.html           # Alert box shortcode (info, warning, error, tip)
+  static/
+    js/
+      mobile-menu.js       # Mobile menu toggle script
+```
+
+## Features
+
+- Sticky top navigation with search input
+- Sidebar navigation for doc pages with active state
+- Breadcrumb navigation
+- Table of contents in right sidebar
+- Previous/Next page navigation
+- Mobile-responsive sidebar via details/summary
+- Card grid section listings
+- Alert shortcode with info, warning, error, and tip variants
+- Syntax highlighting via Hwaro highlight plugin
+- Fuse.js search index generation

--- a/meridian-docs/config.toml
+++ b/meridian-docs/config.toml
@@ -1,0 +1,38 @@
+title = "Meridian Docs"
+description = "Timezone and scheduling API documentation"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [{ user_agent = "*", disallow = [] }]
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[markdown]
+safe = false

--- a/meridian-docs/content/about.md
+++ b/meridian-docs/content/about.md
@@ -1,0 +1,41 @@
++++
+title = "About Meridian"
+description = "Learn about the Meridian platform and its mission"
++++
+
+# About Meridian
+
+Meridian is a timezone and scheduling infrastructure platform designed for teams building globally distributed applications. We handle the complexity of time so you can focus on your product.
+
+## Why Meridian
+
+Working with time is deceptively difficult. Daylight saving transitions, political timezone changes, leap seconds, and ambiguous local times create subtle bugs that are hard to detect and harder to fix. Meridian abstracts these challenges behind a clean, well-tested API.
+
+## Architecture
+
+Meridian runs on a globally distributed network of nodes, each maintaining a synchronized copy of the IANA timezone database. When you make an API call, your request is routed to the nearest node, ensuring low-latency responses regardless of your location.
+
+### Core Components
+
+- **Timezone Engine** -- Parses and applies IANA timezone rules, including historical data back to 1970
+- **Scheduler Service** -- Manages cron-based and interval-based recurring jobs with DST awareness
+- **Conversion API** -- Handles timestamp conversion between any pair of timezones
+- **Notification System** -- Delivers webhook callbacks when scheduled jobs execute or fail
+
+## Data Sources
+
+Meridian uses the IANA Time Zone Database (often called the Olson database) as its primary data source. The database is updated multiple times per year to reflect political decisions about timezone boundaries and DST rules. Meridian syncs these updates within 24 hours of release.
+
+## API Versioning
+
+All Meridian APIs follow semantic versioning. Breaking changes are only introduced in major versions, and previous major versions are supported for at least 18 months after a new major version is released.
+
+| Version | Status     | End of Support |
+|---------|------------|----------------|
+| v3      | Current    | --             |
+| v2      | Maintained | March 2027     |
+| v1      | Deprecated | June 2026      |
+
+## Contact
+
+For support, reach out at support@meridian.dev or visit the community forum at community.meridian.dev.

--- a/meridian-docs/content/docs/scheduling/_index.md
+++ b/meridian-docs/content/docs/scheduling/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Scheduling"
+sort_by = "weight"
+page_template = "doc"
++++
+
+Documentation for the Meridian Scheduling API, including cron expression syntax, recurring job management, and error handling strategies.

--- a/meridian-docs/content/docs/scheduling/cron-expressions.md
+++ b/meridian-docs/content/docs/scheduling/cron-expressions.md
@@ -1,0 +1,121 @@
++++
+title = "Cron Expressions"
+weight = 1
+description = "Cron expression syntax reference and builder guide"
+[taxonomies]
+tags = ["scheduling", "cron"]
++++
+
+## Overview
+
+Meridian uses extended cron expressions to define schedules for recurring jobs. Our syntax supports the standard five-field format plus an optional seconds field for sub-minute precision.
+
+## Expression Format
+
+```
+┌──────────── second (0-59, optional)
+│ ┌────────── minute (0-59)
+│ │ ┌──────── hour (0-23)
+│ │ │ ┌────── day of month (1-31)
+│ │ │ │ ┌──── month (1-12 or JAN-DEC)
+│ │ │ │ │ ┌── day of week (0-7 or SUN-SAT, 0 and 7 are Sunday)
+│ │ │ │ │ │
+* * * * * *
+```
+
+## Syntax Reference
+
+| Symbol | Meaning              | Example        | Description                         |
+|--------|----------------------|----------------|-------------------------------------|
+| `*`    | Any value            | `* * * * *`    | Every minute                        |
+| `,`    | Value list separator | `1,15 * * * *` | At minute 1 and 15                  |
+| `-`    | Range of values      | `1-5 * * * *`  | Every minute from 1 through 5       |
+| `/`    | Step values          | `*/15 * * * *` | Every 15 minutes                    |
+| `L`    | Last                 | `* * * L * *`  | Last day of the month               |
+| `W`    | Nearest weekday      | `* * * 15W * *`| Nearest weekday to the 15th         |
+| `#`    | Nth day of week      | `* * * * * 5#3`| Third Friday of the month           |
+
+## Common Patterns
+
+The table below shows frequently used cron patterns and their schedules.
+
+| Expression              | Schedule                          |
+|-------------------------|-----------------------------------|
+| `* * * * *`             | Every minute                      |
+| `0 * * * *`             | Every hour, on the hour           |
+| `0 0 * * *`             | Every day at midnight             |
+| `0 9 * * 1-5`           | Every weekday at 9:00 AM          |
+| `0 0 1 * *`             | First day of every month          |
+| `0 0 * * 0`             | Every Sunday at midnight          |
+| `*/15 * * * *`          | Every 15 minutes                  |
+| `0 9,17 * * 1-5`        | 9:00 AM and 5:00 PM on weekdays   |
+| `30 2 * * *`            | Every day at 2:30 AM              |
+| `0 0 1 1 *`             | January 1st at midnight (yearly)  |
+| `0 0 L * *`             | Last day of every month           |
+| `0 10 * * 1#1`          | First Monday of every month at 10 AM |
+
+## Timezone-Aware Cron
+
+All Meridian cron expressions are evaluated in a specified timezone. This is critical for schedules that need to fire at local wall-clock time:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "daily-report",
+    "expression": "0 9 * * 1-5",
+    "timezone": "America/New_York",
+    "callback_url": "https://app.example.com/hooks/daily-report"
+  }' \
+  https://api.meridian.dev/v3/schedules
+```
+
+This job fires at 9:00 AM Eastern time every weekday. During DST transitions, the UTC execution time shifts automatically to maintain the 9:00 AM local time.
+
+## Expression Validation
+
+Validate a cron expression without creating a schedule:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "expression": "0 9 * * 1-5",
+    "timezone": "Europe/London"
+  }' \
+  https://api.meridian.dev/v3/schedules/validate
+```
+
+```json
+{
+  "valid": true,
+  "description": "At 09:00, Monday through Friday",
+  "next_5_runs": [
+    "2026-04-03T09:00:00+01:00",
+    "2026-04-06T09:00:00+01:00",
+    "2026-04-07T09:00:00+01:00",
+    "2026-04-08T09:00:00+01:00",
+    "2026-04-09T09:00:00+01:00"
+  ]
+}
+```
+
+## SDK Example
+
+```python
+from meridian import Client
+
+client = Client(api_key="your-api-key")
+
+# Validate and preview a cron expression
+preview = client.schedules.validate(
+    expression="*/30 9-17 * * 1-5",
+    timezone="Asia/Tokyo",
+)
+
+print(preview.description)
+# "Every 30 minutes, between 09:00 and 17:59, Monday through Friday"
+
+for run in preview.next_5_runs:
+    print(run)
+```

--- a/meridian-docs/content/docs/scheduling/error-handling.md
+++ b/meridian-docs/content/docs/scheduling/error-handling.md
@@ -1,0 +1,174 @@
++++
+title = "Error Handling"
+weight = 3
+description = "Error handling, retry strategies, and failure notifications"
+[taxonomies]
+tags = ["scheduling", "errors"]
++++
+
+## Overview
+
+Distributed scheduling introduces failure modes that do not exist in synchronous systems. Network timeouts, server errors, and transient outages are expected. Meridian provides configurable retry strategies and failure notifications to help you build resilient scheduled workflows.
+
+## Retry Configuration
+
+Every job can define a retry policy that controls how Meridian handles callback failures:
+
+```json
+{
+  "retry": {
+    "max_attempts": 5,
+    "backoff": "exponential",
+    "initial_delay": "PT10S",
+    "max_delay": "PT10M",
+    "retry_on": [502, 503, 504]
+  }
+}
+```
+
+### Retry Parameters
+
+| Parameter       | Type     | Default        | Description                                      |
+|----------------|----------|----------------|--------------------------------------------------|
+| `max_attempts` | integer  | 3              | Maximum number of delivery attempts               |
+| `backoff`      | string   | `exponential`  | Backoff strategy: `fixed`, `linear`, `exponential`|
+| `initial_delay`| string   | `PT10S`        | Delay before the first retry (ISO 8601 duration)  |
+| `max_delay`    | string   | `PT5M`         | Maximum delay between retries                     |
+| `retry_on`     | int[]    | [500-599]      | HTTP status codes that trigger a retry            |
+
+## Backoff Strategies
+
+### Fixed Backoff
+
+Every retry waits the same amount of time:
+
+```
+Attempt 1: immediate
+Attempt 2: +10s
+Attempt 3: +10s
+Attempt 4: +10s
+```
+
+### Linear Backoff
+
+Each retry waits incrementally longer:
+
+```
+Attempt 1: immediate
+Attempt 2: +10s
+Attempt 3: +20s
+Attempt 4: +30s
+```
+
+### Exponential Backoff
+
+Each retry doubles the wait time (with jitter), capped at `max_delay`:
+
+```
+Attempt 1: immediate
+Attempt 2: +10s  (+ up to 2s jitter)
+Attempt 3: +20s  (+ up to 4s jitter)
+Attempt 4: +40s  (+ up to 8s jitter)
+Attempt 5: +80s  (+ up to 16s jitter)
+```
+
+Jitter prevents retry storms when many jobs fail simultaneously (for example, during an upstream outage).
+
+## Failure Detection
+
+Meridian considers a callback execution to have failed when any of the following conditions are met:
+
+| Condition                  | Description                                          |
+|---------------------------|------------------------------------------------------|
+| HTTP status 4xx or 5xx    | The callback endpoint returned an error status       |
+| Connection timeout         | Could not establish a TCP connection within 10s      |
+| Read timeout               | Response was not fully received within 30s           |
+| TLS handshake failure      | Certificate validation failed                        |
+| DNS resolution failure     | Could not resolve the callback hostname              |
+
+Successful execution requires an HTTP 2xx response received within the timeout window.
+
+## Dead Letter Queue
+
+When all retry attempts are exhausted, the failed execution is placed in a dead letter queue (DLQ). You can inspect and replay DLQ items:
+
+```bash
+# List dead letter items
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7/dlq"
+```
+
+```json
+{
+  "items": [
+    {
+      "id": "dlq_mN4kR8pW2q",
+      "run_id": "run_q9W3kR7mN2",
+      "job_id": "job_8xK2mP4nL7",
+      "failed_at": "2026-04-02T07:02:45Z",
+      "attempts": 5,
+      "last_error": "Connection timeout after 10000ms",
+      "last_http_status": null,
+      "payload": {
+        "action": "full_sync",
+        "source": "meridian"
+      }
+    }
+  ]
+}
+```
+
+### Replaying Failed Executions
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7/dlq/dlq_mN4kR8pW2q/replay"
+```
+
+This re-enqueues the execution with the original payload and applies the retry policy from scratch.
+
+## Failure Notifications
+
+Configure webhook or email notifications for job failures:
+
+```bash
+curl -X PUT -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "notifications": {
+      "on_failure": {
+        "webhook": "https://app.example.com/hooks/alerts",
+        "email": ["ops@example.com"],
+        "after_attempts": 3
+      },
+      "on_dlq": {
+        "webhook": "https://app.example.com/hooks/alerts",
+        "email": ["ops@example.com", "oncall@example.com"]
+      }
+    }
+  }' \
+  https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7/notifications
+```
+
+The `after_attempts` field controls when failure notifications fire. Setting it to 3 means you only get notified after the third consecutive failure, reducing noise from transient errors.
+
+## Circuit Breaker
+
+Meridian implements a circuit breaker pattern. If a job fails 10 consecutive times, the job is automatically paused and a `circuit_open` notification is sent. This prevents wasted resources on a persistently failing endpoint.
+
+To resume the job after fixing the underlying issue:
+
+```bash
+curl -X PATCH -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "active"}' \
+  https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7
+```
+
+## Monitoring Best Practices
+
+- Set `after_attempts` to at least 2 to avoid alerts on transient failures
+- Use exponential backoff for external API callbacks
+- Monitor the DLQ size as a key operational metric
+- Configure email notifications as a fallback for webhook-based alerting
+- Review execution history weekly to identify patterns in failures

--- a/meridian-docs/content/docs/scheduling/recurring-jobs.md
+++ b/meridian-docs/content/docs/scheduling/recurring-jobs.md
@@ -1,0 +1,186 @@
++++
+title = "Recurring Jobs"
+weight = 2
+description = "Create and manage recurring scheduled jobs"
+[taxonomies]
+tags = ["scheduling", "jobs"]
++++
+
+## Overview
+
+Recurring jobs are long-lived scheduled tasks that execute repeatedly based on a cron expression or a fixed interval. Meridian manages the lifecycle, execution, and monitoring of these jobs across your infrastructure.
+
+## Creating a Recurring Job
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "nightly-data-sync",
+    "description": "Synchronize user data with the analytics warehouse",
+    "schedule": {
+      "expression": "0 2 * * *",
+      "timezone": "America/Chicago"
+    },
+    "callback": {
+      "url": "https://app.example.com/hooks/data-sync",
+      "method": "POST",
+      "headers": {
+        "X-Webhook-Secret": "whsec_abc123"
+      },
+      "body": {
+        "action": "full_sync",
+        "source": "meridian"
+      }
+    },
+    "retry": {
+      "max_attempts": 3,
+      "backoff": "exponential"
+    }
+  }' \
+  https://api.meridian.dev/v3/jobs
+```
+
+```json
+{
+  "id": "job_8xK2mP4nL7",
+  "name": "nightly-data-sync",
+  "status": "active",
+  "schedule": {
+    "expression": "0 2 * * *",
+    "timezone": "America/Chicago",
+    "description": "Every day at 02:00"
+  },
+  "next_run": "2026-04-03T02:00:00-05:00",
+  "created_at": "2026-04-02T12:00:00Z"
+}
+```
+
+## Job Lifecycle
+
+Every recurring job moves through a defined set of states:
+
+| Status       | Description                                              |
+|-------------|----------------------------------------------------------|
+| `active`    | Job is scheduled and will execute at the next run time    |
+| `paused`    | Job exists but will not execute until resumed             |
+| `executing` | Job callback is currently being delivered                 |
+| `completed` | Job has been permanently stopped (terminal state)         |
+| `failed`    | Last execution failed and all retries exhausted           |
+
+## Listing Jobs
+
+Retrieve all jobs for your account, optionally filtered by status:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/jobs?status=active&limit=20"
+```
+
+```json
+{
+  "jobs": [
+    {
+      "id": "job_8xK2mP4nL7",
+      "name": "nightly-data-sync",
+      "status": "active",
+      "next_run": "2026-04-03T02:00:00-05:00",
+      "last_run": "2026-04-02T02:00:00-05:00",
+      "last_run_status": "success",
+      "total_runs": 47,
+      "total_failures": 1
+    }
+  ],
+  "total": 1,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+## Pausing and Resuming
+
+Pause a job to temporarily stop execution without deleting it:
+
+```bash
+# Pause
+curl -X PATCH -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "paused"}' \
+  https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7
+
+# Resume
+curl -X PATCH -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "active"}' \
+  https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7
+```
+
+When resuming a paused job, the next run time is recalculated based on the current time and the cron expression. Missed runs during the pause window are not retroactively executed.
+
+## Execution History
+
+View the execution history for a specific job:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7/runs?limit=5"
+```
+
+```json
+{
+  "runs": [
+    {
+      "id": "run_q9W3kR7mN2",
+      "job_id": "job_8xK2mP4nL7",
+      "scheduled_at": "2026-04-02T02:00:00-05:00",
+      "started_at": "2026-04-02T07:00:00.142Z",
+      "completed_at": "2026-04-02T07:00:01.387Z",
+      "duration_ms": 1245,
+      "status": "success",
+      "http_status": 200,
+      "attempt": 1
+    }
+  ]
+}
+```
+
+## Interval-Based Scheduling
+
+For jobs that need to run at a fixed interval rather than a cron schedule, use the `interval` field:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "health-check",
+    "schedule": {
+      "interval": "PT5M"
+    },
+    "callback": {
+      "url": "https://app.example.com/hooks/health",
+      "method": "GET"
+    }
+  }' \
+  https://api.meridian.dev/v3/jobs
+```
+
+Intervals are specified using ISO 8601 duration format:
+
+| Duration | Meaning         |
+|----------|-----------------|
+| `PT30S`  | Every 30 seconds|
+| `PT5M`   | Every 5 minutes |
+| `PT1H`   | Every hour      |
+| `P1D`    | Every day       |
+| `P1W`    | Every week      |
+
+## Deleting a Job
+
+Permanently remove a job and all its execution history:
+
+```bash
+curl -X DELETE -H "Authorization: Bearer $API_KEY" \
+  https://api.meridian.dev/v3/jobs/job_8xK2mP4nL7
+```
+
+This action is irreversible. Consider pausing instead if you may need the job again.

--- a/meridian-docs/content/docs/timezones/_index.md
+++ b/meridian-docs/content/docs/timezones/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Timezones"
+sort_by = "weight"
+page_template = "doc"
++++
+
+Reference documentation for the Meridian Timezone API, covering the world timezone database, daylight saving time handling, and UTC conversion endpoints.

--- a/meridian-docs/content/docs/timezones/dst-handling.md
+++ b/meridian-docs/content/docs/timezones/dst-handling.md
@@ -1,0 +1,149 @@
++++
+title = "DST Handling"
+weight = 2
+description = "Daylight saving time processing, edge cases, and transition rules"
+[taxonomies]
+tags = ["timezones", "dst"]
++++
+
+## Overview
+
+Daylight saving time (DST) introduces two critical edge cases: the "spring forward" gap (where local times are skipped) and the "fall back" overlap (where local times are repeated). Meridian provides explicit APIs and configuration options to handle both scenarios correctly.
+
+## DST Transition Detection
+
+Use the transitions endpoint to find upcoming DST changes for a timezone:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/timezones/America/New_York/transitions?year=2026"
+```
+
+```json
+{
+  "timezone": "America/New_York",
+  "transitions": [
+    {
+      "type": "spring_forward",
+      "at": "2026-03-08T02:00:00-05:00",
+      "offset_before": "-05:00",
+      "offset_after": "-04:00",
+      "gap_minutes": 60
+    },
+    {
+      "type": "fall_back",
+      "at": "2026-11-01T02:00:00-04:00",
+      "offset_before": "-04:00",
+      "offset_after": "-05:00",
+      "overlap_minutes": 60
+    }
+  ]
+}
+```
+
+## Spring Forward (Gap Times)
+
+During a spring-forward transition, an hour of local time does not exist. For example, in `America/New_York` on March 8, 2026, the time jumps from 01:59:59 EST directly to 03:00:00 EDT. Any timestamp between 02:00:00 and 02:59:59 is invalid.
+
+### Handling Gap Times
+
+When you submit a timestamp that falls within a gap, Meridian's behavior depends on the `gap_strategy` parameter:
+
+| Strategy   | Behavior                                                    |
+|------------|-------------------------------------------------------------|
+| `reject`   | Returns a 422 error with details about the gap              |
+| `forward`  | Moves the time forward to the end of the gap (default)      |
+| `backward` | Moves the time backward to the start of the gap             |
+
+Example using the `reject` strategy:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "timestamp": "2026-03-08T02:30:00",
+    "timezone": "America/New_York",
+    "gap_strategy": "reject"
+  }' \
+  https://api.meridian.dev/v3/timezones/validate
+```
+
+```json
+{
+  "valid": false,
+  "error": "gap_time",
+  "message": "The time 02:30:00 does not exist in America/New_York on 2026-03-08",
+  "gap_start": "2026-03-08T02:00:00",
+  "gap_end": "2026-03-08T03:00:00"
+}
+```
+
+## Fall Back (Ambiguous Times)
+
+During a fall-back transition, an hour of local time occurs twice. For example, in `America/New_York` on November 1, 2026, the time 01:30:00 happens once at EDT (UTC-04:00) and again at EST (UTC-05:00).
+
+### Resolving Ambiguous Times
+
+When you submit an ambiguous timestamp, Meridian resolves it based on the `ambiguity_strategy` parameter:
+
+| Strategy     | Behavior                                                          |
+|-------------|-------------------------------------------------------------------|
+| `earlier`   | Selects the first occurrence (before the transition)               |
+| `later`     | Selects the second occurrence (after the transition, default)      |
+| `reject`    | Returns a 422 error indicating ambiguity                           |
+
+```javascript
+import { Meridian } from '@meridian/sdk';
+
+const client = new Meridian({ apiKey: 'your-api-key' });
+
+// Resolve an ambiguous time to the earlier occurrence
+const result = await client.timezones.resolve({
+  timestamp: '2026-11-01T01:30:00',
+  timezone: 'America/New_York',
+  ambiguity_strategy: 'earlier',
+});
+
+console.log(result.resolved);
+// "2026-11-01T01:30:00-04:00" (EDT, first occurrence)
+```
+
+## DST-Aware Date Arithmetic
+
+When adding or subtracting time across DST boundaries, use the `duration` endpoint with DST awareness enabled:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start": "2026-03-08T01:00:00-05:00",
+    "add": "PT2H",
+    "timezone": "America/New_York",
+    "dst_aware": true
+  }' \
+  https://api.meridian.dev/v3/timezones/duration
+```
+
+```json
+{
+  "start": "2026-03-08T01:00:00-05:00",
+  "end": "2026-03-08T04:00:00-04:00",
+  "wall_clock_hours": 2,
+  "elapsed_seconds": 7200,
+  "dst_transition_crossed": true
+}
+```
+
+Note that the wall clock shows a 3-hour jump (01:00 to 04:00), but only 2 hours of real time elapsed. The `elapsed_seconds` field always reflects actual elapsed time.
+
+## Regions Without DST
+
+Several major regions do not observe DST. When querying transitions for these zones, an empty array is returned:
+
+- `Asia/Tokyo` (Japan)
+- `Asia/Shanghai` (China)
+- `Asia/Kolkata` (India)
+- `Asia/Dubai` (UAE)
+- `Africa/Johannesburg` (South Africa)
+- `Pacific/Honolulu` (US Hawaii)
+- `America/Phoenix` (US Arizona, except Navajo Nation)

--- a/meridian-docs/content/docs/timezones/timezone-database.md
+++ b/meridian-docs/content/docs/timezones/timezone-database.md
@@ -1,0 +1,117 @@
++++
+title = "Timezone Database"
+weight = 1
+description = "World timezone mapping table and IANA database reference"
+[taxonomies]
+tags = ["timezones", "reference"]
++++
+
+## Overview
+
+Meridian maintains a complete mirror of the IANA Time Zone Database, providing access to over 400 timezone identifiers. The database is updated automatically within 24 hours of each upstream release.
+
+## Listing Timezones
+
+Retrieve all available timezones with the list endpoint:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  https://api.meridian.dev/v3/timezones
+```
+
+Response:
+
+```json
+{
+  "count": 419,
+  "timezones": [
+    {
+      "id": "America/New_York",
+      "abbreviation": "EDT",
+      "utc_offset": "-04:00",
+      "dst_active": true
+    },
+    ...
+  ]
+}
+```
+
+## Common Timezone Reference
+
+The table below lists frequently used timezones with their standard abbreviations and UTC offsets.
+
+| IANA Identifier        | Abbreviation | UTC Offset | Region              |
+|------------------------|-------------|------------|---------------------|
+| America/New_York       | EST / EDT   | -05:00     | US Eastern          |
+| America/Chicago        | CST / CDT   | -06:00     | US Central          |
+| America/Denver         | MST / MDT   | -07:00     | US Mountain         |
+| America/Los_Angeles    | PST / PDT   | -08:00     | US Pacific          |
+| America/Anchorage      | AKST / AKDT | -09:00     | US Alaska           |
+| Pacific/Honolulu       | HST         | -10:00     | US Hawaii           |
+| America/Toronto        | EST / EDT   | -05:00     | Canada Eastern      |
+| America/Vancouver      | PST / PDT   | -08:00     | Canada Pacific      |
+| America/Sao_Paulo      | BRT / BRST  | -03:00     | Brazil              |
+| America/Argentina/Buenos_Aires | ART | -03:00     | Argentina           |
+| Europe/London          | GMT / BST   | +00:00     | United Kingdom      |
+| Europe/Paris           | CET / CEST  | +01:00     | France              |
+| Europe/Berlin          | CET / CEST  | +01:00     | Germany             |
+| Europe/Moscow          | MSK         | +03:00     | Russia (Western)    |
+| Europe/Istanbul        | TRT         | +03:00     | Turkey              |
+| Asia/Dubai             | GST         | +04:00     | UAE                 |
+| Asia/Kolkata           | IST         | +05:30     | India               |
+| Asia/Bangkok           | ICT         | +07:00     | Thailand            |
+| Asia/Shanghai          | CST         | +08:00     | China               |
+| Asia/Tokyo             | JST         | +09:00     | Japan               |
+| Asia/Seoul             | KST         | +09:00     | South Korea         |
+| Australia/Sydney       | AEST / AEDT | +10:00     | Australia Eastern   |
+| Australia/Perth        | AWST        | +08:00     | Australia Western   |
+| Pacific/Auckland       | NZST / NZDT | +12:00     | New Zealand         |
+| Africa/Cairo           | EET / EEST  | +02:00     | Egypt               |
+| Africa/Johannesburg    | SAST        | +02:00     | South Africa        |
+| Africa/Lagos           | WAT         | +01:00     | Nigeria             |
+
+## Querying a Single Timezone
+
+Fetch details for a specific timezone by its IANA identifier:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  https://api.meridian.dev/v3/timezones/America/New_York
+```
+
+```json
+{
+  "id": "America/New_York",
+  "abbreviation": "EDT",
+  "utc_offset": "-04:00",
+  "dst_active": true,
+  "dst_start": "2026-03-08T02:00:00-05:00",
+  "dst_end": "2026-11-01T02:00:00-04:00",
+  "current_time": "2026-04-02T08:30:15-04:00",
+  "iana_version": "2026a"
+}
+```
+
+## Timezone Metadata Fields
+
+| Field          | Type    | Description                                          |
+|----------------|---------|------------------------------------------------------|
+| `id`           | string  | IANA timezone identifier                             |
+| `abbreviation` | string  | Current timezone abbreviation (changes with DST)     |
+| `utc_offset`   | string  | Current offset from UTC in +HH:MM format             |
+| `dst_active`   | boolean | Whether daylight saving time is currently in effect   |
+| `dst_start`    | string  | ISO 8601 timestamp of the next or current DST start  |
+| `dst_end`      | string  | ISO 8601 timestamp of the next or current DST end    |
+| `current_time` | string  | Current local time in the timezone                   |
+| `iana_version` | string  | Version of the IANA database in use                  |
+
+## Filtering by Region
+
+You can filter timezones by region using the `region` query parameter:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://api.meridian.dev/v3/timezones?region=Europe"
+```
+
+Valid region values: `Africa`, `America`, `Antarctica`, `Arctic`, `Asia`, `Atlantic`, `Australia`, `Europe`, `Indian`, `Pacific`.

--- a/meridian-docs/content/docs/timezones/utc-conversion.md
+++ b/meridian-docs/content/docs/timezones/utc-conversion.md
@@ -1,0 +1,187 @@
++++
+title = "UTC Conversion"
+weight = 3
+description = "API reference for converting timestamps between UTC and local timezones"
+[taxonomies]
+tags = ["timezones", "api"]
++++
+
+## Overview
+
+The UTC Conversion API allows you to convert timestamps between any pair of timezones, or between UTC and a local timezone. All conversions account for daylight saving time rules automatically.
+
+## Convert Between Timezones
+
+The primary conversion endpoint accepts a source timestamp with its timezone and a target timezone:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "timestamp": "2026-04-02T14:30:00",
+    "from": "America/New_York",
+    "to": "Asia/Tokyo"
+  }' \
+  https://api.meridian.dev/v3/convert
+```
+
+```json
+{
+  "input": "2026-04-02T14:30:00-04:00",
+  "output": "2026-04-03T03:30:00+09:00",
+  "utc": "2026-04-02T18:30:00Z",
+  "offset_diff": "+13:00"
+}
+```
+
+## Request Parameters
+
+| Parameter    | Type   | Required | Description                                        |
+|-------------|--------|----------|----------------------------------------------------|
+| `timestamp` | string | Yes      | ISO 8601 timestamp to convert                      |
+| `from`      | string | Yes      | Source IANA timezone identifier                     |
+| `to`        | string | Yes      | Target IANA timezone identifier                     |
+| `format`    | string | No       | Output format: `iso8601` (default), `unix`, `rfc2822` |
+
+## Batch Conversion
+
+Convert a single timestamp to multiple timezones in one request:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "timestamp": "2026-04-02T09:00:00Z",
+    "targets": [
+      "America/New_York",
+      "Europe/London",
+      "Asia/Tokyo",
+      "Australia/Sydney"
+    ]
+  }' \
+  https://api.meridian.dev/v3/convert/batch
+```
+
+```json
+{
+  "source_utc": "2026-04-02T09:00:00Z",
+  "results": [
+    {
+      "timezone": "America/New_York",
+      "local": "2026-04-02T05:00:00-04:00",
+      "abbreviation": "EDT"
+    },
+    {
+      "timezone": "Europe/London",
+      "local": "2026-04-02T10:00:00+01:00",
+      "abbreviation": "BST"
+    },
+    {
+      "timezone": "Asia/Tokyo",
+      "local": "2026-04-02T18:00:00+09:00",
+      "abbreviation": "JST"
+    },
+    {
+      "timezone": "Australia/Sydney",
+      "local": "2026-04-02T20:00:00+11:00",
+      "abbreviation": "AEDT"
+    }
+  ]
+}
+```
+
+## SDK Usage
+
+### JavaScript / TypeScript
+
+```javascript
+import { Meridian } from '@meridian/sdk';
+
+const client = new Meridian({ apiKey: process.env.MERIDIAN_API_KEY });
+
+// Single conversion
+const result = await client.convert({
+  timestamp: '2026-04-02T14:30:00',
+  from: 'America/New_York',
+  to: 'Europe/Berlin',
+});
+
+console.log(result.output); // "2026-04-02T20:30:00+02:00"
+```
+
+### Python
+
+```python
+from meridian import Client
+
+client = Client(api_key="your-api-key")
+
+result = client.convert(
+    timestamp="2026-04-02T14:30:00",
+    from_tz="America/New_York",
+    to_tz="Europe/Berlin",
+)
+
+print(result.output)  # "2026-04-02T20:30:00+02:00"
+```
+
+### Go
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/meridian/meridian-go"
+)
+
+func main() {
+    client := meridian.NewClient("your-api-key")
+
+    result, err := client.Convert(meridian.ConvertRequest{
+        Timestamp: "2026-04-02T14:30:00",
+        From:      "America/New_York",
+        To:        "Europe/Berlin",
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(result.Output) // "2026-04-02T20:30:00+02:00"
+}
+```
+
+## Unix Timestamp Conversion
+
+When working with Unix timestamps, set the `format` parameter to `unix`:
+
+```bash
+curl -X POST -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "timestamp": "1775312400",
+    "from": "UTC",
+    "to": "America/Los_Angeles",
+    "format": "unix"
+  }' \
+  https://api.meridian.dev/v3/convert
+```
+
+```json
+{
+  "input_unix": 1775312400,
+  "output": "2026-04-02T02:00:00-07:00",
+  "output_unix": 1775312400,
+  "note": "Unix timestamps are timezone-independent; the output_unix matches input"
+}
+```
+
+## Error Codes
+
+| Code | Status | Description                                  |
+|------|--------|----------------------------------------------|
+| `INVALID_TIMEZONE`   | 400 | The provided timezone identifier is not valid |
+| `INVALID_TIMESTAMP`  | 400 | The timestamp could not be parsed             |
+| `GAP_TIME`           | 422 | Timestamp falls in a DST gap                  |
+| `AMBIGUOUS_TIME`     | 422 | Timestamp is ambiguous due to DST overlap     |
+| `RATE_LIMIT`         | 429 | Request rate limit exceeded                   |

--- a/meridian-docs/content/index.md
+++ b/meridian-docs/content/index.md
@@ -1,0 +1,43 @@
++++
+title = "Home"
++++
+
+# Meridian Docs
+
+Welcome to the Meridian platform documentation. Meridian provides a comprehensive suite of APIs for working with timezones, scheduling recurring jobs, and managing time-sensitive operations across distributed systems.
+
+## Documentation Sections
+
+- [Timezone Reference](docs/timezones/) -- World timezone database, DST handling, and UTC conversion APIs
+- [Scheduling](docs/scheduling/) -- Cron expressions, recurring jobs, and error handling strategies
+
+## Quick Start
+
+Get started with the Meridian API in minutes. Install the client library and make your first request:
+
+```bash
+npm install @meridian/sdk
+```
+
+```javascript
+import { Meridian } from '@meridian/sdk';
+
+const client = new Meridian({ apiKey: 'your-api-key' });
+
+// Convert a timestamp between timezones
+const result = await client.timezones.convert({
+  timestamp: '2026-04-02T10:00:00Z',
+  from: 'UTC',
+  to: 'America/New_York',
+});
+
+console.log(result.converted); // "2026-04-02T06:00:00-04:00"
+```
+
+## Key Features
+
+- **400+ Timezone Support** -- Full IANA timezone database with automatic updates
+- **DST-Aware Scheduling** -- Jobs that respect daylight saving transitions
+- **Cron Expression Builder** -- Human-readable cron syntax with validation
+- **Retry Strategies** -- Configurable retry policies for failed scheduled tasks
+- **Sub-second Precision** -- Nanosecond-level timestamp handling

--- a/meridian-docs/static/js/mobile-menu.js
+++ b/meridian-docs/static/js/mobile-menu.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('mobile-menu-btn');
+  const menu = document.getElementById('mobile-menu');
+  let isMenuOpen = false;
+
+  if (btn && menu) {
+    btn.addEventListener('click', () => {
+      isMenuOpen = !isMenuOpen;
+      if (isMenuOpen) {
+        menu.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          menu.classList.remove('opacity-0');
+          menu.classList.remove('pointer-events-none');
+        });
+        document.body.style.overflow = 'hidden';
+      } else {
+        menu.classList.add('opacity-0');
+        menu.classList.add('pointer-events-none');
+        setTimeout(() => {
+          menu.classList.add('hidden');
+        }, 300);
+        document.body.style.overflow = '';
+      }
+    });
+  }
+});

--- a/meridian-docs/templates/404.html
+++ b/meridian-docs/templates/404.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 flex flex-col items-center justify-center text-center">
+    <div class="relative z-10">
+      <h1 class="text-[10rem] font-black text-slate-100 leading-none select-none">404</h1>
+      <div class="absolute inset-0 flex items-center justify-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-text">Page Not Found</h2>
+      </div>
+    </div>
+
+    <p class="text-muted text-lg mb-8 max-w-md mx-auto mt-4">The page you are looking for does not exist, has been removed, or is temporarily unavailable.</p>
+
+    <a href="{{ base_url }}/" class="inline-flex items-center gap-2 px-8 py-3 bg-primary text-white rounded-full font-bold text-sm hover:bg-primary-dark transition-all duration-300 transform hover:-translate-y-1">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
+      Back to Home
+    </a>
+  </main>
+{% include "footer.html" %}

--- a/meridian-docs/templates/doc.html
+++ b/meridian-docs/templates/doc.html
@@ -1,0 +1,106 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-12 grid grid-cols-1 md:grid-cols-[250px_1fr] gap-12">
+    <!-- Mobile Sidebar Toggle -->
+    <div class="md:hidden">
+      <details class="group border border-slate-200 rounded-lg bg-surface">
+        <summary class="flex items-center justify-between p-4 cursor-pointer list-none text-text font-medium focus:outline-none select-none">
+          <span>{{ section.title }} Navigation</span>
+          <svg class="w-5 h-5 text-muted transition-transform duration-300 group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="p-4 border-t border-slate-200 bg-white">
+           {% if section.pages %}
+           <ul class="space-y-1">
+             {% for doc in section.pages %}
+             <li>
+               <a href="{{ base_url }}{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-primary bg-blue-50 border-l-primary font-medium{% else %}text-muted border-l-transparent hover:text-primary hover:bg-blue-50/50 hover:border-l-slate-300{% endif %}">
+                 {{ doc.title }}
+               </a>
+             </li>
+             {% endfor %}
+           </ul>
+           {% endif %}
+        </div>
+      </details>
+    </div>
+
+    <!-- Sidebar -->
+    <aside class="hidden md:block sticky top-24 h-[calc(100vh-120px)] overflow-y-auto pr-6 border-r border-slate-200 scrollbar-thin">
+      {% if section.pages %}
+      <nav class="space-y-8">
+        <div>
+          <h3 class="text-xs uppercase tracking-widest text-slate-400 font-bold mb-4 px-3">{{ section.title }}</h3>
+          <ul class="space-y-1">
+            {% for doc in section.pages %}
+            <li>
+              <a href="{{ base_url }}{{ doc.url }}" class="block py-2 px-3 rounded-lg text-sm transition-all duration-200 border-l-2 {% if doc.url == page.url %}text-primary bg-blue-50 border-l-primary font-medium{% else %}text-muted border-l-transparent hover:text-primary hover:bg-blue-50/50 hover:border-l-slate-300{% endif %}">
+                {{ doc.title }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </nav>
+      {% endif %}
+    </aside>
+
+    <article class="min-w-0 pb-16">
+      <!-- Breadcrumbs -->
+      <div class="flex items-center text-sm text-muted mb-6 overflow-x-auto whitespace-nowrap">
+        <a href="{{ base_url }}/" class="hover:text-primary transition-colors">Home</a>
+        <svg class="w-4 h-4 mx-2 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <a href="{{ base_url }}{{ section.url }}" class="hover:text-primary transition-colors">{{ section.title }}</a>
+        <svg class="w-4 h-4 mx-2 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <span class="text-primary font-medium">{{ page.title }}</span>
+      </div>
+
+      <header class="mb-10 border-b border-slate-200 pb-10">
+        <h1 class="text-4xl font-bold text-text tracking-tight mb-4">{{ page.title }}</h1>
+        {% if page.description %}
+          <p class="text-xl text-muted leading-relaxed max-w-3xl">{{ page.description }}</p>
+        {% endif %}
+      </header>
+
+      <div class="grid grid-cols-1 {% if page.toc %}lg:grid-cols-[1fr_200px]{% endif %} gap-10 items-start">
+        <!-- Content -->
+        <div class="prose prose-lg max-w-none">
+          {{ content }}
+        </div>
+
+        <!-- TOC (Desktop) -->
+        {% if page.toc %}
+        <aside class="hidden lg:block sticky top-24">
+          <div class="border-l border-slate-200 pl-4 py-1">
+            <h4 class="text-xs uppercase tracking-widest text-slate-400 font-bold mb-3">On this page</h4>
+            <div class="toc text-sm text-muted">
+              {{ page.toc }}
+            </div>
+          </div>
+        </aside>
+        {% endif %}
+      </div>
+
+      <!-- Navigation -->
+      <nav class="grid grid-cols-2 gap-6 mt-16 pt-8 border-t border-slate-200">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="group flex flex-col p-4 rounded-xl border border-slate-200 hover:border-primary/50 hover:bg-blue-50/50 transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-primary transition-colors">Previous</span>
+          <span class="text-lg font-semibold text-text group-hover:text-primary transition-colors">
+            &larr; {{ page.lower.title }}
+          </span>
+        </a>
+        {% else %}<div></div>{% endif %}
+
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="group flex flex-col items-end text-right p-4 rounded-xl border border-slate-200 hover:border-primary/50 hover:bg-blue-50/50 transition-all">
+          <span class="text-xs text-muted mb-1 group-hover:text-primary transition-colors">Next</span>
+          <span class="text-lg font-semibold text-text group-hover:text-primary transition-colors">
+            {{ page.higher.title }} &rarr;
+          </span>
+        </a>
+        {% endif %}
+      </nav>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meridian-docs/templates/footer.html
+++ b/meridian-docs/templates/footer.html
@@ -1,0 +1,14 @@
+  </div>
+  <footer class="mt-20 py-12 border-t border-slate-200 text-center">
+    <div class="max-w-6xl mx-auto px-6 flex flex-col items-center justify-center gap-4">
+      <div class="flex items-center gap-2 text-slate-400">
+        <span class="text-sm">Powered by</span>
+        <a href="https://github.com/hahwul/hwaro" class="text-slate-500 hover:text-primary transition-colors font-medium">Hwaro</a>
+      </div>
+      <p class="text-xs text-slate-300">Meridian Docs. All rights reserved.</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/meridian-docs/templates/header.html
+++ b/meridian-docs/templates/header.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+
+  <!-- Google Fonts: IBM Plex Sans + IBM Plex Mono -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#2563eb',
+            'primary-light': '#3b82f6',
+            'primary-dark': '#1d4ed8',
+            gold: '#b8860b',
+            'gold-light': '#d4a017',
+            'gold-dark': '#996515',
+            surface: '#f8fafc',
+            'surface-alt': '#f1f5f9',
+            border: '#e2e8f0',
+            muted: '#64748b',
+            text: '#1e293b',
+          },
+          fontFamily: {
+            sans: ['IBM Plex Sans', 'system-ui', 'sans-serif'],
+            mono: ['IBM Plex Mono', 'monospace'],
+          },
+        },
+      },
+    }
+  </script>
+
+  <style type="text/tailwindcss">
+    /* Prose: markdown rendered content */
+    .prose { @apply text-text/90; }
+    .prose h1, .prose h2, .prose h3 { @apply font-semibold leading-tight text-text; }
+    .prose h1 { @apply text-3xl mt-0 mb-6; }
+    .prose h2 { @apply text-2xl mt-10 mb-4 border-b border-border pb-2; }
+    .prose h3 { @apply text-xl mt-8 mb-3 text-text/90; }
+    .prose p { @apply my-5 leading-relaxed text-muted; }
+    .prose a { @apply text-primary hover:text-primary-dark hover:underline underline-offset-4 decoration-2 decoration-primary/30 transition-all; }
+    .prose strong { @apply text-text font-semibold; }
+    .prose code {
+      @apply bg-surface-alt px-1.5 py-0.5 rounded text-sm font-mono text-primary-dark border border-slate-200;
+    }
+    .prose pre {
+      @apply bg-slate-50 p-5 rounded-xl overflow-x-auto border border-slate-200 my-6;
+    }
+    .prose pre code { @apply bg-transparent p-0 border-0 text-slate-700; }
+    .prose blockquote {
+      @apply my-6 py-3 px-5 border-l-4 border-gold bg-amber-50/50 text-muted italic rounded-r-lg;
+    }
+    .prose blockquote p { @apply my-2; }
+    .prose ul, .prose ol { @apply my-4 ml-6 text-muted; }
+    .prose li { @apply my-1.5 pl-1; }
+    .prose ul li { @apply list-disc marker:text-primary; }
+    .prose ol li { @apply list-decimal marker:text-primary; }
+    .prose img { @apply max-w-full rounded-xl border border-slate-200 shadow-sm; }
+    .prose table { @apply w-full border-collapse my-8 rounded-lg overflow-hidden; }
+    .prose thead { @apply bg-slate-100 text-text; }
+    .prose th, .prose td { @apply px-4 py-3 border-b border-slate-200 text-left text-sm text-muted; }
+    .prose th { @apply font-semibold text-text; }
+    .prose tbody tr:last-child td { @apply border-b-0; }
+    .prose tbody tr:hover { @apply bg-blue-50/30; }
+
+    /* Pagination */
+    nav.pagination { @apply my-8; }
+    nav.pagination .pagination-list {
+      @apply list-none p-0 m-0 flex gap-2 flex-wrap items-center;
+    }
+    nav.pagination a {
+      @apply inline-block px-3 py-1.5 rounded-md border border-border text-muted no-underline text-sm
+             hover:text-primary hover:border-primary/50 hover:bg-blue-50 transition-all;
+    }
+    .pagination-current span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-primary bg-primary text-white text-sm font-medium;
+    }
+    .pagination-disabled span {
+      @apply inline-block px-3 py-1.5 rounded-md border border-slate-100 text-muted opacity-30 text-sm;
+    }
+
+    /* Section list (taxonomy content) */
+    ul.section-list { @apply list-none p-0 my-6 space-y-3; }
+    ul.section-list li {
+      @apply p-4 bg-white rounded-xl border border-slate-200 hover:border-primary/50 transition-colors;
+    }
+    ul.section-list li a { @apply font-medium text-primary hover:text-primary-dark; }
+
+    /* TOC */
+    .toc ul { @apply ml-4 my-0 space-y-1; }
+    .toc li { @apply relative; }
+    .toc a { @apply text-muted no-underline text-sm hover:text-primary transition-colors block py-0.5; }
+    .toc .active > a { @apply text-primary font-medium; }
+
+    /* Alert shortcode */
+    .alert {
+      @apply p-4 rounded-lg border-l-4 my-6 text-sm;
+    }
+    .alert-info {
+      @apply border-l-primary bg-blue-50 text-blue-900;
+    }
+    .alert-warning {
+      @apply border-l-gold bg-amber-50 text-amber-900;
+    }
+    .alert-error {
+      @apply border-l-red-500 bg-red-50 text-red-900;
+    }
+    .alert-tip {
+      @apply border-l-emerald-500 bg-emerald-50 text-emerald-900;
+    }
+  </style>
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body class="font-sans text-text bg-white leading-relaxed selection:bg-primary/20 selection:text-primary-dark" data-section="{{ page.section }}">
+  <div class="sticky top-0 z-50 bg-white border-b border-slate-200">
+    <header class="flex items-center justify-between px-6 py-4 max-w-7xl mx-auto">
+      <div class="flex items-center gap-8">
+        <a href="{{ base_url }}/" class="group flex items-center gap-2 font-bold text-xl text-text no-underline transition-colors z-50 relative">
+          <div class="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+            <span class="text-white text-lg font-bold">M</span>
+          </div>
+          <span>{{ site.title }}</span>
+        </a>
+        <nav class="hidden md:flex gap-1 items-center">
+          <a href="{{ base_url }}/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-primary hover:bg-blue-50 transition-all">Home</a>
+          <a href="{{ base_url }}/docs/timezones/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-primary hover:bg-blue-50 transition-all">Timezones</a>
+          <a href="{{ base_url }}/docs/scheduling/" class="px-3 py-2 rounded-lg text-sm font-medium text-muted hover:text-primary hover:bg-blue-50 transition-all">Scheduling</a>
+        </nav>
+      </div>
+
+      <div class="flex items-center gap-4 z-50 relative">
+        <div class="relative group hidden sm:block">
+          <span class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-muted group-hover:text-primary transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input type="text" placeholder="Search docs..." class="bg-surface border border-slate-200 text-sm rounded-full py-1.5 pl-9 pr-4 w-48 md:w-64 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-all text-text placeholder-muted hover:border-slate-300">
+        </div>
+        <!-- Mobile Menu Button -->
+        <button id="mobile-menu-btn" class="md:hidden p-2 text-muted hover:text-primary transition-colors focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <!-- Mobile Menu Overlay -->
+    <div id="mobile-menu" class="hidden fixed inset-0 z-40 bg-white pt-24 px-6 md:hidden transition-opacity duration-300 opacity-0 pointer-events-none">
+      <nav class="flex flex-col gap-4 text-lg font-medium">
+        <a href="{{ base_url }}/" class="text-muted hover:text-primary py-2 border-b border-slate-100">Home</a>
+        <a href="{{ base_url }}/docs/timezones/" class="text-muted hover:text-primary py-2 border-b border-slate-100">Timezones</a>
+        <a href="{{ base_url }}/docs/scheduling/" class="text-muted hover:text-primary py-2 border-b border-slate-100">Scheduling</a>
+        <!-- Mobile Search -->
+        <div class="relative mt-4">
+           <input type="text" placeholder="Search docs..." class="w-full bg-surface border border-slate-200 text-sm rounded-lg py-3 pl-4 pr-4 focus:outline-none focus:ring-2 focus:ring-primary/30 text-text placeholder-muted">
+        </div>
+      </nav>
+    </div>
+  </div>
+  <div class="max-w-7xl mx-auto px-6">
+
+  <script src="{{ base_url }}/js/mobile-menu.js"></script>

--- a/meridian-docs/templates/page.html
+++ b/meridian-docs/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <article class="prose prose-lg max-w-none">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meridian-docs/templates/section.html
+++ b/meridian-docs/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 max-w-6xl mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-16">
+      <h1 class="text-5xl font-bold text-text tracking-tight mb-6">{{ page.title }}</h1>
+      <div class="prose prose-lg mx-auto text-muted">{{ content }}</div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {% for doc in section.pages %}
+      <a href="{{ base_url }}{{ doc.url }}" class="group relative block p-8 rounded-2xl bg-white border border-slate-200 overflow-hidden transition-all duration-300 hover:border-primary/50 hover:shadow-lg hover:-translate-y-1">
+        <!-- Decoration -->
+        <div class="absolute top-0 right-0 p-6 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+           <svg class="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
+        </div>
+
+        <h3 class="text-xl font-bold text-text mb-3 group-hover:text-primary transition-colors">{{ doc.title }}</h3>
+        {% if doc.description %}
+        <p class="text-muted text-sm leading-relaxed mb-0 group-hover:text-slate-600 transition-colors">{{ doc.description }}</p>
+        {% endif %}
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/meridian-docs/templates/shortcodes/alert.html
+++ b/meridian-docs/templates/shortcodes/alert.html
@@ -1,0 +1,1 @@
+<div class="alert alert-{{ type }}">{{ body }}</div>

--- a/meridian-docs/templates/taxonomy.html
+++ b/meridian-docs/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-blue-50 text-primary text-xs font-bold uppercase tracking-wider mb-4 border border-blue-200">Taxonomy</span>
+      <h1 class="text-4xl md:text-5xl font-bold text-text tracking-tight mb-4">{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Browse all terms in this taxonomy.</p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/meridian-docs/templates/taxonomy_term.html
+++ b/meridian-docs/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="min-h-[calc(100vh-200px)] pt-20 pb-20 max-w-4xl mx-auto">
+    <div class="mb-12 text-center">
+      <span class="inline-block px-3 py-1 rounded-full bg-blue-50 text-primary text-xs font-bold uppercase tracking-wider mb-4 border border-blue-200">Tag</span>
+      <h1 class="text-4xl md:text-5xl font-bold text-text tracking-tight mb-4">#{{ page.title }}</h1>
+      <p class="text-muted text-lg max-w-2xl mx-auto">Posts tagged with <span class="text-text font-medium">{{ page.title }}</span></p>
+    </div>
+
+    <div class="prose prose-lg max-w-none mx-auto">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/pantry/AGENTS.md
+++ b/pantry/AGENTS.md
@@ -1,0 +1,70 @@
+# Pantry
+
+A package manager and registry documentation site built with Hwaro.
+
+## Theme
+
+Light theme with a green/white/light green color palette. Uses solid colors only (no gradients). Designed to feel like a professional package registry portal.
+
+## Color Palette
+
+- Primary green: #16a34a / #15803d
+- Light green accents: #dcfce7 / #bbf7d0
+- Background: #ffffff
+- Surface: #f8fafc
+- Text: #1e293b
+- Muted text: #64748b
+- Border: #e2e8f0
+
+## Fonts
+
+- Body: Source Sans 3 (Google Fonts)
+- Code: Source Code Pro (Google Fonts)
+
+## Structure
+
+```
+pantry/
+  config.toml
+  AGENTS.md
+  content/
+    index.md                          Homepage
+    about.md                          About page
+    docs/
+      getting-started/
+        _index.md                     Section index
+        installation.md               CLI installation guide
+        search-and-install.md         Package search and install
+        configuration.md              pantry.toml reference
+      publishing/
+        _index.md                     Section index
+        versioning.md                 Semver and dependency resolution
+        publish-workflow.md           Publishing workflow
+        deprecation.md                Deprecation and unpublish policies
+  templates/
+    header.html                       Shared header with nav and search
+    footer.html                       Shared footer
+    doc.html                          Documentation page with sidebar and TOC
+    page.html                         Standalone page layout
+    section.html                      Section listing with card grid
+    taxonomy.html                     Taxonomy listing
+    taxonomy_term.html                Taxonomy term page
+    404.html                          Not found page
+    shortcodes/
+      alert.html                      Alert box shortcode
+  static/
+    js/
+      mobile-menu.js                  Mobile menu toggle
+```
+
+## Features
+
+- Syntax highlighting with GitHub theme (CDN)
+- Search enabled (Fuse.js JSON format)
+- Taxonomy support (tags)
+- Sitemap and robots.txt generation
+- Responsive design with mobile sidebar toggle
+- Table of contents in right sidebar on doc pages
+- Breadcrumb navigation
+- Previous/Next page navigation
+- Card grid section listings

--- a/pantry/config.toml
+++ b/pantry/config.toml
@@ -1,0 +1,38 @@
+title = "Pantry"
+description = "Package manager and registry documentation"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [{ user_agent = "*", disallow = [] }]
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[markdown]
+safe = false

--- a/pantry/content/about.md
+++ b/pantry/content/about.md
@@ -1,0 +1,34 @@
++++
+title = "About Pantry"
+template = "page"
+description = "About the Pantry package manager and registry platform."
+tags = ["about"]
++++
+
+## What is Pantry?
+
+Pantry is an open-source package manager and registry designed for modern software teams. It provides a unified workflow for discovering, installing, and publishing reusable code packages across your organization and the wider community.
+
+## Design Principles
+
+**Deterministic builds.** Every installation produces the exact same dependency tree regardless of the order packages were added. The lockfile ensures byte-for-byte reproducibility across machines and CI environments.
+
+**Security first.** All packages are signed and verified. The built-in `pantry audit` command checks your dependency tree against known vulnerability databases and reports issues before they reach production.
+
+**Performance.** Dependency resolution uses a SAT solver optimized for package graphs. Cold installs complete in seconds, and cached installs are nearly instant thanks to a content-addressable store.
+
+**Simplicity.** A single configuration file, `pantry.toml`, defines your project metadata, dependencies, scripts, and workspace layout. No hidden configuration or implicit behavior.
+
+## Architecture
+
+Pantry consists of three components:
+
+1. **CLI** -- The command-line tool installed on developer machines and CI runners. Handles dependency resolution, installation, script execution, and publishing.
+
+2. **Registry** -- The central package index that stores metadata, version information, and download URLs. The public registry is hosted at `registry.pantry.dev`. Organizations can run private registries.
+
+3. **Storage** -- Package tarballs are stored in a content-addressable blob store. The public storage layer uses distributed CDN nodes for fast downloads worldwide.
+
+## License
+
+Pantry is released under the Apache License 2.0. Contributions are welcome via the project repository.

--- a/pantry/content/docs/getting-started/_index.md
+++ b/pantry/content/docs/getting-started/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Getting Started"
+template = "section"
+sort_by = "weight"
+page_template = "doc"
+description = "Install the Pantry CLI, search for packages, and configure your project."
++++

--- a/pantry/content/docs/getting-started/configuration.md
+++ b/pantry/content/docs/getting-started/configuration.md
@@ -1,0 +1,170 @@
++++
+title = "Configuration"
+weight = 3
+template = "doc"
+description = "Reference for the pantry.toml configuration file and environment variables."
+tags = ["config", "reference"]
+[extra]
+category = "Reference"
++++
+
+## Configuration File
+
+All project configuration lives in `pantry.toml` at the root of your project. This file defines your package metadata, dependencies, scripts, and workspace layout.
+
+## Package Metadata
+
+```toml
+[package]
+name = "my-library"
+version = "1.4.0"
+description = "A useful library for data processing"
+license = "MIT"
+authors = ["Alice <alice@example.com>"]
+repository = "https://github.com/alice/my-library"
+homepage = "https://my-library.dev"
+keywords = ["data", "processing", "etl"]
+readme = "README.md"
+include = ["src/**/*", "LICENSE"]
+exclude = ["tests/**/*", "benches/**/*"]
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Package name. Must be lowercase, alphanumeric, with hyphens allowed. |
+| `version` | string | Semantic version (e.g., `1.4.0`). Must follow semver. |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | Short description displayed in search results. Max 200 characters. |
+| `license` | string | SPDX license identifier (e.g., `MIT`, `Apache-2.0`). |
+| `authors` | array | List of author names with optional email addresses. |
+| `repository` | string | URL to the source code repository. |
+| `homepage` | string | URL to the project homepage. |
+| `keywords` | array | Up to 5 keywords for search discovery. |
+| `readme` | string | Path to the README file included in the published package. |
+| `include` | array | Glob patterns for files to include when publishing. |
+| `exclude` | array | Glob patterns for files to exclude when publishing. |
+
+## Dependencies
+
+```toml
+[dependencies]
+reqwest = "0.12.4"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.38", optional = true }
+
+[dev-dependencies]
+jest-runner = "2.1"
+test-utils = { path = "../test-utils" }
+
+[build-dependencies]
+codegen = "0.5"
+```
+
+### Dependency Specification Formats
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| Simple string | `"1.4.0"` | Caret range `^1.4.0` |
+| Table with version | `{ version = "1.4" }` | Same as simple, with extra options |
+| Path dependency | `{ path = "../lib" }` | Local filesystem path |
+| Git dependency | `{ git = "https://...", branch = "main" }` | Git repository reference |
+| Features | `{ version = "1.0", features = ["derive"] }` | Enable optional features |
+| Optional | `{ version = "1.0", optional = true }` | Only installed when feature is activated |
+
+## Scripts
+
+Define reusable commands that run in the project context:
+
+```toml
+[scripts]
+build = "pantry-build --release"
+test = "pantry-test --parallel"
+lint = "pantry-lint src/"
+format = "pantry-fmt --check src/"
+dev = "pantry-serve --watch --port 8080"
+clean = "rm -rf dist/ .pantry-cache/"
+```
+
+Run a script with:
+
+```bash
+pantry run build
+pantry run test
+```
+
+### Script Hooks
+
+Pre and post hooks run automatically before and after a script:
+
+```toml
+[scripts]
+prebuild = "pantry run lint"
+build = "pantry-build --release"
+postbuild = "cp -r dist/ deploy/"
+```
+
+## Workspaces
+
+For monorepo projects, define workspace members:
+
+```toml
+[workspace]
+members = [
+  "packages/core",
+  "packages/cli",
+  "packages/web",
+]
+resolver = "2"
+```
+
+Workspace members share a single lockfile and can reference each other as path dependencies.
+
+## Registry Configuration
+
+```toml
+[registry]
+default = "https://registry.pantry.dev"
+
+[registry.private]
+url = "https://registry.internal.company.com"
+token_env = "PANTRY_PRIVATE_TOKEN"
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PANTRY_HOME` | Base directory for Pantry data | `~/.pantry` |
+| `PANTRY_CACHE_DIR` | Cache directory for downloaded packages | `$PANTRY_HOME/cache` |
+| `PANTRY_REGISTRY` | Override the default registry URL | `https://registry.pantry.dev` |
+| `PANTRY_TOKEN` | Authentication token for publishing | (none) |
+| `PANTRY_LOG` | Log level: `error`, `warn`, `info`, `debug`, `trace` | `warn` |
+| `PANTRY_OFFLINE` | Set to `1` to force offline mode | `0` |
+| `PANTRY_JOBS` | Number of parallel download jobs | Number of CPU cores |
+| `PANTRY_NO_COLOR` | Disable colored output when set to `1` | `0` |
+
+## Global Configuration
+
+User-level configuration is stored at `~/.pantry/config.toml`:
+
+```toml
+[defaults]
+registry = "https://registry.pantry.dev"
+jobs = 8
+color = true
+
+[auth]
+token = "ptry_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+[cache]
+max_size = "10GB"
+ttl_days = 30
+```
+
+Override global settings per-project by adding the same keys to your project `pantry.toml`.

--- a/pantry/content/docs/getting-started/installation.md
+++ b/pantry/content/docs/getting-started/installation.md
@@ -1,0 +1,113 @@
++++
+title = "Installation"
+weight = 1
+template = "doc"
+description = "Install the Pantry CLI on macOS, Linux, and Windows."
+tags = ["setup", "cli"]
+[extra]
+category = "Setup"
++++
+
+## System Requirements
+
+- macOS 12+, Linux (glibc 2.17+), or Windows 10+
+- 50 MB of disk space
+- Network access to `registry.pantry.dev` (or your private registry)
+
+## Install via Script
+
+The recommended method for most users. The install script detects your platform and downloads the correct binary.
+
+### macOS and Linux
+
+```bash
+curl -fsSL https://get.pantry.dev | sh
+```
+
+This installs the `pantry` binary to `/usr/local/bin`. To install to a custom location:
+
+```bash
+curl -fsSL https://get.pantry.dev | INSTALL_DIR=~/.local/bin sh
+```
+
+### Windows
+
+Open PowerShell as Administrator:
+
+```powershell
+irm https://get.pantry.dev/install.ps1 | iex
+```
+
+## Install via Package Managers
+
+### Homebrew (macOS)
+
+```bash
+brew install pantry-dev/tap/pantry
+```
+
+### APT (Debian / Ubuntu)
+
+```bash
+curl -fsSL https://repo.pantry.dev/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/pantry.gpg
+echo "deb [signed-by=/usr/share/keyrings/pantry.gpg] https://repo.pantry.dev/apt stable main" | sudo tee /etc/apt/sources.list.d/pantry.list
+sudo apt update && sudo apt install pantry
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add pantry https://github.com/pantry-dev/scoop-bucket
+scoop install pantry
+```
+
+## Install from Source
+
+Requires Rust 1.75 or later:
+
+```bash
+git clone https://github.com/pantry-dev/pantry.git
+cd pantry
+cargo build --release
+cp target/release/pantry /usr/local/bin/
+```
+
+## Verify Installation
+
+```bash
+pantry --version
+```
+
+Expected output:
+
+```
+pantry 3.2.1 (2025-11-08)
+```
+
+## Shell Completions
+
+Generate completions for your shell:
+
+```bash
+# Bash
+pantry completions bash > /etc/bash_completion.d/pantry
+
+# Zsh
+pantry completions zsh > "${fpath[1]}/_pantry"
+
+# Fish
+pantry completions fish > ~/.config/fish/completions/pantry.fish
+
+# PowerShell
+pantry completions powershell > $PROFILE.CurrentUserAllHosts
+```
+
+## Uninstall
+
+To remove Pantry and its data:
+
+```bash
+pantry self uninstall
+```
+
+This removes the binary and clears the global cache at `~/.pantry/cache`.

--- a/pantry/content/docs/getting-started/search-and-install.md
+++ b/pantry/content/docs/getting-started/search-and-install.md
@@ -1,0 +1,200 @@
++++
+title = "Search and Install"
+weight = 2
+template = "doc"
+description = "Find packages on the registry and install them into your project."
+tags = ["cli", "packages"]
+[extra]
+category = "Usage"
++++
+
+## Initializing a Project
+
+Before installing packages, initialize a Pantry project in your directory:
+
+```bash
+pantry init
+```
+
+This creates a `pantry.toml` file with default settings:
+
+```toml
+[package]
+name = "my-project"
+version = "0.1.0"
+
+[dependencies]
+```
+
+You can also initialize with a specific template:
+
+```bash
+pantry init --template web-app
+```
+
+## Searching for Packages
+
+Search the public registry from the command line:
+
+```bash
+pantry search http-client
+```
+
+Output:
+
+```
+NAME              VERSION   DOWNLOADS   DESCRIPTION
+reqwest           0.12.4    14.2M       HTTP client with async support
+ureq              2.10.0    3.1M        Minimal blocking HTTP client
+hyper-client      1.4.1     8.7M        Low-level HTTP client on hyper
+surf              2.3.2     890K        Friendly HTTP client for async
+isahc             1.7.2     1.5M        Configurable HTTP client
+```
+
+### Filtering Results
+
+Filter by tag, author, or keyword:
+
+```bash
+# Search by tag
+pantry search --tag async http-client
+
+# Search by author
+pantry search --author pantry-team
+
+# Show detailed info for a specific package
+pantry info reqwest
+```
+
+The `pantry info` command displays full metadata:
+
+```
+reqwest 0.12.4
+  HTTP client with async support
+
+  Homepage:    https://github.com/pantry-packages/reqwest
+  Repository:  https://github.com/pantry-packages/reqwest
+  License:     MIT OR Apache-2.0
+  Downloads:   14,201,338
+  Published:   2025-09-14
+  Size:        245 KB
+
+  Dependencies (5):
+    http 1.1    serde 1.0    url 2.5    encoding_rs 0.8    tokio 1.38
+
+  Tags: http, client, async, networking, web
+```
+
+## Installing Packages
+
+### Add a Dependency
+
+```bash
+pantry add reqwest
+```
+
+This resolves the latest compatible version, updates `pantry.toml`, and downloads the package:
+
+```
+Resolving dependencies...
+  + reqwest 0.12.4
+  + http 1.1.1
+  + serde 1.0.203
+  + url 2.5.2
+  + encoding_rs 0.8.34
+  + tokio 1.38.0
+
+Added 6 packages in 1.2s
+```
+
+### Add with Version Constraint
+
+```bash
+# Exact version
+pantry add reqwest@0.12.4
+
+# Version range
+pantry add reqwest@">=0.12.0, <0.13.0"
+
+# Compatible versions (caret)
+pantry add reqwest@^0.12
+
+# Patch-level updates only (tilde)
+pantry add reqwest@~0.12.4
+```
+
+### Add as Dev Dependency
+
+```bash
+pantry add --dev jest-runner
+```
+
+### Install All Dependencies
+
+After cloning a project or updating `pantry.toml`:
+
+```bash
+pantry install
+```
+
+This reads the lockfile (`pantry.lock`) if present and installs the exact recorded versions. If no lockfile exists, it performs fresh resolution and creates one.
+
+## Managing Dependencies
+
+### List Installed Packages
+
+```bash
+pantry list
+```
+
+```
+my-project 0.1.0
++-- reqwest 0.12.4
+|   +-- http 1.1.1
+|   +-- serde 1.0.203
+|   +-- url 2.5.2
+|   +-- encoding_rs 0.8.34
+|   +-- tokio 1.38.0
++-- jest-runner 2.1.0 (dev)
+```
+
+### Update Packages
+
+```bash
+# Update all packages to latest compatible versions
+pantry update
+
+# Update a specific package
+pantry update reqwest
+
+# Check for updates without installing
+pantry outdated
+```
+
+### Remove a Package
+
+```bash
+pantry remove reqwest
+```
+
+## Lockfile
+
+The `pantry.lock` file records the exact version of every installed package. Always commit this file to version control to ensure reproducible builds across your team and CI.
+
+```bash
+# Verify lockfile integrity
+pantry check
+
+# Regenerate lockfile from scratch
+pantry install --frozen=false
+```
+
+## Offline Mode
+
+If you have previously installed a package, Pantry caches it locally. Use offline mode when network access is unavailable:
+
+```bash
+pantry install --offline
+```
+
+This only works if all required packages exist in the local cache at `~/.pantry/cache`.

--- a/pantry/content/docs/publishing/_index.md
+++ b/pantry/content/docs/publishing/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Publishing"
+template = "section"
+sort_by = "weight"
+page_template = "doc"
+description = "Version management, publishing workflows, and deprecation policies."
++++

--- a/pantry/content/docs/publishing/deprecation.md
+++ b/pantry/content/docs/publishing/deprecation.md
@@ -1,0 +1,148 @@
++++
+title = "Deprecation and Unpublish"
+weight = 3
+template = "doc"
+description = "Policies for deprecating versions and removing packages from the registry."
+tags = ["publishing", "deprecation"]
+[extra]
+category = "Policy"
++++
+
+## Overview
+
+Once a package version is published, it becomes part of the dependency graph for potentially thousands of downstream projects. Removing or altering published versions can break builds across the ecosystem. Pantry provides controlled mechanisms to handle problematic releases while minimizing disruption.
+
+## Deprecating a Version
+
+Deprecation marks a version as not recommended without removing it. Deprecated versions remain downloadable and resolvable but display a warning to users.
+
+### Deprecate a Specific Version
+
+```bash
+pantry deprecate my-library@1.3.0 "Security vulnerability in XML parser. Upgrade to 1.3.1 or later."
+```
+
+When a user installs or resolves a deprecated version, they see:
+
+```
+warning: my-library 1.3.0 is deprecated
+  Message: "Security vulnerability in XML parser. Upgrade to 1.3.1 or later."
+```
+
+### Deprecate an Entire Package
+
+```bash
+pantry deprecate my-library "This package has been superseded by my-library-v2."
+```
+
+### Undeprecate
+
+If the deprecation was premature, reverse it:
+
+```bash
+pantry undeprecate my-library@1.3.0
+```
+
+## Yanking a Version
+
+Yanking is stronger than deprecation. A yanked version is excluded from dependency resolution for new installs, but remains downloadable for projects that already have it in their lockfile.
+
+### Yank a Version
+
+```bash
+pantry yank my-library@1.3.0
+```
+
+### Behavior of Yanked Versions
+
+| Scenario | Yanked version behavior |
+|----------|------------------------|
+| New `pantry install` without lockfile | Excluded from resolution. Solver picks a different version. |
+| `pantry install` with lockfile pinning yanked version | Installed normally, but a warning is displayed. |
+| `pantry update` | Replaces yanked version with a non-yanked alternative. |
+| Direct install `pantry add my-library@1.3.0` | Fails with an error explaining the version is yanked. |
+| `pantry info my-library` | Version shown with `[yanked]` label. |
+
+### Unyank
+
+If a version was yanked by mistake:
+
+```bash
+pantry unyank my-library@1.3.0
+```
+
+## Unpublishing
+
+Unpublishing completely removes a version from the registry. This is an irreversible action with strict limitations.
+
+### Time Window
+
+Pantry allows unpublishing only within **72 hours** of the initial publish, and only if:
+
+- The version has fewer than **100 downloads**
+- No other published package depends on the exact version
+- You are the package owner or an organization admin
+
+### Unpublish a Version
+
+```bash
+pantry unpublish my-library@1.3.0
+```
+
+You will be prompted to confirm:
+
+```
+You are about to permanently remove my-library@1.3.0 from the registry.
+This action cannot be undone.
+
+  Downloads: 23
+  Dependents: 0
+  Published: 2 hours ago
+
+Type the package name to confirm: my-library
+```
+
+### Unpublish an Entire Package
+
+Removing all versions of a package is only allowed if every version meets the unpublish criteria:
+
+```bash
+pantry unpublish my-library
+```
+
+After unpublishing all versions, the package name is reserved for 30 days to prevent name-squatting. After 30 days, the name becomes available for new packages.
+
+## Policy Summary
+
+| Action | Effect | Reversible | Time limit | Download limit |
+|--------|--------|------------|------------|----------------|
+| Deprecate | Warning shown to users | Yes | None | None |
+| Yank | Excluded from new resolution | Yes | None | None |
+| Unpublish | Permanently removed | No | 72 hours | 100 downloads |
+
+## Best Practices
+
+**Prefer deprecation over yanking.** Deprecation is the least disruptive option. Use it when a version has known issues but is not actively harmful.
+
+**Prefer yanking over unpublishing.** Yanking prevents new adoption while preserving existing builds. Use it for serious bugs or security issues.
+
+**Reserve unpublishing for accidental releases.** Only unpublish when you have published sensitive data (credentials, proprietary code) or the wrong package entirely.
+
+**Always provide a message.** When deprecating or yanking, include a clear explanation and a recommended upgrade path. This helps downstream maintainers respond quickly.
+
+**Coordinate with dependents.** Before yanking a widely-used version, consider reaching out to major downstream packages to give them time to update.
+
+## Security Advisories
+
+For security vulnerabilities, Pantry integrates with the advisory database. File a security advisory instead of (or in addition to) yanking:
+
+```bash
+pantry advisory create my-library \
+  --versions ">=1.2.0, <1.3.1" \
+  --severity high \
+  --title "XML external entity injection" \
+  --description "The XML parser in versions 1.2.0 through 1.3.0 is vulnerable to XXE attacks." \
+  --patched "1.3.1"
+```
+
+Advisories appear in `pantry audit` results for all affected projects.

--- a/pantry/content/docs/publishing/publish-workflow.md
+++ b/pantry/content/docs/publishing/publish-workflow.md
@@ -1,0 +1,219 @@
++++
+title = "Publish Workflow"
+weight = 2
+template = "doc"
+description = "Step-by-step guide to publishing packages to the Pantry registry."
+tags = ["publishing", "workflow"]
+[extra]
+category = "Guide"
++++
+
+## Prerequisites
+
+Before publishing, ensure you have:
+
+1. A Pantry account at [pantry.dev](https://pantry.dev)
+2. An authentication token configured
+3. A valid `pantry.toml` with required metadata
+
+## Authentication
+
+Log in to generate and store your token:
+
+```bash
+pantry login
+```
+
+This opens a browser for authentication and saves the token to `~/.pantry/config.toml`. For CI environments, set the token via environment variable:
+
+```bash
+export PANTRY_TOKEN=ptry_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+You can also pass it directly:
+
+```bash
+pantry publish --token ptry_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Preparing a Package
+
+### Validate Your Package
+
+Run the check command to verify your package before publishing:
+
+```bash
+pantry check
+```
+
+This validates:
+
+- `pantry.toml` has all required fields (`name`, `version`)
+- Version follows semver format
+- No duplicate dependencies
+- All referenced files exist
+- Package size is within limits (50 MB default)
+- License field uses a valid SPDX identifier
+
+### Preview the Package Contents
+
+See exactly what will be included in the published tarball:
+
+```bash
+pantry pack --list
+```
+
+```
+Files to include (12 files, 145 KB):
+  pantry.toml
+  README.md
+  LICENSE
+  src/lib.rs
+  src/client.rs
+  src/config.rs
+  src/error.rs
+  src/models/mod.rs
+  src/models/request.rs
+  src/models/response.rs
+  src/utils.rs
+  src/version.rs
+```
+
+### Create a Local Tarball
+
+Build the package tarball without publishing:
+
+```bash
+pantry pack
+```
+
+This creates a `.pantry-pkg` file you can inspect or test locally:
+
+```bash
+pantry pack --output ./my-library-1.4.0.pantry-pkg
+```
+
+## Publishing
+
+### Publish to the Public Registry
+
+```bash
+pantry publish
+```
+
+Output:
+
+```
+Packing my-library 1.4.0...
+  Included 12 files (145 KB)
+  Compressed to 42 KB
+
+Uploading to registry.pantry.dev...
+  Published my-library 1.4.0
+
+  https://pantry.dev/packages/my-library/1.4.0
+```
+
+### Publish to a Private Registry
+
+```bash
+pantry publish --registry https://registry.internal.company.com
+```
+
+### Dry Run
+
+Test the entire publish flow without actually uploading:
+
+```bash
+pantry publish --dry-run
+```
+
+## Publishing Checklist
+
+Before every release, walk through these steps:
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| 1. Run tests | `pantry run test` | Verify all tests pass |
+| 2. Update version | Edit `pantry.toml` | Bump version per semver |
+| 3. Update changelog | Edit `CHANGELOG.md` | Document changes for users |
+| 4. Validate | `pantry check` | Catch metadata errors |
+| 5. Preview | `pantry pack --list` | Confirm file list |
+| 6. Dry run | `pantry publish --dry-run` | Full rehearsal |
+| 7. Publish | `pantry publish` | Ship it |
+| 8. Tag release | `git tag v1.4.0` | Mark the release in git |
+
+## CI/CD Publishing
+
+### GitHub Actions Example
+
+```yaml
+name: Publish
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pantry-dev/setup-pantry@v1
+      - run: pantry check
+      - run: pantry run test
+      - run: pantry publish
+        env:
+          PANTRY_TOKEN: ${{ secrets.PANTRY_TOKEN }}
+```
+
+### GitLab CI Example
+
+```yaml
+publish:
+  stage: deploy
+  image: pantry-dev/pantry:latest
+  script:
+    - pantry check
+    - pantry run test
+    - pantry publish
+  only:
+    - tags
+  variables:
+    PANTRY_TOKEN: $PANTRY_TOKEN
+```
+
+## Scoped Packages
+
+Organizations can publish scoped packages under their namespace:
+
+```toml
+[package]
+name = "@myorg/utils"
+version = "2.0.0"
+```
+
+Scoped packages require org membership. Add team members at [pantry.dev/settings/teams](https://pantry.dev/settings/teams).
+
+## Access Control
+
+Configure who can publish updates to your package:
+
+```bash
+# Grant publish access
+pantry access grant @alice my-library
+
+# Revoke publish access
+pantry access revoke @bob my-library
+
+# List collaborators
+pantry access list my-library
+```
+
+## Provenance
+
+Pantry supports build provenance attestation for packages published from CI. This allows consumers to verify that a package was built from a specific commit and workflow:
+
+```bash
+pantry publish --provenance
+```
+
+Provenance metadata is recorded on the registry and displayed on the package page.

--- a/pantry/content/docs/publishing/versioning.md
+++ b/pantry/content/docs/publishing/versioning.md
@@ -1,0 +1,143 @@
++++
+title = "Versioning"
+weight = 1
+template = "doc"
+description = "Semantic versioning rules, version ranges, and dependency resolution."
+tags = ["versioning", "semver", "dependencies"]
+[extra]
+category = "Reference"
++++
+
+## Semantic Versioning
+
+Pantry requires all packages to follow Semantic Versioning 2.0.0 (semver). A version number has the format `MAJOR.MINOR.PATCH`, where:
+
+| Component | When to increment |
+|-----------|-------------------|
+| MAJOR | Incompatible API changes that require consumers to update their code |
+| MINOR | New functionality added in a backward-compatible manner |
+| PATCH | Backward-compatible bug fixes with no new features |
+
+### Pre-release Versions
+
+Pre-release versions are denoted by appending a hyphen and identifiers after the patch number:
+
+```
+1.0.0-alpha
+1.0.0-alpha.1
+1.0.0-beta.3
+1.0.0-rc.1
+```
+
+Pre-release versions have lower precedence than the associated release version. They are excluded from range matching unless explicitly requested.
+
+### Build Metadata
+
+Build metadata is appended with a plus sign and is ignored during version comparison:
+
+```
+1.0.0+build.42
+1.0.0+20250101
+```
+
+## Version Ranges
+
+When specifying dependency versions in `pantry.toml`, you can use several range syntaxes:
+
+### Range Operators
+
+| Syntax | Example | Matches | Description |
+|--------|---------|---------|-------------|
+| Caret `^` | `^1.2.3` | `>=1.2.3, <2.0.0` | Compatible with version. Default when bare version is given. |
+| Tilde `~` | `~1.2.3` | `>=1.2.3, <1.3.0` | Patch-level changes only. |
+| Exact `=` | `=1.2.3` | `1.2.3` | Exactly this version and nothing else. |
+| Greater than | `>1.2.3` | `>1.2.3` | Any version strictly greater. |
+| Greater or equal | `>=1.2.3` | `>=1.2.3` | This version or any later version. |
+| Less than | `<2.0.0` | `<2.0.0` | Any version strictly less. |
+| Less or equal | `<=1.9.9` | `<=1.9.9` | This version or any earlier version. |
+| Wildcard | `1.2.*` | `>=1.2.0, <1.3.0` | Any patch version within minor. |
+| Compound | `>=1.2, <1.5` | `>=1.2.0, <1.5.0` | Multiple constraints combined with comma. |
+
+### Caret Ranges in Detail
+
+The caret range is the default and most commonly used. Its behavior varies based on which components are specified:
+
+| Specifier | Equivalent range | Rationale |
+|-----------|-----------------|-----------|
+| `^1.2.3` | `>=1.2.3, <2.0.0` | Major version is nonzero, so major is fixed |
+| `^0.2.3` | `>=0.2.3, <0.3.0` | Major is zero, so minor is fixed |
+| `^0.0.3` | `>=0.0.3, <0.0.4` | Major and minor are zero, so patch is fixed |
+| `^1.2` | `>=1.2.0, <2.0.0` | Missing patch treated as zero |
+| `^0.0` | `>=0.0.0, <0.1.0` | Minor is fixed |
+| `^1` | `>=1.0.0, <2.0.0` | Only major specified |
+
+### Tilde Ranges in Detail
+
+| Specifier | Equivalent range |
+|-----------|-----------------|
+| `~1.2.3` | `>=1.2.3, <1.3.0` |
+| `~1.2` | `>=1.2.0, <1.3.0` |
+| `~1` | `>=1.0.0, <2.0.0` |
+
+## Dependency Resolution
+
+Pantry uses a SAT-based dependency resolver that guarantees a correct and deterministic solution when one exists.
+
+### Resolution Algorithm
+
+1. **Collect requirements.** Gather all direct dependencies from `pantry.toml` and their transitive dependencies from the registry index.
+
+2. **Build constraint graph.** Each package-version pair becomes a variable. Version ranges are translated into boolean clauses.
+
+3. **Solve.** The SAT solver finds an assignment that satisfies all constraints. If no solution exists, it reports the minimal conflicting set.
+
+4. **Select optimal versions.** Among valid solutions, Pantry prefers the newest version that satisfies all constraints, giving priority to packages closer to the root of the dependency tree.
+
+### Conflict Resolution
+
+When two packages require incompatible versions of the same dependency, the resolver reports the conflict:
+
+```
+error: dependency conflict
+
+  my-app requires reqwest ^0.12
+  analytics requires reqwest ^0.11
+
+  reqwest 0.12.x and 0.11.x cannot coexist.
+
+  Suggestion: Update analytics to a version compatible with reqwest 0.12,
+  or pin reqwest to a version both can accept.
+```
+
+### Resolution Strategies
+
+| Strategy | Flag | Behavior |
+|----------|------|----------|
+| Default | (none) | Prefer newest compatible versions |
+| Minimal | `--minimal` | Prefer oldest compatible versions. Useful for testing minimum supported versions. |
+| Locked | `--frozen` | Use exact versions from `pantry.lock`. Fail if lockfile is outdated. |
+| Eager | `--eager` | Update all transitive dependencies to latest, even if lockfile has valid versions. |
+
+## Version Precedence
+
+Pantry orders versions according to semver rules:
+
+1. Compare MAJOR, then MINOR, then PATCH numerically.
+2. A version without a pre-release tag has higher precedence than one with.
+3. Pre-release precedence is determined by comparing dot-separated identifiers left to right. Numeric identifiers compare as integers; alphanumeric identifiers compare lexically.
+
+### Precedence Examples
+
+```
+0.9.0 < 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta < 1.0.0-rc.1 < 1.0.0 < 1.1.0 < 2.0.0
+```
+
+## Yanked Versions
+
+A yanked version is still downloadable (for reproducibility) but excluded from resolution unless the lockfile already pins it. If your lockfile references a yanked version, Pantry displays a warning:
+
+```
+warning: reqwest 0.12.2 has been yanked.
+  Reason: "contains data corruption bug in multipart uploads"
+  Consider upgrading to 0.12.3 or later.
+```

--- a/pantry/content/index.md
+++ b/pantry/content/index.md
@@ -1,0 +1,37 @@
++++
+title = "Pantry"
+template = "page"
++++
+
+Pantry is a fast, reliable package manager and registry for modern software development. Browse the documentation to learn how to install packages, manage dependencies, and publish your own libraries.
+
+## Documentation
+
+- [Getting Started](docs/getting-started/) -- Install the CLI, search for packages, and configure your project
+- [Publishing](docs/publishing/) -- Versioning, publishing workflows, and deprecation policies
+- [About](about/) -- About the Pantry platform and ecosystem
+
+## Quick Install
+
+```bash
+curl -fsSL https://get.pantry.dev | sh
+```
+
+Then initialize a new project:
+
+```bash
+pantry init my-project
+cd my-project
+pantry install
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Fast resolution | Deterministic dependency resolution in milliseconds |
+| Lockfile support | Reproducible builds with `pantry.lock` |
+| Workspaces | Monorepo support with shared dependencies |
+| Registry | Public and private registry hosting |
+| Audit | Built-in security vulnerability scanning |
+| Scripts | Task runner for build, test, and deploy workflows |

--- a/pantry/static/js/mobile-menu.js
+++ b/pantry/static/js/mobile-menu.js
@@ -1,0 +1,9 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var btn = document.getElementById("mobile-menu-btn");
+  var menu = document.getElementById("mobile-menu");
+  if (btn && menu) {
+    btn.addEventListener("click", function () {
+      menu.classList.toggle("hidden");
+    });
+  }
+});

--- a/pantry/templates/404.html
+++ b/pantry/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <div class="text-center py-20">
+    <h1 class="text-6xl font-bold text-pantry-green mb-4">404</h1>
+    <p class="text-pantry-muted text-lg mb-8">This page could not be found in the registry.</p>
+    <a href="{{ base_url }}/" class="inline-block px-5 py-2.5 bg-pantry-green text-white font-medium rounded-lg hover:bg-pantry-green-dark transition-colors text-sm">Back to Home</a>
+  </div>
+{% include "footer.html" %}

--- a/pantry/templates/doc.html
+++ b/pantry/templates/doc.html
@@ -1,0 +1,75 @@
+{% include "header.html" %}
+  <div class="py-8">
+    <details class="lg:hidden mb-6 border border-pantry-border rounded-lg">
+      <summary class="px-4 py-3 text-sm font-medium text-pantry-text cursor-pointer select-none">
+        Section Navigation
+      </summary>
+      <div class="px-4 pb-3 border-t border-pantry-border">
+        {% if section.pages %}
+        <ul class="space-y-1 text-sm mt-2">
+          {% for doc in section.pages %}
+          <li>
+            <a href="{{ base_url }}{{ doc.url }}" class="block py-1.5 px-2 rounded {% if doc.url == page.url %}bg-pantry-green-light text-pantry-green-dark font-medium{% else %}text-pantry-muted hover:text-pantry-text{% endif %}">
+              {{ doc.title }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+    </details>
+    <div class="grid grid-cols-1 lg:grid-cols-[220px_1fr_180px] gap-10 items-start">
+      <aside class="hidden lg:block sticky top-16 overflow-y-auto max-h-[calc(100vh-100px)] pr-4">
+        <h3 class="text-xs font-bold text-pantry-muted uppercase tracking-wider mb-3">{{ section.title }}</h3>
+        {% if section.pages %}
+        <ul class="space-y-1 text-sm">
+          {% for doc in section.pages %}
+          <li>
+            <a href="{{ base_url }}{{ doc.url }}" class="block py-1.5 px-3 rounded {% if doc.url == page.url %}bg-pantry-green-light text-pantry-green-dark font-medium border-l-2 border-pantry-green{% else %}text-pantry-muted hover:text-pantry-text hover:bg-pantry-surface{% endif %} transition-colors">
+              {{ doc.title }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </aside>
+      <article class="min-w-0">
+        <nav class="flex items-center gap-2 text-xs text-pantry-muted mb-6">
+          <a href="{{ base_url }}/" class="hover:text-pantry-green">Home</a>
+          <span>/</span>
+          <a href="{{ base_url }}{{ section.url }}" class="hover:text-pantry-green">{{ section.title }}</a>
+          <span>/</span>
+          <span class="text-pantry-text">{{ page.title }}</span>
+        </nav>
+        <div class="flex items-center gap-3 mb-2">
+          <h1 class="text-2xl font-bold text-pantry-text">{{ page.title }}</h1>
+          {% if page.extra.category %}
+          <span class="px-2 py-0.5 bg-pantry-green-light text-pantry-green-dark text-xs font-medium rounded">{{ page.extra.category }}</span>
+          {% endif %}
+        </div>
+        {% if page.description %}
+        <p class="text-pantry-muted text-sm mb-6">{{ page.description }}</p>
+        {% endif %}
+        <div class="prose">
+          {{ content }}
+        </div>
+        <div class="mt-10 pt-6 border-t border-pantry-border flex justify-between text-sm">
+          {% if page.lower %}
+          <a href="{{ base_url }}{{ page.lower.url }}" class="text-pantry-muted hover:text-pantry-green transition-colors">&larr; {{ page.lower.title }}</a>
+          {% else %}<div></div>{% endif %}
+          {% if page.higher %}
+          <a href="{{ base_url }}{{ page.higher.url }}" class="text-pantry-muted hover:text-pantry-green transition-colors">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </div>
+      </article>
+      <aside class="hidden lg:block sticky top-16 text-sm">
+        {% if page.toc %}
+        <h3 class="text-xs font-bold text-pantry-muted uppercase tracking-wider mb-3">On this page</h3>
+        <div class="toc text-xs text-pantry-muted">
+          {{ page.toc }}
+        </div>
+        {% endif %}
+      </aside>
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/pantry/templates/footer.html
+++ b/pantry/templates/footer.html
@@ -1,0 +1,11 @@
+  </div>
+  <footer class="border-t border-pantry-border bg-pantry-surface py-6 mt-16">
+    <div class="max-w-7xl mx-auto px-6 text-center text-xs text-pantry-muted">
+      <p>Pantry Documentation. Powered by <a href="https://github.com/hahwul/hwaro" class="text-pantry-green hover:underline">Hwaro</a>.</p>
+    </div>
+  </footer>
+  <script src="{{ base_url }}/js/mobile-menu.js"></script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/pantry/templates/header.html
+++ b/pantry/templates/header.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&family=Source+Code+Pro:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            pantry: {
+              green: '#16a34a',
+              'green-dark': '#15803d',
+              'green-light': '#dcfce7',
+              'green-accent': '#bbf7d0',
+              bg: '#ffffff',
+              surface: '#f8fafc',
+              border: '#e2e8f0',
+              text: '#1e293b',
+              muted: '#64748b',
+            },
+          },
+          fontFamily: {
+            sans: ['"Source Sans 3"', 'system-ui', 'sans-serif'],
+            mono: ['"Source Code Pro"', 'ui-monospace', 'monospace'],
+          },
+        },
+      },
+    }
+  </script>
+  <style type="text/tailwindcss">
+    body { @apply bg-pantry-bg text-pantry-text font-sans; }
+    .prose { @apply max-w-none text-pantry-text; }
+    .prose h1 { @apply text-2xl font-bold mb-6 text-pantry-text; }
+    .prose h2 { @apply text-xl font-bold mt-10 mb-4 text-pantry-text border-b border-pantry-border pb-2; }
+    .prose h3 { @apply text-lg font-semibold mt-8 mb-3 text-pantry-text; }
+    .prose h4 { @apply text-base font-semibold mt-6 mb-2 text-pantry-text; }
+    .prose p { @apply my-3 leading-relaxed; }
+    .prose a { @apply text-pantry-green hover:text-pantry-green-dark hover:underline; }
+    .prose strong { @apply font-semibold; }
+    .prose code { @apply bg-pantry-green-light px-1.5 py-0.5 rounded text-sm font-mono text-pantry-green-dark; }
+    .prose pre { @apply bg-gray-900 text-gray-100 p-4 rounded-lg my-4 overflow-x-auto text-sm leading-relaxed; }
+    .prose pre code { @apply bg-transparent p-0 text-gray-100; }
+    .prose ul, .prose ol { @apply my-3 ml-6; }
+    .prose li { @apply my-1.5; }
+    .prose ul li { @apply list-disc marker:text-pantry-green; }
+    .prose ol li { @apply list-decimal marker:text-pantry-green; }
+    .prose table { @apply w-full border-collapse my-6 text-sm; }
+    .prose thead { @apply bg-pantry-green-light; }
+    .prose th { @apply px-4 py-2.5 text-left font-semibold border border-pantry-border text-pantry-green-dark; }
+    .prose td { @apply px-4 py-2.5 border border-pantry-border; }
+    .prose tbody tr:hover { @apply bg-pantry-surface; }
+    .prose blockquote { @apply border-l-4 border-pantry-green pl-4 my-4 text-pantry-muted italic; }
+    .toc ul { @apply ml-4 my-0 space-y-1; }
+    .toc li { @apply relative; }
+    .toc a { @apply text-pantry-muted no-underline text-xs hover:text-pantry-green transition-colors block py-0.5; }
+    .alert { @apply p-4 rounded-lg my-4 text-sm border; }
+    .alert-info { @apply bg-pantry-green-light border-pantry-green-accent text-pantry-green-dark; }
+    .alert-warning { @apply bg-amber-50 border-amber-200 text-amber-800; }
+    .alert-error { @apply bg-red-50 border-red-200 text-red-800; }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <nav class="border-b border-pantry-border bg-pantry-bg sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
+      <div class="flex items-center gap-8">
+        <a href="{{ base_url }}/" class="font-bold text-pantry-text hover:text-pantry-green transition-colors flex items-center gap-2">
+          <svg class="w-5 h-5 text-pantry-green" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+          {{ site.title }}
+        </a>
+        <div class="hidden md:flex items-center gap-5 text-sm">
+          <a href="{{ base_url }}/docs/getting-started/" class="text-pantry-muted hover:text-pantry-green transition-colors">Getting Started</a>
+          <a href="{{ base_url }}/docs/publishing/" class="text-pantry-muted hover:text-pantry-green transition-colors">Publishing</a>
+        </div>
+      </div>
+      <div class="flex items-center gap-4">
+        <div class="hidden sm:block relative">
+          <input type="text" id="search-input" placeholder="Search docs..." class="w-48 lg:w-64 px-3 py-1.5 text-sm border border-pantry-border rounded-lg bg-pantry-surface text-pantry-text placeholder-pantry-muted focus:outline-none focus:border-pantry-green focus:ring-1 focus:ring-pantry-green">
+          <div id="search-results" class="hidden absolute top-full right-0 mt-1 w-80 bg-white border border-pantry-border rounded-lg shadow-lg max-h-80 overflow-y-auto z-50"></div>
+        </div>
+        <button id="mobile-menu-btn" class="md:hidden text-pantry-muted hover:text-pantry-text" aria-label="Toggle menu">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+    </div>
+    <div id="mobile-menu" class="hidden md:hidden border-t border-pantry-border bg-pantry-surface">
+      <div class="px-6 py-3 space-y-2 text-sm">
+        <a href="{{ base_url }}/docs/getting-started/" class="block py-1.5 text-pantry-muted hover:text-pantry-green">Getting Started</a>
+        <a href="{{ base_url }}/docs/publishing/" class="block py-1.5 text-pantry-muted hover:text-pantry-green">Publishing</a>
+        <div class="pt-2">
+          <input type="text" placeholder="Search docs..." class="w-full px-3 py-1.5 text-sm border border-pantry-border rounded-lg bg-white text-pantry-text placeholder-pantry-muted focus:outline-none focus:border-pantry-green">
+        </div>
+      </div>
+    </div>
+  </nav>
+  <div class="max-w-7xl mx-auto px-6">

--- a/pantry/templates/page.html
+++ b/pantry/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <article class="prose">
+      <h1>{{ page.title }}</h1>
+      {{ content }}
+    </article>
+  </div>
+{% include "footer.html" %}

--- a/pantry/templates/section.html
+++ b/pantry/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <div class="py-10">
+    <header class="mb-8">
+      <h1 class="text-2xl font-bold text-pantry-text mb-2">{{ page.title }}</h1>
+      <div class="prose text-pantry-muted">{{ content }}</div>
+    </header>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {% for page in section.pages %}
+      <a href="{{ base_url }}{{ page.url }}" class="block p-5 bg-pantry-surface border border-pantry-border rounded-lg hover:border-pantry-green transition-colors group">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="font-semibold text-pantry-text group-hover:text-pantry-green transition-colors">{{ page.title }}</h2>
+            {% if page.description %}
+            <p class="text-sm text-pantry-muted mt-1.5 leading-relaxed">{{ page.description }}</p>
+            {% endif %}
+          </div>
+          {% if page.extra.category %}
+          <span class="shrink-0 text-xs px-2 py-0.5 bg-pantry-green-light text-pantry-green-dark rounded font-medium">{{ page.extra.category }}</span>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/pantry/templates/shortcodes/alert.html
+++ b/pantry/templates/shortcodes/alert.html
@@ -1,0 +1,1 @@
+<div class="alert alert-{{ type }}">{{ body }}</div>

--- a/pantry/templates/taxonomy.html
+++ b/pantry/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <h1 class="text-2xl font-bold text-pantry-text mb-6">{{ page.title }}</h1>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/pantry/templates/taxonomy_term.html
+++ b/pantry/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <h1 class="text-2xl font-bold text-pantry-text mb-6">{{ page.title }}</h1>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/quarry/AGENTS.md
+++ b/quarry/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md         # Homepage content
+│   ├── about.md         # About page
+│   └── docs/            # Documentation sections
+│       ├── queries/     # SQL query reference
+│       │   ├── _index.md
+│       │   ├── select-basics.md
+│       │   ├── joins-and-subqueries.md
+│       │   └── window-functions.md
+│       └── optimization/ # Query optimization guides
+│           ├── _index.md
+│           ├── execution-plans.md
+│           ├── partitioning.md
+│           └── indexing.md
+├── templates/           # HTML templates
+│   ├── header.html      # Dark theme header with Tailwind CDN
+│   ├── footer.html      # Footer with Hwaro credit
+│   ├── doc.html         # Sidebar + content doc layout
+│   ├── page.html        # Simple centered page layout
+│   ├── section.html     # Card grid section listing
+│   ├── taxonomy.html    # Taxonomy term listing
+│   ├── taxonomy_term.html # Pages for a taxonomy term
+│   ├── 404.html         # Error page
+│   └── shortcodes/
+│       └── alert.html   # Alert box shortcode
+└── static/
+    └── js/
+        └── mobile-menu.js # Mobile menu toggle
+```
+
+## Theme Details
+
+- **Design**: Dark theme data analytics console
+- **Color palette**: Dark navy (#0f172a / #1e293b), amber accent (#f59e0b / #d97706), white text (#e2e8f0), slate muted (#94a3b8)
+- **Fonts**: Inter (body), JetBrains Mono (code)
+- **CSS Framework**: Tailwind CSS via CDN with custom config
+- **No gradients**: All backgrounds use solid colors
+
+## Key Features
+
+- Dark themed documentation layout with sidebar navigation
+- Three-column doc layout: sidebar, content, table of contents
+- Mobile-responsive with collapsible navigation
+- SQL syntax highlighting via Highlight.js
+- Keyboard shortcut (/) to focus search
+- Breadcrumb navigation in doc pages
+- Previous/next page navigation
+- Tag taxonomy for content classification
+- Alert shortcode for callout boxes

--- a/quarry/config.toml
+++ b/quarry/config.toml
@@ -1,0 +1,38 @@
+title = "Quarry"
+description = "Data warehouse and analytics query documentation"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [{ user_agent = "*", disallow = [] }]
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+
+[markdown]
+safe = false

--- a/quarry/content/about.md
+++ b/quarry/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "About"
+description = "About the Quarry documentation platform"
++++
+
+## About Quarry
+
+Quarry is a documentation platform for data warehouse and analytics query patterns. It serves as a centralized knowledge base for data engineers, analysts, and anyone working with SQL at scale.
+
+### Purpose
+
+Modern data warehouses handle petabytes of data across thousands of tables. Writing efficient queries requires deep understanding of SQL semantics, query planning, and storage internals. Quarry collects this knowledge into a single, searchable reference.
+
+### What You Will Find
+
+- **Query Patterns** -- Fundamental and advanced SQL techniques, from basic SELECT statements to complex window functions and recursive CTEs.
+- **Optimization Strategies** -- Practical guidance on execution plans, partitioning, and indexing that applies across major warehouse platforms.
+- **Real Examples** -- Every concept is illustrated with working SQL against realistic schemas, not toy examples.
+
+### Target Audience
+
+This documentation is written for:
+
+- **Data Engineers** building and maintaining warehouse schemas and ETL pipelines
+- **Data Analysts** writing ad-hoc and scheduled queries against warehouse tables
+- **Platform Engineers** tuning warehouse performance and managing infrastructure
+
+### Technology
+
+Quarry is built with [Hwaro](https://github.com/hahwul/hwaro), a fast static site generator written in Crystal. The dark theme is designed to reduce eye strain during long analysis sessions.

--- a/quarry/content/docs/optimization/_index.md
+++ b/quarry/content/docs/optimization/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Optimization"
+template = "section"
+sort_by = "weight"
+page_template = "doc"
+description = "Strategies for improving query performance, reducing cost, and scaling warehouse workloads."
++++

--- a/quarry/content/docs/optimization/execution-plans.md
+++ b/quarry/content/docs/optimization/execution-plans.md
@@ -1,0 +1,166 @@
++++
+title = "Execution Plans"
+description = "Reading and understanding query execution plans for performance analysis"
+weight = 1
+[taxonomies]
+tags = ["optimization", "execution-plans", "explain"]
++++
+
+## Understanding Execution Plans
+
+An execution plan (or query plan) shows how the database engine will execute your query. Reading these plans is the single most important skill for query optimization.
+
+### Generating a Plan
+
+Most warehouse platforms support `EXPLAIN` or similar commands.
+
+```sql
+-- PostgreSQL / Redshift
+EXPLAIN ANALYZE
+SELECT
+    c.region,
+    COUNT(*) AS order_count,
+    SUM(o.order_total) AS revenue
+FROM warehouse.orders o
+JOIN warehouse.customers c ON o.customer_id = c.customer_id
+WHERE o.created_at >= '2025-01-01'
+GROUP BY c.region;
+```
+
+### Example EXPLAIN Output
+
+```text
+HashAggregate  (cost=45892.33..45892.45 rows=12 width=44)
+  Group Key: c.region
+  ->  Hash Join  (cost=3412.00..42678.21 rows=428549 width=36)
+        Hash Cond: (o.customer_id = c.customer_id)
+        ->  Seq Scan on orders o  (cost=0.00..35120.00 rows=428549 width=16)
+              Filter: (created_at >= '2025-01-01 00:00:00'::timestamp)
+              Rows Removed by Filter: 571451
+        ->  Hash  (cost=2150.00..2150.00 rows=120000 width=28)
+              ->  Seq Scan on customers c  (cost=0.00..2150.00 rows=120000 width=28)
+
+Planning Time: 0.284 ms
+Execution Time: 312.447 ms
+```
+
+### Reading the Plan
+
+Plans are read from the inside out (bottom to top, most indented to least).
+
+| Component | Meaning |
+|-----------|---------|
+| **Seq Scan** | Full table scan -- reads every row |
+| **Index Scan** | Uses an index to find specific rows |
+| **Hash Join** | Builds a hash table from one input, probes with the other |
+| **Merge Join** | Joins two sorted inputs -- efficient for large sorted datasets |
+| **Nested Loop** | For each row in outer, scan inner -- efficient for small outer sets |
+| **HashAggregate** | Aggregation using a hash table |
+| **Sort** | Explicit sort operation |
+| **cost** | Estimated startup and total cost (arbitrary units) |
+| **rows** | Estimated number of rows produced |
+
+### Key Metrics
+
+When using `EXPLAIN ANALYZE`, you get actual execution statistics:
+
+```text
+->  Seq Scan on orders o
+      (cost=0.00..35120.00 rows=428549 width=16)
+      (actual time=0.012..187.340 rows=428549 loops=1)
+      Filter: (created_at >= '2025-01-01')
+      Rows Removed by Filter: 571451
+      Buffers: shared hit=12480 read=3200
+```
+
+| Metric | Description |
+|--------|-------------|
+| `actual time` | Real elapsed time (startup..total) in ms |
+| `rows` | Actual rows returned vs. estimated |
+| `loops` | Number of times this node was executed |
+| `Buffers: shared hit` | Pages read from cache |
+| `Buffers: read` | Pages read from disk |
+| `Rows Removed by Filter` | Rows scanned but discarded by filter |
+
+### Identifying Problems
+
+#### Inaccurate Row Estimates
+
+When estimated rows differ significantly from actual rows, the planner may choose a suboptimal strategy.
+
+```text
+-- Estimated 100 rows, actually 2.5 million
+->  Index Scan on events
+      (cost=0.57..385.20 rows=100 width=64)
+      (actual time=0.032..4521.889 rows=2500000 loops=1)
+```
+
+This typically means statistics are stale. Run `ANALYZE` on the table.
+
+#### Sequential Scans on Large Tables
+
+If you see `Seq Scan` on a table with millions of rows and a selective filter, consider adding an index or using partition pruning.
+
+#### Spill to Disk
+
+Hash operations that exceed `work_mem` spill to disk, dramatically slowing execution.
+
+```text
+->  HashAggregate
+      Batches: 4  Memory Usage: 8241kB  Disk Usage: 45632kB
+```
+
+### Warehouse-Specific Plans
+
+#### Snowflake
+
+```sql
+-- Snowflake uses a profile, not traditional EXPLAIN
+SELECT *
+FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));
+
+-- Or use the Query Profile in the web UI
+```
+
+Key Snowflake metrics:
+- **Partitions scanned** vs. **total partitions** -- measures pruning efficiency
+- **Bytes spilled to local/remote storage** -- indicates insufficient memory
+- **Percentage scanned from cache** -- measures warehouse cache effectiveness
+
+#### BigQuery
+
+```sql
+-- BigQuery shows plan in the execution details tab
+-- Estimated bytes processed is shown before execution
+SELECT
+    region,
+    COUNT(*) AS cnt
+FROM `project.dataset.orders`
+WHERE DATE(created_at) >= '2025-01-01'
+GROUP BY region;
+```
+
+BigQuery key metrics:
+- **Bytes processed** -- directly impacts cost
+- **Slot time** -- total compute time across all workers
+- **Shuffle bytes** -- data moved between stages
+
+### Optimization Workflow
+
+1. Run the query with `EXPLAIN ANALYZE`
+2. Identify the most expensive node (highest actual time)
+3. Check if row estimates match actuals
+4. Look for sequential scans that could benefit from indexes or partitioning
+5. Check for disk spills in hash operations
+6. Apply fixes (add index, update statistics, rewrite query)
+7. Re-run `EXPLAIN ANALYZE` to verify improvement
+
+### Common Plan Improvements
+
+| Problem | Solution |
+|---------|----------|
+| Seq Scan with selective filter | Add an index on filter column |
+| Large hash join spilling to disk | Increase `work_mem` or pre-filter tables |
+| Inaccurate row estimates | Run `ANALYZE` to update statistics |
+| Sort on large dataset | Add index matching ORDER BY |
+| Nested Loop with large outer | Rewrite to use Hash or Merge Join |

--- a/quarry/content/docs/optimization/indexing.md
+++ b/quarry/content/docs/optimization/indexing.md
@@ -1,0 +1,253 @@
++++
+title = "Indexing Strategies"
+description = "Index types, design patterns, and maintenance strategies for warehouse workloads"
+weight = 3
+[taxonomies]
+tags = ["optimization", "indexing", "performance"]
++++
+
+## Why Indexing Matters
+
+Indexes allow the database to locate rows without scanning the entire table. In warehouse environments with billions of rows, the right index can reduce query time from minutes to milliseconds.
+
+### Index vs. Full Table Scan
+
+| Approach | Row Access Pattern | Best For |
+|----------|-------------------|----------|
+| Full scan | Reads every row | Queries returning large fraction of table |
+| Index scan | Reads specific rows via index | Selective queries (small result set) |
+| Index-only scan | Reads from index alone | Queries where all columns are in the index |
+
+## Index Types
+
+### B-Tree Index
+
+The default and most common index type. Supports equality and range queries.
+
+```sql
+-- Single column
+CREATE INDEX idx_orders_customer
+    ON warehouse.orders (customer_id);
+
+-- Composite (multi-column)
+CREATE INDEX idx_orders_customer_date
+    ON warehouse.orders (customer_id, created_at);
+
+-- Supports these queries efficiently:
+-- WHERE customer_id = 12345
+-- WHERE customer_id = 12345 AND created_at >= '2025-01-01'
+-- WHERE customer_id BETWEEN 1000 AND 2000
+```
+
+### Column Order in Composite Indexes
+
+The order of columns in a composite index matters. The index is useful for queries that filter on a **leftmost prefix** of the index columns.
+
+```sql
+-- Index: (customer_id, created_at, status)
+
+-- Uses index (full prefix match):
+WHERE customer_id = 12345 AND created_at >= '2025-01-01' AND status = 'completed'
+
+-- Uses index (leftmost prefix):
+WHERE customer_id = 12345 AND created_at >= '2025-01-01'
+
+-- Uses index (leftmost column only):
+WHERE customer_id = 12345
+
+-- Cannot use index (skips leftmost column):
+WHERE created_at >= '2025-01-01' AND status = 'completed'
+```
+
+### Hash Index
+
+Optimized for equality lookups only. Smaller than B-Tree for this use case.
+
+```sql
+CREATE INDEX idx_orders_status_hash
+    ON warehouse.orders USING HASH (status);
+
+-- Efficient: WHERE status = 'completed'
+-- Not efficient: WHERE status IN ('completed', 'pending')
+-- Not supported: WHERE status > 'a'
+```
+
+### GIN (Generalized Inverted Index)
+
+For columns containing arrays, JSONB, or full-text search vectors.
+
+```sql
+-- Index on JSONB column
+CREATE INDEX idx_events_payload
+    ON warehouse.events USING GIN (payload);
+
+-- Supports queries like:
+-- WHERE payload @> '{"type": "purchase"}'
+-- WHERE payload ? 'coupon_code'
+```
+
+### BRIN (Block Range Index)
+
+Extremely small indexes for naturally ordered data. Stores min/max values per block range.
+
+```sql
+CREATE INDEX idx_orders_created_brin
+    ON warehouse.orders USING BRIN (created_at)
+    WITH (pages_per_range = 128);
+```
+
+BRIN works well when the physical order of rows on disk correlates with the indexed column (e.g., append-only tables with a timestamp).
+
+| Index Type | Size | Equality | Range | Array/JSON | Best For |
+|-----------|------|----------|-------|------------|----------|
+| B-Tree | Medium | Yes | Yes | No | General purpose |
+| Hash | Small | Yes | No | No | Equality-only lookups |
+| GIN | Large | Yes | No | Yes | JSONB, arrays, full-text |
+| BRIN | Tiny | No | Yes | No | Naturally ordered large tables |
+
+## Partial Indexes
+
+Index only a subset of rows, reducing index size and maintenance cost.
+
+```sql
+-- Only index active orders
+CREATE INDEX idx_orders_active
+    ON warehouse.orders (customer_id, created_at)
+    WHERE status = 'active';
+
+-- Only index recent data
+CREATE INDEX idx_orders_recent
+    ON warehouse.orders (customer_id)
+    WHERE created_at >= '2025-01-01';
+```
+
+## Covering Indexes (INCLUDE)
+
+Add non-key columns to the index to enable index-only scans.
+
+```sql
+CREATE INDEX idx_orders_covering
+    ON warehouse.orders (customer_id, created_at)
+    INCLUDE (order_total, status);
+
+-- This query can be answered entirely from the index:
+SELECT customer_id, created_at, order_total, status
+FROM warehouse.orders
+WHERE customer_id = 12345
+  AND created_at >= '2025-01-01';
+```
+
+## Expression Indexes
+
+Index the result of a function or expression.
+
+```sql
+-- Index on date truncation
+CREATE INDEX idx_orders_month
+    ON warehouse.orders (DATE_TRUNC('month', created_at));
+
+-- Index on lower-cased email
+CREATE INDEX idx_customers_email_lower
+    ON warehouse.customers (LOWER(email));
+```
+
+## Index Design Process
+
+1. **Identify slow queries** from query logs or monitoring
+2. **Check execution plans** to see where scans occur
+3. **Identify selective columns** -- columns that filter to a small percentage of rows
+4. **Design the index** based on query patterns (consider composite indexes)
+5. **Test with EXPLAIN ANALYZE** to verify the index is used
+6. **Monitor index usage** and drop unused indexes
+
+### Checking Index Usage
+
+```sql
+-- PostgreSQL: check index usage statistics
+SELECT
+    schemaname,
+    tablename,
+    indexname,
+    idx_scan AS times_used,
+    idx_tup_read AS rows_read,
+    idx_tup_fetch AS rows_fetched,
+    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
+FROM pg_stat_user_indexes
+WHERE schemaname = 'warehouse'
+ORDER BY idx_scan DESC;
+```
+
+## Warehouse-Specific Considerations
+
+### Columnar Warehouses
+
+Many modern warehouses (Snowflake, BigQuery, Redshift) use columnar storage with zone maps or micro-partitions instead of traditional indexes.
+
+| Platform | Index Equivalent | How to Influence |
+|----------|-----------------|-----------------|
+| Snowflake | Micro-partition pruning | Clustering keys |
+| BigQuery | Partition + cluster pruning | PARTITION BY + CLUSTER BY |
+| Redshift | Zone maps + sort keys | SORTKEY declaration |
+| DuckDB | Automatic zone maps | Natural insertion order |
+
+### Redshift Sort Keys
+
+```sql
+-- Compound sort key: optimizes filters on leading columns
+CREATE TABLE warehouse.orders (
+    order_id BIGINT,
+    customer_id BIGINT,
+    created_at TIMESTAMP,
+    order_total DECIMAL(12,2)
+)
+SORTKEY (created_at, customer_id);
+
+-- Interleaved sort key: equal weight to all specified columns
+CREATE TABLE warehouse.orders (
+    order_id BIGINT,
+    customer_id BIGINT,
+    created_at TIMESTAMP,
+    region VARCHAR(20)
+)
+INTERLEAVED SORTKEY (created_at, region, customer_id);
+```
+
+## Index Maintenance
+
+### Bloat and Reindexing
+
+Indexes accumulate bloat from updates and deletes. Periodically rebuild.
+
+```sql
+-- Rebuild a specific index
+REINDEX INDEX idx_orders_customer;
+
+-- Rebuild all indexes on a table
+REINDEX TABLE warehouse.orders;
+
+-- Concurrent rebuild (no lock, PostgreSQL 12+)
+REINDEX INDEX CONCURRENTLY idx_orders_customer;
+```
+
+### Monitoring Index Size
+
+```sql
+SELECT
+    indexname,
+    pg_size_pretty(pg_relation_size(indexrelid)) AS size
+FROM pg_stat_user_indexes
+WHERE tablename = 'orders'
+ORDER BY pg_relation_size(indexrelid) DESC;
+```
+
+### When to Drop an Index
+
+- The index is never used (check `idx_scan` in `pg_stat_user_indexes`)
+- The index duplicates another index (e.g., single-column index on the first column of a composite)
+- Write performance is more critical than read performance for that table
+- The table is small enough that sequential scans are fast
+
+```sql
+-- Drop unused index
+DROP INDEX IF EXISTS idx_orders_old_status;
+```

--- a/quarry/content/docs/optimization/partitioning.md
+++ b/quarry/content/docs/optimization/partitioning.md
@@ -1,0 +1,245 @@
++++
+title = "Table Partitioning"
+description = "Partitioning strategies for warehouse tables to improve query performance and manageability"
+weight = 2
+[taxonomies]
+tags = ["optimization", "partitioning", "storage"]
++++
+
+## What is Partitioning?
+
+Partitioning divides a large table into smaller, manageable segments based on column values. The primary benefit is **partition pruning**: the query engine skips partitions that cannot contain relevant data, dramatically reducing I/O.
+
+### Partitioning vs. Sharding
+
+| Aspect | Partitioning | Sharding |
+|--------|-------------|----------|
+| Scope | Single database/warehouse | Multiple databases/nodes |
+| Transparency | Queries treat it as one table | Application must route queries |
+| Purpose | Performance and manageability | Horizontal scaling |
+
+## Partitioning Strategies
+
+### Range Partitioning
+
+Divide data by continuous ranges, most commonly dates.
+
+```sql
+-- PostgreSQL declarative partitioning
+CREATE TABLE warehouse.orders (
+    order_id     BIGINT,
+    customer_id  BIGINT,
+    order_total  DECIMAL(12,2),
+    created_at   TIMESTAMP NOT NULL,
+    status       VARCHAR(20)
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE warehouse.orders_2025_q1
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-01-01') TO ('2025-04-01');
+
+CREATE TABLE warehouse.orders_2025_q2
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-04-01') TO ('2025-07-01');
+
+CREATE TABLE warehouse.orders_2025_q3
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-07-01') TO ('2025-10-01');
+
+CREATE TABLE warehouse.orders_2025_q4
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-10-01') TO ('2026-01-01');
+```
+
+### List Partitioning
+
+Divide data by discrete values.
+
+```sql
+CREATE TABLE warehouse.orders (
+    order_id     BIGINT,
+    customer_id  BIGINT,
+    order_total  DECIMAL(12,2),
+    region       VARCHAR(20) NOT NULL,
+    created_at   TIMESTAMP
+) PARTITION BY LIST (region);
+
+CREATE TABLE warehouse.orders_us
+    PARTITION OF warehouse.orders
+    FOR VALUES IN ('us-east', 'us-west', 'us-central');
+
+CREATE TABLE warehouse.orders_eu
+    PARTITION OF warehouse.orders
+    FOR VALUES IN ('eu-west', 'eu-central', 'eu-north');
+
+CREATE TABLE warehouse.orders_apac
+    PARTITION OF warehouse.orders
+    FOR VALUES IN ('ap-east', 'ap-south', 'ap-southeast');
+```
+
+### Hash Partitioning
+
+Distribute data evenly across N partitions. Useful when no natural range or list column exists.
+
+```sql
+CREATE TABLE warehouse.events (
+    event_id     BIGINT,
+    user_id      BIGINT,
+    event_type   VARCHAR(50),
+    payload      JSONB,
+    created_at   TIMESTAMP
+) PARTITION BY HASH (user_id);
+
+CREATE TABLE warehouse.events_p0
+    PARTITION OF warehouse.events
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+
+CREATE TABLE warehouse.events_p1
+    PARTITION OF warehouse.events
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+
+CREATE TABLE warehouse.events_p2
+    PARTITION OF warehouse.events
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+
+CREATE TABLE warehouse.events_p3
+    PARTITION OF warehouse.events
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+```
+
+### Composite Partitioning
+
+Combine multiple strategies for large-scale tables.
+
+```sql
+-- Range by date, then list by region
+CREATE TABLE warehouse.orders (
+    order_id     BIGINT,
+    region       VARCHAR(20),
+    created_at   DATE NOT NULL,
+    order_total  DECIMAL(12,2)
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE warehouse.orders_2025_q1
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-01-01') TO ('2025-04-01')
+    PARTITION BY LIST (region);
+```
+
+## Partition Pruning
+
+Partition pruning is automatic when your WHERE clause references the partition key.
+
+```sql
+-- Prunes to only Q1 partition
+SELECT COUNT(*) FROM warehouse.orders
+WHERE created_at >= '2025-01-15'
+  AND created_at < '2025-02-15';
+
+-- No pruning: filter does not reference partition key
+SELECT COUNT(*) FROM warehouse.orders
+WHERE customer_id = 12345;
+```
+
+### Verifying Pruning
+
+```sql
+EXPLAIN
+SELECT COUNT(*) FROM warehouse.orders
+WHERE created_at >= '2025-01-01'
+  AND created_at < '2025-04-01';
+```
+
+Look for output like:
+
+```text
+Append  (cost=0.00..28450.00 rows=1000000 width=0)
+  ->  Seq Scan on orders_2025_q1
+        Filter: (created_at >= '2025-01-01' AND created_at < '2025-04-01')
+```
+
+Only `orders_2025_q1` is scanned; other partitions are pruned.
+
+## Warehouse-Specific Partitioning
+
+### BigQuery
+
+BigQuery uses partitioning on ingestion time, date/timestamp columns, or integer ranges.
+
+```sql
+CREATE TABLE project.dataset.orders
+PARTITION BY DATE(created_at)
+CLUSTER BY customer_id, region
+AS SELECT * FROM project.dataset.orders_staging;
+```
+
+### Snowflake
+
+Snowflake uses automatic micro-partitioning. You influence pruning through clustering keys.
+
+```sql
+ALTER TABLE warehouse.orders
+    CLUSTER BY (created_at, region);
+```
+
+### Redshift
+
+Redshift uses distribution keys and sort keys rather than traditional partitions.
+
+```sql
+CREATE TABLE warehouse.orders (
+    order_id     BIGINT,
+    customer_id  BIGINT,
+    order_total  DECIMAL(12,2),
+    created_at   TIMESTAMP
+)
+DISTSTYLE KEY
+DISTKEY (customer_id)
+SORTKEY (created_at);
+```
+
+## Choosing a Partition Key
+
+| Factor | Recommendation |
+|--------|---------------|
+| Time-series data | Partition by date (daily, monthly, or quarterly) |
+| Regional data | Partition by region if queries filter by region |
+| High cardinality | Avoid -- too many partitions harm metadata performance |
+| Even distribution | Ensure partitions are roughly equal in size |
+| Query patterns | Choose the column most frequently used in WHERE |
+
+### Partition Size Guidelines
+
+- Target 100MB to 1GB per partition for columnar warehouses
+- Avoid more than 10,000 partitions per table
+- Too few partitions limits pruning benefit
+- Too many partitions increases planning overhead and metadata storage
+
+## Maintenance
+
+### Adding New Partitions
+
+```sql
+-- Monthly partition creation (automate via scheduled job)
+CREATE TABLE warehouse.orders_2025_10
+    PARTITION OF warehouse.orders
+    FOR VALUES FROM ('2025-10-01') TO ('2025-11-01');
+```
+
+### Dropping Old Partitions
+
+Dropping a partition is instantaneous compared to deleting rows.
+
+```sql
+-- Remove data older than retention period
+DROP TABLE warehouse.orders_2023_q1;
+```
+
+### Detaching Partitions
+
+Detach without dropping for archival or analysis.
+
+```sql
+ALTER TABLE warehouse.orders
+    DETACH PARTITION warehouse.orders_2023_q1;
+```

--- a/quarry/content/docs/queries/_index.md
+++ b/quarry/content/docs/queries/_index.md
@@ -1,0 +1,7 @@
++++
+title = "SQL Queries"
+template = "section"
+sort_by = "weight"
+page_template = "doc"
+description = "Comprehensive reference for SQL query patterns used in data warehouse analytics."
++++

--- a/quarry/content/docs/queries/joins-and-subqueries.md
+++ b/quarry/content/docs/queries/joins-and-subqueries.md
@@ -1,0 +1,241 @@
++++
+title = "Joins and Subqueries"
+description = "JOIN types, subquery patterns, and set operations for warehouse analytics"
+weight = 2
+[taxonomies]
+tags = ["sql", "joins", "subqueries"]
++++
+
+## JOIN Operations
+
+Joins combine rows from two or more tables based on a related column. In warehouse environments, join performance is heavily influenced by data distribution and table sizes.
+
+### JOIN Types
+
+| Type | Behavior | Use Case |
+|------|----------|----------|
+| `INNER JOIN` | Returns only matching rows | Fact-to-dimension lookups |
+| `LEFT JOIN` | All rows from left, matched from right | Preserving all base records |
+| `RIGHT JOIN` | All rows from right, matched from left | Rarely used; rewrite as LEFT |
+| `FULL OUTER JOIN` | All rows from both sides | Reconciliation and diff queries |
+| `CROSS JOIN` | Cartesian product | Date spine generation |
+
+### INNER JOIN
+
+The most common join in analytics. Returns only rows that match in both tables.
+
+```sql
+SELECT
+    o.order_id,
+    o.order_total,
+    c.customer_name,
+    c.region
+FROM warehouse.orders o
+INNER JOIN warehouse.customers c
+    ON o.customer_id = c.customer_id
+WHERE o.created_at >= '2025-01-01';
+```
+
+### LEFT JOIN
+
+Preserves all rows from the left table. Unmatched right-side columns return NULL.
+
+```sql
+SELECT
+    c.customer_id,
+    c.customer_name,
+    COUNT(o.order_id) AS order_count,
+    COALESCE(SUM(o.order_total), 0) AS lifetime_value
+FROM warehouse.customers c
+LEFT JOIN warehouse.orders o
+    ON c.customer_id = o.customer_id
+    AND o.created_at >= '2025-01-01'
+GROUP BY c.customer_id, c.customer_name;
+```
+
+Note the filter on `created_at` is placed in the ON clause, not WHERE. Placing it in WHERE would convert the LEFT JOIN into an INNER JOIN.
+
+### Multi-Table Joins
+
+Warehouse queries commonly join a fact table to multiple dimension tables.
+
+```sql
+SELECT
+    o.order_id,
+    o.created_at,
+    c.customer_name,
+    c.region,
+    p.product_name,
+    p.category,
+    oi.quantity,
+    oi.unit_price
+FROM warehouse.orders o
+INNER JOIN warehouse.customers c
+    ON o.customer_id = c.customer_id
+INNER JOIN warehouse.order_items oi
+    ON o.order_id = oi.order_id
+INNER JOIN warehouse.products p
+    ON oi.product_id = p.product_id
+WHERE o.created_at BETWEEN '2025-01-01' AND '2025-03-31';
+```
+
+### CROSS JOIN for Date Spines
+
+Generate a complete date range, useful for filling gaps in time series data.
+
+```sql
+WITH date_spine AS (
+    SELECT
+        DATEADD('day', seq, '2025-01-01'::DATE) AS dt
+    FROM (
+        SELECT ROW_NUMBER() OVER (ORDER BY 1) - 1 AS seq
+        FROM warehouse.orders
+        LIMIT 365
+    )
+),
+daily_orders AS (
+    SELECT
+        DATE_TRUNC('day', created_at) AS dt,
+        COUNT(*) AS order_count
+    FROM warehouse.orders
+    WHERE created_at >= '2025-01-01'
+    GROUP BY 1
+)
+SELECT
+    ds.dt,
+    COALESCE(do.order_count, 0) AS order_count
+FROM date_spine ds
+LEFT JOIN daily_orders do
+    ON ds.dt = do.dt
+ORDER BY ds.dt;
+```
+
+## Subqueries
+
+Subqueries are queries nested inside other queries. They appear in SELECT, FROM, and WHERE clauses.
+
+### Scalar Subqueries
+
+Return a single value. Useful in SELECT for per-row calculations against aggregates.
+
+```sql
+SELECT
+    customer_id,
+    order_total,
+    order_total - (
+        SELECT AVG(order_total)
+        FROM warehouse.orders
+        WHERE created_at >= '2025-01-01'
+    ) AS diff_from_avg
+FROM warehouse.orders
+WHERE created_at >= '2025-01-01';
+```
+
+### Correlated Subqueries
+
+Reference columns from the outer query. Executed once per outer row, so use with caution on large tables.
+
+```sql
+SELECT
+    c.customer_id,
+    c.customer_name,
+    (
+        SELECT MAX(o.created_at)
+        FROM warehouse.orders o
+        WHERE o.customer_id = c.customer_id
+    ) AS last_order_date
+FROM warehouse.customers c;
+```
+
+### EXISTS and NOT EXISTS
+
+Test for the presence or absence of related rows. Generally more efficient than IN for large datasets.
+
+```sql
+-- Customers who have placed at least one order in 2025
+SELECT c.customer_id, c.customer_name
+FROM warehouse.customers c
+WHERE EXISTS (
+    SELECT 1
+    FROM warehouse.orders o
+    WHERE o.customer_id = c.customer_id
+      AND o.created_at >= '2025-01-01'
+);
+
+-- Customers with no orders at all
+SELECT c.customer_id, c.customer_name
+FROM warehouse.customers c
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM warehouse.orders o
+    WHERE o.customer_id = c.customer_id
+);
+```
+
+### Common Table Expressions (CTEs)
+
+CTEs improve readability by breaking complex queries into named steps.
+
+```sql
+WITH monthly_revenue AS (
+    SELECT
+        DATE_TRUNC('month', created_at) AS month,
+        SUM(order_total) AS revenue
+    FROM warehouse.orders
+    WHERE status = 'completed'
+    GROUP BY 1
+),
+revenue_with_growth AS (
+    SELECT
+        month,
+        revenue,
+        LAG(revenue) OVER (ORDER BY month) AS prev_month_revenue,
+        ROUND(
+            100.0 * (revenue - LAG(revenue) OVER (ORDER BY month))
+            / NULLIF(LAG(revenue) OVER (ORDER BY month), 0),
+            2
+        ) AS growth_pct
+    FROM monthly_revenue
+)
+SELECT * FROM revenue_with_growth
+ORDER BY month;
+```
+
+## Set Operations
+
+Combine result sets from multiple queries.
+
+| Operation | Behavior |
+|-----------|----------|
+| `UNION ALL` | Concatenate all rows (including duplicates) |
+| `UNION` | Concatenate and deduplicate |
+| `INTERSECT` | Rows present in both result sets |
+| `EXCEPT` | Rows in first set but not in second |
+
+```sql
+-- All customers who ordered in Q1 or Q2
+SELECT DISTINCT customer_id FROM warehouse.orders
+WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'
+
+UNION
+
+SELECT DISTINCT customer_id FROM warehouse.orders
+WHERE created_at BETWEEN '2025-04-01' AND '2025-06-30';
+
+-- Customers who ordered in Q1 but not Q2
+SELECT DISTINCT customer_id FROM warehouse.orders
+WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'
+
+EXCEPT
+
+SELECT DISTINCT customer_id FROM warehouse.orders
+WHERE created_at BETWEEN '2025-04-01' AND '2025-06-30';
+```
+
+### Join Performance Tips
+
+- Join on integer keys rather than strings when possible
+- Filter fact tables before joining to dimension tables
+- Use `UNION ALL` instead of `UNION` when duplicates are acceptable
+- Prefer CTEs over deeply nested subqueries for readability
+- Be cautious with `CROSS JOIN` -- the output size is the product of both inputs

--- a/quarry/content/docs/queries/select-basics.md
+++ b/quarry/content/docs/queries/select-basics.md
@@ -1,0 +1,162 @@
++++
+title = "SELECT Basics"
+description = "Fundamental SQL SELECT patterns for warehouse queries"
+weight = 1
+[taxonomies]
+tags = ["sql", "select", "fundamentals"]
++++
+
+## The SELECT Statement
+
+The `SELECT` statement is the foundation of every analytics query. In a data warehouse context, understanding how to write precise, efficient SELECT statements is critical because even small inefficiencies multiply across billions of rows.
+
+### Basic Syntax
+
+```sql
+SELECT
+    column1,
+    column2,
+    aggregate_function(column3) AS alias
+FROM schema.table_name
+WHERE condition
+GROUP BY column1, column2
+HAVING aggregate_condition
+ORDER BY column1
+LIMIT 100;
+```
+
+### Column Selection
+
+Always select only the columns you need. Warehouse storage is columnar, so each additional column in your SELECT adds I/O cost.
+
+```sql
+-- Bad: scans all columns
+SELECT * FROM warehouse.orders;
+
+-- Good: scans only required columns
+SELECT
+    order_id,
+    customer_id,
+    order_total,
+    created_at
+FROM warehouse.orders;
+```
+
+### Filtering with WHERE
+
+Apply filters early to reduce the amount of data processed downstream.
+
+```sql
+SELECT
+    customer_id,
+    SUM(order_total) AS total_spend
+FROM warehouse.orders
+WHERE created_at >= '2025-01-01'
+  AND status = 'completed'
+GROUP BY customer_id;
+```
+
+### Common Filter Patterns
+
+| Pattern | Example | Notes |
+|---------|---------|-------|
+| Date range | `WHERE dt BETWEEN '2025-01-01' AND '2025-03-31'` | Partition-friendly |
+| NULL check | `WHERE email IS NOT NULL` | Use IS, not = |
+| IN list | `WHERE region IN ('us-east', 'us-west')` | Keep lists short |
+| LIKE pattern | `WHERE name LIKE 'prod_%'` | Prefix patterns can use indexes |
+| NOT EXISTS | `WHERE NOT EXISTS (SELECT 1 FROM ...)` | Preferred over NOT IN for NULLs |
+
+### Aggregation
+
+Aggregate functions collapse rows into summary values. The most common aggregations in warehouse queries:
+
+```sql
+SELECT
+    DATE_TRUNC('month', created_at) AS month,
+    COUNT(*) AS order_count,
+    COUNT(DISTINCT customer_id) AS unique_customers,
+    SUM(order_total) AS revenue,
+    AVG(order_total) AS avg_order_value,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY order_total) AS median_order
+FROM warehouse.orders
+WHERE created_at >= '2025-01-01'
+GROUP BY DATE_TRUNC('month', created_at)
+ORDER BY month;
+```
+
+### CASE Expressions
+
+Use `CASE` to create derived columns based on conditional logic.
+
+```sql
+SELECT
+    order_id,
+    order_total,
+    CASE
+        WHEN order_total >= 1000 THEN 'high'
+        WHEN order_total >= 100  THEN 'medium'
+        ELSE 'low'
+    END AS value_tier,
+    CASE WHEN is_first_order THEN 1 ELSE 0 END AS new_customer_flag
+FROM warehouse.orders;
+```
+
+### Conditional Aggregation
+
+Combine `CASE` with aggregate functions for pivot-style analysis.
+
+```sql
+SELECT
+    region,
+    COUNT(*) AS total_orders,
+    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+    SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) AS cancelled,
+    ROUND(
+        100.0 * SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) / COUNT(*),
+        2
+    ) AS completion_rate
+FROM warehouse.orders
+GROUP BY region
+ORDER BY total_orders DESC;
+```
+
+### Example Schema
+
+The examples in this documentation use the following warehouse schema:
+
+| Table | Description | Approximate Rows |
+|-------|-------------|-----------------|
+| `warehouse.orders` | Transactional order records | 500M |
+| `warehouse.customers` | Customer dimension table | 12M |
+| `warehouse.products` | Product catalog dimension | 200K |
+| `warehouse.order_items` | Line items per order | 1.8B |
+| `warehouse.events` | Clickstream event log | 50B |
+
+### DISTINCT and Deduplication
+
+```sql
+-- Simple distinct
+SELECT DISTINCT region, country
+FROM warehouse.customers;
+
+-- Deduplication with ROW_NUMBER (see Window Functions)
+SELECT *
+FROM (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY customer_id
+            ORDER BY updated_at DESC
+        ) AS rn
+    FROM warehouse.customers_raw
+) t
+WHERE rn = 1;
+```
+
+### Best Practices
+
+- Select only the columns you need to minimize columnar I/O
+- Push filters into WHERE clauses rather than HAVING when possible
+- Use date partition columns in WHERE to enable partition pruning
+- Prefer `COUNT(DISTINCT x)` carefully -- it can be expensive at scale
+- Alias all computed columns for clarity in downstream consumption

--- a/quarry/content/docs/queries/window-functions.md
+++ b/quarry/content/docs/queries/window-functions.md
@@ -1,0 +1,239 @@
++++
+title = "Window Functions"
+description = "ROW_NUMBER, RANK, LAG, LEAD, and other window functions for analytics"
+weight = 3
+[taxonomies]
+tags = ["sql", "window-functions", "analytics"]
++++
+
+## Window Functions Overview
+
+Window functions perform calculations across a set of rows related to the current row, without collapsing the result set like GROUP BY. They are essential for ranking, running totals, moving averages, and row-to-row comparisons.
+
+### Syntax
+
+```sql
+function_name(arguments) OVER (
+    [PARTITION BY partition_columns]
+    [ORDER BY sort_columns [ASC|DESC]]
+    [ROWS|RANGE BETWEEN frame_start AND frame_end]
+)
+```
+
+### Window Function Categories
+
+| Category | Functions | Purpose |
+|----------|-----------|---------|
+| Ranking | `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE` | Assign ordinal positions |
+| Offset | `LAG`, `LEAD`, `FIRST_VALUE`, `LAST_VALUE` | Access other rows |
+| Aggregate | `SUM`, `AVG`, `COUNT`, `MIN`, `MAX` | Running/sliding calculations |
+
+## Ranking Functions
+
+### ROW_NUMBER
+
+Assigns a unique sequential number within each partition. No ties -- every row gets a distinct number.
+
+```sql
+SELECT
+    customer_id,
+    order_id,
+    order_total,
+    created_at,
+    ROW_NUMBER() OVER (
+        PARTITION BY customer_id
+        ORDER BY created_at DESC
+    ) AS order_recency_rank
+FROM warehouse.orders;
+```
+
+Common use: deduplication. Keep only the most recent record per entity.
+
+```sql
+WITH ranked AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY customer_id
+            ORDER BY updated_at DESC
+        ) AS rn
+    FROM warehouse.customers_raw
+)
+SELECT * FROM ranked WHERE rn = 1;
+```
+
+### RANK and DENSE_RANK
+
+Unlike `ROW_NUMBER`, these handle ties.
+
+```sql
+SELECT
+    product_id,
+    category,
+    total_revenue,
+    RANK() OVER (
+        PARTITION BY category
+        ORDER BY total_revenue DESC
+    ) AS revenue_rank,
+    DENSE_RANK() OVER (
+        PARTITION BY category
+        ORDER BY total_revenue DESC
+    ) AS dense_revenue_rank
+FROM warehouse.product_summary;
+```
+
+| product_id | category | total_revenue | revenue_rank | dense_revenue_rank |
+|-----------|----------|---------------|-------------|-------------------|
+| 101 | Electronics | 50000 | 1 | 1 |
+| 102 | Electronics | 50000 | 1 | 1 |
+| 103 | Electronics | 42000 | 3 | 2 |
+| 104 | Electronics | 38000 | 4 | 3 |
+
+- `RANK` skips numbers after ties (1, 1, 3)
+- `DENSE_RANK` does not skip (1, 1, 2)
+
+### NTILE
+
+Divides rows into N roughly equal groups.
+
+```sql
+SELECT
+    customer_id,
+    lifetime_value,
+    NTILE(10) OVER (ORDER BY lifetime_value DESC) AS decile
+FROM warehouse.customer_summary;
+```
+
+## Offset Functions
+
+### LAG and LEAD
+
+Access values from preceding or following rows.
+
+```sql
+SELECT
+    month,
+    revenue,
+    LAG(revenue, 1) OVER (ORDER BY month) AS prev_month,
+    LEAD(revenue, 1) OVER (ORDER BY month) AS next_month,
+    revenue - LAG(revenue, 1) OVER (ORDER BY month) AS mom_change,
+    ROUND(
+        100.0 * (revenue - LAG(revenue, 1) OVER (ORDER BY month))
+        / NULLIF(LAG(revenue, 1) OVER (ORDER BY month), 0),
+        2
+    ) AS mom_change_pct
+FROM warehouse.monthly_revenue
+ORDER BY month;
+```
+
+| month | revenue | prev_month | next_month | mom_change | mom_change_pct |
+|-------|---------|------------|------------|------------|----------------|
+| 2025-01 | 1200000 | NULL | 1350000 | NULL | NULL |
+| 2025-02 | 1350000 | 1200000 | 1280000 | 150000 | 12.50 |
+| 2025-03 | 1280000 | 1350000 | 1420000 | -70000 | -5.19 |
+| 2025-04 | 1420000 | 1280000 | NULL | 140000 | 10.94 |
+
+### FIRST_VALUE and LAST_VALUE
+
+```sql
+SELECT
+    order_id,
+    customer_id,
+    order_total,
+    created_at,
+    FIRST_VALUE(order_total) OVER (
+        PARTITION BY customer_id
+        ORDER BY created_at
+    ) AS first_order_value,
+    LAST_VALUE(order_total) OVER (
+        PARTITION BY customer_id
+        ORDER BY created_at
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) AS latest_order_value
+FROM warehouse.orders;
+```
+
+Note: `LAST_VALUE` requires an explicit frame clause. The default frame (`ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`) only looks at rows up to the current row, which makes `LAST_VALUE` return the current row's value.
+
+## Aggregate Window Functions
+
+### Running Totals
+
+```sql
+SELECT
+    created_at,
+    order_total,
+    SUM(order_total) OVER (
+        ORDER BY created_at
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS running_total
+FROM warehouse.orders
+WHERE customer_id = 12345
+ORDER BY created_at;
+```
+
+### Moving Averages
+
+```sql
+SELECT
+    dt,
+    daily_revenue,
+    AVG(daily_revenue) OVER (
+        ORDER BY dt
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+    ) AS seven_day_avg,
+    AVG(daily_revenue) OVER (
+        ORDER BY dt
+        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+    ) AS thirty_day_avg
+FROM warehouse.daily_revenue_summary
+ORDER BY dt;
+```
+
+### Percent of Total
+
+```sql
+SELECT
+    region,
+    category,
+    revenue,
+    ROUND(
+        100.0 * revenue / SUM(revenue) OVER (PARTITION BY region),
+        2
+    ) AS pct_of_region,
+    ROUND(
+        100.0 * revenue / SUM(revenue) OVER (),
+        2
+    ) AS pct_of_total
+FROM warehouse.regional_category_revenue;
+```
+
+## Frame Specification
+
+The frame clause controls which rows are included in the window calculation.
+
+| Frame | Meaning |
+|-------|---------|
+| `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` | All rows from start to current (default) |
+| `ROWS BETWEEN 6 PRECEDING AND CURRENT ROW` | Current row plus 6 preceding rows |
+| `ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING` | Centered window of 7 rows |
+| `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` | Entire partition |
+| `RANGE BETWEEN INTERVAL '7' DAY PRECEDING AND CURRENT ROW` | Date-based range window |
+
+### Best Practices
+
+- Name your window with `WINDOW` clause when reusing the same partition and order across multiple functions
+- Be explicit about frame clauses, especially with `LAST_VALUE`
+- Use `QUALIFY` (where supported) to filter on window function results without a subquery
+- Window functions are computed after WHERE, GROUP BY, and HAVING -- plan accordingly
+- Avoid ordering by non-deterministic expressions in window definitions
+
+```sql
+-- Using QUALIFY to simplify deduplication (Snowflake, BigQuery, DuckDB)
+SELECT *
+FROM warehouse.customers_raw
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY customer_id
+    ORDER BY updated_at DESC
+) = 1;
+```

--- a/quarry/content/index.md
+++ b/quarry/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "Quarry"
+description = "Data warehouse and analytics query documentation"
++++
+
+<div class="py-16 text-center">
+  <h1 class="text-4xl font-bold text-white mb-4">Quarry</h1>
+  <p class="text-lg text-qry-muted max-w-2xl mx-auto mb-10">A comprehensive reference for data warehouse queries, optimization strategies, and analytics patterns. Built for data engineers and analysts.</p>
+  <div class="flex justify-center gap-4 flex-wrap">
+    <a href="docs/queries/" class="inline-block px-6 py-2.5 bg-qry-accent text-qry-bg font-semibold rounded-lg hover:bg-qry-accent-dark transition-colors">Query Reference</a>
+    <a href="docs/optimization/" class="inline-block px-6 py-2.5 bg-qry-surface border border-qry-border text-white font-semibold rounded-lg hover:border-qry-accent/50 transition-colors">Optimization Guide</a>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto pb-16">
+  <div class="p-6 bg-qry-surface border border-qry-border rounded-lg">
+    <h3 class="text-lg font-semibold text-white mb-2">SQL Queries</h3>
+    <p class="text-sm text-qry-muted mb-4">Master SELECT statements, JOINs, subqueries, and window functions with practical examples drawn from real warehouse schemas.</p>
+    <a href="docs/queries/" class="text-sm text-qry-accent hover:underline">Browse queries &rarr;</a>
+  </div>
+  <div class="p-6 bg-qry-surface border border-qry-border rounded-lg">
+    <h3 class="text-lg font-semibold text-white mb-2">Performance Optimization</h3>
+    <p class="text-sm text-qry-muted mb-4">Learn to read execution plans, design efficient partitioning schemes, and choose the right indexing strategies for your workload.</p>
+    <a href="docs/optimization/" class="text-sm text-qry-accent hover:underline">Browse optimization &rarr;</a>
+  </div>
+</div>

--- a/quarry/static/js/mobile-menu.js
+++ b/quarry/static/js/mobile-menu.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var btn = document.getElementById('mobileMenuBtn');
+  var menu = document.getElementById('mobileMenu');
+  if (btn && menu) {
+    btn.addEventListener('click', function () {
+      menu.classList.toggle('hidden');
+    });
+  }
+
+  var searchInput = document.getElementById('searchInput');
+  if (searchInput) {
+    document.addEventListener('keydown', function (e) {
+      if (e.key === '/' && document.activeElement !== searchInput) {
+        e.preventDefault();
+        searchInput.focus();
+      }
+      if (e.key === 'Escape') {
+        searchInput.blur();
+      }
+    });
+  }
+});

--- a/quarry/templates/404.html
+++ b/quarry/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <div class="text-center py-24">
+    <h1 class="text-6xl font-bold text-white mb-4">404</h1>
+    <p class="text-qry-muted text-lg mb-8">Query returned no results. The page you are looking for does not exist.</p>
+    <a href="{{ base_url }}/" class="inline-block px-6 py-2.5 bg-qry-accent text-qry-bg font-medium rounded-lg hover:bg-qry-accent-dark transition-colors">Return to Home</a>
+  </div>
+{% include "footer.html" %}

--- a/quarry/templates/doc.html
+++ b/quarry/templates/doc.html
@@ -1,0 +1,66 @@
+{% include "header.html" %}
+  <div class="py-10">
+    <div class="lg:hidden mb-6">
+      <details class="bg-qry-surface border border-qry-border rounded-lg">
+        <summary class="px-4 py-3 text-sm font-medium text-qry-text cursor-pointer">Section Navigation</summary>
+        <div class="px-4 pb-3 space-y-1">
+          {% if section.pages %}
+          {% for doc in section.pages %}
+          <a href="{{ base_url }}{{ doc.url }}" class="block py-1.5 px-2 rounded text-sm {% if doc.url == page.url %}bg-qry-accent/10 text-qry-accent font-medium{% else %}text-qry-muted hover:text-white{% endif %}">
+            {{ doc.title }}
+          </a>
+          {% endfor %}
+          {% endif %}
+        </div>
+      </details>
+    </div>
+    <div class="grid grid-cols-1 lg:grid-cols-[220px_1fr_180px] gap-10 items-start">
+      <aside class="hidden lg:block sticky top-16 overflow-y-auto max-h-[calc(100vh-100px)]">
+        <h3 class="text-xs font-bold text-qry-accent uppercase tracking-wider mb-4">{{ section.title }}</h3>
+        {% if section.pages %}
+        <ul class="space-y-1 text-sm">
+          {% for doc in section.pages %}
+          <li>
+            <a href="{{ base_url }}{{ doc.url }}" class="block py-1.5 px-3 rounded {% if doc.url == page.url %}bg-qry-accent/10 text-qry-accent font-medium border-l-2 border-qry-accent{% else %}text-qry-muted hover:text-white hover:bg-qry-surface{% endif %} transition-all">
+              {{ doc.title }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </aside>
+      <article class="min-w-0">
+        <nav class="flex items-center gap-2 text-xs text-qry-muted mb-6">
+          <a href="{{ base_url }}/" class="hover:text-white transition-colors">Home</a>
+          <span class="text-qry-border">/</span>
+          <a href="{{ base_url }}{{ section.url }}" class="hover:text-white transition-colors">{{ section.title }}</a>
+          <span class="text-qry-border">/</span>
+          <span class="text-qry-text">{{ page.title }}</span>
+        </nav>
+        <h1 class="text-2xl font-bold text-white mb-2">{{ page.title }}</h1>
+        {% if page.description %}
+        <p class="text-qry-muted mb-8 pb-4 border-b border-qry-border">{{ page.description }}</p>
+        {% endif %}
+        <div class="prose">
+          {{ content }}
+        </div>
+        <div class="mt-10 pt-6 border-t border-qry-border flex justify-between text-sm">
+          {% if page.lower %}
+          <a href="{{ base_url }}{{ page.lower.url }}" class="text-qry-muted hover:text-qry-accent transition-colors">&larr; {{ page.lower.title }}</a>
+          {% else %}<div></div>{% endif %}
+          {% if page.higher %}
+          <a href="{{ base_url }}{{ page.higher.url }}" class="text-qry-muted hover:text-qry-accent transition-colors">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </div>
+      </article>
+      <aside class="hidden lg:block sticky top-16 text-sm">
+        {% if page.toc %}
+        <h3 class="text-xs font-bold text-qry-muted uppercase tracking-wider mb-3">On this page</h3>
+        <div class="toc text-xs text-qry-muted">
+          {{ page.toc }}
+        </div>
+        {% endif %}
+      </aside>
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/quarry/templates/footer.html
+++ b/quarry/templates/footer.html
@@ -1,0 +1,11 @@
+  </div>
+  <footer class="border-t border-qry-border bg-qry-dark py-6 mt-16">
+    <div class="max-w-7xl mx-auto px-6 text-center text-xs text-qry-muted">
+      <p>Powered by <a href="https://github.com/hahwul/hwaro" class="text-qry-accent hover:underline">Hwaro</a></p>
+    </div>
+  </footer>
+  <script src="{{ base_url }}/js/mobile-menu.js"></script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/quarry/templates/header.html
+++ b/quarry/templates/header.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description }}">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            qry: {
+              bg: '#0f172a',
+              surface: '#1e293b',
+              border: '#334155',
+              text: '#e2e8f0',
+              muted: '#94a3b8',
+              accent: '#f59e0b',
+              'accent-dark': '#d97706',
+              dark: '#0b1120',
+            },
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'monospace'],
+          },
+        },
+      },
+    }
+  </script>
+  <style type="text/tailwindcss">
+    body { @apply bg-qry-bg text-qry-text font-sans; }
+    .prose { @apply max-w-none text-qry-text; }
+    .prose h1 { @apply text-2xl font-bold mb-6 text-white; }
+    .prose h2 { @apply text-xl font-bold mt-10 mb-4 text-white border-b border-qry-border pb-2; }
+    .prose h3 { @apply text-lg font-semibold mt-8 mb-3 text-qry-text; }
+    .prose h4 { @apply text-base font-semibold mt-6 mb-2 text-qry-text; }
+    .prose p { @apply my-3 leading-relaxed text-qry-muted; }
+    .prose a { @apply text-qry-accent hover:text-qry-accent-dark hover:underline; }
+    .prose strong { @apply font-semibold text-white; }
+    .prose code { @apply bg-qry-surface px-1.5 py-0.5 rounded text-sm font-mono text-qry-accent border border-qry-border; }
+    .prose pre { @apply bg-qry-dark text-qry-text p-4 rounded-lg my-4 overflow-x-auto font-mono text-sm border border-qry-border; }
+    .prose pre code { @apply bg-transparent p-0 border-0 text-qry-text; }
+    .prose blockquote { @apply my-4 py-2 px-4 border-l-4 border-qry-accent bg-qry-surface text-qry-muted rounded-r; }
+    .prose ul, .prose ol { @apply my-3 ml-6; }
+    .prose li { @apply my-1.5 text-qry-muted; }
+    .prose ul li { @apply list-disc marker:text-qry-accent; }
+    .prose ol li { @apply list-decimal marker:text-qry-accent; }
+    .prose table { @apply w-full border-collapse my-6 text-sm; }
+    .prose thead { @apply bg-qry-surface; }
+    .prose th { @apply px-4 py-2.5 text-left font-semibold text-qry-accent border border-qry-border; }
+    .prose td { @apply px-4 py-2.5 border border-qry-border text-qry-muted; }
+    .prose tbody tr:hover { @apply bg-qry-surface; }
+    .toc ul { @apply ml-4 my-0 space-y-1; }
+    .toc li { @apply relative; }
+    .toc a { @apply text-qry-muted no-underline text-xs hover:text-qry-accent transition-colors block py-0.5; }
+    .alert { @apply my-4 p-4 rounded-lg border text-sm; }
+    .alert-info { @apply bg-qry-surface border-blue-500/30 text-blue-300; }
+    .alert-warning { @apply bg-qry-surface border-qry-accent/30 text-qry-accent; }
+    .alert-danger { @apply bg-qry-surface border-red-500/30 text-red-300; }
+    .alert-tip { @apply bg-qry-surface border-emerald-500/30 text-emerald-300; }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <nav class="border-b border-qry-border bg-qry-bg sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
+      <div class="flex items-center gap-8">
+        <a href="{{ base_url }}/" class="flex items-center gap-2 font-bold text-white hover:text-qry-accent transition-colors">
+          <svg class="w-5 h-5 text-qry-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
+          {{ site.title }}
+        </a>
+        <div class="hidden md:flex items-center gap-5 text-sm">
+          <a href="{{ base_url }}/docs/queries/" class="text-qry-muted hover:text-white transition-colors">Queries</a>
+          <a href="{{ base_url }}/docs/optimization/" class="text-qry-muted hover:text-white transition-colors">Optimization</a>
+          <a href="{{ base_url }}/about/" class="text-qry-muted hover:text-white transition-colors">About</a>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div class="hidden sm:block relative">
+          <input type="text" id="searchInput" placeholder="Search docs..." class="bg-qry-surface border border-qry-border rounded-lg px-3 py-1.5 text-sm text-qry-text placeholder:text-qry-muted focus:outline-none focus:border-qry-accent w-48 lg:w-64">
+          <kbd class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-qry-muted bg-qry-bg border border-qry-border rounded px-1.5 py-0.5">/</kbd>
+        </div>
+        <button id="mobileMenuBtn" class="md:hidden text-qry-muted hover:text-white" onclick="document.getElementById('mobileMenu').classList.toggle('hidden')">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+    </div>
+    <div id="mobileMenu" class="hidden md:hidden border-t border-qry-border px-6 py-3 space-y-2">
+      <a href="{{ base_url }}/docs/queries/" class="block text-sm text-qry-muted hover:text-white py-1">Queries</a>
+      <a href="{{ base_url }}/docs/optimization/" class="block text-sm text-qry-muted hover:text-white py-1">Optimization</a>
+      <a href="{{ base_url }}/about/" class="block text-sm text-qry-muted hover:text-white py-1">About</a>
+    </div>
+  </nav>
+  <div class="max-w-7xl mx-auto px-6">

--- a/quarry/templates/page.html
+++ b/quarry/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold text-white mb-6">{{ page.title }}</h1>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/quarry/templates/section.html
+++ b/quarry/templates/section.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <div class="py-10">
+    <header class="mb-10">
+      <h1 class="text-2xl font-bold text-white mb-2">{{ page.title }}</h1>
+      <div class="prose text-qry-muted">{{ content }}</div>
+    </header>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {% for page in section.pages %}
+      <a href="{{ base_url }}{{ page.url }}" class="block p-5 bg-qry-surface border border-qry-border rounded-lg hover:border-qry-accent/50 transition-all group">
+        <h2 class="font-semibold text-white group-hover:text-qry-accent transition-colors mb-2">{{ page.title }}</h2>
+        {% if page.description %}<p class="text-sm text-qry-muted">{{ page.description }}</p>{% endif %}
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/quarry/templates/shortcodes/alert.html
+++ b/quarry/templates/shortcodes/alert.html
@@ -1,0 +1,1 @@
+<div class="alert alert-{{ type }}">{{ body }}</div>

--- a/quarry/templates/taxonomy.html
+++ b/quarry/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <h1 class="text-2xl font-bold text-white mb-6">{{ page.title }}</h1>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/quarry/templates/taxonomy_term.html
+++ b/quarry/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <div class="py-10 max-w-3xl mx-auto">
+    <h1 class="text-2xl font-bold text-white mb-6">{{ page.title }}</h1>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -709,6 +709,11 @@
     "landing",
     "timezone"
   ],
+  "meridian-docs": [
+    "light",
+    "docs",
+    "scheduling"
+  ],
   "micro": [
     "light",
     "blog",
@@ -808,6 +813,11 @@
     "light",
     "docs",
     "design"
+  ],
+  "pantry": [
+    "light",
+    "docs",
+    "package-manager"
   ],
   "paper": [
     "light",
@@ -914,6 +924,11 @@
   "pulse-api": [
     "dark",
     "docs"
+  ],
+  "quarry": [
+    "dark",
+    "docs",
+    "data-warehouse"
   ],
   "quill": [
     "light",


### PR DESCRIPTION
## Summary
- **meridian-docs**: Timezone/scheduling API documentation site (light theme, blue/white/gold palette) - IBM Plex Sans/Mono fonts, world timezone mapping tables, cron expression builder guide, DST handling docs
- **quarry**: Data warehouse/analytics query documentation site (dark theme, navy/amber/white palette) - Inter/JetBrains Mono fonts, SQL query examples, execution plan visualization, partitioning/indexing strategy guides
- **pantry**: Package manager/registry documentation site (light theme, green/white palette) - Source Sans 3/Source Code Pro fonts, CLI installation guides, semver version range tables, publish/deprecation workflows

All examples feature sidebar navigation, TOC, breadcrumbs, prev/next navigation, mobile responsive layout, and search support.

Closes #377
Closes #378
Closes #379

## Test plan
- [ ] `hwaro serve` each example and verify all pages render correctly
- [ ] Verify sidebar navigation and active state highlighting
- [ ] Verify mobile responsive layout and mobile menu toggle
- [ ] Confirm no gradients are used in any template
- [ ] Check all internal links resolve correctly