### PR TITLE
Add Windows 95 classic gray bezel theme

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -1893,5 +1893,11 @@
     "agency",
     "deconstructivism",
     "architecture"
+  ],
+  "windows95": [
+    "light",
+    "retro",
+    "os",
+    "nostalgia"
   ]
 }

--- a/windows95/config.toml
+++ b/windows95/config.toml
@@ -1,0 +1,9 @@
+base_url = "https://example.com"
+title = "Windows 95 Classic"
+description = "A classic Windows 95 gray bezel design."
+
+[markdown]
+safe = true
+
+[extra]
+author = "Hwaro"

--- a/windows95/content/_index.md
+++ b/windows95/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "My Documents"
+template = "index.html"
++++
+
+Welcome to my personal computer. Please browse the files below.

--- a/windows95/content/posts/_index.md
+++ b/windows95/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+template = "section.html"
++++
+
+This directory contains various text documents.

--- a/windows95/content/posts/hello-world.md
+++ b/windows95/content/posts/hello-world.md
@@ -1,0 +1,9 @@
++++
+title = "Hello World"
+date = 1995-08-24
++++
+
+Hello World! This is a simple text document written in Notepad.
+It feels just like the good old days of computing.
+
+There are no gradients or emojis here, only pure text and nostalgia.

--- a/windows95/templates/base.html
+++ b/windows95/templates/base.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.title }}</title>
+    {% include "header.html" %}
+</head>
+<body>
+    <div class="desktop">
+        <div class="window">
+            <div class="window-titlebar">
+                <div class="window-title">
+                    <span style="margin-right: 5px; background: #fff; width: 14px; height: 14px; border: 1px solid #000; display: inline-block;"></span>
+                    {% if page.title %}{{ page.title }}{% else %}Explorer{% endif %}
+                </div>
+                <div class="window-controls">
+                    <button class="win-btn" aria-label="Minimize">_</button>
+                    <button class="win-btn" aria-label="Maximize">[]</button>
+                    <button class="win-btn" aria-label="Close">X</button>
+                </div>
+            </div>
+            <div class="menubar">
+                <div class="menu-item">File</div>
+                <div class="menu-item">Edit</div>
+                <div class="menu-item">View</div>
+                <div class="menu-item">Help</div>
+            </div>
+            <div class="window-content">
+                {% block content %}{% endblock content %}
+            </div>
+        </div>
+    </div>
+
+    <div class="taskbar">
+        <a href="{{ config.base_url }}" class="start-btn">
+            <span style="display:inline-block; width:16px; height:16px; background-color: #000; border: 1px solid #fff;"></span>
+            Start
+        </a>
+        <div class="taskbar-divider"></div>
+        <a href="{{ config.base_url }}" class="taskbar-item active">
+            <span style="display:inline-block; width:14px; height:14px; background-color: #fff; border: 1px solid #000; margin-right: 4px;"></span>
+            Explorer
+        </a>
+        <div class="taskbar-clock">
+            <span id="clock">12:00 PM</span>
+        </div>
+    </div>
+
+    <script>
+        function updateClock() {
+            const now = new Date();
+            let hours = now.getHours();
+            let minutes = now.getMinutes();
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            hours = hours % 12;
+            hours = hours ? hours : 12;
+            minutes = minutes < 10 ? '0' + minutes : minutes;
+            const strTime = hours + ':' + minutes + ' ' + ampm;
+            document.getElementById('clock').innerText = strTime;
+        }
+        setInterval(updateClock, 1000);
+        updateClock();
+    </script>
+</body>
+</html>

--- a/windows95/templates/header.html
+++ b/windows95/templates/header.html
@@ -1,0 +1,307 @@
+<style>
+    :root {
+        --win-bg: #c0c0c0;
+        --win-border-light: #ffffff;
+        --win-border-light-inner: #dfdfdf;
+        --win-border-dark: #000000;
+        --win-border-dark-inner: #808080;
+        --win-title-bg: #000080;
+        --win-title-text: #ffffff;
+        --win-text: #000000;
+        --desktop-bg: #008080;
+    }
+
+    body, html {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        font-family: 'MS Sans Serif', 'Arial', sans-serif;
+        font-size: 14px;
+        background-color: var(--desktop-bg);
+        color: var(--win-text);
+        overflow: hidden;
+    }
+
+    .desktop {
+        position: relative;
+        height: calc(100vh - 40px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+
+    .window {
+        background-color: var(--win-bg);
+        border-top: 2px solid var(--win-border-light);
+        border-left: 2px solid var(--win-border-light);
+        border-right: 2px solid var(--win-border-dark);
+        border-bottom: 2px solid var(--win-border-dark);
+        box-shadow: inset 1px 1px var(--win-border-light-inner), inset -1px -1px var(--win-border-dark-inner);
+        width: 100%;
+        max-width: 800px;
+        max-height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .window-titlebar {
+        background-color: var(--win-title-bg);
+        color: var(--win-title-text);
+        padding: 2px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-weight: bold;
+        margin: 2px;
+    }
+
+    .window-title {
+        padding-left: 4px;
+        display: flex;
+        align-items: center;
+    }
+
+    .window-controls {
+        display: flex;
+        gap: 2px;
+    }
+
+    .win-btn {
+        background-color: var(--win-bg);
+        border-top: 1px solid var(--win-border-light);
+        border-left: 1px solid var(--win-border-light);
+        border-right: 1px solid var(--win-border-dark);
+        border-bottom: 1px solid var(--win-border-dark);
+        box-shadow: inset 1px 1px var(--win-border-light-inner), inset -1px -1px var(--win-border-dark-inner);
+        font-family: 'MS Sans Serif', 'Arial', sans-serif;
+        font-weight: bold;
+        font-size: 12px;
+        min-width: 20px;
+        min-height: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        cursor: pointer;
+        color: var(--win-text);
+    }
+
+    .win-btn:active {
+        border-top: 1px solid var(--win-border-dark);
+        border-left: 1px solid var(--win-border-dark);
+        border-right: 1px solid var(--win-border-light);
+        border-bottom: 1px solid var(--win-border-light);
+        box-shadow: inset 1px 1px var(--win-border-dark-inner), inset -1px -1px var(--win-border-light-inner);
+        padding-top: 2px;
+        padding-left: 2px;
+    }
+
+    .window-content {
+        padding: 15px;
+        overflow-y: auto;
+        background-color: var(--win-bg);
+        flex-grow: 1;
+    }
+
+    .document {
+        background-color: #ffffff;
+        border-top: 2px solid var(--win-border-dark-inner);
+        border-left: 2px solid var(--win-border-dark-inner);
+        border-right: 2px solid var(--win-border-light);
+        border-bottom: 2px solid var(--win-border-light);
+        box-shadow: inset 1px 1px var(--win-border-dark), inset -1px -1px var(--win-border-light-inner);
+        padding: 20px;
+        margin-top: 10px;
+        min-height: 200px;
+    }
+
+    .taskbar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 40px;
+        background-color: var(--win-bg);
+        border-top: 2px solid var(--win-border-light);
+        display: flex;
+        align-items: center;
+        padding: 0 4px;
+        z-index: 1000;
+        box-shadow: inset 0 1px var(--win-border-light-inner);
+    }
+
+    .start-btn {
+        background-color: var(--win-bg);
+        border-top: 2px solid var(--win-border-light);
+        border-left: 2px solid var(--win-border-light);
+        border-right: 2px solid var(--win-border-dark);
+        border-bottom: 2px solid var(--win-border-dark);
+        box-shadow: inset 1px 1px var(--win-border-light-inner), inset -1px -1px var(--win-border-dark-inner);
+        font-weight: bold;
+        padding: 4px 8px;
+        text-decoration: none;
+        color: var(--win-text);
+        display: flex;
+        align-items: center;
+        gap: 5px;
+    }
+
+    .start-btn:active {
+        border-top: 2px solid var(--win-border-dark);
+        border-left: 2px solid var(--win-border-dark);
+        border-right: 2px solid var(--win-border-light);
+        border-bottom: 2px solid var(--win-border-light);
+        box-shadow: inset 1px 1px var(--win-border-dark-inner), inset -1px -1px var(--win-border-light-inner);
+        padding: 5px 7px 3px 9px;
+    }
+
+    .taskbar-item {
+        background-color: var(--win-bg);
+        border-top: 2px solid var(--win-border-light);
+        border-left: 2px solid var(--win-border-light);
+        border-right: 2px solid var(--win-border-dark);
+        border-bottom: 2px solid var(--win-border-dark);
+        box-shadow: inset 1px 1px var(--win-border-light-inner), inset -1px -1px var(--win-border-dark-inner);
+        padding: 4px 8px;
+        text-decoration: none;
+        color: var(--win-text);
+        margin-right: 4px;
+        display: flex;
+        align-items: center;
+    }
+
+    .taskbar-item.active {
+        border-top: 2px solid var(--win-border-dark);
+        border-left: 2px solid var(--win-border-dark);
+        border-right: 2px solid var(--win-border-light);
+        border-bottom: 2px solid var(--win-border-light);
+        box-shadow: inset 1px 1px var(--win-border-dark-inner), inset -1px -1px var(--win-border-light-inner);
+        padding: 5px 7px 3px 9px;
+        background-color: #d4d4d4;
+    }
+
+    .taskbar-divider {
+        width: 2px;
+        height: 30px;
+        background-color: var(--win-border-light);
+        border-left: 1px solid var(--win-border-dark-inner);
+        margin: 0 8px;
+    }
+
+    .taskbar-clock {
+        margin-left: auto;
+        border-top: 2px solid var(--win-border-dark-inner);
+        border-left: 2px solid var(--win-border-dark-inner);
+        border-right: 2px solid var(--win-border-light);
+        border-bottom: 2px solid var(--win-border-light);
+        box-shadow: inset 1px 1px var(--win-border-dark), inset -1px -1px var(--win-border-light-inner);
+        padding: 4px 10px;
+    }
+
+    a {
+        color: #0000ff;
+        text-decoration: none;
+    }
+
+    a:hover {
+        text-decoration: underline;
+    }
+
+    a:visited {
+        color: #800080;
+    }
+
+    hr {
+        border: none;
+        border-top: 1px solid var(--win-border-dark-inner);
+        border-bottom: 1px solid var(--win-border-light);
+        margin: 15px 0;
+    }
+
+    ul.directory-list {
+        list-style-type: none;
+        padding-left: 0;
+    }
+
+    ul.directory-list li {
+        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+    }
+
+    ul.directory-list a {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--win-text);
+        text-decoration: none;
+        padding: 2px 4px;
+    }
+
+    ul.directory-list a:hover {
+        background-color: var(--win-title-bg);
+        color: var(--win-title-text);
+    }
+
+    ul.directory-list a:hover .icon-file, ul.directory-list a:hover .icon-folder {
+        /* Keep icons looking the same on hover */
+    }
+
+    .icon-file {
+        display: inline-block;
+        width: 16px;
+        height: 20px;
+        background-color: #fff;
+        border: 1px solid var(--win-text);
+        position: relative;
+    }
+
+    .icon-file::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        border-top: 6px solid var(--win-bg);
+        border-left: 6px solid var(--win-border-dark-inner);
+    }
+
+    .icon-folder {
+        display: inline-block;
+        width: 20px;
+        height: 16px;
+        background-color: #ffd700;
+        border: 1px solid var(--win-text);
+        position: relative;
+    }
+
+    .icon-folder::before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: -1px;
+        width: 8px;
+        height: 4px;
+        background-color: #ffd700;
+        border: 1px solid var(--win-text);
+        border-bottom: none;
+    }
+
+    .menubar {
+        display: flex;
+        gap: 15px;
+        padding: 4px 10px;
+        border-bottom: 1px solid var(--win-border-dark-inner);
+        box-shadow: 0 1px 0 var(--win-border-light);
+        margin-bottom: 10px;
+    }
+
+    .menu-item {
+        cursor: pointer;
+    }
+
+    .menu-item::first-letter {
+        text-decoration: underline;
+    }
+</style>

--- a/windows95/templates/index.html
+++ b/windows95/templates/index.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div style="display: flex; gap: 10px; align-items: center; margin-bottom: 15px;">
+        <div class="icon-folder" style="width: 32px; height: 24px;"></div>
+        <h2 style="margin: 0;">C:\My Documents</h2>
+    </div>
+
+    <div class="document" style="min-height: auto; padding: 10px;">
+        {{ section.content | safe }}
+    </div>
+
+    <hr>
+
+    <h3>Files</h3>
+    <ul class="directory-list">
+        {% set sections = get_section(path="posts/_index.md") %}
+        {% for page in sections.pages %}
+            <li>
+                <a href="{{ config.base_url }}{{ page.path }}">
+                    <span class="icon-file"></span>
+                    {{ page.title }}.txt
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock content %}

--- a/windows95/templates/page.html
+++ b/windows95/templates/page.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <div style="display: flex; gap: 10px; align-items: center;">
+            <div class="icon-file" style="width: 24px; height: 30px;"></div>
+            <h2 style="margin: 0;">{{ page.title }}.txt - Notepad</h2>
+        </div>
+        <a href="{{ config.base_url }}" class="win-btn" style="text-decoration: none; padding: 2px 8px; font-weight: normal;">&lt; Back</a>
+    </div>
+
+    <div class="document">
+        <div style="font-family: 'Courier New', Courier, monospace;">
+            {{ page.content | safe }}
+        </div>
+    </div>
+{% endblock content %}

--- a/windows95/templates/section.html
+++ b/windows95/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div style="display: flex; gap: 10px; align-items: center; margin-bottom: 15px;">
+        <div class="icon-folder" style="width: 32px; height: 24px;"></div>
+        <h2 style="margin: 0;">{{ section.title }}</h2>
+    </div>
+
+    <div class="document" style="min-height: auto; padding: 10px;">
+        {{ section.content | safe }}
+    </div>
+
+    <hr>
+
+    <h3>Contents</h3>
+    <ul class="directory-list">
+        {% for page in section.pages %}
+            <li>
+                <a href="{{ config.base_url }}{{ page.path }}">
+                    <span class="icon-file"></span>
+                    {{ page.title }}.txt
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock content %}


### PR DESCRIPTION
This commit adds a new `windows95` example site to the Hwaro repository. 

Key details:
- Created the necessary directory structure (`windows95/content/`, `windows95/templates/`, `windows95/static/css/`).
- Added standard Zola/Hwaro configuration in `config.toml` (without the incompatible `theme` attribute).
- Created a classic retro Windows 95 gray bezel layout leveraging solid borders (light and dark) rather than gradients.
- Added a `desktop` space, `taskbar`, `start` button, `clock`, and `window` elements styled in a retro UI fashion.
- Created `base.html`, `index.html`, `section.html`, `page.html`, and `header.html` Tera templates, utilizing `{{ config.base_url }}` appropriately.
- Included sample content (`_index.md` and `posts/hello-world.md`).
- Appended relevant retro OS tags to `tags.json` safely.
- Verified visual design via Playwright, strictly adhering to user guidelines: NO gradients and NO emojis.

---
*PR created automatically by Jules for task [8245282328862709392](https://jules.google.com/task/8245282328862709392) started by @hahwul*