### PR TITLE
feat: add RetroMac theme

### DIFF
--- a/retromac/config.toml
+++ b/retromac/config.toml
@@ -1,0 +1,54 @@
+title = "RetroMac"
+description = "클래식 Mac OS 9 시스템 UI 디자인"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin"] }
+]
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/retromac/content/_index.md
+++ b/retromac/content/_index.md
@@ -1,0 +1,16 @@
++++
+title = "Mac OS 9 Experience"
+description = "Welcome to the classic Mac OS 9 design theme."
++++
+
+Welcome to **RetroMac**, a Hwaro theme inspired by the classic Mac OS 9 user interface.
+
+This theme features the iconic Platinum appearance with window borders, title bars with pinstripes, classic Chicago and Geneva typography, and a distinct lack of gradients.
+
+### Features
+* Platinum window style layouts
+* Classic button styles (outset borders, solid colors)
+* Pinstripe title bars (implemented with inline SVG to avoid gradients)
+* Clean, flat appearance typical of the late 90s classic Mac OS
+
+Enjoy the nostalgia!

--- a/retromac/content/about.md
+++ b/retromac/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About RetroMac"
+date = "2024-01-01"
+description = "About this classic theme"
++++
+
+### The Platinum Experience
+
+The "Platinum" appearance was introduced in Mac OS 8 and continued through Mac OS 9. It featured a distinct grey, beveled aesthetic that moved away from the earlier black-and-white flat UI of System 7, but retained a very clean, structured feel.
+
+This theme replicates that look using modern web technologies, specifically relying on solid colors, borders, and SVG patterns to simulate the classic UI elements without using any CSS gradients or modern effects like heavy drop shadows or rounded corners.
+
+### Design Principles
+
+1. **Strictly No Gradients**: We use SVG patterns for things like the title bar pinstripes.
+2. **Solid Colors**: The classic interface relied on a limited palette of greys (#dddddd, #eeeeee) and distinct accent colors.
+3. **Typography**: We use `Geneva, Chicago, sans-serif` as the primary font stack to mimic the classic OS fonts.
+
+```python
+def classic_mac_greeting():
+    print("Welcome to Mac OS 9!")
+```

--- a/retromac/templates/base.html
+++ b/retromac/templates/base.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    {{ og_all_tags | safe }}
+    {{ canonical_tag | safe }}
+    {{ highlight_tags | safe }}
+    {{ auto_includes | safe }}
+    {% include "header.html" %}
+</head>
+<body>
+    <div class="desktop">
+        <!-- Classic Mac OS Menu Bar -->
+        <div class="menu-bar">
+            <div class="menu-item apple-logo"></div>
+            <div class="menu-item active">File</div>
+            <div class="menu-item">Edit</div>
+            <div class="menu-item">View</div>
+            <div class="menu-item">Special</div>
+            <div class="menu-item">Help</div>
+            <div class="clock" id="clock">10:00 AM</div>
+        </div>
+
+        <div class="desktop-content">
+            {% block content %}{% endblock %}
+        </div>
+
+        <!-- Desktop Icons (Decorative) -->
+        <div class="desktop-icons">
+            <a href="{{ base_url }}/" class="desktop-icon">
+                <div class="icon-img" style="background-color: #ffffff; border: 1px solid #000; width: 32px; height: 32px; margin: 0 auto; display: flex; align-items: center; justify-content: center;">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
+                </div>
+                <span>Macintosh HD</span>
+            </a>
+            <a href="{{ base_url }}/about.md" class="desktop-icon">
+                <div class="icon-img" style="background-color: #ffffff; border: 1px solid #000; width: 32px; height: 32px; margin: 0 auto; display: flex; align-items: center; justify-content: center;">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
+                </div>
+                <span>About</span>
+            </a>
+        </div>
+
+        {% include "footer.html" %}
+    </div>
+
+    <script>
+        // Simple clock
+        function updateClock() {
+            const now = new Date();
+            let hours = now.getHours();
+            let minutes = now.getMinutes();
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            hours = hours % 12;
+            hours = hours ? hours : 12;
+            minutes = minutes < 10 ? '0' + minutes : minutes;
+            const strTime = hours + ':' + minutes + ' ' + ampm;
+            document.getElementById('clock').textContent = strTime;
+        }
+        setInterval(updateClock, 1000);
+        updateClock();
+    </script>
+</body>
+</html>

--- a/retromac/templates/footer.html
+++ b/retromac/templates/footer.html
@@ -1,0 +1,4 @@
+<!-- Footer content (minimal for classic OS) -->
+<div style="display: none;">
+    &copy; {{ current_year }} {{ site.title }}
+</div>

--- a/retromac/templates/header.html
+++ b/retromac/templates/header.html
@@ -1,0 +1,216 @@
+<style>
+/* RetroMac OS 9 Theme CSS */
+:root {
+    --mac-bg: #5555aa; /* Classic desktop pattern color */
+    --mac-window-bg: #eeeeee;
+    --mac-window-border: #000000;
+    --mac-highlight: #000000;
+    --mac-text: #000000;
+    --mac-menubar: #ffffff;
+    --mac-titlebar-bg: #dddddd;
+    --mac-pinstripe: url('data:image/svg+xml;utf8,<svg width="4" height="4" xmlns="http://www.w3.org/2000/svg"><rect width="4" height="4" fill="%23dddddd"/><line x1="0" y1="1" x2="4" y2="1" stroke="%23cccccc" stroke-width="1"/><line x1="0" y1="3" x2="4" y2="3" stroke="%23ffffff" stroke-width="1"/></svg>');
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: "Geneva", "Chicago", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    color: var(--mac-text);
+    background-color: var(--mac-bg);
+    /* Simple desktop pattern */
+    background-image: url('data:image/svg+xml;utf8,<svg width="2" height="2" xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" fill="%235555aa"/><rect x="1" y="1" width="1" height="1" fill="%235555aa"/><rect x="1" y="0" width="1" height="1" fill="%236666bb"/><rect x="0" y="1" width="1" height="1" fill="%236666bb"/></svg>');
+    height: 100vh;
+    overflow: hidden;
+}
+
+.desktop {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    position: relative;
+}
+
+/* Menu Bar */
+.menu-bar {
+    background-color: var(--mac-menubar);
+    height: 20px;
+    border-bottom: 1px solid var(--mac-window-border);
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.2);
+    z-index: 1000;
+}
+
+.menu-item {
+    padding: 0 10px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    cursor: default;
+}
+
+.menu-item:hover, .menu-item.active {
+    background-color: var(--mac-highlight);
+    color: #ffffff;
+}
+
+.apple-logo {
+    font-size: 14px;
+}
+
+.clock {
+    margin-left: auto;
+    padding: 0 10px;
+}
+
+/* Desktop Icons */
+.desktop-icons {
+    position: absolute;
+    top: 40px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+    z-index: 10;
+}
+
+.desktop-icon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+    color: #ffffff;
+    text-shadow: 1px 1px 0 #000;
+    width: 64px;
+}
+
+.desktop-icon span {
+    margin-top: 4px;
+    text-align: center;
+    background-color: transparent;
+    padding: 2px 4px;
+}
+
+.desktop-icon:hover span {
+    background-color: var(--mac-highlight);
+    color: #ffffff;
+    text-shadow: none;
+}
+
+/* Window Style */
+.desktop-content {
+    flex: 1;
+    padding: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    overflow-y: auto;
+    z-index: 20;
+}
+
+.mac-window {
+    background-color: var(--mac-window-bg);
+    border: 1px solid var(--mac-window-border);
+    box-shadow: 2px 2px 0 rgba(0,0,0,0.5);
+    width: 100%;
+    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+}
+
+.window-titlebar {
+    height: 22px;
+    background-color: var(--mac-titlebar-bg);
+    background-image: var(--mac-pinstripe);
+    border-bottom: 1px solid var(--mac-window-border);
+    display: flex;
+    align-items: center;
+    padding: 0 5px;
+    position: relative;
+}
+
+.window-close-btn {
+    width: 12px;
+    height: 12px;
+    background-color: var(--mac-window-bg);
+    border: 1px solid var(--mac-window-border);
+    margin-right: 10px;
+    box-shadow: inset 1px 1px 0 #ffffff, inset -1px -1px 0 #aaaaaa;
+}
+
+.window-title {
+    background-color: var(--mac-titlebar-bg);
+    padding: 0 10px;
+    margin: 0 auto;
+    font-weight: bold;
+    text-align: center;
+    border-left: 1px solid var(--mac-window-border);
+    border-right: 1px solid var(--mac-window-border);
+}
+
+.window-content {
+    padding: 20px;
+    background-color: #ffffff;
+    border: 1px solid #aaaaaa;
+    margin: 2px;
+    min-height: 200px;
+    overflow-y: auto;
+}
+
+/* Content Typography */
+h1, h2, h3 {
+    font-family: "Chicago", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    border-bottom: 1px solid var(--mac-window-border);
+    padding-bottom: 5px;
+}
+
+a {
+    color: #0000ee;
+    text-decoration: underline;
+}
+
+a:visited {
+    color: #551a8b;
+}
+
+pre {
+    background-color: #eeeeee;
+    border: 1px solid #cccccc;
+    padding: 10px;
+    font-family: monospace;
+    overflow-x: auto;
+}
+
+code {
+    background-color: #eeeeee;
+    padding: 2px 4px;
+    font-family: monospace;
+}
+
+blockquote {
+    border-left: 3px solid #000000;
+    margin-left: 0;
+    padding-left: 10px;
+    font-style: italic;
+}
+
+/* Buttons */
+button, .button {
+    background-color: var(--mac-window-bg);
+    border: 1px solid var(--mac-window-border);
+    padding: 4px 12px;
+    font-family: "Geneva", "Chicago", sans-serif;
+    font-size: 12px;
+    cursor: pointer;
+    box-shadow: inset 1px 1px 0 #ffffff, inset -1px -1px 0 #aaaaaa;
+}
+
+button:active, .button:active {
+    box-shadow: inset 1px 1px 0 #aaaaaa, inset -1px -1px 0 #ffffff;
+    background-color: #dddddd;
+}
+</style>

--- a/retromac/templates/index.html
+++ b/retromac/templates/index.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mac-window">
+    <div class="window-titlebar">
+        <div class="window-close-btn"></div>
+        <div class="window-title">System Drive</div>
+    </div>
+    <div class="window-content" style="background-color: var(--mac-window-bg); border: none;">
+        <div style="background-color: #ffffff; border: 1px solid #000; padding: 20px;">
+            <h1>{{ page.title }}</h1>
+            {{ content | safe }}
+
+            <div style="margin-top: 20px;">
+                <p>Read more:</p>
+                <ul>
+                    <li><a href="{{ base_url }}/about.md">About RetroMac</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/retromac/templates/page.html
+++ b/retromac/templates/page.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mac-window">
+    <div class="window-titlebar">
+        <div class="window-close-btn"></div>
+        <div class="window-title">{{ page.title }}</div>
+    </div>
+    <div class="window-content">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}<p style="color: #666; margin-top: -10px;">{{ page.date | date(format="%Y-%m-%d") }}</p>{% endif %}
+
+        {{ content | safe }}
+
+        <div style="margin-top: 30px; text-align: right;">
+            <a href="{{ base_url }}/" class="button" style="text-decoration: none; color: black;">OK</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/retromac/templates/section.html
+++ b/retromac/templates/section.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mac-window">
+    <div class="window-titlebar">
+        <div class="window-close-btn"></div>
+        <div class="window-title">{{ section.title }}</div>
+    </div>
+    <div class="window-content" style="background-color: var(--mac-window-bg); border: none;">
+        <div style="background-color: #ffffff; border: 1px solid #000; padding: 20px;">
+            <h1>{{ section.title }}</h1>
+            {{ content | safe }}
+
+            <div style="margin-top: 20px;">
+                <ul>
+                {% for post in section.pages %}
+                    <li>
+                        <a href="{{ post.url }}">{{ post.title }}</a>
+                        {% if post.date %}- {{ post.date | date(format="%Y-%m-%d") }}{% endif %}
+                    </li>
+                {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1894,4 +1894,12 @@
     "deconstructivism",
     "architecture"
   ]
+,
+  "retromac": [
+    "light",
+    "mac",
+    "os9",
+    "retro",
+    "system"
+  ]
 }


### PR DESCRIPTION
Adds the `retromac` theme, bringing a classic Mac OS 9 design to the Hwaro example sites. The theme uses no gradients and relies on SVG data URIs to replicate the iconic pinstripes and desktop pattern of the Platinum interface.

---
*PR created automatically by Jules for task [7974377695491102395](https://jules.google.com/task/7974377695491102395) started by @hahwul*