### PR TITLE
feat: add Newspaper classic broadsheet theme

### DIFF
--- a/newspaper/config.toml
+++ b/newspaper/config.toml
@@ -1,0 +1,49 @@
+title = "The Daily Chronicle"
+description = "Classic Broadsheet Newspaper Layout"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+]
+
+[feeds]
+enabled = true
+filename = "atom.xml"
+type = "atom"
+truncate = 0
+limit = 20
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/newspaper/content/_index.md
+++ b/newspaper/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Daily Chronicle - Front Page"
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
+generate_feeds = true
+transparent = true
++++

--- a/newspaper/content/posts/_index.md
+++ b/newspaper/content/posts/_index.md
@@ -1,0 +1,9 @@
++++
+title = "All Articles"
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
+generate_feeds = true
+transparent = false
++++

--- a/newspaper/content/posts/global-trade.md
+++ b/newspaper/content/posts/global-trade.md
@@ -1,0 +1,16 @@
++++
+title = "Global Trade Expansion Announced"
+date = "1905-04-11"
+authors = ["Beatrice Sterling"]
+tags = ["economy", "trade", "maritime"]
+[extra]
+subtitle = "New Shipping Routes Promise Wealth from Distant Shores"
++++
+
+In a stunning announcement at the Exchange this morning, the Consortium of Maritime Merchants revealed plans for unprecedented expansion of their shipping fleets. The new routes are set to connect our ports directly with the most remote markets of the East, bypassing traditional intermediaries and promising a flood of exotic goods at significantly reduced prices.
+
+"The oceans are no longer barriers, but highways of commerce," declared the Consortium's chairman. "With the advent of the new steam-turbine vessels, the journey that once took months will be completed in mere weeks."
+
+The news sent a shockwave through the financial district, with shares in shipping and rail companies surging to record highs. Warehouses along the docks are already undergoing rapid expansion to accommodate the anticipated influx of silk, spices, and precious metals.
+
+However, smaller merchants express concern that this consolidation of power by the Consortium will drive them out of business. "They are monopolizing the sea," lamented one local trader. Furthermore, dockworkers unions are preparing for strikes, demanding that the immense profits promised by this venture be shared with the men who load and unload the perilous cargo.

--- a/newspaper/content/posts/industrial-age.md
+++ b/newspaper/content/posts/industrial-age.md
@@ -1,0 +1,16 @@
++++
+title = "The Industrial Age Reaches New Heights"
+date = "1905-04-12"
+authors = ["Arthur Penhaligon"]
+tags = ["industry", "progress", "cities"]
+[extra]
+subtitle = "Towers of Steel Touch the Heavens in the Great Metropolis"
++++
+
+A marvel of modern engineering was unveiled yesterday as the final rivet was driven into the framework of what is now the tallest structure in the civilized world. Crowds gathered in the streets below, their faces turned upwards in collective awe as the steel skeleton rose into the clouds.
+
+The chief engineer, speaking to reporters from a precarious perch some forty stories above the pavement, declared that this is merely the beginning. "We have conquered the earth, and now we reach for the sky," he proclaimed, his voice barely audible over the roaring wind and the staccato rhythm of the riveting hammers.
+
+Critics argue that such hubris will inevitably lead to disaster, citing the unnatural sway of the towers in strong gales. However, proponents point to the economic boon these vertical cities provide, housing thousands of workers and businesses in an area that once accommodated only a few dozen.
+
+The impact on the common man is profound. The shadow of progress falls long across the cobblestone streets, forever altering the skyline and the very nature of urban life. As the smoke from the foundries mingles with the clouds, one cannot help but wonder what further miracles—or terrors—the coming decades will bring.

--- a/newspaper/content/posts/mysterious-lights.md
+++ b/newspaper/content/posts/mysterious-lights.md
@@ -1,0 +1,16 @@
++++
+title = "Mysterious Lights Witnessed Over the Harbor"
+date = "1905-04-10"
+authors = ["Elias Thorne"]
+tags = ["mystery", "local", "unexplained"]
+[extra]
+subtitle = "Citizens Report Strange Phenomena in the Night Sky"
++++
+
+Panic and confusion swept through the waterfront districts last night as hundreds of residents reported seeing unearthly, luminescent orbs dancing in the sky above the harbor. The phenomenon, which lasted for nearly an hour, has baffled local authorities and scientific minds alike.
+
+Eyewitnesses describe the lights as shifting hues from a sickly green to a brilliant violet, moving with a speed and agility impossible for any known aircraft or natural weather event. "They zipped about like fireflies, but larger than any ship," reported a night watchman at Pier 4. "There was no sound, just a terrible, cold light."
+
+Professor H. Abernathy of the Royal Observatory dismissed the reports as "mass hysteria brought on by swamp gas and unusual atmospheric reflection," a statement that has done little to quell the public's unease.
+
+Rumors run rampant in the taverns, ranging from secret military testing to visitors from beyond the stars. Until a satisfactory explanation is provided, the citizens remain on edge, casting wary glances toward the heavens as twilight descends.

--- a/newspaper/static/css/style.css
+++ b/newspaper/static/css/style.css
@@ -1,0 +1,283 @@
+/* Variables */
+:root {
+    --bg-color: #fcfbf9; /* Slightly off-white newsprint */
+    --text-color: #1a1a1a;
+    --border-color: #111;
+    --link-color: #333;
+    --font-serif: "Georgia", "Times New Roman", serif;
+    --font-sans: "Arial", "Helvetica", sans-serif;
+}
+
+/* Base Styles */
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: var(--font-serif);
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+    font-size: 16px;
+}
+
+a {
+    color: var(--link-color);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--link-color);
+}
+
+a:hover {
+    color: #000;
+    border-bottom: 1px solid #000;
+}
+
+/* Layout */
+.content-wrapper {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Masthead */
+.masthead {
+    text-align: center;
+    border-bottom: 4px double var(--border-color);
+    padding: 10px 0 20px 0;
+    margin: 20px auto;
+    max-width: 1200px;
+}
+
+.masthead-top {
+    display: flex;
+    justify-content: space-between;
+    text-transform: uppercase;
+    font-family: var(--font-sans);
+    font-size: 0.8rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+    letter-spacing: 1px;
+}
+
+.masthead-title {
+    font-family: var(--font-serif);
+    font-size: 5rem;
+    font-weight: normal;
+    text-transform: uppercase;
+    margin: 10px 0;
+    letter-spacing: -2px;
+}
+
+.masthead-title a {
+    color: var(--text-color);
+    border: none;
+}
+
+.masthead-bottom {
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 2px;
+    border-top: 1px solid var(--border-color);
+    padding-top: 5px;
+}
+
+/* Navigation */
+.main-nav {
+    text-align: center;
+    border-bottom: 1px solid var(--border-color);
+    padding: 10px 0;
+    margin-bottom: 30px;
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.main-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.main-nav li {
+    display: inline-block;
+    margin: 0 15px;
+}
+
+.main-nav a {
+    border: none;
+    font-weight: bold;
+}
+
+/* Typography & Headings */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-serif);
+    font-weight: bold;
+    margin-top: 0;
+}
+
+.headline-lead {
+    font-size: 3.5rem;
+    line-height: 1.1;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.subheadline {
+    font-size: 1.5rem;
+    font-style: italic;
+    text-align: center;
+    margin-bottom: 20px;
+    font-weight: normal;
+}
+
+.headline-secondary {
+    font-size: 2rem;
+    line-height: 1.1;
+    margin-bottom: 10px;
+}
+
+.subheadline-small {
+    font-size: 1.1rem;
+    font-style: italic;
+    margin-bottom: 10px;
+}
+
+.headline-full {
+    font-size: 3rem;
+    line-height: 1.1;
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.subheadline-full {
+    font-size: 1.5rem;
+    font-style: italic;
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+/* Byline */
+.byline {
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    text-align: center;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    padding: 5px 0;
+    margin-bottom: 20px;
+}
+
+.dateline {
+    font-family: var(--font-sans);
+    font-weight: bold;
+    text-transform: uppercase;
+    text-align: center;
+    font-size: 0.9rem;
+    margin-bottom: 30px;
+}
+
+/* Columns */
+.columns-2 {
+    column-count: 2;
+    column-gap: 40px;
+    column-rule: 1px solid #ccc;
+}
+
+.columns-3 {
+    column-count: 3;
+    column-gap: 30px;
+    column-rule: 1px solid #ccc;
+}
+
+.article-body p {
+    margin-bottom: 1em;
+    text-align: justify;
+}
+
+/* Dropcap */
+.dropcap {
+    float: left;
+    font-size: 4rem;
+    line-height: 0.8;
+    padding-top: 4px;
+    padding-right: 8px;
+    font-family: var(--font-serif);
+    font-weight: bold;
+}
+
+/* Grids */
+.newspaper-grid {
+    display: flex;
+    flex-direction: column;
+}
+
+.article-divider {
+    border: 0;
+    height: 4px;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+    margin: 40px 0;
+}
+
+.secondary-articles {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 30px;
+}
+
+.article-secondary {
+    border-right: 1px solid #ccc;
+    padding-right: 30px;
+}
+
+.article-secondary:last-child {
+    border-right: none;
+    padding-right: 0;
+}
+
+/* Full Article */
+.article-full {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.article-tags {
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid #ccc;
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+}
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    border-top: 4px double var(--border-color);
+    padding: 20px 0;
+    margin: 60px auto 20px auto;
+    max-width: 1200px;
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 1px;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+    .columns-3 { column-count: 2; }
+    .secondary-articles { grid-template-columns: repeat(2, 1fr); }
+    .article-secondary:nth-child(2) { border-right: none; padding-right: 0; }
+    .masthead-title { font-size: 4rem; }
+}
+
+@media (max-width: 600px) {
+    .columns-2, .columns-3 { column-count: 1; column-rule: none; }
+    .secondary-articles { grid-template-columns: 1fr; }
+    .article-secondary { border-right: none; padding-right: 0; border-bottom: 1px solid #ccc; padding-bottom: 20px; margin-bottom: 20px; }
+    .masthead-title { font-size: 3rem; }
+    .masthead-top { flex-direction: column; text-align: center; gap: 5px; }
+}

--- a/newspaper/templates/footer.html
+++ b/newspaper/templates/footer.html
@@ -1,0 +1,6 @@
+    </main>
+    <footer class="site-footer">
+        <p>&copy; {{ current_year | default("1900") }} {{ site.title }}. Printed daily.</p>
+    </footer>
+</body>
+</html>

--- a/newspaper/templates/header.html
+++ b/newspaper/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+    <header class="masthead">
+        <div class="masthead-top">
+            <span class="masthead-date">{{ current_date | date(format="%A, %B %d, %Y") | default("Monday, January 1, 1900") }}</span>
+            <span class="masthead-price">TWO CENTS</span>
+        </div>
+        <h1 class="masthead-title"><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+        <div class="masthead-bottom">
+            <span>{{ site.description }}</span>
+        </div>
+    </header>
+    <nav class="main-nav">
+        <ul>
+            <li><a href="{{ base_url }}/">Front Page</a></li>
+            <li><a href="{{ base_url }}/posts">All Articles</a></li>
+            <li><a href="{{ base_url }}/tags">Tags</a></li>
+        </ul>
+    </nav>
+    <main class="content-wrapper">

--- a/newspaper/templates/page.html
+++ b/newspaper/templates/page.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<article class="article-full">
+    <header class="article-header">
+        <h1 class="headline-full">{{ page.title }}</h1>
+        {% if page.extra.subtitle %}<p class="subheadline-full">{{ page.extra.subtitle }}</p>{% endif %}
+        <div class="article-meta">
+            <p class="byline">By {{ page.authors | default(["The Editors"]) | join(", ") }}</p>
+            <p class="dateline">{{ page.date | date(format="%B %d, %Y") }}</p>
+        </div>
+    </header>
+
+    <div class="article-content columns-2">
+        <span class="dropcap">{{ page.content | striptags | first }}</span>{{ page.content | safe | replace(page.content | striptags | first, "", 1) }}
+    </div>
+
+    {% if page.tags %}
+    <div class="article-tags">
+        <strong>Filed under:</strong>
+        {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/newspaper/templates/section.html
+++ b/newspaper/templates/section.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+
+{% if section.pages_count > 0 %}
+<div class="newspaper-grid">
+    {% for post in section.pages %}
+        {% if loop.index == 1 %}
+        <article class="article-lead">
+            <header>
+                <h2 class="headline-lead"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h2>
+                {% if post.extra.subtitle %}<p class="subheadline">{{ post.extra.subtitle }}</p>{% endif %}
+                <p class="byline">By {{ post.authors | default(["The Editors"]) | join(", ") }} &bull; {{ post.date | date(format="%B %d, %Y") }}</p>
+            </header>
+            <div class="article-body columns-3">
+                {{ post.summary | default(post.content) | strip_html | truncate_words(n=300) }}
+                <a href="{{ post.url | absolute_url }}" class="read-more">Read Full Story &raquo;</a>
+            </div>
+        </article>
+        <hr class="article-divider">
+        <div class="secondary-articles">
+        {% else %}
+        <article class="article-secondary">
+            <header>
+                <h3 class="headline-secondary"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h3>
+                {% if post.extra.subtitle %}<p class="subheadline-small">{{ post.extra.subtitle }}</p>{% endif %}
+            </header>
+            <div class="article-body">
+                <p>{{ post.summary | default(post.content) | strip_html | truncate_words(n=100) }} <a href="{{ post.url | absolute_url }}">more &raquo;</a></p>
+            </div>
+        </article>
+        {% endif %}
+    {% endfor %}
+    {% if section.pages_count > 1 %}
+        </div>
+    {% endif %}
+</div>
+{% else %}
+    <p>No news to report today.</p>
+{% endif %}
+
+{% include "footer.html" %}

--- a/newspaper/templates/taxonomy.html
+++ b/newspaper/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+
+<div class="taxonomy-list">
+    <h1 class="headline-secondary">Index of Tags</h1>
+    <ul class="tag-cloud">
+        {% for term in taxonomy_terms %}
+            <li><a href="{{ base_url }}/tags/{{ term | slugify }}">{{ term }}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+
+{% include "footer.html" %}

--- a/newspaper/templates/taxonomy_term.html
+++ b/newspaper/templates/taxonomy_term.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+
+<div class="taxonomy-term">
+    <h1 class="headline-secondary">Stories filed under: "{{ taxonomy_term }}"</h1>
+    <div class="secondary-articles">
+        {% for post in taxonomy_pages %}
+        <article class="article-secondary">
+            <header>
+                <h3 class="headline-secondary"><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h3>
+            </header>
+            <div class="article-body">
+                <p>{{ post.summary | default(post.content) | strip_html | truncate_words(n=50) }} <a href="{{ post.url | absolute_url }}">read &raquo;</a></p>
+            </div>
+        </article>
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1893,5 +1893,18 @@
     "agency",
     "deconstructivism",
     "architecture"
+  ],
+  "techbyte": [
+    "light",
+    "blog",
+    "tech",
+    "card"
+  ]
+,
+  "newspaper": [
+    "light",
+    "blog",
+    "editorial",
+    "newspaper"
   ]
 }


### PR DESCRIPTION
This PR introduces the `newspaper` example site, a light-themed classic broadsheet layout for Hwaro. It uses serif typography, drop caps, and a multi-column layout using CSS `column-count` to simulate the look and feel of a traditional 1900s newspaper. No gradients or emojis were used.

Features include:
- A prominent masthead
- Multi-column article grid for section pages
- Clean, long-form reading view for individual articles
- Sample articles with mock 1900s content.

---
*PR created automatically by Jules for task [12251733147190281859](https://jules.google.com/task/12251733147190281859) started by @hahwul*