### PR TITLE
Add ArtDeco Theme

### DIFF
--- a/artdeco/config.toml
+++ b/artdeco/config.toml
@@ -1,0 +1,45 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "ArtDeco"
+description = "1920s Gatsby Style, Gold Lines Theme"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/artdeco/content/about.md
+++ b/artdeco/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About The Era"
+date = "2025-01-16"
+description = "Information about the ArtDeco movement."
+template = "page"
++++
+
+## The Art Deco Movement
+
+Art Deco, short for *Arts Décoratifs*, is characterized by rich colors, bold geometry, and decadent detail work. Having reached the height of its popularity in the 1920s, '30s, and '40s, the style still brings in glamour, luxury, and order with symmetrical designs.
+
+This theme embraces those core tenets:
+- **Deep Blacks & Navy:** For a luxurious backdrop.
+- **Gold & Brass Accents:** Highlighting structure and form.
+- **Symmetry & Geometry:** Sharp angles and prominent lines.

--- a/artdeco/content/index.md
+++ b/artdeco/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "The Gatsby Gala"
+date = "2025-01-15"
+description = "A grand celebration of 1920s style and elegance."
+template = "page"
++++
+
+<div class="artdeco-intro">
+  <h2>Welcome to the Roaring Twenties</h2>
+  <p>Step into an era of unparalleled elegance, geometric precision, and lavish celebrations. The ArtDeco theme brings the iconic 1920s style to your modern static site.</p>
+</div>
+
+<div class="artdeco-features">
+  <div class="feature-box">
+    <h3>Geometric Design</h3>
+    <p>Clean, precise lines defining every structure.</p>
+  </div>
+  <div class="feature-box">
+    <h3>Gold Accents</h3>
+    <p>Luxurious golden borders and typography against deep, dark backgrounds.</p>
+  </div>
+  <div class="feature-box">
+    <h3>Elegant Typography</h3>
+    <p>Classic serif fonts combined with structured sans-serif elements.</p>
+  </div>
+</div>

--- a/artdeco/content/posts/_index.md
+++ b/artdeco/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/artdeco/templates/footer.html
+++ b/artdeco/templates/footer.html
@@ -1,0 +1,7 @@
+        </main>
+        <footer>
+            <p>&copy; {{ current_year }} {{ site_title }}. Elegance Preserved.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/artdeco/templates/header.html
+++ b/artdeco/templates/header.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site_description }}{% endif %}">
+
+    <!-- ArtDeco Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --bg-color: #0b0f14;
+            --text-color: #e5e5e0;
+            --gold: #d4af37;
+            --gold-dim: #a67c00;
+            --font-heading: 'Cormorant Garamond', serif;
+            --font-body: 'Montserrat', sans-serif;
+            --border-width: 2px;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-body);
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--gold);
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            font-weight: 600;
+            text-align: center;
+        }
+
+        a {
+            color: var(--gold);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        a:hover {
+            color: var(--text-color);
+        }
+
+        /* The Outer Frame (Art Deco style) */
+        .page-wrapper {
+            max-width: 900px;
+            margin: 2rem auto;
+            padding: 2rem;
+            flex: 1;
+            position: relative;
+        }
+
+        .page-wrapper::before,
+        .page-wrapper::after {
+            content: '';
+            position: absolute;
+            border: var(--border-width) solid var(--gold);
+            pointer-events: none;
+        }
+
+        .page-wrapper::before {
+            top: 0; left: 0; right: 0; bottom: 0;
+            border-width: 4px;
+        }
+
+        .page-wrapper::after {
+            top: 10px; left: 10px; right: 10px; bottom: 10px;
+            border-width: 1px;
+        }
+
+        /* Header */
+        header {
+            text-align: center;
+            padding: 2rem 0 1rem;
+            border-bottom: 2px solid var(--gold);
+            margin-bottom: 2rem;
+            position: relative;
+        }
+
+        header::after {
+            content: '';
+            display: block;
+            width: 50%;
+            height: 1px;
+            background-color: var(--gold);
+            margin: 5px auto 0;
+        }
+
+        .site-title {
+            font-size: 3rem;
+            margin: 0;
+            letter-spacing: 4px;
+        }
+
+        nav {
+            margin-top: 1rem;
+        }
+
+        nav a {
+            font-family: var(--font-heading);
+            font-size: 1.2rem;
+            margin: 0 1rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        /* Content Areas */
+        main {
+            padding: 0 1rem;
+        }
+
+        .artdeco-intro {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+
+        .artdeco-features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+
+        .feature-box {
+            border: 1px solid var(--gold);
+            padding: 1.5rem;
+            text-align: center;
+            position: relative;
+        }
+
+        /* Corner accents for boxes */
+        .feature-box::before, .feature-box::after {
+            content: '';
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            border: 2px solid var(--gold);
+        }
+
+        .feature-box::before {
+            top: -5px; left: -5px;
+            border-right: none;
+            border-bottom: none;
+        }
+
+        .feature-box::after {
+            bottom: -5px; right: -5px;
+            border-left: none;
+            border-top: none;
+        }
+
+        /* Footer */
+        footer {
+            text-align: center;
+            padding: 2rem 0;
+            margin-top: auto;
+            border-top: 1px solid var(--gold);
+            font-size: 0.9rem;
+            font-family: var(--font-heading);
+            letter-spacing: 1px;
+            color: var(--gold-dim);
+        }
+
+        /* Typography inside markdown */
+        article p {
+            margin-bottom: 1.5rem;
+        }
+
+        article blockquote {
+            border-left: 3px solid var(--gold);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            font-style: italic;
+            color: var(--gold-dim);
+        }
+
+        article img {
+            max-width: 100%;
+            height: auto;
+            border: 2px solid var(--gold);
+            padding: 5px;
+        }
+
+        hr {
+            border: 0;
+            height: 1px;
+            background-color: var(--gold);
+            margin: 2rem 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="page-wrapper">
+        <header>
+            <h1 class="site-title"><a href="{{ base_url }}/">{{ site_title }}</a></h1>
+            <nav>
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about">About</a>
+                <a href="{{ base_url }}/posts">Posts</a>
+            </nav>
+        </header>
+        <main>

--- a/artdeco/templates/page.html
+++ b/artdeco/templates/page.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+<article>
+    <header class="post-header">
+        <h2>{{ page.title }}</h2>
+        {% if page.date %}
+        <p style="text-align: center; color: var(--gold-dim); font-family: var(--font-heading); margin-top: -10px;">
+            {{ page.date | date("%B %d, %Y") }}
+        </p>
+        {% endif %}
+    </header>
+
+    <div class="post-content">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/artdeco/templates/section.html
+++ b/artdeco/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<div class="section-container">
+    <h2>{{ section.title | default("Posts") }}</h2>
+
+    <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-item" style="margin-bottom: 2rem; border-bottom: 1px dashed var(--gold-dim); padding-bottom: 1.5rem;">
+            <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+            {% if post.date %}
+            <div style="color: var(--gold-dim); font-family: var(--font-heading); font-size: 0.9rem; text-align: center; margin-bottom: 1rem;">
+                {{ post.date | date("%B %d, %Y") }}
+            </div>
+            {% endif %}
+            <p>{{ post.summary | default(post.content | strip_html | truncate_words(30)) }}</p>
+            <div style="text-align: center; margin-top: 1rem;">
+                <a href="{{ post.url }}" style="font-family: var(--font-heading); text-transform: uppercase; font-size: 0.9rem; border: 1px solid var(--gold); padding: 5px 15px;">Read More</a>
+            </div>
+        </article>
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1894,4 +1894,10 @@
     "deconstructivism",
     "architecture"
   ]
+,
+  "artdeco": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ]
 }


### PR DESCRIPTION
Added the new `artdeco` theme to the Hwaro examples repository. The theme features a 1920s Gatsby style with geometric gold lines, deep dark backgrounds, elegant serif typography, and strictly adheres to the rule of using no gradients and no emojis. The structure includes proper `config.toml`, markdown content pages, and HTML templates, and the theme has been securely added to `tags.json`.

---
*PR created automatically by Jules for task [11593818021987986241](https://jules.google.com/task/11593818021987986241) started by @hahwul*