### PR TITLE
Add Repoussé Theme Example

### DIFF
--- a/repousse/AGENTS.md
+++ b/repousse/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/repousse/config.toml
+++ b/repousse/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Repoussé Theme"
+description = "A bold, creative, and elegant repoussé aesthetic theme for Hwaro"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/repousse/content/_index.md
+++ b/repousse/content/_index.md
@@ -1,0 +1,10 @@
++++
+title = "The Art of Repoussé"
+description = "A bold, creative, and elegant repoussé aesthetic theme for Hwaro"
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
++++
+
+Welcome to the repoussé gallery. This theme simulates the ancient metalworking technique of hammering from the reverse side to create intricate relief designs. Observe the embossed headers, the engraved panels, and the riveted structural elements, all constructed entirely with pure CSS colors and shadows, devoid of gradients.

--- a/repousse/content/about.md
+++ b/repousse/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "The Artisan's Workshop"
+date = "2025-10-24"
+description = "Discover the tools and techniques."
+tags = ["craft", "metalwork"]
++++
+
+To truly master the art of repoussé, one requires patience, vision, and a set of carefully crafted tools. The hammer must strike with precision, pushing the malleable metal outwards without breaking the surface.
+
+> The copper yields to the hammer, yet retains the memory of the strike.
+
+### Fundamental Techniques
+
+1. **Annealing:** The metal must be repeatedly heated and cooled to maintain its malleability.
+2. **Pitch Bowl:** A bowl filled with resilient pitch supports the metal while allowing it to deform.
+3. **Chasing:** The complementary technique of refining the details from the front face.
+
+```text
+The rhythmic sound of the hammer on the anvil.
+```
+
+In this digital iteration, our tools are `box-shadow` and `text-shadow`. We carefully calculate the offsets and opacities to simulate light catching the raised surfaces and shadows pooling in the recesses.

--- a/repousse/content/copper-etchings.md
+++ b/repousse/content/copper-etchings.md
@@ -1,0 +1,12 @@
++++
+title = "Copper Etchings"
+date = "2025-10-25"
+description = "A study in depth and contrast."
+tags = ["copper", "design"]
++++
+
+Copper offers a warm, inviting canvas for the artisan. Its base tone is rich, and it takes shadows beautifully. The repoussé technique on copper results in a dramatic interplay of light.
+
+By layering inset and outset shadows, we can create the illusion of a panel that has been stamped and hammered. The dark recesses (`var(--metal-shadow)`) contrast sharply with the illuminated edges (`var(--metal-highlight)`).
+
+Observe the typography. The bold, serif fonts suggest permanence and history, as if etched directly into the digital plate.

--- a/repousse/templates/404.html
+++ b/repousse/templates/404.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="site-main" style="text-align: center; padding-top: 4rem;">
+    <h1 style="font-size: 6rem; margin-bottom: 0;">404</h1>
+    <p style="font-size: 1.5rem;">The plate has not been forged.</p>
+    <div class="repousse-divider"></div>
+    <a href="{{ site.base_url | default(value="/") }}">Return to the Anvil</a>
+  </main>
+{% include "footer.html" %}

--- a/repousse/templates/footer.html
+++ b/repousse/templates/footer.html
@@ -1,0 +1,7 @@
+    <footer class="site-footer">
+      &copy; 2025 {{ site.title | default(value="Repoussé") }}. Crafted with hammer and anvil.
+    </footer>
+  </div>
+  {{ auto_includes_js | default(value="") | safe }}
+</body>
+</html>

--- a/repousse/templates/header.html
+++ b/repousse/templates/header.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value="en") }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | default(value="") | escape }}">
+  <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      /* Base repousse metal colors */
+      --metal-base: #a67c52; /* Bronze/Copper base */
+      --metal-light: #cfa882;
+      --metal-dark: #664627;
+      --metal-shadow: #2c1a0c;
+      --metal-highlight: #eed8bf;
+
+      --bg-color: #1a1614; /* Dark tarnished background */
+      --text-color: #f4e8dc;
+      --text-muted: #c4b09c;
+
+      --border-color: #4a3320;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: "Cormorant Garamond", serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-color);
+      background-color: var(--bg-color);
+      /* Base texture simulation using noise and faint background colors if needed,
+         but NO gradients are allowed, so we stick to solid bg. */
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 3rem;
+
+      /* The Repoussé Metal Plate Effect */
+      background-color: var(--metal-base);
+      color: var(--metal-shadow);
+
+      /* Complex box-shadow to simulate hammered metal edge */
+      box-shadow:
+        inset 0 0 10px var(--metal-shadow),
+        inset 0 0 20px var(--metal-shadow),
+        inset 2px 2px 5px var(--metal-highlight),
+        inset -2px -2px 5px var(--metal-shadow),
+        inset 5px 5px 15px rgba(238, 216, 191, 0.4),
+        inset -5px -5px 15px rgba(44, 26, 12, 0.6),
+        0 10px 30px rgba(0,0,0,0.8),
+        0 0 0 2px var(--metal-dark),
+        0 0 0 8px var(--metal-base),
+        0 0 0 10px var(--metal-shadow);
+
+      border-radius: 4px;
+      position: relative;
+    }
+
+    /* Decorative corner rivets */
+    .site-wrapper::before,
+    .site-wrapper::after {
+      content: "";
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      background-color: var(--metal-base);
+      border-radius: 50%;
+      box-shadow:
+        inset 2px 2px 3px var(--metal-highlight),
+        inset -2px -2px 3px var(--metal-shadow),
+        1px 1px 2px rgba(0,0,0,0.5);
+    }
+
+    .site-wrapper::before { top: 15px; left: 15px; }
+    .site-wrapper::after { bottom: 15px; right: 15px; }
+
+    .site-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding-bottom: 2rem;
+      border-bottom: 3px double var(--metal-shadow);
+      margin-bottom: 2rem;
+      position: relative;
+    }
+
+    /* Inner rivets for header */
+    .site-header::before,
+    .site-header::after {
+      content: "";
+      position: absolute;
+      bottom: -6px;
+      width: 8px;
+      height: 8px;
+      background-color: var(--metal-base);
+      border-radius: 50%;
+      box-shadow:
+        inset 1px 1px 2px var(--metal-highlight),
+        inset -1px -1px 2px var(--metal-shadow),
+        1px 1px 1px rgba(0,0,0,0.5);
+    }
+    .site-header::before { left: 10%; }
+    .site-header::after { right: 10%; }
+
+    .site-logo {
+      font-family: "Cinzel Decorative", serif;
+      font-weight: 900;
+      font-size: 3rem;
+      color: var(--metal-base);
+      text-decoration: none;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      text-align: center;
+
+      /* Embossed text effect */
+      text-shadow:
+        -1px -1px 1px var(--metal-highlight),
+        1px 1px 2px var(--metal-shadow),
+        0px 0px 4px rgba(0,0,0,0.3);
+    }
+
+    .site-header nav {
+      display: flex;
+      gap: 2rem;
+      margin-top: 1.5rem;
+    }
+
+    .site-header nav a {
+      font-family: "Playfair Display", serif;
+      color: var(--metal-shadow);
+      text-decoration: none;
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0.5rem 1rem;
+      border: 1px solid transparent;
+      transition: all 0.3s ease;
+    }
+
+    .site-header nav a:hover {
+      /* Engraved hover effect */
+      border: 1px solid var(--metal-shadow);
+      background-color: rgba(44, 26, 12, 0.05);
+      box-shadow:
+        inset 1px 1px 3px var(--metal-shadow),
+        inset -1px -1px 3px var(--metal-highlight);
+    }
+
+    .site-main {
+      min-height: calc(100vh - 400px);
+    }
+
+    .site-footer {
+      margin-top: 3rem;
+      padding: 2rem 0;
+      border-top: 3px double var(--metal-shadow);
+      color: var(--metal-shadow);
+      font-size: 0.95rem;
+      text-align: center;
+      font-family: "Playfair Display", serif;
+      position: relative;
+    }
+
+    /* Inner rivets for footer */
+    .site-footer::before,
+    .site-footer::after {
+      content: "";
+      position: absolute;
+      top: -6px;
+      width: 8px;
+      height: 8px;
+      background-color: var(--metal-base);
+      border-radius: 50%;
+      box-shadow:
+        inset 1px 1px 2px var(--metal-highlight),
+        inset -1px -1px 2px var(--metal-shadow),
+        1px 1px 1px rgba(0,0,0,0.5);
+    }
+    .site-footer::before { left: 10%; }
+    .site-footer::after { right: 10%; }
+
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      font-family: "Cinzel Decorative", serif;
+      line-height: 1.2;
+      color: var(--metal-base);
+      margin-top: 1.5em;
+      margin-bottom: 0.75em;
+      font-weight: 700;
+
+      /* Embossed text effect */
+      text-shadow:
+        -1px -1px 1px var(--metal-highlight),
+        1px 1px 2px var(--metal-shadow);
+    }
+
+    h1 { font-size: 2.5rem; text-align: center; border-bottom: 1px solid var(--metal-shadow); padding-bottom: 0.5rem; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.4rem; }
+
+    p { margin: 1.2em 0; font-size: 1.15rem; color: var(--metal-shadow); text-align: justify; }
+
+    a {
+      color: #110904;
+      text-decoration: underline;
+      text-decoration-color: rgba(44, 26, 12, 0.4);
+      text-underline-offset: 4px;
+    }
+
+    a:hover {
+      color: #000;
+      text-decoration-color: var(--metal-shadow);
+    }
+
+    code {
+      background: rgba(0,0,0,0.05);
+      padding: 0.2rem 0.4rem;
+      border-radius: 2px;
+      font-size: 0.9em;
+      font-family: "Courier New", Courier, monospace;
+      color: var(--metal-dark);
+      /* Etched look */
+      box-shadow: inset 1px 1px 2px var(--metal-shadow);
+    }
+
+    pre {
+      background: var(--bg-color);
+      color: var(--text-color);
+      padding: 1.5rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      border: 4px solid var(--metal-dark);
+      box-shadow:
+        inset 0 0 10px rgba(0,0,0,0.8),
+        0 2px 5px rgba(0,0,0,0.2);
+    }
+    pre code {
+      background: none;
+      padding: 0;
+      box-shadow: none;
+      color: inherit;
+    }
+
+    blockquote {
+      margin: 2rem 0;
+      padding: 1.5rem 2rem;
+      border-left: none;
+      background-color: transparent;
+      font-family: "Playfair Display", serif;
+      font-style: italic;
+      font-size: 1.3rem;
+      color: var(--metal-shadow);
+      position: relative;
+      text-align: center;
+    }
+
+    blockquote::before {
+      content: "“";
+      font-family: "Cinzel Decorative", serif;
+      font-size: 4rem;
+      position: absolute;
+      top: -1rem;
+      left: 0;
+      color: rgba(44, 26, 12, 0.2);
+    }
+    blockquote::after {
+      content: "”";
+      font-family: "Cinzel Decorative", serif;
+      font-size: 4rem;
+      position: absolute;
+      bottom: -3rem;
+      right: 0;
+      color: rgba(44, 26, 12, 0.2);
+    }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; }
+    ul.section-list li {
+      margin-bottom: 1.5rem;
+      padding: 1.5rem;
+      background: transparent;
+
+      /* Engraved panel effect */
+      box-shadow:
+        inset 1px 1px 4px var(--metal-shadow),
+        inset -1px -1px 4px var(--metal-highlight);
+      border: 1px solid rgba(44, 26, 12, 0.1);
+    }
+
+    ul.section-list li h2 {
+      margin-top: 0;
+      border-bottom: none;
+      font-size: 1.5rem;
+    }
+
+    ul.section-list li a {
+      text-decoration: none;
+    }
+
+    .post-meta {
+      font-family: "Playfair Display", serif;
+      font-size: 0.9rem;
+      color: var(--metal-dark);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 1rem;
+      display: block;
+    }
+
+    .taxonomy-desc { color: var(--metal-dark); margin-bottom: 2rem; font-style: italic; text-align: center;}
+
+    nav.pagination { margin: 3rem 0; display: flex; justify-content: center; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 1rem; align-items: center; }
+    nav.pagination a, .pagination-current span, .pagination-disabled span {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      font-family: "Cinzel Decorative", serif;
+      font-weight: bold;
+      color: var(--metal-shadow);
+      text-decoration: none;
+
+      /* Raised button effect */
+      box-shadow:
+        1px 1px 3px var(--metal-shadow),
+        -1px -1px 3px var(--metal-highlight);
+      background-color: var(--metal-base);
+    }
+
+    nav.pagination a:hover {
+      /* Pressed button effect */
+      box-shadow:
+        inset 1px 1px 3px var(--metal-shadow),
+        inset -1px -1px 3px var(--metal-highlight);
+    }
+
+    .pagination-current span {
+      box-shadow:
+        inset 2px 2px 4px var(--metal-shadow),
+        inset -1px -1px 2px var(--metal-highlight);
+      background-color: rgba(44, 26, 12, 0.1);
+    }
+    .pagination-disabled span {
+      opacity: 0.5;
+      box-shadow: none;
+      border: 1px solid var(--metal-dark);
+    }
+
+    /* Added extra structural elements for repoussé feel */
+    .repousse-divider {
+      height: 4px;
+      margin: 2rem 0;
+      background: transparent;
+      border-top: 1px solid var(--metal-shadow);
+      border-bottom: 1px solid var(--metal-highlight);
+      position: relative;
+    }
+
+    .repousse-divider::after {
+      content: "";
+      position: absolute;
+      top: -4px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 12px;
+      height: 12px;
+      background-color: var(--metal-base);
+      border-radius: 50%;
+      box-shadow:
+        inset 1px 1px 2px var(--metal-highlight),
+        inset -1px -1px 2px var(--metal-shadow);
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .site-wrapper { padding: 1.5rem; margin: 1rem; }
+      .site-logo { font-size: 2rem; }
+      .site-header nav { flex-direction: column; gap: 0.5rem; align-items: center; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css | default(value="") | safe }}
+  {{ auto_includes_css | default(value="") | safe }}
+</head>
+<body data-section="{{ page.section | default(value="") }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ site.base_url | default(value="/") }}" class="site-logo">{{ site.title | default(value="Repoussé") }}</a>
+      <nav>
+        <a href="{{ site.base_url | default(value="/") }}">Gallery</a>
+        <a href="{{ site.base_url | default(value="/") }}/about/">Artisan</a>
+      </nav>
+    </header>

--- a/repousse/templates/page.html
+++ b/repousse/templates/page.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.title %}
+      <h1>{{ page.title | escape }}</h1>
+      {% if page.date %}
+        <span class="post-meta">{{ page.date | date(format="%B %d, %Y") }}</span>
+      {% endif %}
+    {% endif %}
+
+    <div class="repousse-divider"></div>
+
+    <article>
+      {{ content | safe }}
+    </article>
+
+    <div class="repousse-divider"></div>
+  </main>
+{% include "footer.html" %}

--- a/repousse/templates/section.html
+++ b/repousse/templates/section.html
@@ -1,0 +1,53 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.title %}
+      <h1>{{ page.title | escape }}</h1>
+    {% elif section.title %}
+      <h1>{{ section.title | escape }}</h1>
+    {% endif %}
+
+    {% if content %}
+      <div class="taxonomy-desc">
+        {{ content | safe }}
+      </div>
+      <div class="repousse-divider"></div>
+    {% endif %}
+
+    <ul class="section-list">
+      {% for p in section.pages %}
+      <li>
+        <h2><a href="{{ p.permalink | default(value=p.url) | default(value="#") }}">{{ p.title | escape }}</a></h2>
+        {% if p.date %}
+          <span class="post-meta">{{ p.date | date(format="%B %d, %Y") }}</span>
+        {% endif %}
+        {% if p.summary %}
+          <p>{{ p.summary | strip_html | safe }}</p>
+        {% elif p.description %}
+          <p>{{ p.description | escape }}</p>
+        {% endif %}
+        <a href="{{ p.permalink | default(value=p.url) | default(value="#") }}">Read more...</a>
+      </li>
+      {% endfor %}
+    </ul>
+
+    {% if paginator %}
+      <nav class="pagination">
+        <ul class="pagination-list">
+          {% if paginator.previous %}
+            <li><a href="{{ paginator.previous }}">&laquo; Prev</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>&laquo; Prev</span></li>
+          {% endif %}
+
+          <li class="pagination-current"><span>{{ paginator.current_index }} / {{ paginator.number_pagers }}</span></li>
+
+          {% if paginator.next %}
+            <li><a href="{{ paginator.next }}">Next &raquo;</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>Next &raquo;</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/repousse/templates/shortcodes/alert.html
+++ b/repousse/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/repousse/templates/taxonomy.html
+++ b/repousse/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>Tags</h1>
+    <div class="repousse-divider"></div>
+    <ul class="section-list">
+      {% for term in taxonomy_terms %}
+      <li>
+        <a href="{{ term.permalink }}"><strong>{{ term.name }}</strong> ({{ term.pages | length }})</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/repousse/templates/taxonomy_term.html
+++ b/repousse/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>Pages tagged with "{{ taxonomy_term.name }}"</h1>
+    <div class="repousse-divider"></div>
+    <ul class="section-list">
+      {% for p in taxonomy_term.pages %}
+      <li>
+        <h2><a href="{{ p.permalink | default(value=p.url) | default(value="#") }}">{{ p.title | escape }}</a></h2>
+        {% if p.date %}
+          <span class="post-meta">{{ p.date | date(format="%B %d, %Y") }}</span>
+        {% endif %}
+        {% if p.summary %}
+          <p>{{ p.summary | strip_html | safe }}</p>
+        {% elif p.description %}
+          <p>{{ p.description | escape }}</p>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Adds the new "repoussé" example site to the repository. The theme utilizes solid colors, `box-shadow`, and `text-shadow` to simulate a hammered metal (embossed/engraved) aesthetic, strictly avoiding gradients and emojis. Does not modify tags.json.

---
*PR created automatically by Jules for task [3366642145500171935](https://jules.google.com/task/3366642145500171935) started by @hahwul*