### PR TITLE
feat: add tempera theme

### DIFF
--- a/tempera/config.toml
+++ b/tempera/config.toml
@@ -1,0 +1,8 @@
+title = "Tempera"
+description = "A bold, creative, and elegant tempera aesthetic"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+taxonomies = []

--- a/tempera/content/_index.md
+++ b/tempera/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Art of Tempera"
+sort_by = "date"
++++
+
+Welcome to a digital canvas inspired by egg tempera painting. This aesthetic relies on bold, flat blocks of color, sharp contrasts, and thick structural outlines, entirely forsaking modern gradients and softness.
+
+It is a testament to the materials of old: gesso, ochre, malachite, and carbon black. Experience the structure and striking elegance of pure, unadulterated pigment.

--- a/tempera/content/about.md
+++ b/tempera/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About Tempera"
+date = 2023-10-25
+description = "Understanding the philosophy behind this theme."
++++
+
+<span class="tempera-accent">The Philosophy</span>
+
+The Tempera aesthetic is bold, creative, and strictly elegant. By rejecting CSS gradients and emojis, we force ourselves to find beauty in pure typography, rigid boundaries, and solid, striking colors.
+
+> True elegance is not in the abundance of effects, but in the perfection of constraints.
+
+### The Colors
+
+*   **Parchment:** The foundation.
+*   **Carbon Black:** The structure.
+*   **Ochre:** The warmth.
+*   **Lapis Lazuli:** The depth.
+*   **Vermilion:** The passion.
+*   **Malachite:** The life.

--- a/tempera/static/css/style.css
+++ b/tempera/static/css/style.css
@@ -1,0 +1,201 @@
+/* Tempera Aesthetic CSS */
+/* Bold, creative, and elegant. No gradients, no emojis. */
+/* Using rich tempera paint colors: ochre, lapis lazuli, vermilion, malachite, carbon black. */
+
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
+
+:root {
+  --color-bg: #f5f2e6; /* Parchment / gesso base */
+  --color-text: #1a1a1a; /* Carbon black */
+  --color-ochre: #c48a31; /* Golden ochre */
+  --color-lapis: #1a3a6b; /* Lapis lazuli */
+  --color-vermilion: #b33927; /* Vermilion */
+  --color-malachite: #2a5a3b; /* Malachite green */
+  --color-lead-white: #faf9f6; /* Flake white */
+  --border-thick: 4px solid var(--color-text);
+  --border-thin: 1px solid var(--color-text);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: 'Lora', serif;
+  line-height: 1.8;
+  font-size: 18px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Cinzel', serif;
+  font-weight: 700;
+  color: var(--color-lapis);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+h1 {
+  font-size: 3.5rem;
+  text-align: center;
+  border-bottom: var(--border-thick);
+  padding-bottom: 1rem;
+  color: var(--color-vermilion);
+}
+
+h2 {
+  font-size: 2rem;
+  border-bottom: var(--border-thin);
+  padding-bottom: 0.5rem;
+}
+
+a {
+  color: var(--color-vermilion);
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom: 2px solid var(--color-ochre);
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  background-color: var(--color-ochre);
+  color: var(--color-lead-white);
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+header {
+  border-bottom: var(--border-thick);
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  border: none;
+  padding: 0;
+  text-align: left;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1.5rem;
+}
+
+nav a {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.2rem;
+  color: var(--color-lapis);
+  border: none;
+  text-transform: uppercase;
+}
+
+nav a:hover {
+  background-color: transparent;
+  color: var(--color-vermilion);
+}
+
+article {
+  background-color: var(--color-lead-white);
+  padding: 3rem;
+  border: var(--border-thin);
+  box-shadow: 10px 10px 0 var(--color-ochre);
+  margin-bottom: 3rem;
+}
+
+.meta {
+  font-family: 'Playfair Display', serif;
+  font-style: italic;
+  color: var(--color-malachite);
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+blockquote {
+  margin: 2rem 0;
+  padding: 2rem;
+  border-left: 8px solid var(--color-vermilion);
+  background-color: var(--color-bg);
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  font-style: italic;
+  color: var(--color-lapis);
+}
+
+code {
+  background-color: var(--color-bg);
+  padding: 0.2rem 0.5rem;
+  border: var(--border-thin);
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+pre {
+  background-color: var(--color-text);
+  color: var(--color-lead-white);
+  padding: 1.5rem;
+  border: var(--border-thick);
+  border-color: var(--color-ochre);
+  overflow-x: auto;
+}
+
+pre code {
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  padding: 0;
+}
+
+footer {
+  text-align: center;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: var(--border-thick);
+  font-family: 'Cinzel', serif;
+  font-size: 0.9rem;
+  color: var(--color-malachite);
+}
+
+/* Bold creative elements */
+.tempera-panel {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin: 3rem 0;
+}
+
+.tempera-box {
+  border: var(--border-thick);
+  padding: 2rem;
+  background-color: var(--color-lapis);
+  color: var(--color-lead-white);
+  box-shadow: -10px 10px 0 var(--color-vermilion);
+}
+
+.tempera-box h3 {
+  color: var(--color-ochre);
+  margin-top: 0;
+}
+
+.tempera-accent {
+  display: inline-block;
+  background-color: var(--color-malachite);
+  color: var(--color-lead-white);
+  padding: 0.5rem 1rem;
+  font-family: 'Cinzel', serif;
+  text-transform: uppercase;
+  border: var(--border-thin);
+  box-shadow: 4px 4px 0 var(--color-text);
+}

--- a/tempera/templates/base.html
+++ b/tempera/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1><a href="{{ config.base_url }}" style="border: none; color: inherit;">{{ config.title }}</a></h1>
+            <nav>
+                <ul>
+                    <li><a href="{{ config.base_url }}">Home</a></li>
+                    <li><a href="{{ get_url(path="about") }}">About</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock content %}
+        </main>
+
+        <footer>
+            <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}. Crafted with Tempera.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/tempera/templates/index.html
+++ b/tempera/templates/index.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article>
+    <h1>{{ section.title }}</h1>
+
+    <div class="content">
+        {{ section.content | safe }}
+    </div>
+
+    <div class="tempera-panel">
+        <div class="tempera-box">
+            <h3>Lapis Lazuli</h3>
+            <p>A deep blue pigment used in antiquity and the Middle Ages, highly prized for its brilliant hue and incredible cost.</p>
+        </div>
+        <div class="tempera-box" style="background-color: var(--color-vermilion); box-shadow: -10px 10px 0 var(--color-lapis);">
+            <h3 style="color: var(--color-lead-white);">Vermilion</h3>
+            <p>A brilliant red or scarlet pigment originally made from the powdered mineral cinnabar. Bold, toxic, and legendary.</p>
+        </div>
+    </div>
+
+    <h2>Recent Chronicles</h2>
+    <div class="post-list">
+        {% for page in section.pages %}
+        <div style="margin-bottom: 2rem; padding-bottom: 1rem; border-bottom: var(--border-thin);">
+            <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            {% if page.date %}
+            <div class="meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+            {% endif %}
+            <p>{{ page.description | default(value=page.summary) }}</p>
+        </div>
+        {% endfor %}
+    </div>
+</article>
+{% endblock content %}

--- a/tempera/templates/page.html
+++ b/tempera/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article>
+    <h1>{{ page.title }}</h1>
+
+    {% if page.date %}
+    <div class="meta">Written on {{ page.date | date(format="%B %d, %Y") }}</div>
+    {% endif %}
+
+    <div class="content">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Added a new Hwaro example site named 'tempera'. The theme features a bold, creative, and elegant design utilizing solid colors, distinct borders, and strong typography to create a classic 'tempera paint' aesthetic.

Adhered strictly to constraints:
- Created the necessary structure (`tempera/config.toml`, `tempera/templates/`, `tempera/static/`, `tempera/content/`).
- Avoided all CSS gradients (e.g., `linear-gradient`, `radial-gradient`), relying on flat colors, `border`, and `box-shadow` for visual flair.
- Kept the UI and content completely free of emojis.
- Did not touch `tags.json`.

---
*PR created automatically by Jules for task [13984388772971645098](https://jules.google.com/task/13984388772971645098) started by @hahwul*