### PR TITLE
Add parquetry Hwaro example site

### DIFF
--- a/parquetry/config.toml
+++ b/parquetry/config.toml
@@ -1,0 +1,9 @@
+title = "Parquetry"
+description = "A bold, creative, and elegant geometric woodblock pattern design."
+base_url = "https://example.com"
+compile_sass = false
+minify_html = true
+default_language = "en"
+
+[extra]
+author = "Hwaro"

--- a/parquetry/content/_index.md
+++ b/parquetry/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "The Art of Parquetry"
+sort_by = "weight"
++++
+
+Welcome to the Parquetry collection. This space celebrates geometric design, the beauty of varied wood tones, and intricate craftsmanship.

--- a/parquetry/content/chevron.md
+++ b/parquetry/content/chevron.md
@@ -1,0 +1,10 @@
++++
+title = "Chevron Angles"
+date = 2023-10-03
+weight = 3
+[extra]
+block_type = "square"
+color_theme = "maple"
++++
+
+Distinct from herringbone, chevron features wood blocks cut at an angle, meeting at a perfect point. It creates a seamless, continuous V-shape that speaks of precision and modernity.

--- a/parquetry/content/herringbone.md
+++ b/parquetry/content/herringbone.md
@@ -1,0 +1,10 @@
++++
+title = "Herringbone Symphony"
+date = 2023-10-02
+weight = 2
+[extra]
+block_type = "vertical"
+color_theme = "cherry"
++++
+
+The herringbone pattern is a classic of parquetry. Its interlocking rectangles create a sense of movement, directing the eye along intricate zig-zag paths.

--- a/parquetry/content/marquetry.md
+++ b/parquetry/content/marquetry.md
@@ -1,0 +1,10 @@
++++
+title = "Marquetry Details"
+date = 2023-10-04
+weight = 4
+[extra]
+block_type = "horizontal"
+color_theme = "mahogany"
++++
+
+While parquetry involves geometric shapes, marquetry takes it further by introducing curves and intricate pictures. Sometimes, the line between the two blurs in exquisite craftsmanship.

--- a/parquetry/content/oak-and-walnut.md
+++ b/parquetry/content/oak-and-walnut.md
@@ -1,0 +1,10 @@
++++
+title = "Oak & Walnut"
+date = 2023-10-01
+weight = 1
+[extra]
+block_type = "horizontal"
+color_theme = "oak"
++++
+
+Oak provides strength and a beautiful light grain, contrasting with the dark, rich elegance of walnut. Together they form striking geometric contrasts in any parquet arrangement.

--- a/parquetry/static/css/style.css
+++ b/parquetry/static/css/style.css
@@ -1,0 +1,276 @@
+/* Parquetry Styles */
+:root {
+    /* Wood Palette (Solid Colors ONLY) */
+    --wood-oak: #cbb493;
+    --wood-oak-dark: #b59b79;
+    --wood-walnut: #5c4033;
+    --wood-walnut-dark: #4a3329;
+    --wood-cherry: #8b4513;
+    --wood-cherry-dark: #70370f;
+    --wood-maple: #e5d3b3;
+    --wood-maple-dark: #cabd9e;
+    --wood-mahogany: #662211;
+    --wood-mahogany-dark: #4d1a0d;
+
+    /* Structural Colors */
+    --bg-base: #1a1512;
+    --text-main: #f5f0eb;
+    --text-muted: #d9d0c5;
+    --joint-color: #0d0a08;
+
+    /* Typography */
+    --font-heading: 'Playfair Display', serif;
+    --font-body: 'Lora', serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-base);
+    color: var(--text-main);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    padding: 2rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+a:hover {
+    color: var(--wood-maple);
+}
+
+/* Header */
+.site-header {
+    text-align: center;
+    margin-bottom: 4rem;
+    padding-bottom: 2rem;
+    border-bottom: 4px solid var(--wood-oak);
+    border-bottom-style: double;
+}
+
+.site-title {
+    font-family: var(--font-heading);
+    font-size: 4rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--wood-maple);
+    margin-bottom: 0.5rem;
+}
+
+.site-description {
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-size: 1.2rem;
+    color: var(--text-muted);
+}
+
+/* Parquet Grid Layout */
+.parquet-floor {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-auto-rows: 280px;
+    grid-auto-flow: dense;
+    gap: 8px; /* The "joints" between blocks */
+    background-color: var(--joint-color);
+    padding: 8px;
+    border: 12px solid var(--wood-walnut);
+    box-shadow: inset 0 0 0 4px var(--joint-color),
+                0 10px 30px rgba(0,0,0,0.5);
+    max-width: 1400px;
+    margin: 0 auto;
+    flex-grow: 1;
+}
+
+/* Base Block Styles */
+.intro-block, .parquet-block {
+    position: relative;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    transition: transform 0.3s ease;
+    overflow: hidden;
+}
+
+.intro-block {
+    grid-column: span 2;
+    grid-row: span 1;
+    background-color: var(--wood-maple);
+    color: var(--joint-color);
+    border: 4px solid var(--wood-maple-dark);
+}
+
+.intro-content {
+    font-size: 1.2rem;
+    font-weight: 600;
+}
+
+/* Block Geometry Types */
+.parquet-block.square {
+    grid-column: span 1;
+    grid-row: span 1;
+}
+
+.parquet-block.horizontal {
+    grid-column: span 2;
+    grid-row: span 1;
+}
+
+.parquet-block.vertical {
+    grid-column: span 1;
+    grid-row: span 2;
+}
+
+/* Wood Color Themes (Solid Colors ONLY, NO Gradients) */
+.parquet-block.oak {
+    background-color: var(--wood-oak);
+    color: var(--joint-color);
+    border: 4px solid var(--wood-oak-dark);
+    box-shadow: inset 0 0 0 2px rgba(255,255,255,0.2);
+}
+
+.parquet-block.walnut {
+    background-color: var(--wood-walnut);
+    color: var(--text-main);
+    border: 4px solid var(--wood-walnut-dark);
+    box-shadow: inset 0 0 0 2px rgba(0,0,0,0.2);
+}
+
+.parquet-block.cherry {
+    background-color: var(--wood-cherry);
+    color: var(--text-main);
+    border: 4px solid var(--wood-cherry-dark);
+    box-shadow: inset 0 0 0 2px rgba(0,0,0,0.2);
+}
+
+.parquet-block.maple {
+    background-color: var(--wood-maple);
+    color: var(--joint-color);
+    border: 4px solid var(--wood-maple-dark);
+    box-shadow: inset 0 0 0 2px rgba(255,255,255,0.3);
+}
+
+.parquet-block.mahogany {
+    background-color: var(--wood-mahogany);
+    color: var(--text-main);
+    border: 4px solid var(--wood-mahogany-dark);
+    box-shadow: inset 0 0 0 2px rgba(0,0,0,0.3);
+}
+
+/* Block Interaction */
+.parquet-block:hover {
+    transform: scale(0.98);
+    z-index: 10;
+}
+
+/* Block Typography */
+.block-title {
+    font-family: var(--font-heading);
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+    line-height: 1.2;
+}
+
+.block-date {
+    display: block;
+    font-size: 0.9rem;
+    font-style: italic;
+    margin-bottom: 1rem;
+    opacity: 0.8;
+}
+
+.block-summary {
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+/* Single Page Styles */
+.page-content {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: var(--wood-maple);
+    color: var(--joint-color);
+    padding: 3rem;
+    border: 16px solid var(--wood-walnut);
+    box-shadow: inset 0 0 0 4px var(--joint-color),
+                0 20px 40px rgba(0,0,0,0.4);
+    position: relative;
+}
+
+/* Adding a decorative 'inlay' border */
+.page-content::before {
+    content: '';
+    position: absolute;
+    top: 10px; right: 10px; bottom: 10px; left: 10px;
+    border: 2px solid var(--wood-walnut-dark);
+    pointer-events: none;
+}
+
+.article-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    border-bottom: 2px solid var(--wood-walnut-dark);
+    padding-bottom: 1rem;
+}
+
+.article-title {
+    font-family: var(--font-heading);
+    font-size: 3rem;
+    color: var(--wood-mahogany);
+    margin-bottom: 0.5rem;
+}
+
+.article-date {
+    font-style: italic;
+    color: var(--wood-walnut);
+}
+
+.article-body h2 {
+    font-family: var(--font-heading);
+    color: var(--wood-cherry);
+    margin: 2rem 0 1rem;
+}
+
+.article-body p {
+    margin-bottom: 1.5rem;
+}
+
+.back-link {
+    margin-top: 4rem;
+    text-align: center;
+    font-family: var(--font-heading);
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.back-link a {
+    color: var(--wood-mahogany);
+    border-bottom: 2px solid transparent;
+}
+
+.back-link a:hover {
+    border-bottom-color: var(--wood-mahogany);
+}
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 2px solid var(--wood-walnut);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}

--- a/parquetry/templates/index.html
+++ b/parquetry/templates/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="header-inner">
+            <h1 class="site-title"><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
+            <p class="site-description">{{ config.description }}</p>
+        </div>
+    </header>
+
+    {% block content %}
+    <main class="parquet-floor">
+        <div class="intro-block">
+            <div class="intro-content">
+                {{ section.content | safe }}
+            </div>
+        </div>
+
+        {% for page in section.pages %}
+            <article class="parquet-block {{ page.extra.block_type | default(value='square') }} {{ page.extra.color_theme | default(value='oak') }}">
+                <div class="block-inner">
+                    <h2 class="block-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                    {% if page.date %}
+                        <time class="block-date" datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>
+                    {% endif %}
+                    <div class="block-summary">
+                        {{ page.content | striptags | truncate(length=120) | safe }}
+                    </div>
+                </div>
+            </article>
+        {% endfor %}
+    </main>
+    {% endblock content %}
+
+    <footer class="site-footer">
+        <p>&copy; 2024 {{ config.extra.author }}. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/parquetry/templates/page.html
+++ b/parquetry/templates/page.html
@@ -1,0 +1,20 @@
+{% extends "index.html" %}
+
+{% block content %}
+<main class="page-content">
+    <article class="single-article">
+        <header class="article-header">
+            <h1 class="article-title">{{ page.title }}</h1>
+            {% if page.date %}
+                <time class="article-date" datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>
+            {% endif %}
+        </header>
+        <div class="article-body">
+            {{ page.content | safe }}
+        </div>
+        <div class="back-link">
+            <a href="{{ config.base_url }}">Return to Collection</a>
+        </div>
+    </article>
+</main>
+{% endblock content %}


### PR DESCRIPTION
Added the new `parquetry` example site for Hwaro. It features a bold, creative, and elegant geometric woodblock pattern design using strict solid colors, borders, and CSS grid to simulate a parquet floor. It strictly avoids any modifications to `tags.json`, emojis, or CSS gradients per the requirements.

---
*PR created automatically by Jules for task [15352345441668295174](https://jules.google.com/task/15352345441668295174) started by @hahwul*