### PR TITLE
feat: add lithograph example site

### DIFF
--- a/lithograph/config.toml
+++ b/lithograph/config.toml
@@ -1,0 +1,28 @@
+title = "Lithograph"
+description = "A bold, creative, and elegant lithograph print aesthetic."
+base_url = "http://localhost:1111"
+
+# The language code. Default is 'en'
+default_language = "en"
+
+# A list of glob patterns specifying the files to ignore in the `content` directory
+ignored_content = []
+
+compile_sass = false
+build_search_index = false
+
+[markdown]
+highlight_code = true
+highlight_theme = "base16-ocean-dark"
+render_emoji = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+feed = true
+
+[extra]
+author = "Publisher"

--- a/lithograph/content/_index.md
+++ b/lithograph/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Lithograph Press"
++++
+
+Welcome to the digital lithograph press. This space is dedicated to bold, creative, and elegant ideas pressed firmly onto the web. Here, we embrace the stark contrast of ink on paper, the structure of solid borders, and the weight of classic typography.
+
+The process of lithography relies on the simple principle that oil and water do not mix. We apply a similar philosophy to our design: clarity and distinction over muddled gradients.
+
+Enjoy exploring the archive of prints.

--- a/lithograph/content/about.md
+++ b/lithograph/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About the Press"
++++
+
+This digital press is a homage to the art of lithography. We believe that constraints breed creativity. By limiting ourselves to solid colors, distinct lines, and pure typography, we strive to create a web experience that feels substantial and permanent, much like ink pressed firmly into paper.
+
+The publisher remains dedicated to the craft of clear communication without the artifice of gradients or modern novelties.

--- a/lithograph/content/posts/_index.md
+++ b/lithograph/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Archive of Prints"
+sort_by = "date"
+template = "section.html"
+page_template = "page.html"
++++

--- a/lithograph/content/posts/bold-contrast.md
+++ b/lithograph/content/posts/bold-contrast.md
@@ -1,0 +1,19 @@
++++
+title = "Bold Contrast"
+date = 2024-03-12
+description = "Why strong contrast matters in visual communication."
+[taxonomies]
+tags = ["design", "theory"]
++++
+
+In a world filled with subtle shadows and infinite gradients, making a deliberate choice to use harsh lines and strong contrast is a powerful statement.
+
+### The Power of Black and White
+
+When you remove color, you are forced to focus on form. The structure of a page becomes its primary means of communication.
+
+1. Hierarchy becomes clear.
+2. Shapes are defined by their boundaries, not their shading.
+3. Typography takes center stage.
+
+We use the deep charcoal of our text to cut into the creamy background of our digital paper, much like an etching tool cuts into a plate. There is no ambiguity. Every element is exactly where it is intended to be.

--- a/lithograph/content/posts/the-art-of-the-press.md
+++ b/lithograph/content/posts/the-art-of-the-press.md
@@ -1,0 +1,35 @@
++++
+title = "The Art of the Press"
+date = 2024-03-10
+description = "An exploration of early printing techniques."
+[taxonomies]
+tags = ["history", "design", "technique"]
++++
+
+Lithography was invented in 1796 by German author and actor Alois Senefelder as a cheap method of publishing theatrical works. It revolutionized the printing industry and paved the way for modern offset printing.
+
+<!-- more -->
+
+### The Principle
+
+Lithography originally used an image drawn with oil, fat, or wax onto the surface of a smooth, level lithographic limestone plate. The stone was treated with a mixture of acid and gum arabic, etching the portions of the stone that were not protected by the grease-based image.
+
+When the stone was subsequently moistened, these etched areas retained water; an oil-based ink could then be applied and would be repelled by the water, sticking only to the original drawing.
+
+> The simplicity of the principle—that grease and water repel each other—is what makes the process both elegant and deeply complex in its execution.
+
+### Modern Equivalents
+
+Today, we emulate this stark beauty on the web by choosing solid colors, sharp borders, and deliberate typography. We avoid the smooth blending of colors, preferring the distinct edges that characterize a true print.
+
+```css
+/* Example of our digital ink */
+.digital-ink {
+  color: #1a1a1a;
+  background-color: #f4f1ea;
+  border: 4px solid #1a1a1a;
+  box-shadow: 10px 10px 0 #1a1a1a;
+}
+```
+
+The contrast must be high. The impact must be immediate. This is the art of the digital press.

--- a/lithograph/static/css/style.css
+++ b/lithograph/static/css/style.css
@@ -1,0 +1,247 @@
+:root {
+  /* Lithograph color palette */
+  --bg-color: #f4f1ea; /* Creamy paper */
+  --text-color: #1a1a1a; /* Charcoal black ink */
+  --accent-color: #c93b22; /* Classic lithograph red */
+  --border-color: #1a1a1a;
+  --secondary-bg: #e8e4d9; /* Slightly darker paper for contrast */
+
+  --font-body: 'Georgia', serif;
+  --font-heading: 'Playfair Display', 'Times New Roman', serif;
+  --font-mono: 'Courier New', monospace;
+
+  /* No gradients used here */
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  font-size: 18px;
+  /* Add texture using repeating linear but we are strictly avoiding any gradients,
+     so we use an SVG pattern or just solid background */
+  background-image: url('data:image/svg+xml;utf8,<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h40v40H0V0zm20 20h20v20H20V20z" fill="%23e8e4d9" fill-opacity="0.2" fill-rule="evenodd"/></svg>');
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: 1rem;
+  color: var(--text-color);
+  border-bottom: 2px solid var(--border-color);
+  padding-bottom: 0.5rem;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 900;
+  text-align: center;
+  border-top: 4px solid var(--border-color);
+  border-bottom: 4px solid var(--border-color);
+  padding: 1rem 0;
+  margin: 2rem 0;
+}
+
+h2 {
+  font-size: 2rem;
+  color: var(--accent-color);
+  border-bottom-color: var(--accent-color);
+}
+
+p {
+  margin-bottom: 1.5rem;
+  text-align: justify;
+}
+
+a {
+  color: var(--accent-color);
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+a:hover {
+  border-bottom-color: var(--accent-color);
+}
+
+/* Layout */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  background-color: var(--bg-color);
+  border: 4px solid var(--border-color);
+  box-shadow: 10px 10px 0 var(--border-color); /* Solid shadow, no gradient */
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+  position: relative;
+}
+
+.container::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  border: 1px solid var(--border-color);
+  pointer-events: none;
+}
+
+/* Header */
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+nav {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1rem;
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+nav a {
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+}
+
+nav a:hover {
+  border-color: var(--text-color);
+  border-bottom-color: var(--text-color);
+}
+
+/* Print/Lithograph Image Effect */
+.lithograph-image {
+  border: 2px solid var(--border-color);
+  padding: 10px;
+  background-color: var(--secondary-bg);
+  display: block;
+  margin: 2rem auto;
+  max-width: 100%;
+  filter: grayscale(100%) contrast(120%);
+}
+
+.lithograph-image-caption {
+  text-align: center;
+  font-family: var(--font-heading);
+  font-style: italic;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+/* Post List */
+.post-list {
+  list-style: none;
+}
+
+.post-item {
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px dashed var(--border-color);
+}
+
+.post-item:last-child {
+  border-bottom: none;
+}
+
+.post-title {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  border: none;
+  text-transform: none;
+}
+
+.post-meta {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: #555;
+  margin-bottom: 1rem;
+}
+
+.post-summary {
+  font-style: italic;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  margin-top: 4rem;
+  padding-top: 1rem;
+  border-top: 4px solid var(--border-color);
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 4px solid var(--accent-color);
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+  font-style: italic;
+  background-color: var(--secondary-bg);
+  padding: 1.5rem;
+  box-shadow: 4px 4px 0 var(--border-color);
+}
+
+/* Code */
+code {
+  font-family: var(--font-mono);
+  background-color: var(--secondary-bg);
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--border-color);
+}
+
+pre {
+  background-color: var(--secondary-bg);
+  padding: 1.5rem;
+  border: 2px solid var(--border-color);
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  box-shadow: 6px 6px 0 var(--border-color);
+}
+
+pre code {
+  background-color: transparent;
+  padding: 0;
+  border: none;
+}
+
+/* Taxonomy tags */
+.tags {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  margin-top: 1rem;
+}
+
+.tags li a {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  background-color: var(--text-color);
+  color: var(--bg-color);
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--text-color);
+  text-transform: uppercase;
+}
+
+.tags li a:hover {
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+  color: var(--bg-color);
+}

--- a/lithograph/templates/base.html
+++ b/lithograph/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value="en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock %}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1><a href="{{ config.base_url }}" style="color: inherit; text-decoration: none; border: none;">{{ config.title }}</a></h1>
+            <p style="font-family: var(--font-heading); font-style: italic;">{{ config.description }}</p>
+            <nav>
+                <a href="{{ config.base_url }}">Home</a>
+                <a href="{{ get_url(path="posts") }}">Prints</a>
+                <a href="{{ get_url(path="about") }}">About</a>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            <p>&copy; {{ now() | date(format="%Y") }} {{ config.extra.author | default(value="Publisher") }}. All rights reserved.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/lithograph/templates/index.html
+++ b/lithograph/templates/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="content">
+        {{ section.content | safe }}
+    </div>
+
+    <h2>Recent Prints</h2>
+
+    {% set section_posts = get_section(path="posts/_index.md") %}
+    <ul class="post-list">
+    {% for page in section_posts.pages | slice(end=3) %}
+        <li class="post-item">
+            <h3 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <div class="post-meta">
+                {% if page.date %}
+                    Published on {{ page.date | date(format="%B %d, %Y") }}
+                {% endif %}
+            </div>
+            {% if page.summary %}
+                <p class="post-summary">{{ page.summary | safe }}</p>
+            {% elif page.description %}
+                <p class="post-summary">{{ page.description }}</p>
+            {% endif %}
+            <a href="{{ page.permalink }}">Read Full Print &rarr;</a>
+        </li>
+    {% endfor %}
+    </ul>
+
+    <div style="text-align: center; margin-top: 2rem;">
+        <a href="{{ get_url(path="posts") }}" style="font-family: var(--font-heading); text-transform: uppercase; letter-spacing: 1px; border: 2px solid var(--border-color); padding: 0.5rem 1rem; box-shadow: 4px 4px 0 var(--border-color);">View the Archive</a>
+    </div>
+{% endblock content %}

--- a/lithograph/templates/page.html
+++ b/lithograph/templates/page.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <article>
+        <h2>{{ page.title }}</h2>
+        <div class="post-meta" style="text-align: center; margin-bottom: 2rem;">
+            {% if page.date %}
+                Printed on {{ page.date | date(format="%B %d, %Y") }}
+            {% endif %}
+
+            {% if page.taxonomies.tags %}
+                <ul class="tags" style="justify-content: center; margin-top: 0.5rem;">
+                {% for tag in page.taxonomies.tags %}
+                    <li><a href="{{ get_taxonomy_url(kind="tags", name=tag) }}">{{ tag }}</a></li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+
+        <div class="content">
+            {{ page.content | safe }}
+        </div>
+    </article>
+{% endblock content %}

--- a/lithograph/templates/section.html
+++ b/lithograph/templates/section.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <h2>{{ section.title }}</h2>
+
+    {% if section.content %}
+    <div class="content">
+        {{ section.content | safe }}
+    </div>
+    {% endif %}
+
+    <ul class="post-list">
+    {% for page in section.pages %}
+        <li class="post-item">
+            <h3 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <div class="post-meta">
+                {% if page.date %}
+                    Published on {{ page.date | date(format="%B %d, %Y") }}
+                {% endif %}
+            </div>
+            {% if page.summary %}
+                <p class="post-summary">{{ page.summary | safe }}</p>
+            {% elif page.description %}
+                <p class="post-summary">{{ page.description }}</p>
+            {% endif %}
+
+            {% if page.taxonomies.tags %}
+                <ul class="tags">
+                {% for tag in page.taxonomies.tags %}
+                    <li><a href="{{ get_taxonomy_url(kind="tags", name=tag) }}">{{ tag }}</a></li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endblock content %}

--- a/lithograph/templates/taxonomy.html
+++ b/lithograph/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}{{ taxonomy.name | capitalize }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <h2>{{ taxonomy.name | capitalize }}</h2>
+
+    <ul class="tags">
+    {% for term in terms %}
+        <li><a href="{{ term.permalink }}">{{ term.name }} ({{ term.pages | length }})</a></li>
+    {% endfor %}
+    </ul>
+{% endblock content %}

--- a/lithograph/templates/taxonomy_list.html
+++ b/lithograph/templates/taxonomy_list.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}{{ taxonomy.name | capitalize }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <h2>{{ taxonomy.name | capitalize }}</h2>
+
+    <ul class="tags">
+    {% for term in terms %}
+        <li><a href="{{ term.permalink }}">{{ term.name }} ({{ term.pages | length }})</a></li>
+    {% endfor %}
+    </ul>
+{% endblock content %}

--- a/lithograph/templates/taxonomy_single.html
+++ b/lithograph/templates/taxonomy_single.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}{{ term.name }} - {{ taxonomy.name | capitalize }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <h2>{{ taxonomy.name | capitalize }}: {{ term.name }}</h2>
+
+    <ul class="post-list">
+    {% for page in term.pages %}
+        <li class="post-item">
+            <h3 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <div class="post-meta">
+                {% if page.date %}
+                    Published on {{ page.date | date(format="%B %d, %Y") }}
+                {% endif %}
+            </div>
+            {% if page.summary %}
+                <p class="post-summary">{{ page.summary | safe }}</p>
+            {% elif page.description %}
+                <p class="post-summary">{{ page.description }}</p>
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endblock content %}

--- a/lithograph/templates/taxonomy_term.html
+++ b/lithograph/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}{{ term.name }} - {{ taxonomy.name | capitalize }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+    <h2>{{ taxonomy.name | capitalize }}: {{ term.name }}</h2>
+
+    <ul class="post-list">
+    {% for page in term.pages %}
+        <li class="post-item">
+            <h3 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <div class="post-meta">
+                {% if page.date %}
+                    Published on {{ page.date | date(format="%B %d, %Y") }}
+                {% endif %}
+            </div>
+            {% if page.summary %}
+                <p class="post-summary">{{ page.summary | safe }}</p>
+            {% elif page.description %}
+                <p class="post-summary">{{ page.description }}</p>
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endblock content %}


### PR DESCRIPTION
Adds a new Hwaro example site featuring a bold, creative, and elegant lithograph print aesthetic. Uses solid colors, intricate borders, and elegant typography to simulate early printing techniques, strictly avoiding CSS gradients and emojis.

---
*PR created automatically by Jules for task [9961743606709565628](https://jules.google.com/task/9961743606709565628) started by @hahwul*