### PR TITLE
feat: add electroplate example site

### DIFF
--- a/electroplate/config.toml
+++ b/electroplate/config.toml
@@ -1,0 +1,9 @@
+title = "Electroplate"
+description = "A bold, creative, and elegant design simulating electroplated metal."
+base_url = "https://example.com"
+compile_sass = false
+minify_html = true
+default_language = "en"
+
+[extra]
+author = "Hwaro"

--- a/electroplate/content/_index.md
+++ b/electroplate/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Electroplate Aesthetics"
+description = "Welcome to the polished and reflective world of Electroplate."
++++
+
+Experience the shine and structural elegance of our electroplated aesthetic. We use intricate shadows and reflections without relying on standard CSS gradients. The result is a striking, bold, and metallic look that stands out.

--- a/electroplate/content/about.md
+++ b/electroplate/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About Electroplate"
+description = "More about this shiny, metallic theme."
++++
+
+This theme focuses on bold, creative, and elegant design, specifically targeting a metallic 'electroplated' look. By carefully manipulating box-shadows, inset shadows, borders, and text-shadows, it crafts a feeling of chrome, silver, or gold surfaces catching the light.
+
+No emojis or standard CSS gradients are used in this theme.

--- a/electroplate/static/css/style.css
+++ b/electroplate/static/css/style.css
@@ -1,0 +1,221 @@
+/* Electroplate Aesthetics - Bold, Creative, and Elegant */
+/* STRICTLY NO GRADIENTS */
+
+:root {
+    /* Base metallic colors */
+    --base-metal: #c0c5ce;
+    --dark-metal: #8c929a;
+    --light-metal: #e6e9ef;
+    --highlight: #ffffff;
+    --shadow: #5a5f66;
+    --deep-shadow: #2b2d30;
+
+    /* Text colors */
+    --text-main: #33363b;
+    --text-light: #5a5f66;
+    --text-emboss-light: #ffffff;
+    --text-emboss-dark: #8c929a;
+
+    /* Chrome/Electroplate effect colors */
+    --plate-rim-light: #ffffff;
+    --plate-rim-dark: #44474d;
+    --plate-surface: #d8dce3;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--base-metal);
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: var(--text-main);
+    line-height: 1.6;
+
+    /* Simulate a very subtle, large scale metallic surface reflection using solid shadows */
+    box-shadow: inset 0 0 100px rgba(90, 95, 102, 0.2);
+    min-height: 100vh;
+}
+
+a {
+    color: var(--text-main);
+    text-decoration: none;
+    font-weight: bold;
+}
+
+/* Typography Effects */
+.embossed-text {
+    font-size: 3rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--plate-surface);
+    /* Complex text-shadow to simulate embossed metal */
+    text-shadow:
+        -1px -1px 1px var(--plate-rim-light),
+        1px 1px 2px var(--deep-shadow),
+        0px 0px 10px rgba(255, 255, 255, 0.5);
+    margin-bottom: 0.5rem;
+}
+
+.embossed-text-small {
+    font-size: 1.5rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--plate-surface);
+    text-shadow:
+        -1px -1px 1px var(--plate-rim-light),
+        1px 1px 2px var(--deep-shadow);
+    margin-bottom: 0.5rem;
+}
+
+.engraved-text {
+    font-size: 1.2rem;
+    color: var(--dark-metal);
+    /* Complex text-shadow to simulate engraved text */
+    text-shadow:
+        1px 1px 1px var(--plate-rim-light),
+        -1px -1px 1px var(--deep-shadow);
+}
+
+.engraved-text-small {
+    font-size: 1rem;
+    color: var(--dark-metal);
+    text-shadow:
+        1px 1px 1px var(--plate-rim-light),
+        -1px -1px 1px var(--deep-shadow);
+}
+
+/* Structural Elements */
+.metallic-panel {
+    background-color: var(--plate-surface);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    /* Electroplate border/panel effect using solid box-shadows */
+    box-shadow:
+        0 5px 15px rgba(43, 45, 48, 0.4),
+        inset 0 2px 2px var(--plate-rim-light),
+        inset 0 -2px 5px var(--plate-rim-dark),
+        inset 2px 0 2px var(--plate-rim-light),
+        inset -2px 0 5px var(--plate-rim-dark);
+
+    border-bottom: 1px solid var(--deep-shadow);
+}
+
+.metallic-panel.logo a {
+    font-size: 1.5rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    color: var(--plate-surface);
+    text-shadow:
+        -1px -1px 1px var(--plate-rim-light),
+        1px 1px 2px var(--deep-shadow);
+}
+
+.content-wrapper {
+    max-width: 900px;
+    margin: 3rem auto;
+    padding: 0 1rem;
+}
+
+/* Cards / Containers */
+.metallic-card {
+    background-color: var(--plate-surface);
+    padding: 2.5rem;
+    margin-bottom: 2rem;
+    border-radius: 4px;
+
+    /* Thick, highly reflective electroplate edge effect */
+    box-shadow:
+        0 10px 30px rgba(43, 45, 48, 0.5),
+        0 0 0 2px var(--dark-metal),
+        0 0 0 4px var(--plate-rim-light),
+        0 0 0 6px var(--dark-metal),
+        inset 0 3px 5px var(--plate-rim-light),
+        inset 0 -3px 10px var(--plate-rim-dark),
+        inset 3px 0 5px var(--plate-rim-light),
+        inset -3px 0 10px var(--plate-rim-dark);
+}
+
+.mini-card {
+    padding: 1.5rem;
+}
+
+/* Buttons */
+.metallic-btn {
+    display: inline-block;
+    padding: 0.5rem 1.5rem;
+    background-color: var(--plate-surface);
+    color: var(--text-main);
+    font-weight: bold;
+    text-transform: uppercase;
+    border-radius: 3px;
+
+    /* Raised metallic button effect */
+    box-shadow:
+        0 4px 6px rgba(43, 45, 48, 0.3),
+        inset 0 2px 3px var(--plate-rim-light),
+        inset 0 -2px 3px var(--plate-rim-dark),
+        inset 2px 0 3px var(--plate-rim-light),
+        inset -2px 0 3px var(--plate-rim-dark);
+
+    transition: all 0.1s ease;
+}
+
+.metallic-btn:hover {
+    /* Inverted shadow to simulate pressing in */
+    box-shadow:
+        0 1px 2px rgba(43, 45, 48, 0.5),
+        inset 0 3px 5px var(--plate-rim-dark),
+        inset 0 -1px 2px var(--plate-rim-light),
+        inset 3px 0 5px var(--plate-rim-dark),
+        inset -1px 0 2px var(--plate-rim-light);
+    transform: translateY(2px);
+}
+
+footer.metallic-panel {
+    margin-top: 4rem;
+    border-top: 1px solid var(--plate-rim-light);
+    border-bottom: none;
+    justify-content: center;
+    font-size: 0.9rem;
+    color: var(--dark-metal);
+    text-shadow: 1px 1px 1px var(--plate-rim-light);
+}
+
+/* Inner content styling */
+.content p {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+}
+
+/* Decorative screw/rivet elements using radial-like effect purely with box-shadows */
+.metallic-card {
+    position: relative;
+}
+
+.metallic-card::before,
+.metallic-card::after {
+    content: '';
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background-color: var(--dark-metal);
+    border-radius: 50%;
+    /* Rivet shadow effect */
+    box-shadow:
+        inset 0 2px 2px var(--deep-shadow),
+        inset 0 -2px 2px var(--plate-rim-light),
+        0 1px 1px var(--plate-rim-light);
+}
+
+.metallic-card::before {
+    top: 15px;
+    left: 15px;
+}
+
+.metallic-card::after {
+    bottom: 15px;
+    right: 15px;
+}

--- a/electroplate/templates/base.html
+++ b/electroplate/templates/base.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}{{ config.title }}</title>
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <header class="metallic-panel">
+        <div class="logo">
+            <a href="{{ config.base_url }}">{{ config.title }}</a>
+        </div>
+        <nav>
+            <a href="{{ config.base_url }}/about" class="metallic-btn">About</a>
+        </nav>
+    </header>
+
+    <main class="content-wrapper">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="metallic-panel">
+        <p>&copy; {{ config.title }} - Styled with reflective shadows.</p>
+    </footer>
+</body>
+</html>

--- a/electroplate/templates/index.html
+++ b/electroplate/templates/index.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero metallic-card">
+    <h1 class="embossed-text">{{ section.title }}</h1>
+    <p class="engraved-text">{{ section.description }}</p>
+    <div class="content">
+        {{ section.content | safe }}
+    </div>
+</section>
+
+<section class="pages-list">
+    {% for page in section.pages %}
+        <article class="metallic-card mini-card">
+            <h2 class="embossed-text-small"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+            <p class="engraved-text-small">{{ page.description }}</p>
+        </article>
+    {% endfor %}
+</section>
+{% endblock content %}

--- a/electroplate/templates/page.html
+++ b/electroplate/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="metallic-card page-card">
+    <header>
+        <h1 class="embossed-text">{{ page.title }}</h1>
+        {% if page.description %}
+            <p class="engraved-text">{{ page.description }}</p>
+        {% endif %}
+    </header>
+    <div class="content">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Created the 'electroplate' Hwaro example site featuring a bold, creative, and elegant metallic look. The aesthetic relies entirely on stacked `box-shadow` and `text-shadow` layers using solid colors to simulate reflections and depth. 

- Adheres to the constraint of avoiding `linear-gradient` and `radial-gradient`.
- No emojis used in templates or content.
- `tags.json` was left unmodified.
- Evaluated via local Zola build and verified via Playwright visual script.

---
*PR created automatically by Jules for task [8910585021190731217](https://jules.google.com/task/8910585021190731217) started by @hahwul*