### PR TITLE
feat: add glyphic theme

### DIFF
--- a/glyphic/config.toml
+++ b/glyphic/config.toml
@@ -1,0 +1,7 @@
+base_url = "https://example.com"
+title = "Glyphic"
+description = "A bold, creative, and elegant glyphic theme."
+default_language = "en"
+
+[extra]
+author = "Hwaro User"

--- a/glyphic/content/_index.md
+++ b/glyphic/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "The Glyphic Archives"
+sort_by = "date"
++++
+
+Welcome to the Glyphic Archives, where wisdom is carved into digital stone.

--- a/glyphic/content/ancient-carvings.md
+++ b/glyphic/content/ancient-carvings.md
@@ -1,0 +1,7 @@
++++
+title = "Ancient Carvings"
+date = 2023-11-20
++++
+
+The art of carving text into stone creates a timeless feeling. Without the use of soft gradients, we rely on harsh shadows and solid colors to create depth.
+We avoid the use of modern pictorial symbols, focusing purely on the form and weight of typography.

--- a/glyphic/static/css/style.css
+++ b/glyphic/static/css/style.css
@@ -1,0 +1,164 @@
+:root {
+    --bg-color: #e8e6e1; /* Light stone color */
+    --text-color: #2c2a27; /* Dark engraved text */
+    --accent-color: #8b2500; /* Rust/terracotta accent */
+    --shadow-color-dark: #c4c1b9;
+    --shadow-color-light: #ffffff;
+
+    --font-heading: 'Cinzel', serif;
+    --font-body: 'Lora', serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-body);
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+    padding: 2rem;
+    max-width: 900px;
+    margin: 0 auto;
+    font-size: 1.125rem;
+}
+
+/* Typography and Carved Effect */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 800;
+    color: var(--text-color);
+    /* Debossed/carved text effect */
+    text-shadow: 1px 1px 0px var(--shadow-color-light),
+                 -1px -1px 0px var(--shadow-color-dark);
+}
+
+a {
+    color: var(--text-color);
+    text-decoration: none;
+    border-bottom: 2px solid var(--accent-color);
+    transition: all 0.3s ease;
+}
+
+a:hover {
+    color: var(--accent-color);
+    border-bottom-width: 4px;
+}
+
+/* Header */
+.site-header {
+    text-align: center;
+    margin-bottom: 4rem;
+    padding-bottom: 2rem;
+    border-bottom: 4px solid var(--text-color);
+    box-shadow: 0 4px 0 -2px var(--shadow-color-light); /* Adds a subtle ridge to the border */
+}
+
+.site-title {
+    font-size: 3.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.site-title a {
+    border-bottom: none;
+}
+
+.site-title a:hover {
+    color: var(--text-color);
+    text-shadow: 1px 1px 0px var(--shadow-color-light),
+                 -1px -1px 0px var(--accent-color);
+}
+
+.site-description {
+    font-family: var(--font-heading);
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--accent-color);
+    letter-spacing: 0.05em;
+    text-shadow: 1px 1px 0px var(--shadow-color-light);
+}
+
+/* Main Content Containers - Embossed stone blocks */
+.archive-intro, .carving-entry, .single-carving {
+    background-color: var(--bg-color);
+    padding: 2.5rem;
+    margin-bottom: 3rem;
+    border: 2px solid var(--text-color);
+    /* Heavy solid shadow for an extruded block look */
+    box-shadow: 8px 8px 0px var(--text-color),
+                1px 1px 0px var(--shadow-color-light) inset,
+                -1px -1px 0px var(--shadow-color-dark) inset;
+}
+
+/* Archive List */
+.archive-title {
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    text-align: center;
+}
+
+.archive-content {
+    text-align: center;
+    margin-bottom: 2rem;
+    font-style: italic;
+}
+
+.carvings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.entry-title {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.entry-title a {
+    border-bottom: none;
+}
+
+.entry-title a:hover {
+    color: var(--accent-color);
+}
+
+.entry-date, .carving-date {
+    font-family: var(--font-heading);
+    font-size: 0.9rem;
+    color: var(--accent-color);
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+/* Single Carving (Page) */
+.carving-header {
+    margin-bottom: 2rem;
+    border-bottom: 2px solid var(--text-color);
+    padding-bottom: 1rem;
+}
+
+.carving-title {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.carving-body p {
+    margin-bottom: 1.5rem;
+}
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 4px solid var(--text-color);
+    font-family: var(--font-heading);
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-shadow: 1px 1px 0px var(--shadow-color-light);
+}

--- a/glyphic/templates/base.html
+++ b/glyphic/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;800&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <h1 class="site-title"><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
+        <p class="site-description">{{ config.description }}</p>
+    </header>
+
+    <main class="content-container">
+        {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; {{ config.extra.author | default(value="Author") }}</p>
+    </footer>
+</body>
+</html>

--- a/glyphic/templates/index.html
+++ b/glyphic/templates/index.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="archive-intro">
+    <h2 class="archive-title">{{ section.title }}</h2>
+    <div class="archive-content">
+        {{ section.content | safe }}
+    </div>
+</section>
+
+<section class="carvings-list">
+    {% for page in section.pages %}
+    <article class="carving-entry">
+        <h3 class="entry-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+        {% if page.date %}
+        <p class="entry-date">{{ page.date | date(format="%Y-%m-%d") }}</p>
+        {% endif %}
+        <div class="entry-summary">
+            {{ page.summary | default(value=page.content | striptags | truncate(length=150)) | safe }}
+        </div>
+    </article>
+    {% endfor %}
+</section>
+{% endblock content %}

--- a/glyphic/templates/page.html
+++ b/glyphic/templates/page.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+
+{% block content %}
+<article class="single-carving">
+    <header class="carving-header">
+        <h1 class="carving-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <p class="carving-date">{{ page.date | date(format="%Y-%m-%d") }}</p>
+        {% endif %}
+    </header>
+    <div class="carving-body">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Adds the 'glyphic' theme. The design implements an ancient stone carving aesthetic using solid colors, sharp borders, and shadows. The implementation avoids gradients and emojis, conforming to the specific constraints.

---
*PR created automatically by Jules for task [10298448864069986884](https://jules.google.com/task/10298448864069986884) started by @hahwul*