### PR TITLE
Add Cloisonne Theme

### DIFF
--- a/cloisonne/config.toml
+++ b/cloisonne/config.toml
@@ -1,0 +1,7 @@
+base_url = "https://example.com"
+title = "Cloisonne"
+description = "An elegant cloisonne enamel inspired aesthetic."
+default_language = "en"
+
+[extra]
+author = "Hwaro"

--- a/cloisonne/content/_index.md
+++ b/cloisonne/content/_index.md
@@ -1,0 +1,22 @@
++++
+title = "The Art of Cloisonne"
+description = "A delicate dance of wire and glass."
++++
+
+# The Art of Cloisonne
+
+Cloisonne is an ancient technique for decorating metalwork objects with colored material held in place or separated by metal strips or wire, normally of gold. In recent centuries, vitreous enamel has been used, and inlays of cut gemstones, glass and other materials were also used during older periods.
+
+## The Process
+
+First, the craftsman shapes fine metal wires to create a design, soldering them to a metal base. The resulting compartments (cloisons in French) are then filled with enamel paste.
+
+1.  **Forming the base**: Often made of copper, brass, or bronze.
+2.  **Creating the cloisons**: Thin strips of metal are bent and attached to the base.
+3.  **Applying the enamel**: Colored glass powder mixed with water is applied to the cloisons.
+4.  **Firing**: The object is fired in a kiln, melting the enamel.
+5.  **Polishing**: The surface is polished smooth until the metal wires are flush with the enamel.
+
+## A Legacy of Elegance
+
+The resulting objects are vibrant, durable, and breathtakingly intricate. The contrast between the shining metal wire and the deep, vivid colors of the enamel creates a uniquely captivating aesthetic.

--- a/cloisonne/static/css/style.css
+++ b/cloisonne/static/css/style.css
@@ -1,0 +1,140 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap');
+
+:root {
+    --gold-wire: #D4AF37;
+    --gold-wire-dark: #AA8C2C;
+    --enamel-lapis: #1A365D;
+    --enamel-jade: #007A5E;
+    --enamel-ruby: #9B111E;
+    --enamel-onyx: #0F0F0F;
+    --enamel-ivory: #FDFBF7;
+    --wire-thickness: 4px;
+    --wire-thin: 2px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--enamel-lapis);
+    color: var(--enamel-ivory);
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.2rem;
+    line-height: 1.6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.cloison-container {
+    max-width: 800px;
+    margin: 40px;
+    background-color: var(--enamel-onyx);
+    border: var(--wire-thickness) solid var(--gold-wire);
+    border-radius: 40px 0 40px 0;
+    position: relative;
+    box-shadow: 0 0 0 var(--wire-thin) var(--gold-wire-dark) inset,
+                0 0 0 var(--wire-thin) var(--gold-wire-dark); /* Faking a double wire or shadow with solid colors, but no gradient! */
+    overflow: hidden;
+}
+
+.cloison-header {
+    background-color: var(--enamel-ruby);
+    padding: 60px 40px;
+    text-align: center;
+    border-bottom: var(--wire-thickness) solid var(--gold-wire);
+    border-radius: 0 0 40px 0;
+}
+
+.cloison-header h1 {
+    font-family: 'Cinzel', serif;
+    font-size: 3.5rem;
+    color: var(--gold-wire);
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 4px;
+    text-shadow: 2px 2px 0px var(--enamel-onyx);
+}
+
+.cloison-header p {
+    font-size: 1.5rem;
+    color: var(--enamel-ivory);
+    margin: 10px 0 0;
+    font-style: italic;
+}
+
+.cloison-body {
+    padding: 40px;
+    background-color: var(--enamel-jade);
+    border-radius: 40px 0 40px 0;
+    border: var(--wire-thickness) solid var(--gold-wire);
+    margin: 20px;
+}
+
+.cloison-body h2 {
+    font-family: 'Cinzel', serif;
+    color: var(--gold-wire);
+    font-size: 2rem;
+    border-bottom: var(--wire-thin) solid var(--gold-wire);
+    padding-bottom: 10px;
+    margin-top: 0;
+}
+
+.cloison-body p, .cloison-body ul, .cloison-body li {
+    color: var(--enamel-ivory);
+}
+
+.cloison-body ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.cloison-body li {
+    margin-bottom: 15px;
+    padding-left: 20px;
+    position: relative;
+}
+
+.cloison-body li::before {
+    content: "◇";
+    color: var(--gold-wire);
+    position: absolute;
+    left: 0;
+    top: 0;
+    font-size: 1.2rem;
+}
+
+.cloison-footer {
+    text-align: center;
+    padding: 20px;
+    background-color: var(--enamel-lapis);
+    border-top: var(--wire-thickness) solid var(--gold-wire);
+    color: var(--gold-wire);
+    font-family: 'Cinzel', serif;
+    letter-spacing: 2px;
+}
+
+/* Add some intricate background details using CSS borders/shapes */
+.cloison-ornament {
+    position: absolute;
+    width: 60px;
+    height: 60px;
+    background-color: var(--enamel-lapis);
+    border: var(--wire-thickness) solid var(--gold-wire);
+    border-radius: 50%;
+    z-index: 10;
+}
+
+.ornament-top-right {
+    top: -30px;
+    right: -30px;
+}
+
+.ornament-bottom-left {
+    bottom: -30px;
+    left: -30px;
+}

--- a/cloisonne/templates/index.html
+++ b/cloisonne/templates/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config.title }}</title>
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+
+    <div class="cloison-container">
+        <div class="cloison-ornament ornament-top-right"></div>
+        <div class="cloison-ornament ornament-bottom-left"></div>
+
+        <header class="cloison-header">
+            <h1>{{ section.title }}</h1>
+            {% if section.description %}
+                <p>{{ section.description }}</p>
+            {% endif %}
+        </header>
+
+        <main class="cloison-body">
+            {{ section.content | safe }}
+        </main>
+
+        <footer class="cloison-footer">
+            &copy; {{ now() | date(format="%Y") }} {{ config.extra.author }} - The Art of Cloisonne
+        </footer>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
Added a new Hwaro example site using an elegant, cloisonné-inspired aesthetic. The layout utilizes beautiful jewel tones separated by solid gold borders to simulate wirework, while avoiding the use of CSS gradients and emojis.

---
*PR created automatically by Jules for task [15867183363244902078](https://jules.google.com/task/15867183363244902078) started by @hahwul*