### PR TITLE
feat: add chiaroscuro theme example

### DIFF
--- a/chiaroscuro/config.toml
+++ b/chiaroscuro/config.toml
@@ -1,0 +1,7 @@
+base_url = "https://example.com"
+title = "Chiaroscuro"
+description = "A bold, creative, and elegant chiaroscuro theme featuring high contrast and solid shadows."
+default_language = "en"
+
+[extra]
+author = "Hwaro User"

--- a/chiaroscuro/content/_index.md
+++ b/chiaroscuro/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "The Art of Shadow"
+sort_by = "weight"
++++
+
+In the realm of chiaroscuro, form is defined not by lines, but by the stark intersection of illumination and absolute darkness. We embrace the void to reveal the subject. True depth emerges when light is a scarce commodity, meticulously carved from the blackness.

--- a/chiaroscuro/content/edge-of-light.md
+++ b/chiaroscuro/content/edge-of-light.md
@@ -1,0 +1,8 @@
++++
+title = "The Edge of Light"
+description = "A minimalist study of boundaries."
+date = 2023-12-20
+weight = 3
++++
+
+A minimalist approach to the boundary where illumination ends and shadow begins abruptly.

--- a/chiaroscuro/content/intersecting-voids.md
+++ b/chiaroscuro/content/intersecting-voids.md
@@ -1,0 +1,8 @@
++++
+title = "Intersecting Voids"
+description = "Angular geometry emerging from darkness."
+date = 2023-11-02
+weight = 2
++++
+
+Sharp angles and solid geometric shadows create a sense of imposing, quiet architecture.

--- a/chiaroscuro/content/study-in-black.md
+++ b/chiaroscuro/content/study-in-black.md
@@ -1,0 +1,8 @@
++++
+title = "Study in Black"
+description = "An exploration of negative space and weight."
+date = 2023-10-15
+weight = 1
++++
+
+This piece explores the profound weight of solid black forms against a stark, unyielding white background.

--- a/chiaroscuro/static/css/style.css
+++ b/chiaroscuro/static/css/style.css
@@ -1,0 +1,458 @@
+/* CHIAROSCURO THEME */
+/* Bold, creative, and elegant design utilizing high contrast, solid shadows, and typography. */
+/* NO GRADIENTS. NO EMOJIS. */
+
+:root {
+    --color-black: #050505;
+    --color-white: #fafafa;
+    --color-off-black: #111111;
+    --color-off-white: #f0f0f0;
+    --color-accent: #e0e0e0;
+
+    --font-serif: 'Bodoni Moda', serif;
+    --font-sans: 'DM Sans', sans-serif;
+
+    --shadow-solid-sm: 4px 4px 0px var(--color-black);
+    --shadow-solid-md: 8px 8px 0px var(--color-black);
+    --shadow-solid-lg: 16px 16px 0px var(--color-black);
+
+    /* Inverted shadows for dark blocks */
+    --shadow-solid-light: 8px 8px 0px var(--color-white);
+}
+
+/* Base Styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--color-white);
+    color: var(--color-black);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    overflow-x: hidden;
+}
+
+/* Container */
+.chiaroscuro-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 0 5vw;
+}
+
+/* Header */
+.c-header {
+    padding: 4rem 0;
+    border-bottom: 4px solid var(--color-black);
+    margin-bottom: 4rem;
+}
+
+.c-header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+}
+
+.c-site-title {
+    font-family: var(--font-serif);
+    font-size: 3.5rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: -2px;
+    color: var(--color-black);
+    text-decoration: none;
+    line-height: 1;
+}
+
+.c-nav {
+    display: flex;
+    gap: 2rem;
+}
+
+.c-nav-link {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--color-black);
+    text-decoration: none;
+    padding-bottom: 0.25rem;
+    border-bottom: 2px solid transparent;
+    transition: border-color 0.2s;
+}
+
+.c-nav-link:hover {
+    border-bottom-color: var(--color-black);
+}
+
+/* Hero Section */
+.c-hero {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    gap: 4rem;
+    margin-bottom: 8rem;
+    align-items: center;
+    position: relative;
+}
+
+.c-hero-content {
+    position: relative;
+    z-index: 2;
+}
+
+.c-hero-title {
+    font-family: var(--font-serif);
+    font-size: 6rem;
+    font-weight: 900;
+    line-height: 1.1;
+    letter-spacing: -3px;
+    margin-bottom: 2rem;
+    text-transform: uppercase;
+    color: var(--color-white);
+
+    /* Simulating a cutout effect using text shadow */
+    text-shadow:
+        -2px -2px 0 var(--color-black),
+         2px -2px 0 var(--color-black),
+        -2px  2px 0 var(--color-black),
+         2px  2px 0 var(--color-black),
+         4px  4px 0 var(--color-black),
+         6px  6px 0 var(--color-black);
+}
+
+.c-hero-desc {
+    font-family: var(--font-sans);
+    font-size: 1.5rem;
+    font-weight: 400;
+    max-width: 600px;
+    margin-bottom: 2rem;
+    border-left: 4px solid var(--color-black);
+    padding-left: 1.5rem;
+}
+
+.c-hero-accent-line {
+    width: 100px;
+    height: 8px;
+    background-color: var(--color-black);
+}
+
+.c-hero-shadow-element {
+    background-color: var(--color-black);
+    height: 100%;
+    min-height: 400px;
+    width: 100%;
+    /* Solid shadow */
+    box-shadow: -16px 16px 0px var(--color-accent);
+    position: relative;
+}
+
+.c-hero-shadow-element::after {
+    content: '';
+    position: absolute;
+    top: -20px;
+    right: -20px;
+    width: 100px;
+    height: 100px;
+    background-color: var(--color-white);
+    border: 4px solid var(--color-black);
+    z-index: 1;
+}
+
+/* Gallery / Posts Grid */
+.c-gallery {
+    margin-bottom: 8rem;
+}
+
+.c-gallery-header {
+    margin-bottom: 4rem;
+    border-top: 2px solid var(--color-black);
+    padding-top: 1rem;
+}
+
+.c-gallery-title {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+}
+
+.c-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    gap: 4rem;
+}
+
+.c-card {
+    display: flex;
+    flex-direction: column;
+}
+
+.c-card-visual {
+    background-color: var(--color-off-white);
+    aspect-ratio: 4/5;
+    border: 4px solid var(--color-black);
+    box-shadow: var(--shadow-solid-md);
+    margin-bottom: 2rem;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.c-card:hover .c-card-visual {
+    transform: translate(-4px, -4px);
+    box-shadow: var(--shadow-solid-lg);
+}
+
+.c-card-visual-inner {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    background-color: var(--color-white);
+    border: 2px solid var(--color-black);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Abstract shapes for cards using pure CSS borders/shapes */
+.c-art-shape {
+    background-color: var(--color-black);
+}
+
+.c-art-shape-1 {
+    width: 60%;
+    height: 60%;
+    border-radius: 50%;
+    box-shadow: -10px 10px 0 var(--color-accent);
+}
+
+.c-art-shape-2 {
+    width: 70%;
+    height: 40%;
+    transform: rotate(-15deg);
+    box-shadow: -10px 10px 0 var(--color-accent);
+}
+
+.c-art-shape-3 {
+    width: 0;
+    height: 0;
+    background-color: transparent;
+    border-left: 60px solid transparent;
+    border-right: 60px solid transparent;
+    border-bottom: 100px solid var(--color-black);
+    filter: drop-shadow(-10px 10px 0 var(--color-accent));
+}
+
+.c-card-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+
+.c-card-title {
+    font-family: var(--font-serif);
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+}
+
+.c-card-title a {
+    color: var(--color-black);
+    text-decoration: none;
+}
+
+.c-card-title a:hover {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
+}
+
+.c-card-desc {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    color: var(--color-off-black);
+    margin-bottom: 2rem;
+    flex-grow: 1;
+}
+
+.c-card-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid var(--color-black);
+    padding-top: 1rem;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.c-card-date {
+    color: var(--color-black);
+}
+
+.c-card-action {
+    color: var(--color-black);
+}
+
+/* Statement Section */
+.c-statement {
+    background-color: var(--color-black);
+    color: var(--color-white);
+    padding: 6rem;
+    margin-bottom: 8rem;
+    position: relative;
+    box-shadow: var(--shadow-solid-light);
+    border: 4px solid var(--color-black);
+}
+
+.c-statement-content {
+    max-width: 800px;
+    margin: 0 auto;
+    position: relative;
+    z-index: 2;
+}
+
+.c-statement-title {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin-bottom: 2rem;
+    color: var(--color-accent);
+}
+
+.c-statement-text {
+    font-family: var(--font-serif);
+    font-size: 2.5rem;
+    line-height: 1.4;
+    font-style: italic;
+}
+
+.c-statement-text p {
+    margin-bottom: 1.5rem;
+}
+
+.c-statement-shadow {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 30%;
+    height: 100%;
+    background-color: var(--color-off-black);
+    z-index: 1;
+    border-left: 1px solid var(--color-accent);
+}
+
+/* Footer */
+.c-footer {
+    border-top: 8px solid var(--color-black);
+    padding: 4rem 0;
+    margin-bottom: 2rem;
+}
+
+.c-footer-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    font-family: var(--font-sans);
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    line-height: 1.2;
+}
+
+.c-author {
+    font-size: 1rem;
+    color: var(--color-black);
+}
+
+/* Page Template Styles */
+.c-page-header {
+    margin-bottom: 4rem;
+}
+
+.c-page-title {
+    font-family: var(--font-serif);
+    font-size: 4rem;
+    font-weight: 900;
+    line-height: 1.1;
+    margin-bottom: 1rem;
+}
+
+.c-page-meta {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    text-transform: uppercase;
+    border-top: 2px solid var(--color-black);
+    border-bottom: 2px solid var(--color-black);
+    padding: 1rem 0;
+    margin-bottom: 4rem;
+}
+
+.c-page-content {
+    font-family: var(--font-sans);
+    font-size: 1.25rem;
+    line-height: 1.8;
+    max-width: 800px;
+    margin: 0 auto 8rem auto;
+}
+
+.c-page-content p {
+    margin-bottom: 2rem;
+}
+
+.c-page-content h2 {
+    font-family: var(--font-serif);
+    font-size: 2.5rem;
+    margin: 4rem 0 2rem 0;
+    border-bottom: 4px solid var(--color-black);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .c-hero {
+        grid-template-columns: 1fr;
+    }
+
+    .c-hero-shadow-element {
+        min-height: 300px;
+        order: -1;
+    }
+
+    .c-hero-title {
+        font-size: 4rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .c-site-title {
+        font-size: 2.5rem;
+    }
+
+    .c-nav {
+        display: none;
+    }
+
+    .c-statement {
+        padding: 3rem;
+    }
+
+    .c-statement-text {
+        font-size: 1.75rem;
+    }
+
+    .c-footer-inner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2rem;
+    }
+}

--- a/chiaroscuro/templates/base.html
+++ b/chiaroscuro/templates/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Bodoni Moda for elegant serif, and DM Sans for clean sans-serif -->
+    <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:ital,opsz,wght@0,6..96,400..900;1,6..96,400..900&family=DM+Sans:opsz,wght@9..40,400..700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="chiaroscuro-container">
+        <header class="c-header">
+            <div class="c-header-inner">
+                <a href="{{ config.base_url }}" class="c-site-title">{{ config.title }}</a>
+                <nav class="c-nav">
+                    <a href="{{ config.base_url }}" class="c-nav-link">Home</a>
+                    <a href="#" class="c-nav-link">Exhibitions</a>
+                    <a href="#" class="c-nav-link">Artists</a>
+                </nav>
+            </div>
+        </header>
+
+        <main class="c-main">
+            {% block content %}{% endblock content %}
+        </main>
+
+        <footer class="c-footer">
+            <div class="c-footer-inner">
+                <p>&copy; {{ config.title }}. <br>Light and Shadow.</p>
+                {% if config.extra.author %}
+                <p class="c-author">By {{ config.extra.author }}</p>
+                {% endif %}
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/chiaroscuro/templates/index.html
+++ b/chiaroscuro/templates/index.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="c-home-layout">
+    <section class="c-hero">
+        <div class="c-hero-content">
+            <h1 class="c-hero-title">{{ section.title | default(value=config.title) }}</h1>
+            {% if config.description %}
+            <p class="c-hero-desc">{{ config.description }}</p>
+            {% endif %}
+            <div class="c-hero-accent-line"></div>
+        </div>
+        <div class="c-hero-shadow-element"></div>
+    </section>
+
+    <section class="c-gallery">
+        <div class="c-gallery-header">
+            <h2 class="c-gallery-title">Selected Works</h2>
+        </div>
+        <div class="c-gallery-grid">
+            {% for page in section.pages %}
+            <article class="c-card">
+                <div class="c-card-visual">
+                    <div class="c-card-visual-inner">
+                        <!-- Abstract shapes using pure CSS borders to simulate artwork -->
+                        <div class="c-art-shape c-art-shape-{{ loop.index }}"></div>
+                    </div>
+                </div>
+                <div class="c-card-content">
+                    <h3 class="c-card-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+                    {% if page.description %}
+                    <p class="c-card-desc">{{ page.description }}</p>
+                    {% endif %}
+                    <div class="c-card-meta">
+                        {% if page.date %}
+                        <time class="c-card-date" datetime="{{ page.date }}">{{ page.date | date(format="%B %Y") }}</time>
+                        {% endif %}
+                        <span class="c-card-action">View &rarr;</span>
+                    </div>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+    </section>
+
+    <section class="c-statement">
+        <div class="c-statement-content">
+            <h2 class="c-statement-title">The Philosophy of Contrast</h2>
+            <p class="c-statement-text">
+                {{ section.content | safe }}
+            </p>
+        </div>
+        <div class="c-statement-shadow"></div>
+    </section>
+</div>
+{% endblock content %}

--- a/chiaroscuro/templates/page.html
+++ b/chiaroscuro/templates/page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="c-page">
+    <header class="c-page-header">
+        <h1 class="c-page-title">{{ page.title }}</h1>
+        <div class="c-page-meta">
+            {% if page.date %}
+            <time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>
+            {% endif %}
+        </div>
+    </header>
+
+    <div class="c-page-content">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
This pull request adds the new 'chiaroscuro' theme example for Hwaro. It features a bold, creative, and elegant design prioritizing strong contrast and shadows using solid box-shadows, stark monochrome layouts, and sophisticated serif typography. 

Strict adherence to constraints:
- `tags.json` is untouched.
- No `linear-gradient` or `radial-gradient` is used in the CSS.
- No emojis are present in any files.

---
*PR created automatically by Jules for task [11267912311418697169](https://jules.google.com/task/11267912311418697169) started by @hahwul*