### PR TITLE
Add etching theme

### DIFF
--- a/etching/config.toml
+++ b/etching/config.toml
@@ -1,0 +1,41 @@
+title = "The Etching Collection"
+description = "A bold, creative, and elegant design inspired by the timeless art of copperplate etching."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/etching/content/_index.md
+++ b/etching/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Art of Etching"
++++
+
+This collection celebrates the timeless elegance of copperplate etching. Through deliberate, monochromatic strokes, we carve meaning into the digital space.
+
+The aesthetic relies entirely on the interplay of ink and paper. We eschew modern gradients and colorful diversions in favor of stark contrast, intricate cross-hatching, and typographic excellence. Every border and line is treated with the precision of a master engraver's burin.
+
+Explore the delicate balance between positive and negative space, where simplicity meets profound detail.

--- a/etching/static/css/style.css
+++ b/etching/static/css/style.css
@@ -1,0 +1,243 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Cinzel:wght@400;600;700&display=swap');
+
+:root {
+    --paper: #f4f1ea;
+    --paper-dark: #e8e4d9;
+    --ink: #1a1918;
+    --ink-light: #3a3836;
+    --accent: #782a22; /* deep oxblood */
+
+    --font-heading: 'Cinzel', 'Times New Roman', serif;
+    --font-body: 'Cormorant Garamond', 'Georgia', serif;
+
+    /* SVG Cross-hatching pattern for backgrounds */
+    --pattern-hatch: url('data:image/svg+xml;utf8,<svg width="6" height="6" xmlns="http://www.w3.org/2000/svg"><path d="M-1,1 l2,-2 M0,6 l6,-6 M5,7 l2,-2 M-1,5 l2,-2 M0,0 l6,6 M5,-1 l2,2" stroke="%231a1918" stroke-width="0.3" fill="none" opacity="0.15"/></svg>');
+    --pattern-lines: url('data:image/svg+xml;utf8,<svg width="4" height="4" xmlns="http://www.w3.org/2000/svg"><path d="M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2" stroke="%231a1918" stroke-width="0.4" fill="none" opacity="0.2"/></svg>');
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--paper);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 1.25rem;
+    line-height: 1.6;
+    /* Apply a subtle paper texture over everything */
+    background-image: url('data:image/svg+xml;utf8,<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><filter id="noise"><feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" stitchTiles="stitch"/></filter><rect width="100%25" height="100%25" filter="url(%23noise)" opacity="0.05"/></svg>');
+    position: relative;
+}
+
+/* Page Frame */
+body::before {
+    content: '';
+    position: fixed;
+    top: 15px; left: 15px; right: 15px; bottom: 15px;
+    border: 1px solid var(--ink);
+    outline: 2px solid var(--ink);
+    outline-offset: 4px;
+    pointer-events: none;
+    z-index: 999;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    color: var(--ink);
+    margin-bottom: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+h1 {
+    font-size: 3.5rem;
+    text-align: center;
+    border-bottom: 2px solid var(--ink);
+    padding-bottom: 0.5rem;
+    margin-bottom: 2rem;
+    position: relative;
+}
+
+h1::after {
+    content: '';
+    position: absolute;
+    bottom: -6px;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background-color: var(--ink);
+}
+
+h2 {
+    font-size: 2.2rem;
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 0.25rem;
+    margin-top: 2.5rem;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px dashed var(--accent);
+    transition: color 0.3s, border-bottom 0.3s;
+}
+
+a:hover {
+    color: var(--ink);
+    border-bottom: 1px solid var(--ink);
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 4rem 2rem;
+    position: relative;
+    z-index: 10;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 4rem;
+    padding: 3rem 2rem;
+    background-color: var(--paper);
+    border: 4px double var(--ink);
+    position: relative;
+    background-image: var(--pattern-hatch);
+}
+
+header::before {
+    content: '';
+    position: absolute;
+    top: 6px; left: 6px; right: 6px; bottom: 6px;
+    border: 1px solid var(--ink);
+    background-color: var(--paper);
+    z-index: -1;
+}
+
+header h1 {
+    border: none;
+    margin-bottom: 0.5rem;
+}
+
+header h1::after {
+    display: none;
+}
+
+header p.subtitle {
+    font-size: 1.4rem;
+    font-style: italic;
+    color: var(--ink-light);
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.etching-plate {
+    background-color: var(--paper);
+    border: 1px solid var(--ink);
+    padding: 1.5rem;
+    position: relative;
+    box-shadow: 6px 6px 0 var(--ink);
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.etching-plate::before {
+    content: '';
+    position: absolute;
+    top: -4px; left: -4px; right: -4px; bottom: -4px;
+    border: 1px solid var(--ink);
+    z-index: -1;
+}
+
+.etching-plate:hover {
+    transform: translate(-3px, -3px);
+    box-shadow: 9px 9px 0 var(--ink);
+}
+
+.plate-image-placeholder {
+    width: 100%;
+    height: 200px;
+    border: 1px solid var(--ink);
+    margin-bottom: 1rem;
+    background-color: var(--paper-dark);
+    background-image: var(--pattern-lines);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-heading);
+    color: var(--ink);
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.plate-title {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.plate-desc {
+    font-size: 1.1rem;
+    color: var(--ink-light);
+}
+
+.engraved-divider {
+    height: 1px;
+    background-color: var(--ink);
+    margin: 4rem 0;
+    position: relative;
+}
+
+.engraved-divider::before {
+    content: '';
+    position: absolute;
+    top: -3px;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background-color: var(--ink);
+}
+
+.engraved-divider::after {
+    content: '◈';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: var(--paper);
+    padding: 0 10px;
+    color: var(--ink);
+    font-size: 1.5rem;
+    font-family: var(--font-body); /* Ensure it renders with correct styling */
+}
+
+/* Avoiding emojis rule, so using geometric unicode character ◈ which is a classic dingbat */
+
+footer {
+    text-align: center;
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 2px solid var(--ink);
+    font-family: var(--font-heading);
+    letter-spacing: 0.05em;
+    font-size: 1rem;
+    color: var(--ink-light);
+}
+
+footer::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 1px;
+    background-color: var(--ink);
+    margin-bottom: 2rem;
+    margin-top: -2.3rem;
+}

--- a/etching/templates/base.html
+++ b/etching/templates/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value="en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <div class="container">
+        {% block content %}{% endblock %}
+
+        <footer>
+            <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}. All rights reserved.</p>
+            <p>Crafted with patience and precision.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/etching/templates/index.html
+++ b/etching/templates/index.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header>
+    <h1>{{ config.title }}</h1>
+    <p class="subtitle">{{ config.description }}</p>
+</header>
+
+<main>
+    <div class="content-body">
+        {{ section.content | safe }}
+    </div>
+
+    <div class="engraved-divider"></div>
+
+    <h2>Featured Prints</h2>
+
+    <div class="gallery-grid">
+        <article class="etching-plate">
+            <div class="plate-image-placeholder">Fig. I</div>
+            <h3 class="plate-title">The First Impression</h3>
+            <p class="plate-desc">A study in bold lines and intricate cross-hatching techniques. Note the depth achieved through precise spacing.</p>
+        </article>
+
+        <article class="etching-plate">
+            <div class="plate-image-placeholder">Fig. II</div>
+            <h3 class="plate-title">Architectural Draft</h3>
+            <p class="plate-desc">Geometric precision rendered with a sharp burin. The classic proportions echo ancient structural designs.</p>
+        </article>
+
+        <article class="etching-plate">
+            <div class="plate-image-placeholder">Fig. III</div>
+            <h3 class="plate-title">Botanical Study</h3>
+            <p class="plate-desc">Delicate curves and sweeping textures mimicking the natural flow of organic forms, pressed into fine paper.</p>
+        </article>
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
Added a new Hwaro example site featuring a bold, creative, and elegant copperplate etching aesthetic. The theme utilizes solid colors, intricate CSS borders, SVG patterns for cross-hatching, and classic serif typography, while strictly avoiding CSS gradients and emojis. Did not modify tags.json.

---
*PR created automatically by Jules for task [482044121411848573](https://jules.google.com/task/482044121411848573) started by @hahwul*