### PR TITLE
feat: add copperplate theme example site

### DIFF
--- a/copperplate/config.toml
+++ b/copperplate/config.toml
@@ -1,0 +1,9 @@
+base_url = "https://example.com"
+title = "Copperplate Elegance"
+description = "A bold, creative, and elegant copperplate-inspired design."
+default_language = "en"
+compile_sass = false
+minify_html = false
+
+[extra]
+author = "Jules"

--- a/copperplate/content/_index.md
+++ b/copperplate/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Art of Copperplate"
+description = "A bold, creative, and elegant copperplate-inspired design."
++++
+
+The copperplate aesthetic is characterized by delicate, sweeping curves and precise, varying line widths that create a sense of refined elegance. Originally used in intaglio printing and classical calligraphy, this style conveys a meticulous craftsmanship that is both historic and enduring.
+
+In this digital reimagining, we focus on high contrast, intricate typography, and structural borders to bring the essence of engraved copper onto the screen. It is an exploration of form and flourishes, capturing the sophisticated beauty of classic typography and intricate line work.

--- a/copperplate/static/css/style.css
+++ b/copperplate/static/css/style.css
@@ -1,0 +1,232 @@
+:root {
+    --bg-color: #f7f4eb; /* Cream/parchment background */
+    --text-color: #2c251e; /* Deep brownish black */
+    --copper-color: #b87333; /* Classic copper */
+    --copper-dark: #8c5322;
+    --copper-light: #e09e5c;
+    --border-color: #3b3127;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Playfair Display', serif;
+    line-height: 1.6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+/* Page Borders to simulate an engraved plate */
+.page-border {
+    width: 100%;
+    max-width: 1000px;
+    border: 4px solid var(--border-color);
+    padding: 6px;
+    background-color: var(--bg-color);
+    box-shadow:
+        10px 10px 0px 0px rgba(44, 37, 30, 0.1),
+        inset 0 0 0 1px var(--copper-dark);
+}
+
+.inner-border {
+    border: 1px solid var(--border-color);
+    padding: 3rem;
+    position: relative;
+    /* Simulate etched corners */
+    background-image:
+        url('data:image/svg+xml;utf8,<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M0,20 L20,0" stroke="%233b3127" stroke-width="1"/></svg>'),
+        url('data:image/svg+xml;utf8,<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 L20,20" stroke="%233b3127" stroke-width="1"/></svg>'),
+        url('data:image/svg+xml;utf8,<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M0,0 L20,20" stroke="%233b3127" stroke-width="1"/></svg>'),
+        url('data:image/svg+xml;utf8,<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M0,20 L20,0" stroke="%233b3127" stroke-width="1"/></svg>');
+    background-position: top left, top right, bottom left, bottom right;
+    background-repeat: no-repeat;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 4rem;
+}
+
+header h1 {
+    font-family: 'Cinzel', serif;
+    font-size: 3rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-weight: 600;
+    color: var(--copper-dark);
+    margin: 1rem 0;
+    /* Create an etched text effect using text-shadow */
+    text-shadow:
+        1px 1px 0px var(--bg-color),
+        2px 2px 0px rgba(44, 37, 30, 0.2);
+}
+
+.header-flourish {
+    font-family: 'Pinyon Script', cursive;
+    font-size: 2.5rem;
+    color: var(--copper-color);
+}
+
+.hero {
+    text-align: center;
+    margin-bottom: 4rem;
+}
+
+.script-title {
+    font-family: 'Pinyon Script', cursive;
+    font-size: 4.5rem;
+    font-weight: normal;
+    color: var(--text-color);
+    margin-bottom: 1rem;
+    /* Elegant shadow without gradient */
+    text-shadow: 2px 2px 0px var(--copper-light);
+    transform: rotate(-2deg);
+}
+
+.engraving-line {
+    width: 60%;
+    height: 1px;
+    background-color: transparent;
+    margin: 2rem auto;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 2px solid var(--text-color);
+    position: relative;
+}
+
+.engraving-line::before, .engraving-line::after {
+    content: '';
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    background-color: var(--copper-dark);
+    border-radius: 50%;
+    top: -2px;
+}
+
+.engraving-line::before { left: -10px; }
+.engraving-line::after { right: -10px; }
+
+.content-body {
+    font-size: 1.2rem;
+    max-width: 700px;
+    margin: 0 auto;
+    text-align: justify;
+    text-justify: inter-word;
+    /* Simulating old ink */
+    color: #38312a;
+}
+
+.content-body p {
+    margin-bottom: 1.5rem;
+}
+
+.content-body p:first-child::first-letter {
+    font-family: 'Cinzel', serif;
+    font-size: 4rem;
+    float: left;
+    margin-right: 0.5rem;
+    line-height: 1;
+    color: var(--copper-dark);
+    text-shadow: 1px 1px 0px var(--border-color);
+}
+
+.ornament {
+    font-size: 2rem;
+    color: var(--copper-color);
+    margin: 3rem 0;
+}
+
+.gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.plate {
+    border: 1px solid var(--border-color);
+    padding: 8px;
+    background-color: #fff;
+    /* Solid shadows for a physical plate feel */
+    box-shadow:
+        4px 4px 0px 0px var(--copper-color),
+        5px 5px 0px 0px var(--border-color);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.plate:hover {
+    transform: translate(-2px, -2px);
+    box-shadow:
+        6px 6px 0px 0px var(--copper-color),
+        7px 7px 0px 0px var(--border-color);
+}
+
+.plate-inner {
+    border: 1px dashed var(--copper-dark);
+    padding: 2rem 1rem;
+    text-align: center;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background-color: var(--bg-color);
+}
+
+.plate-inner h3 {
+    font-family: 'Cinzel', serif;
+    font-size: 1.5rem;
+    color: var(--text-color);
+    margin-bottom: 0.5rem;
+}
+
+.plate-inner p {
+    font-family: 'Pinyon Script', cursive;
+    font-size: 1.5rem;
+    color: var(--copper-dark);
+}
+
+footer {
+    text-align: center;
+    margin-top: 5rem;
+    font-family: 'Cinzel', serif;
+    font-size: 0.9rem;
+    color: var(--copper-dark);
+}
+
+.footer-line {
+    width: 100px;
+    height: 1px;
+    background-color: var(--border-color);
+    margin: 0 auto 1rem auto;
+}
+
+.author-credits {
+    margin-top: 0.5rem;
+    font-family: 'Playfair Display', serif;
+    font-style: italic;
+    color: var(--text-color);
+}
+
+/* Media Queries */
+@media (max-width: 768px) {
+    .inner-border {
+        padding: 1.5rem;
+    }
+
+    header h1 {
+        font-size: 2rem;
+    }
+
+    .script-title {
+        font-size: 3.5rem;
+    }
+}

--- a/copperplate/templates/base.html
+++ b/copperplate/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}{{ config.title }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;800&family=Pinyon+Script&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <div class="page-border">
+        <div class="inner-border">
+            <header>
+                <div class="header-flourish">~</div>
+                <h1>{{ config.title }}</h1>
+                <div class="header-flourish">~</div>
+            </header>
+
+            <main>
+                {% block content %}{% endblock content %}
+            </main>
+
+            <footer>
+                <div class="footer-line"></div>
+                <p>Est. 2024</p>
+                <p class="author-credits">Design by {{ config.extra.author }}</p>
+            </footer>
+        </div>
+    </div>
+</body>
+</html>

--- a/copperplate/templates/index.html
+++ b/copperplate/templates/index.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero">
+    <h2 class="script-title">{{ section.title }}</h2>
+    <div class="engraving-line"></div>
+    <div class="content-body">
+        {{ section.content | safe }}
+    </div>
+    <div class="ornament">
+        <span>&#10086;</span>
+    </div>
+</section>
+
+<section class="gallery">
+    <article class="plate">
+        <div class="plate-inner">
+            <h3>Plate I</h3>
+            <p>The Foundations of Flourish</p>
+        </div>
+    </article>
+    <article class="plate">
+        <div class="plate-inner">
+            <h3>Plate II</h3>
+            <p>Mastery of the Pen</p>
+        </div>
+    </article>
+    <article class="plate">
+        <div class="plate-inner">
+            <h3>Plate III</h3>
+            <p>Intaglio Printing</p>
+        </div>
+    </article>
+</section>
+{% endblock content %}


### PR DESCRIPTION
Adds the 'copperplate' theme example site for Hwaro. The design focuses on high contrast, intricate typography, and structural borders to bring the essence of engraved copper onto the screen. It avoids all gradients and emojis as per instructions, and does not modify tags.json.

---
*PR created automatically by Jules for task [7787244412838446437](https://jules.google.com/task/7787244412838446437) started by @hahwul*