### PR TITLE
feat: Add Anamorphic theme example site

### DIFF
--- a/anamorphic/config.toml
+++ b/anamorphic/config.toml
@@ -1,0 +1,15 @@
+base_url = "https://example.com"
+title = "Anamorphic Design"
+description = "A bold, creative, and elegant anamorphic theme."
+default_language = "en"
+compile_sass = false
+minify_html = true
+
+[extra]
+author = "Hwaro Designer"
+
+[markdown]
+highlight_code = true
+highlight_theme = "css"
+
+taxonomies = []

--- a/anamorphic/content/_index.md
+++ b/anamorphic/content/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Home"
+sort_by = "weight"
++++

--- a/anamorphic/content/about.md
+++ b/anamorphic/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About Anamorphic"
+description = "Discover the concept behind the anamorphic theme."
+weight = 1
+template = "page.html"
++++
+
+This theme embraces the anamorphic aesthetic: creating art and design that relies on specific perspectives, optical illusions, and severe geometric distortion to form a cohesive image or layout.
+
+We strictly avoid the use of CSS gradients, relying instead on solid blocks of color, sharp contrasts, and precise styling of typography to produce depth and volume. Emojis are also excluded to maintain a pure, structural, and somewhat brutalist typographic atmosphere.
+
+By combining CSS 3D transforms, skewing, and multiple solid box-shadows, we create digital brutalism that feels almost physical and printed.

--- a/anamorphic/static/css/style.css
+++ b/anamorphic/static/css/style.css
@@ -1,0 +1,304 @@
+/* Anamorphic Theme CSS
+   Constraints:
+   - NO gradients (linear-gradient, radial-gradient, etc.)
+   - NO emojis
+   Features:
+   - Solid colors, bold typography, high contrast
+   - 3D Transforms, perspective, skew to simulate depth and optical illusions
+   - Overlapping elements, solid shadows
+*/
+
+:root {
+  --bg-color: #f0f0f0; /* Off-white background */
+  --text-primary: #111111; /* Deep black text */
+  --accent-color: #ff3300; /* Vibrant red-orange accent */
+  --secondary-color: #0044ff; /* Deep blue secondary */
+  --font-main: 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-main);
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  line-height: 1.6;
+  overflow-x: hidden;
+  /* Apply perspective to body for 3D effects on children */
+  perspective: 1200px;
+  perspective-origin: 50% 50%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header & Navigation */
+header {
+  padding: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  z-index: 100;
+  background-color: var(--bg-color);
+  border-bottom: 2px solid var(--text-primary);
+}
+
+.site-title {
+  font-size: 2.5rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -2px;
+  text-decoration: none;
+  color: var(--text-primary);
+  /* Anamorphic text effect */
+  transform: skewX(-15deg);
+  display: inline-block;
+  position: relative;
+}
+
+.site-title::after {
+  content: '';
+  position: absolute;
+  top: 10%;
+  left: 5px;
+  width: 100%;
+  height: 100%;
+  background-color: var(--accent-color);
+  z-index: -1;
+  transform: translate(-10px, 5px);
+  mix-blend-mode: multiply;
+}
+
+nav a {
+  text-decoration: none;
+  color: var(--text-primary);
+  font-weight: bold;
+  margin-left: 2rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  position: relative;
+  transition: transform 0.3s ease;
+}
+
+nav a:hover {
+  transform: skewX(-10deg) scale(1.1);
+  color: var(--secondary-color);
+}
+
+/* Main Layout */
+main {
+  flex-grow: 1;
+  padding: 4rem 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* Anamorphic Hero Section */
+.hero {
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transform-style: preserve-3d;
+}
+
+.hero-text-container {
+  position: relative;
+  transform: rotateY(-15deg) rotateX(10deg);
+  transition: transform 0.5s ease;
+}
+
+.hero-text-container:hover {
+  transform: rotateY(0deg) rotateX(0deg);
+}
+
+.hero h1 {
+  font-size: 8rem;
+  font-weight: 900;
+  line-height: 0.9;
+  text-transform: uppercase;
+  margin: 0;
+  position: relative;
+  z-index: 2;
+  color: var(--bg-color);
+  /* Solid text shadow for 3D extrusion effect */
+  text-shadow:
+    1px 1px 0 var(--text-primary),
+    2px 2px 0 var(--text-primary),
+    3px 3px 0 var(--text-primary),
+    4px 4px 0 var(--text-primary),
+    5px 5px 0 var(--text-primary),
+    6px 6px 0 var(--text-primary),
+    7px 7px 0 var(--text-primary),
+    8px 8px 0 var(--text-primary),
+    9px 9px 0 var(--accent-color),
+    10px 10px 0 var(--accent-color),
+    11px 11px 0 var(--accent-color),
+    12px 12px 0 var(--accent-color);
+}
+
+.hero p {
+  font-size: 1.5rem;
+  font-weight: bold;
+  max-width: 600px;
+  margin-top: 2rem;
+  background-color: var(--text-primary);
+  color: var(--bg-color);
+  padding: 1rem 2rem;
+  display: inline-block;
+  transform: translateZ(50px) skewY(-3deg);
+  border: 4px solid var(--accent-color);
+  box-shadow: -15px 15px 0 var(--secondary-color);
+}
+
+/* Content Blocks (Anamorphic grids) */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 4rem;
+  margin-top: 6rem;
+  transform-style: preserve-3d;
+}
+
+.card {
+  background-color: var(--bg-color);
+  border: 3px solid var(--text-primary);
+  padding: 2rem;
+  position: relative;
+  transition: transform 0.4s ease-out, box-shadow 0.4s ease-out;
+  /* Initial skewed state */
+  transform: rotateX(5deg) rotateY(10deg);
+  box-shadow:
+    -5px 5px 0 var(--text-primary),
+    -10px 10px 0 var(--accent-color);
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  right: 10px;
+  bottom: 10px;
+  border: 2px solid var(--secondary-color);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: rotateX(0deg) rotateY(0deg) translate(-5px, -5px);
+  box-shadow:
+    -10px 10px 0 var(--text-primary),
+    -20px 20px 0 var(--accent-color);
+}
+
+.card h2 {
+  font-size: 2rem;
+  font-weight: 900;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  transform: translateZ(30px);
+}
+
+.card a {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--bg-color);
+  background-color: var(--text-primary);
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  font-weight: bold;
+  text-transform: uppercase;
+  transform: skewX(-15deg);
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.card a:hover {
+  background-color: var(--accent-color);
+  transform: skewX(-15deg) translateY(-3px);
+}
+
+/* Content Page Typography */
+.content-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  background: var(--bg-color);
+  padding: 4rem;
+  border: 5px solid var(--text-primary);
+  position: relative;
+  box-shadow: 20px 20px 0 var(--secondary-color);
+}
+
+.content-wrapper::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  border: 2px dashed var(--accent-color);
+  pointer-events: none;
+  transform: translate(-15px, -15px);
+  z-index: -1;
+}
+
+.content-wrapper h1 {
+  font-size: 4rem;
+  text-transform: uppercase;
+  letter-spacing: -2px;
+  margin-bottom: 2rem;
+  border-bottom: 8px solid var(--accent-color);
+  padding-bottom: 1rem;
+  display: inline-block;
+}
+
+.content-wrapper p {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.8;
+}
+
+/* Optical Illusion Decorative Elements */
+.optical-line {
+  position: absolute;
+  background-color: var(--text-primary);
+  z-index: -2;
+}
+
+.line-1 {
+  width: 200%;
+  height: 4px;
+  top: 30%;
+  left: -50%;
+  transform: rotate(-15deg);
+}
+
+.line-2 {
+  width: 4px;
+  height: 200%;
+  top: -50%;
+  right: 15%;
+  transform: rotate(25deg);
+  background-color: var(--secondary-color);
+}
+
+/* Footer */
+footer {
+  background-color: var(--text-primary);
+  color: var(--bg-color);
+  padding: 3rem 2rem;
+  text-align: center;
+  border-top: 10px solid var(--accent-color);
+  margin-top: auto;
+}
+
+footer p {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}

--- a/anamorphic/templates/base.html
+++ b/anamorphic/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ config.description }}{% endif %}">
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <header>
+        <a href="{{ config.base_url }}" class="site-title">{{ config.title }}</a>
+        <nav>
+            <a href="{{ config.base_url }}">Home</a>
+            <a href="{{ get_url(path="about") }}">About</a>
+        </nav>
+    </header>
+
+    <!-- Decorative optical illusion lines -->
+    <div class="optical-line line-1"></div>
+    <div class="optical-line line-2"></div>
+
+    <main>
+        {% block content %}{% endblock content %}
+    </main>
+
+    <footer>
+        <p>&copy; {{ config.title }}. Designed with perspective.</p>
+    </footer>
+</body>
+</html>

--- a/anamorphic/templates/index.html
+++ b/anamorphic/templates/index.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero">
+    <div class="hero-text-container">
+        <h1>Anamorphic</h1>
+        <p>A bold exploration of perspective, contrast, and form. No gradients.</p>
+    </div>
+</section>
+
+<section class="grid">
+    {% for page in section.pages %}
+    <article class="card">
+        <h2>{{ page.title }}</h2>
+        <p>{{ page.description }}</p>
+        <a href="{{ page.permalink }}">View Details</a>
+    </article>
+    {% endfor %}
+</section>
+{% endblock content %}

--- a/anamorphic/templates/page.html
+++ b/anamorphic/templates/page.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="content-wrapper">
+    <h1>{{ page.title }}</h1>
+    {{ page.content | safe }}
+</article>
+{% endblock content %}


### PR DESCRIPTION
This PR adds the 'anamorphic' theme to the Hwaro example sites.

It achieves a bold and creative optical illusion using strict CSS styling:
- Uses 3D transforms (`perspective`, `rotateX`, `skew`) for depth
- Does not use gradients (`linear-gradient`, `radial-gradient`), relying instead on overlapping solid elements and typography for 3d volume
- Uses high-contrast UI (black, red, blue, off-white)
- Does not use emojis in the content or layout
- `tags.json` was strictly not modified

The Zola build succeeds without any errors. Visual tests using Playwright confirm the correct aesthetic.

---
*PR created automatically by Jules for task [5194213268914424943](https://jules.google.com/task/5194213268914424943) started by @hahwul*