### PR TITLE
feat: Add bold 'woodblock' Hwaro theme

### DIFF
--- a/woodblock/config.toml
+++ b/woodblock/config.toml
@@ -1,0 +1,8 @@
+base_url = "https://example.com"
+title = "Woodblock Impressions"
+description = "A bold, creative, and elegant woodblock printing aesthetic"
+default_language = "en"
+
+
+[extra]
+author = "Artisan"

--- a/woodblock/content/_index.md
+++ b/woodblock/content/_index.md
@@ -1,0 +1,17 @@
++++
+title = "The Art of the Woodblock"
+description = "Carved lines, bold impressions, and lasting impact."
+transparent = true
++++
+
+## A Timeless Craft
+
+Woodblock printing represents the striking interplay between positive and negative space. The raw texture of the grain, the sharp gouge marks, and the deep, rich ink transfers all contribute to a uniquely bold and elegant visual language.
+
+### Core Principles
+
+1.  **Carving the Block**: Removing what is not needed to reveal the form.
+2.  **Inking the Surface**: Applying heavy, opaque colors with a brayer.
+3.  **Pressing the Paper**: Using physical pressure to transfer the image, leaving an indelible mark.
+
+This digital interpretation embraces those same constraints: high contrast, solid colors, and pronounced structural borders. No soft fades, just deliberate marks.

--- a/woodblock/static/css/style.css
+++ b/woodblock/static/css/style.css
@@ -1,0 +1,308 @@
+:root {
+    --color-paper: #f0eadd;
+    --color-ink-black: #111111;
+    --color-ink-red: #c93a2f;
+    --color-ink-blue: #1c3d5a;
+
+    --border-thick: 10px solid var(--color-ink-black);
+    --border-medium: 5px solid var(--color-ink-black);
+    --border-thin: 2px solid var(--color-ink-black);
+
+    --font-heading: 'Oswald', sans-serif;
+    --font-body: 'Libre Baskerville', serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--color-paper);
+    color: var(--color-ink-black);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    filter: url('#paper-texture');
+    padding: 2vw;
+    overflow-x: hidden;
+}
+
+.site-wrapper {
+    max-width: 1200px;
+    margin: 0 auto;
+    position: relative;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    line-height: 1.1;
+    letter-spacing: 0.05em;
+}
+
+p {
+    margin-bottom: 1.5rem;
+    font-size: 1.15rem;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+/* Base Block Print Style */
+.block-print {
+    border: var(--border-thick);
+    background-color: var(--color-paper);
+    position: relative;
+    box-shadow: 15px 15px 0 var(--color-ink-black);
+}
+
+.block-print::before {
+    content: "";
+    position: absolute;
+    top: -6px; left: -6px; right: -6px; bottom: -6px;
+    border: var(--border-thin);
+    pointer-events: none;
+    z-index: 10;
+}
+
+.ink-bleed {
+    filter: url('#ink-bleed');
+}
+
+.wood-grain {
+    filter: url('#wood-grain');
+}
+
+/* Header */
+.site-header {
+    padding: 3rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    background-color: var(--color-ink-black);
+    color: var(--color-paper);
+    box-shadow: 15px 15px 0 var(--color-ink-red);
+}
+
+.site-title {
+    font-size: 6rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    letter-spacing: 0.15em;
+    color: var(--color-paper);
+    text-shadow:
+        4px 4px 0 var(--color-ink-red),
+        -4px -4px 0 var(--color-ink-blue);
+}
+
+.site-subtitle {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: var(--color-paper);
+    border-top: var(--border-medium);
+    border-color: var(--color-paper);
+    display: inline-block;
+    padding-top: 1rem;
+}
+
+/* Hero Block */
+.hero-block {
+    padding: 5rem 3rem;
+    margin-bottom: 4rem;
+    text-align: center;
+    background-color: var(--color-paper);
+    box-shadow: 15px 15px 0 var(--color-ink-blue);
+}
+
+.hero-title {
+    font-size: 4rem;
+    margin-bottom: 1.5rem;
+    color: var(--color-ink-blue);
+}
+
+.hero-description {
+    font-size: 1.8rem;
+    font-style: italic;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+/* Content Area */
+.content-wrapper {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 4rem;
+    margin-bottom: 4rem;
+}
+
+@media (min-width: 900px) {
+    .content-wrapper {
+        grid-template-columns: 3fr 2fr;
+    }
+}
+
+.prose {
+    padding: 3rem;
+    border: var(--border-medium);
+    background-color: var(--color-paper);
+    box-shadow: 10px 10px 0 var(--color-ink-black);
+}
+
+.prose h2 {
+    font-size: 2.5rem;
+    color: var(--color-ink-red);
+    border-bottom: var(--border-thick);
+    padding-bottom: 1rem;
+    margin-bottom: 2rem;
+    display: inline-block;
+}
+
+.prose h3 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+}
+
+.prose ul {
+    margin-bottom: 2rem;
+    padding-left: 1.5rem;
+    list-style-type: square;
+}
+
+.prose li {
+    margin-bottom: 0.8rem;
+    font-size: 1.2rem;
+}
+
+.prose p {
+    font-size: 1.25rem;
+    line-height: 1.8;
+}
+
+.prose strong {
+    font-weight: 700;
+    background-color: var(--color-ink-black);
+    color: var(--color-paper);
+    padding: 0.1rem 0.4rem;
+}
+
+/* Gallery Grid (Wood Carvings) */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 3rem;
+}
+
+.gallery-item {
+    background-color: var(--color-paper);
+    box-shadow: 12px 12px 0 var(--color-ink-black);
+    position: relative;
+    border: var(--border-medium);
+}
+
+.wood-carving {
+    height: 250px;
+    width: 100%;
+    border-bottom: var(--border-medium);
+    position: relative;
+    overflow: hidden;
+}
+
+.carving-1 {
+    background-color: var(--color-ink-blue);
+}
+.carving-1::after {
+    content: "";
+    position: absolute;
+    top: -20%; left: 30%; width: 40%; height: 140%;
+    background-color: var(--color-paper);
+    transform: rotate(15deg);
+    border-left: var(--border-thick);
+    border-right: var(--border-thick);
+}
+
+.carving-2 {
+    background-color: var(--color-ink-red);
+}
+.carving-2::before {
+    content: "";
+    position: absolute;
+    top: 50%; left: 50%;
+    width: 120px; height: 120px;
+    background-color: var(--color-paper);
+    border: 15px solid var(--color-ink-black);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: 20px 20px 0 var(--color-ink-blue);
+}
+
+.carving-3 {
+    background-color: var(--color-paper);
+}
+.carving-3::before {
+    content: "";
+    position: absolute;
+    top: 20px; left: 20px; right: 20px; bottom: 20px;
+    background-color: var(--color-ink-black);
+    box-shadow:
+        inset 20px 20px 0 var(--color-ink-red),
+        inset -20px -20px 0 var(--color-ink-blue);
+}
+
+.caption {
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    font-weight: 700;
+    text-align: center;
+    font-size: 1.4rem;
+    letter-spacing: 0.1em;
+    padding: 1.5rem;
+    background-color: var(--color-paper);
+    color: var(--color-ink-black);
+}
+
+/* Footer */
+.site-footer {
+    padding: 3rem;
+    margin-top: 5rem;
+    background-color: var(--color-ink-black);
+    color: var(--color-paper);
+    border: var(--border-thick);
+    border-color: var(--color-paper);
+    box-shadow: 15px 15px 0 var(--color-ink-black);
+    position: relative;
+}
+
+.site-footer .footer-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.site-footer p {
+    margin-bottom: 0;
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    font-size: 1.1rem;
+    letter-spacing: 0.15em;
+}
+
+.stamp-mark {
+    width: 60px;
+    height: 60px;
+    border: 5px solid var(--color-ink-red);
+    color: var(--color-ink-red);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    font-weight: 700;
+    background-color: var(--color-paper);
+    transform: rotate(-8deg);
+    box-shadow: 5px 5px 0 var(--color-ink-black);
+}

--- a/woodblock/templates/base.html
+++ b/woodblock/templates/base.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock %}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Oswald:wght@500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="site-wrapper">
+        <header class="site-header ink-bleed">
+            <div class="header-inner">
+                <div class="site-branding">
+                    <h1 class="site-title"><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
+                    <p class="site-subtitle">{{ config.description }}</p>
+                </div>
+            </div>
+        </header>
+
+        <main class="site-content">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="site-footer">
+            <div class="footer-inner">
+                <p>&copy; {{ config.extra.author | default(value="Author") }}. All rights reserved.</p>
+                <div class="stamp-mark ink-bleed">印</div>
+            </div>
+        </footer>
+    </div>
+
+    <!-- SVG Filters for woodblock texture -->
+    <svg style="position: absolute; width: 0; height: 0;" aria-hidden="true">
+        <defs>
+            <filter id="wood-grain" x="0%" y="0%" width="100%" height="100%">
+                <feTurbulence type="fractalNoise" baseFrequency="0.08 0.8" numOctaves="3" result="noise" />
+                <feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 0.1 0" in="noise" result="coloredNoise" />
+                <feComposite operator="in" in="coloredNoise" in2="SourceGraphic" result="composite" />
+                <feBlend mode="multiply" in="composite" in2="SourceGraphic" result="blend" />
+            </filter>
+
+            <filter id="ink-bleed" x="-10%" y="-10%" width="120%" height="120%">
+                <feTurbulence type="fractalNoise" baseFrequency="0.05" numOctaves="3" result="noise" />
+                <feDisplacementMap in="SourceGraphic" in2="noise" scale="4" xChannelSelector="R" yChannelSelector="G" result="displaced" />
+            </filter>
+
+            <filter id="paper-texture">
+                <feTurbulence type="fractalNoise" baseFrequency="0.015" result="noise" />
+                <feDiffuseLighting in="noise" lighting-color="#fff" surfaceScale="1.5">
+                    <feDistantLight azimuth="45" elevation="60" />
+                </feDiffuseLighting>
+                <feBlend mode="multiply" in="SourceGraphic" in2="noise" />
+            </filter>
+        </defs>
+    </svg>
+</body>
+</html>

--- a/woodblock/templates/index.html
+++ b/woodblock/templates/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}{% if section.title %}{{ section.title }} | {% endif %}{{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="hero-block block-print ink-bleed">
+    <div class="hero-content">
+        <h2 class="hero-title">{{ section.title }}</h2>
+        <p class="hero-description">{{ section.description }}</p>
+    </div>
+</article>
+
+<div class="content-wrapper">
+    <div class="prose block-print ink-bleed">
+        {{ section.content | safe }}
+    </div>
+
+    <div class="gallery-grid">
+        <div class="gallery-item block-print">
+            <div class="wood-carving carving-1 wood-grain"></div>
+            <div class="caption">First Impression</div>
+        </div>
+        <div class="gallery-item block-print">
+            <div class="wood-carving carving-2 wood-grain"></div>
+            <div class="caption">Second Cut</div>
+        </div>
+        <div class="gallery-item block-print">
+            <div class="wood-carving carving-3 wood-grain"></div>
+            <div class="caption">Final Press</div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds the `woodblock` Hwaro example site. The design features a traditional printmaking aesthetic with SVG filters replicating wood grain and ink bleed, solid geometries, offset borders, and thick typography, strictly adhering to constraints against gradients, emojis, and changes to tags.json.

---
*PR created automatically by Jules for task [1658943726743118398](https://jules.google.com/task/1658943726743118398) started by @hahwul*