### PR TITLE
Add 'sgraffito' Hwaro example theme

### DIFF
--- a/sgraffito/config.toml
+++ b/sgraffito/config.toml
@@ -1,0 +1,11 @@
+title = "Sgraffito"
+description = "A bold, creative, and elegant design featuring a Sgraffito aesthetic."
+base_url = "http://localhost:3000"
+default_language = "en"
+
+[markdown]
+highlight_code = true
+highlight_theme = "css"
+
+[extra]
+author = "Hwaro Examples"

--- a/sgraffito/content/_index.md
+++ b/sgraffito/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Home"
+sort_by = "date"
+transparent = true
++++
+
+Welcome to the Sgraffito theme. This design is inspired by the classical architectural technique where layers of plaster are applied and then scratched away to reveal the contrasting colors beneath.
+
+Here we use bold typography and thick, solid offsets to create a layered, physical feel in the browser.

--- a/sgraffito/content/about.md
+++ b/sgraffito/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About Sgraffito"
+date = 2024-04-06
++++
+
+The sgraffito technique dates back to antiquity, but found widespread use in the Renaissance. By applying multiple layers of contrasting colored plaster and meticulously scraping away the top layer before it fully sets, artisans could create striking, durable murals and geometric patterns on building facades.
+
+## The Digital Translation
+
+In this theme, we mimic that effect using:
+
+*   **High Contrast:** Deep charcoal backgrounds layered over terracotta or light cream.
+*   **Solid Shadows:** Using CSS `box-shadow` and `text-shadow` with solid offsets (no blur) to give elements thickness and reveal a "base" color.
+*   **Text Strokes:** Webkit text stroke properties to outline large type, letting the background color show through as if the text itself was scraped out of the page.
+*   **Irregular Borders:** Using CSS `clip-path` to "chip" away the corners of containers, mimicking the rough edge of dried plaster.
+
+> "To scratch the surface is not to deface, but to reveal what lies beneath."
+
+This aesthetic completely eschews modern, smooth web design trends like gradients and soft dropshadows in favor of something raw and physical.

--- a/sgraffito/content/posts/_index.md
+++ b/sgraffito/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section.html"
++++
+
+A collection of writings.

--- a/sgraffito/content/posts/first-post.md
+++ b/sgraffito/content/posts/first-post.md
@@ -1,0 +1,16 @@
++++
+title = "The Art of the Scratch"
+date = 2024-04-05
++++
+
+Sgraffito comes from the Italian word *graffiare*, meaning "to scratch". It is a technique of wall decor, produced by applying layers of plaster tinted in contrasting colors to a moistened surface, or in ceramics, by applying to an unfired ceramic body two successive layers of contrasting slip or glaze, and then in either case scratching so as to produce an outline drawing.
+
+### History
+
+Sgraffito on walls has been used in Europe since classical times, and it was common in Italy in the 16th century, and can be found in African art. In combination with ornamental decoration these techniques formed an alternative to the prevailing painting of walls.
+
+### Modern Usage
+
+Today, we can apply these same concepts to digital interfaces. By restricting our toolset—refusing gradients, blurs, and other 'soft' effects—we are forced to rely on stark contrast, typography, and geometry to build our visual hierarchy.
+
+This results in a bold, striking presentation that demands attention and provides a refreshing break from typical corporate web design.

--- a/sgraffito/static/css/style.css
+++ b/sgraffito/static/css/style.css
@@ -1,0 +1,273 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Outfit:wght@300;400;600&display=swap');
+
+:root {
+  --top-layer: #151515;
+  --bottom-layer: #f5eedc;
+  --accent-layer: #b84a39; /* terracotta */
+  --font-serif: 'Cormorant Garamond', serif;
+  --font-sans: 'Outfit', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--top-layer);
+  color: var(--bottom-layer);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+/* Background "scratch" lines to simulate sgraffito wall scraping */
+.scratch-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.scratch-bg .s1 { position: absolute; top: -10%; left: 45%; width: 2px; height: 120%; background-color: var(--bottom-layer); opacity: 0.05; transform: rotate(4deg); }
+.scratch-bg .s2 { position: absolute; top: -10%; left: 75%; width: 1px; height: 120%; background-color: var(--bottom-layer); opacity: 0.07; transform: rotate(-2deg); }
+.scratch-bg .s3 { position: absolute; top: 30%; left: -10%; width: 120%; height: 1px; background-color: var(--bottom-layer); opacity: 0.04; transform: rotate(11deg); }
+.scratch-bg .s4 { position: absolute; top: 60%; left: -10%; width: 120%; height: 2px; background-color: var(--accent-layer); opacity: 0.03; transform: rotate(-5deg); }
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+  position: relative;
+}
+
+header {
+  padding: 4rem 0 2rem;
+  border-bottom: 2px solid var(--bottom-layer);
+  position: relative;
+  margin-bottom: 4rem;
+}
+
+/* Scraped text effect using webkit-text-stroke and solid text-shadows */
+header h1 {
+  font-family: var(--font-serif);
+  font-size: 5rem;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+  color: var(--top-layer);
+  -webkit-text-stroke: 1px var(--bottom-layer);
+  text-shadow: 4px 4px 0 var(--accent-layer), 8px 8px 0 var(--bottom-layer);
+  line-height: 1.1;
+}
+
+header p {
+  font-size: 1.2rem;
+  margin-top: 1.5rem;
+  font-style: italic;
+  font-family: var(--font-serif);
+  color: var(--bottom-layer);
+  max-width: 600px;
+}
+
+nav {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+nav a {
+  color: var(--bottom-layer);
+  text-decoration: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  padding: 0.5rem 1rem;
+  position: relative;
+  background-color: var(--top-layer);
+  border: 1px solid var(--bottom-layer);
+  transition: all 0.3s ease;
+}
+
+nav a::after {
+  content: "";
+  position: absolute;
+  top: 4px; left: 4px; right: -4px; bottom: -4px;
+  background-color: var(--accent-layer);
+  z-index: -1;
+  transition: all 0.3s ease;
+}
+
+nav a:hover {
+  background-color: var(--bottom-layer);
+  color: var(--top-layer);
+}
+
+nav a:hover::after {
+  top: 8px; left: 8px; right: -8px; bottom: -8px;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
+
+/* Posts / Sections list */
+.post-card-wrapper {
+  position: relative;
+}
+
+.post-card {
+  border: 2px solid var(--bottom-layer);
+  padding: 2.5rem;
+  background-color: var(--top-layer);
+  /* Chipped corners to look like chipped plaster */
+  clip-path: polygon(
+    0 20px, 20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%
+  );
+  position: relative;
+  z-index: 1;
+}
+
+.post-card-wrapper::after {
+  content: "";
+  position: absolute;
+  top: 12px; left: 12px; right: -12px; bottom: -12px;
+  background-color: var(--accent-layer);
+  z-index: 0;
+  clip-path: polygon(
+    0 20px, 20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%
+  );
+}
+
+.post-card h2 {
+  font-family: var(--font-serif);
+  font-size: 2.5rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--bottom-layer);
+  border-bottom: 1px dashed var(--bottom-layer);
+  padding-bottom: 1rem;
+}
+
+.post-card h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.post-card h2 a:hover {
+  color: var(--accent-layer);
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  color: var(--accent-layer);
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+.post-summary {
+  font-size: 1.1rem;
+}
+
+/* Page content styling */
+article.page-content h1 {
+  font-family: var(--font-serif);
+  font-size: 4rem;
+  color: var(--top-layer);
+  -webkit-text-stroke: 1px var(--bottom-layer);
+  text-shadow: 2px 2px 0 var(--accent-layer), 4px 4px 0 var(--bottom-layer);
+  margin-bottom: 0.5rem;
+  line-height: 1.2;
+}
+
+article.page-content .page-meta {
+  font-family: var(--font-sans);
+  color: var(--accent-layer);
+  margin-bottom: 3rem;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+article.page-content p {
+  font-size: 1.15rem;
+  margin-bottom: 1.5rem;
+}
+
+article.page-content h2, article.page-content h3 {
+  font-family: var(--font-serif);
+  color: var(--bottom-layer);
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid var(--accent-layer);
+  padding-bottom: 0.5rem;
+  display: inline-block;
+}
+
+article.page-content h2 { font-size: 2.5rem; }
+article.page-content h3 { font-size: 2rem; }
+
+article.page-content blockquote {
+  border: 1px solid var(--bottom-layer);
+  border-left: 8px solid var(--accent-layer);
+  margin: 2.5rem 0;
+  padding: 1.5rem 2rem;
+  font-family: var(--font-serif);
+  font-size: 1.6rem;
+  font-style: italic;
+  background-color: var(--top-layer);
+  position: relative;
+}
+
+article.page-content blockquote::after {
+  content: "";
+  position: absolute;
+  top: 6px; left: 6px; right: -6px; bottom: -6px;
+  background-color: var(--bottom-layer);
+  z-index: -1;
+  opacity: 0.1;
+}
+
+article.page-content ul, article.page-content ol {
+  font-size: 1.15rem;
+  margin-bottom: 1.5rem;
+  padding-left: 2rem;
+}
+
+article.page-content li {
+  margin-bottom: 0.5rem;
+}
+
+article.page-content a {
+  color: var(--accent-layer);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-layer);
+  transition: all 0.2s ease;
+}
+
+article.page-content a:hover {
+  background-color: var(--accent-layer);
+  color: var(--top-layer);
+}
+
+footer {
+  margin-top: 6rem;
+  padding: 3rem 0;
+  border-top: 2px dashed var(--bottom-layer);
+  text-align: center;
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  color: var(--bottom-layer);
+}
+
+footer p {
+  margin: 0;
+}

--- a/sgraffito/templates/base.html
+++ b/sgraffito/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value="en") }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}{{ config.title }}</title>
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% elif section.description %}{{ section.description }}{% else %}{{ config.description }}{% endif %}">
+  <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+  <div class="scratch-bg">
+    <div class="s1"></div>
+    <div class="s2"></div>
+    <div class="s3"></div>
+    <div class="s4"></div>
+  </div>
+
+  <div class="container">
+    <header>
+      <h1><a href="{{ config.base_url }}" style="text-decoration: none; color: inherit;">{{ config.title }}</a></h1>
+      <p>{{ config.description }}</p>
+      <nav>
+        <a href="{{ config.base_url }}">Home</a>
+        <a href="{{ get_url(path="about") }}">About</a>
+        <a href="{{ get_url(path="posts") }}">Writing</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      <p>&copy; {{ now() | date(format="%Y") }} {{ config.extra.author | default(value=config.title) }}. Designed with a Sgraffito aesthetic.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/sgraffito/templates/index.html
+++ b/sgraffito/templates/index.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% if section.content %}
+    <article class="page-content">
+      {{ section.content | safe }}
+    </article>
+  {% endif %}
+
+  <div class="posts-list">
+    {% for page in section.pages %}
+      <div class="post-card-wrapper" style="margin-bottom: 3rem;">
+        <article class="post-card">
+          <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+          {% if page.date %}
+            <div class="post-meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+          {% endif %}
+          <div class="post-summary">
+            {% if page.summary %}
+              {{ page.summary | safe }}
+            {% else %}
+              {{ page.content | striptags | truncate(length=150) | safe }}
+            {% endif %}
+          </div>
+        </article>
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/sgraffito/templates/page.html
+++ b/sgraffito/templates/page.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}
+    <div class="page-meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+  {% endif %}
+  {{ page.content | safe }}
+</article>
+{% endblock %}

--- a/sgraffito/templates/section.html
+++ b/sgraffito/templates/section.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+  <h1>{{ section.title }}</h1>
+  {% if section.content %}
+    {{ section.content | safe }}
+  {% endif %}
+</article>
+
+<div class="posts-list" style="margin-top: 3rem;">
+  {% for page in section.pages %}
+    <div class="post-card-wrapper" style="margin-bottom: 3rem;">
+      <article class="post-card">
+        <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+        {% if page.date %}
+          <div class="post-meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+        {% endif %}
+        <div class="post-summary">
+          {% if page.summary %}
+            {{ page.summary | safe }}
+          {% else %}
+            {{ page.content | striptags | truncate(length=150) | safe }}
+          {% endif %}
+        </div>
+      </article>
+    </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/sgraffito/zola.log
+++ b/sgraffito/zola.log
@@ -1,0 +1,10 @@
+Building site...
+Checking all internal links with anchors.
+> Successfully checked 0 internal link(s) with anchors.
+-> Creating 2 pages (0 orphan) and 1 sections
+Done in 10ms.
+
+Listening for changes in /app/sgraffito/{config.toml,content,static,templates}
+Press Ctrl+C to stop
+
+Web server is available at http://127.0.0.1:3000


### PR DESCRIPTION
Adds a new bold, creative, and elegant Hwaro example theme inspired by the Sgraffito plaster technique. Using deep charcoal backgrounds layered over terracotta/cream, solid drop-shadows, clipped paths for chipped borders, and elegant serif typography, the theme achieves a physical "scratched" look without relying on gradients or emojis.

---
*PR created automatically by Jules for task [3519177214121794088](https://jules.google.com/task/3519177214121794088) started by @hahwul*