### PR TITLE
feat: Add bold 'magnetar' theme example site

### DIFF
--- a/magnetar/config.toml
+++ b/magnetar/config.toml
@@ -1,0 +1,8 @@
+title = "Magnetar"
+base_url = "https://example.com"
+compile_sass = false
+build_search_index = false
+
+[extra]
+author = "Hwaro"
+description = "A bold, elegant theme inspired by magnetic fields and pulsars."

--- a/magnetar/content/_index.md
+++ b/magnetar/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Magnetar"
++++
+The most powerful magnetic forces in the universe.
+
+A magnetar is a type of neutron star with an extremely powerful magnetic field. The decay of the magnetic field powers the emission of high-energy electromagnetic radiation, particularly X-rays and gamma rays.

--- a/magnetar/static/css/style.css
+++ b/magnetar/static/css/style.css
@@ -1,0 +1,255 @@
+:root {
+    --bg-color: #030305; /* Deep space black */
+    --text-main: #f0f0f0;
+    --accent-core: #ffffff; /* Core brightness */
+    --accent-cyan: #00ffff;
+    --accent-magenta: #ff00ff;
+    --accent-violet: #6b00ff;
+    --font-heading: 'Syncopate', sans-serif;
+    --font-body: 'Space Mono', monospace;
+    --glow-cyan: 0 0 10px rgba(0, 255, 255, 0.5), 0 0 20px rgba(0, 255, 255, 0.3), 0 0 30px rgba(0, 255, 255, 0.1);
+    --glow-magenta: 0 0 10px rgba(255, 0, 255, 0.5), 0 0 20px rgba(255, 0, 255, 0.3), 0 0 30px rgba(255, 0, 255, 0.1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    display: flex;
+    justify-content: center;
+}
+
+/* Background grid via border-image or multiple solid shadows, NO GRADIENTS */
+.field-lines {
+    position: fixed;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    pointer-events: none;
+    z-index: -1;
+    /* Creating a concentric circle effect using box-shadows to simulate magnetic fields */
+    border-radius: 50%;
+    border: 1px solid rgba(107, 0, 255, 0.1);
+    box-shadow:
+        inset 0 0 0 50px transparent,
+        inset 0 0 0 51px rgba(107, 0, 255, 0.1),
+        inset 0 0 0 100px transparent,
+        inset 0 0 0 101px rgba(107, 0, 255, 0.1),
+        inset 0 0 0 150px transparent,
+        inset 0 0 0 151px rgba(107, 0, 255, 0.1),
+        inset 0 0 0 200px transparent,
+        inset 0 0 0 201px rgba(107, 0, 255, 0.1),
+        inset 0 0 0 250px transparent,
+        inset 0 0 0 251px rgba(107, 0, 255, 0.1),
+        inset 0 0 0 300px transparent,
+        inset 0 0 0 301px rgba(107, 0, 255, 0.2),
+        inset 0 0 0 350px transparent,
+        inset 0 0 0 351px rgba(107, 0, 255, 0.2),
+        inset 0 0 0 400px transparent,
+        inset 0 0 0 401px rgba(107, 0, 255, 0.2),
+        inset 0 0 0 450px transparent,
+        inset 0 0 0 451px rgba(107, 0, 255, 0.2),
+        inset 0 0 0 500px transparent,
+        inset 0 0 0 501px rgba(107, 0, 255, 0.3),
+        inset 0 0 0 600px transparent,
+        inset 0 0 0 601px rgba(107, 0, 255, 0.3),
+        inset 0 0 0 700px transparent,
+        inset 0 0 0 701px rgba(107, 0, 255, 0.4),
+        inset 0 0 0 800px transparent,
+        inset 0 0 0 801px rgba(0, 255, 255, 0.2),
+        inset 0 0 0 900px transparent,
+        inset 0 0 0 901px rgba(0, 255, 255, 0.1),
+        inset 0 0 0 1000px transparent,
+        inset 0 0 0 1001px rgba(255, 0, 255, 0.1);
+    animation: rotateField 120s linear infinite;
+    transform-origin: center;
+}
+
+@keyframes rotateField {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.container {
+    max-width: 900px;
+    width: 100%;
+    padding: 4rem 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 5rem;
+}
+
+h1.glow-text {
+    font-family: var(--font-heading);
+    font-size: 5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent-core);
+    text-shadow: 0 0 20px var(--accent-cyan), 0 0 40px var(--accent-cyan), 0 0 80px var(--accent-violet);
+    margin-bottom: 1rem;
+    animation: pulseGlow 4s ease-in-out infinite alternate;
+}
+
+@keyframes pulseGlow {
+    0% {
+        text-shadow: 0 0 15px var(--accent-cyan), 0 0 30px var(--accent-cyan), 0 0 60px var(--accent-violet);
+    }
+    100% {
+        text-shadow: 0 0 25px var(--accent-cyan), 0 0 50px var(--accent-cyan), 0 0 100px var(--accent-magenta);
+    }
+}
+
+.subtitle {
+    font-size: 1.2rem;
+    color: var(--accent-cyan);
+    letter-spacing: 0.05em;
+    opacity: 0.8;
+}
+
+h2, h3 {
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent-core);
+}
+
+h2 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    text-shadow: var(--glow-magenta);
+    border-bottom: 2px solid var(--accent-magenta);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+h3 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.content-box {
+    margin-bottom: 5rem;
+    padding: 3rem;
+    background-color: rgba(3, 3, 5, 0.7);
+    border: 1px solid var(--accent-magenta);
+    box-shadow: var(--glow-magenta);
+    position: relative;
+}
+
+.content-box::before, .content-box::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--accent-cyan);
+}
+
+.content-box::before {
+    top: -5px;
+    left: -5px;
+    border-right: none;
+    border-bottom: none;
+}
+
+.content-box::after {
+    bottom: -5px;
+    right: -5px;
+    border-left: none;
+    border-top: none;
+}
+
+.prose {
+    font-size: 1.1rem;
+    color: #ccc;
+    text-shadow: 0 0 2px rgba(255,255,255,0.2);
+}
+
+.prose p {
+    margin-bottom: 1.5rem;
+}
+
+.features {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+}
+
+.feature-card {
+    background-color: rgba(3, 3, 5, 0.8);
+    border: 1px solid var(--accent-cyan);
+    box-shadow: inset 0 0 20px rgba(0, 255, 255, 0.1), var(--glow-cyan);
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-5px);
+    box-shadow: inset 0 0 30px rgba(0, 255, 255, 0.2), 0 0 20px var(--accent-cyan), 0 0 40px var(--accent-cyan);
+}
+
+.card-inner {
+    padding: 2.5rem;
+    position: relative;
+    z-index: 2;
+}
+
+/* Simulated magnetic poles on cards */
+.feature-card::before {
+    content: '+';
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-family: var(--font-heading);
+    font-size: 2rem;
+    color: var(--accent-cyan);
+    opacity: 0.5;
+}
+
+.feature-card::after {
+    content: '-';
+    position: absolute;
+    bottom: 10px;
+    left: 15px;
+    font-family: var(--font-heading);
+    font-size: 3rem;
+    color: var(--accent-magenta);
+    opacity: 0.5;
+    line-height: 1;
+}
+
+footer {
+    margin-top: 6rem;
+    text-align: center;
+    border-top: 1px solid rgba(255,255,255,0.1);
+    padding-top: 2rem;
+    font-size: 0.9rem;
+    color: #777;
+}
+
+@media (max-width: 768px) {
+    h1.glow-text {
+        font-size: 3rem;
+    }
+    h2 {
+        font-size: 2rem;
+    }
+    .content-box {
+        padding: 2rem;
+    }
+}

--- a/magnetar/templates/index.html
+++ b/magnetar/templates/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value="en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config.title }}</title>
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+    <link href="https://fonts.googleapis.com/css2?family=Syncopate:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="field-lines"></div>
+    <div class="container">
+        <header>
+            <h1 class="glow-text">{{ config.title }}</h1>
+            <p class="subtitle">{{ config.extra.description }}</p>
+        </header>
+
+        <main>
+            <section class="content-box">
+                <h2>Forces</h2>
+                <div class="prose">
+                    {{ section.content | safe }}
+                </div>
+            </section>
+
+            <section class="features">
+                <div class="feature-card">
+                    <div class="card-inner">
+                        <h3>Pulsar</h3>
+                        <p>Rapid rotation and intense magnetic flux.</p>
+                    </div>
+                </div>
+                <div class="feature-card">
+                    <div class="card-inner">
+                        <h3>Emission</h3>
+                        <p>X-rays and gamma rays radiated outward.</p>
+                    </div>
+                </div>
+                <div class="feature-card">
+                    <div class="card-inner">
+                        <h3>Resonance</h3>
+                        <p>The universe vibrates with magnetic energy.</p>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <footer>
+            <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}. Designed with immense forces.</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Adds a new Hwaro theme example site named `magnetar`.

The design represents a dark-themed space/magnetar aesthetic. It uses multiple layers of inset `box-shadow` on a pseudo-element to create concentric glowing rings that look like magnetic field lines, without using any `radial-gradient` or `linear-gradient` functions. 

The styling also features glowing typography using text-shadow, a retro-futuristic font pairing (Syncopate and Space Mono), and hover effects on cards that mimic magnetic poles (+ and -).

Tested locally with Playwright and visually verified that the design looks bold, creative, and elegant while avoiding any gradient functions or emojis.

---
*PR created automatically by Jules for task [7580394827323914282](https://jules.google.com/task/7580394827323914282) started by @hahwul*