### PR TITLE
feat: Add linocut theme to Hwaro example sites

### DIFF
--- a/example-sites/linocut/config.toml
+++ b/example-sites/linocut/config.toml
@@ -1,0 +1,10 @@
+base_url = "https://example.com"
+title = "Linocut Printmaking"
+description = "A bold, elegant aesthetic inspired by linocut printmaking, featuring high contrast and rough edges."
+compile_sass = false
+build_search_index = false
+generate_feed = true
+
+[extra]
+author = "Artisan Printer"
+footer_text = "© 2024 Linocut Press"

--- a/example-sites/linocut/content/_index.md
+++ b/example-sites/linocut/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Art of the Cut"
+sort_by = "date"
+template = "index.html"
+page_template = "page.html"
++++
+
+Welcome to the digital atelier. This space explores the tactile, high-contrast world of relief printing translated to the web. Every mark is intentional, every edge carries the texture of the tool.

--- a/example-sites/linocut/content/ink-and-pressure.md
+++ b/example-sites/linocut/content/ink-and-pressure.md
@@ -1,0 +1,17 @@
++++
+title = "Ink and Pressure"
+date = 2024-06-02
+description = "The alchemy of transferring the carved image to paper."
++++
+
+Once the carving is complete, the transformation begins. A thick, tacky ink is rolled out onto a glass slab until it reaches the perfect consistency. The sound it makes is distinctive: a sharp, even hiss as the brayer moves back and forth.
+
+## The Transfer
+
+The ink is applied to the relief surface of the block in thin, even layers. Too much ink, and the fine details will fill in; too little, and the print will appear weak and mottled.
+
+The paper is then carefully registered and placed over the inked block. Through the application of pressure--either by hand with a baren or through the heavy rollers of an etching press--the ink is transferred from the linoleum to the paper fibers.
+
+## The Reveal
+
+Peeling the paper back from the block is always a moment of revelation. The carved image, previously seen in reverse and obscured by ink, is finally visible in its true orientation. The stark contrast between the heavy ink and the bare paper defines the classic linocut aesthetic: bold, immediate, and undeniably physical.

--- a/example-sites/linocut/content/the-gouge.md
+++ b/example-sites/linocut/content/the-gouge.md
@@ -1,0 +1,19 @@
++++
+title = "The Gouge and the Block"
+date = 2024-05-15
+description = "Understanding the fundamental tools of relief printing."
++++
+
+The process begins with a blank block of linoleum and a set of sharp gouges. Unlike painting, where marks are added to a surface, relief printing is a process of subtraction. You must carve away everything you do not want to print.
+
+## The Negative Space
+
+This fundamental inversion requires a shift in perspective. The artist must think in terms of negative space. What remains on the block will catch the ink; what is removed will remain the color of the paper.
+
+> "The block resists the tool. It is in this resistance that the character of the print is born."
+
+## The Weight of the Line
+
+A V-gouge creates thin, precise lines, while a U-gouge clears larger areas but leaves distinct, parallel ridges. The direction and depth of the cut become the texture of the final image. A heavy hand creates deep, stark contrasts; a light, chattering technique creates atmosphere and tone.
+
+The aesthetic is inherently bold. Subtle gradations are difficult, forcing the artist to rely on stark black-and-white contrasts or distinct blocks of solid color.

--- a/example-sites/linocut/static/css/style.css
+++ b/example-sites/linocut/static/css/style.css
@@ -1,0 +1,250 @@
+/* Linocut Printmaking Aesthetic */
+:root {
+    --bg-color: #fdfaf6; /* Rough cream paper */
+    --ink-color: #1a1a1a; /* Thick black ink */
+    --accent-color: #c93a2c; /* Block printing red ink */
+    --font-heading: 'Cinzel', serif;
+    --font-body: 'Playfair Display', serif;
+    --font-mono: 'Courier Prime', monospace;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--ink-color);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    font-size: 18px;
+    /* Subtle noise overlay for paper texture */
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+    filter: url('#heavy-ink');
+}
+
+a {
+    color: var(--ink-color);
+    text-decoration: none;
+    border-bottom: 2px solid var(--ink-color);
+    transition: all 0.2s ease;
+    filter: url('#carved-edges');
+}
+
+a:hover {
+    color: var(--accent-color);
+    border-color: var(--accent-color);
+    background-color: var(--ink-color);
+}
+
+/* Typography elements */
+p {
+    margin-bottom: 1.5rem;
+}
+
+strong {
+    font-weight: 700;
+}
+
+em {
+    font-style: italic;
+}
+
+blockquote {
+    border-left: 8px solid var(--ink-color);
+    padding: 1rem 2rem;
+    margin: 2rem 0;
+    font-style: italic;
+    font-size: 1.2rem;
+    filter: url('#carved-edges');
+    background-color: rgba(26, 26, 26, 0.05);
+}
+
+/* Layout */
+.site-header {
+    border-bottom: 6px solid var(--ink-color);
+    padding: 3rem 1rem;
+    text-align: center;
+    filter: url('#carved-edges');
+}
+
+.header-inner {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.site-title {
+    font-size: 3rem;
+    font-family: var(--font-heading);
+    border: none;
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+
+.site-title:hover {
+    background-color: transparent;
+    color: var(--accent-color);
+}
+
+.site-description {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.site-main {
+    flex: 1;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 4rem 1rem;
+    width: 100%;
+}
+
+.site-footer {
+    border-top: 6px solid var(--ink-color);
+    padding: 2rem 1rem;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    filter: url('#carved-edges');
+}
+
+/* Index / Grid */
+.section-intro {
+    margin-bottom: 4rem;
+    font-size: 1.2rem;
+    text-align: center;
+}
+
+.post-grid {
+    display: grid;
+    gap: 3rem;
+}
+
+.post-card {
+    border: 4px solid var(--ink-color);
+    padding: 2rem;
+    filter: url('#carved-edges');
+    background-color: var(--bg-color);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+}
+
+/* Solid drop shadow to simulate thick block */
+.post-card::after {
+    content: '';
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    right: -8px;
+    bottom: -8px;
+    background-color: var(--ink-color);
+    z-index: -1;
+    filter: url('#carved-edges');
+}
+
+.post-card:hover {
+    transform: translate(-2px, -2px);
+}
+
+.post-card:hover::after {
+    top: 10px;
+    left: 10px;
+    right: -10px;
+    bottom: -10px;
+}
+
+.post-card .post-title {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-card .post-title a {
+    border: none;
+}
+
+.post-card .post-title a:hover {
+    background-color: transparent;
+}
+
+.post-meta {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-color);
+}
+
+.post-summary {
+    margin-bottom: 1.5rem;
+}
+
+.read-more {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border: 2px solid var(--ink-color);
+    font-family: var(--font-heading);
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+}
+
+/* Single Post */
+.single-post .post-header {
+    margin-bottom: 3rem;
+    text-align: center;
+    border-bottom: 2px solid var(--ink-color);
+    padding-bottom: 2rem;
+    filter: url('#carved-edges');
+}
+
+.single-post .post-title {
+    font-size: 3.5rem;
+}
+
+.post-content img {
+    max-width: 100%;
+    height: auto;
+    border: 4px solid var(--ink-color);
+    filter: url('#carved-edges') grayscale(100%) contrast(150%);
+    margin: 2rem 0;
+}
+
+/* Code blocks styling for consistency with printmaking theme */
+pre {
+    background-color: var(--ink-color);
+    color: var(--bg-color);
+    padding: 1.5rem;
+    overflow-x: auto;
+    margin: 2rem 0;
+    filter: url('#carved-edges');
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+}
+
+code {
+    font-family: var(--font-mono);
+    background-color: rgba(26, 26, 26, 0.1);
+    padding: 0.2rem 0.4rem;
+}
+
+pre code {
+    background-color: transparent;
+    padding: 0;
+}

--- a/example-sites/linocut/templates/base.html
+++ b/example-sites/linocut/templates/base.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value="en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Courier+Prime&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- SVG Filter for Carved Edges -->
+    <svg style="width: 0; height: 0; position: absolute;" aria-hidden="true" focusable="false">
+      <defs>
+        <filter id="carved-edges">
+          <feTurbulence type="fractalNoise" baseFrequency="0.08" numOctaves="3" result="noise" />
+          <feDisplacementMap in="SourceGraphic" in2="noise" scale="3" xChannelSelector="R" yChannelSelector="G" />
+        </filter>
+        <filter id="heavy-ink">
+          <feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="2" result="noise" />
+          <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G" />
+          <feColorMatrix type="matrix" values="
+            1 0 0 0 0
+            0 1 0 0 0
+            0 0 1 0 0
+            0 0 0 1.2 -0.1" />
+        </filter>
+      </defs>
+    </svg>
+
+    <header class="site-header">
+        <div class="header-inner">
+            <a href="{{ config.base_url }}" class="site-title">{{ config.title }}</a>
+            <p class="site-description">{{ config.description }}</p>
+        </div>
+    </header>
+
+    <main class="site-main">
+        {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+        <div class="footer-inner">
+            <p>{{ config.extra.footer_text | default(value="© " ~ config.title) }}</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/example-sites/linocut/templates/index.html
+++ b/example-sites/linocut/templates/index.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="index-content">
+    {% if section.content %}
+        <div class="section-intro">
+            {{ section.content | safe }}
+        </div>
+    {% endif %}
+
+    <div class="post-grid">
+        {% for page in section.pages %}
+        <article class="post-card">
+            <h2 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.date %}
+            <div class="post-meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+            {% endif %}
+            <div class="post-summary">
+                {% if page.summary %}
+                    {{ page.summary | safe }}
+                {% else %}
+                    {{ page.content | striptags | truncate(length=150) }}
+                {% endif %}
+            </div>
+            <a href="{{ page.permalink }}" class="read-more">Read Entry</a>
+        </article>
+        {% endfor %}
+    </div>
+</div>
+{% endblock content %}

--- a/example-sites/linocut/templates/page.html
+++ b/example-sites/linocut/templates/page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+
+{% block content %}
+<article class="single-post">
+    <header class="post-header">
+        <h1 class="post-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="post-meta">Carved on {{ page.date | date(format="%B %d, %Y") }}</div>
+        {% endif %}
+    </header>
+
+    <div class="post-content">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
This PR adds a new 'linocut' theme to the Hwaro example sites. The theme embraces a bold, creative, and elegant design inspired by block printing, utilizing high-contrast solid colors (charcoal, cream, red), classic typography, and custom inline SVG filters to simulate rough, hand-carved edges and heavy ink textures. Per the requirements, it strictly avoids CSS gradients and emojis, relying entirely on solid shadows and borders to create visual depth, and does not modify the `tags.json` file.

---
*PR created automatically by Jules for task [1334094348476125201](https://jules.google.com/task/1334094348476125201) started by @hahwul*