### PR TITLE
Add ferrofluid theme

### DIFF
--- a/ferrofluid/config.toml
+++ b/ferrofluid/config.toml
@@ -1,0 +1,9 @@
+title = "Ferrofluid"
+base_url = "https://example.com"
+compile_sass = false
+minify_html = true
+build_search_index = false
+
+[extra]
+author = "Hwaro"
+description = "A bold, elegant, and creative ferrofluid theme without gradients."

--- a/ferrofluid/content/_index.md
+++ b/ferrofluid/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Ferrofluid Dynamics"
++++
+
+This is a study in form, magnetism, and fluid mechanics. Ferrofluids are liquids that become strongly magnetized in the presence of a magnetic field.
+
+We visualize these intense forces through pure CSS and SVG filters, relying heavily on the gooey effect to simulate liquid viscosity, and sharp shapes to simulate the spikes that form along magnetic field lines.
+
+Embrace the dark, liquid contrast. No gradients. No emojis. Just pure, mathematical aesthetics.

--- a/ferrofluid/static/css/style.css
+++ b/ferrofluid/static/css/style.css
@@ -1,0 +1,222 @@
+:root {
+    --bg-color: #f0f0f0;
+    --text-color: #111111;
+    --fluid-color: #111111;
+    --fluid-highlight: #333333;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    overflow-x: hidden;
+    line-height: 1.6;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2rem 4rem;
+    border-bottom: 2px solid var(--fluid-color);
+}
+
+.logo {
+    font-size: 2rem;
+    font-weight: 900;
+    text-decoration: none;
+    color: var(--text-color);
+    letter-spacing: -2px;
+}
+
+.nav a {
+    margin-left: 2rem;
+    text-decoration: none;
+    color: var(--text-color);
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    position: relative;
+}
+
+.nav a::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background-color: var(--fluid-color);
+    transition: width 0.3s ease;
+}
+
+.nav a:hover::after {
+    width: 100%;
+}
+
+.main-container {
+    padding: 4rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    min-height: 80vh;
+}
+
+.hero {
+    position: relative;
+    z-index: 2;
+}
+
+.hero-title {
+    font-size: 6rem;
+    font-weight: 900;
+    line-height: 0.9;
+    letter-spacing: -4px;
+    margin-bottom: 2rem;
+    text-shadow: 4px 4px 0px rgba(0,0,0,0.1);
+}
+
+.hero-subtitle {
+    font-size: 1.5rem;
+    font-weight: 400;
+    max-width: 400px;
+}
+
+/* Ferrofluid Gooey Animation */
+.ferrofluid-container {
+    position: absolute;
+    top: 50%;
+    right: -20%;
+    transform: translateY(-50%);
+    width: 400px;
+    height: 400px;
+    filter: url('#goo');
+    z-index: -1;
+}
+
+.center-mass {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 150px;
+    height: 150px;
+    background-color: var(--fluid-color);
+    border-radius: 50%;
+    box-shadow: inset -10px -10px 0px var(--fluid-highlight);
+    animation: pulse 4s infinite alternate ease-in-out;
+}
+
+.drop {
+    position: absolute;
+    background-color: var(--fluid-color);
+    border-radius: 50%;
+    box-shadow: inset -5px -5px 0px var(--fluid-highlight);
+}
+
+.drop-1 { width: 80px; height: 80px; top: 20%; left: 30%; animation: orbit 6s infinite linear; }
+.drop-2 { width: 100px; height: 100px; top: 60%; left: 20%; animation: orbit 8s infinite linear reverse; }
+.drop-3 { width: 60px; height: 60px; top: 70%; left: 60%; animation: orbit 5s infinite linear; }
+.drop-4 { width: 120px; height: 120px; top: 30%; left: 70%; animation: orbit 10s infinite linear reverse; }
+.drop-5 { width: 50px; height: 50px; top: 10%; left: 50%; animation: orbit 4s infinite linear; }
+.drop-6 { width: 70px; height: 70px; top: 80%; left: 40%; animation: orbit 7s infinite linear reverse; }
+.drop-7 { width: 90px; height: 90px; top: 40%; left: 10%; animation: orbit 9s infinite linear; }
+.drop-8 { width: 40px; height: 40px; top: 50%; left: 80%; animation: orbit 5s infinite linear reverse; }
+
+@keyframes pulse {
+    0% { transform: translate(-50%, -50%) scale(1); }
+    100% { transform: translate(-50%, -50%) scale(1.1); }
+}
+
+@keyframes orbit {
+    0% { transform: rotate(0deg) translateX(100px) rotate(0deg); }
+    100% { transform: rotate(360deg) translateX(100px) rotate(-360deg); }
+}
+
+/* Content Section */
+.content-section {
+    align-self: center;
+    font-size: 1.2rem;
+    font-weight: 500;
+    max-width: 500px;
+}
+
+.content-section p {
+    margin-bottom: 1.5rem;
+}
+
+/* Spikes (Magnetic field representation) */
+.spikes-container {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100px;
+    display: flex;
+    justify-content: space-around;
+    align-items: flex-end;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.spike {
+    width: 0;
+    height: 0;
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-bottom: 50px solid var(--fluid-color);
+    transform-origin: bottom center;
+    animation: spike-pulse 2s infinite alternate ease-in-out;
+}
+
+.s1 { border-bottom-width: 80px; animation-delay: 0.1s; }
+.s2 { border-bottom-width: 120px; animation-delay: 0.5s; }
+.s3 { border-bottom-width: 60px; animation-delay: 0.2s; }
+.s4 { border-bottom-width: 150px; animation-delay: 0.7s; }
+.s5 { border-bottom-width: 90px; animation-delay: 0.3s; }
+.s6 { border-bottom-width: 110px; animation-delay: 0.6s; }
+.s7 { border-bottom-width: 70px; animation-delay: 0.4s; }
+
+@keyframes spike-pulse {
+    0% { transform: scaleY(1); }
+    100% { transform: scaleY(1.4); }
+}
+
+/* Footer */
+.footer {
+    padding: 2rem 4rem;
+    border-top: 2px solid var(--fluid-color);
+    text-align: center;
+    font-weight: 700;
+    font-size: 0.8rem;
+    letter-spacing: 2px;
+}
+
+/* Page styles */
+.page-container {
+    padding: 4rem;
+    max-width: 800px;
+    margin: 0 auto;
+    min-height: 80vh;
+}
+
+.page-title {
+    font-size: 4rem;
+    font-weight: 900;
+    margin-bottom: 2rem;
+    letter-spacing: -2px;
+}
+
+.page-content {
+    font-size: 1.2rem;
+}
+
+.page-content p {
+    margin-bottom: 1.5rem;
+}

--- a/ferrofluid/static/js/main.js
+++ b/ferrofluid/static/js/main.js
@@ -1,0 +1,1 @@
+console.log("Ferrofluid Theme initialized.");

--- a/ferrofluid/templates/base.html
+++ b/ferrofluid/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+</head>
+<body>
+    <!-- SVG Filter for the Ferrofluid Goo Effect -->
+    <svg style="visibility: hidden; position: absolute;" width="0" height="0" xmlns="http://www.w3.org/2000/svg" version="1.1">
+        <defs>
+            <filter id="goo">
+                <feGaussianBlur in="SourceGraphic" stdDeviation="12" result="blur" />
+                <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 22 -9" result="goo" />
+                <feComposite in="SourceGraphic" in2="goo" operator="atop"/>
+            </filter>
+        </defs>
+    </svg>
+
+    <header class="header">
+        <a href="{{ config.base_url }}" class="logo">FERROFLUID</a>
+        <nav class="nav">
+            <a href="{{ config.base_url }}">MAGNETISM</a>
+            <a href="{{ config.base_url }}">DYNAMICS</a>
+        </nav>
+    </header>
+
+    {% block content %}{% endblock %}
+
+    <footer class="footer">
+        <p>FERROFLUID DYNAMICS. PURE CSS & SVG. NO GRADIENTS.</p>
+    </footer>
+
+    <script src="{{ get_url(path='js/main.js') }}"></script>
+</body>
+</html>

--- a/ferrofluid/templates/index.html
+++ b/ferrofluid/templates/index.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main class="main-container">
+    <div class="hero">
+        <h1 class="hero-title">MAGNETIC<br>FLUIDS</h1>
+        <p class="hero-subtitle">The aesthetics of liquid dynamics under intense magnetic fields.</p>
+
+        <div class="ferrofluid-container">
+            <div class="drop drop-1"></div>
+            <div class="drop drop-2"></div>
+            <div class="drop drop-3"></div>
+            <div class="drop drop-4"></div>
+            <div class="drop drop-5"></div>
+            <div class="drop drop-6"></div>
+            <div class="drop drop-7"></div>
+            <div class="drop drop-8"></div>
+            <div class="drop center-mass"></div>
+        </div>
+    </div>
+
+    <section class="content-section">
+        {{ section.content | safe }}
+    </section>
+
+    <div class="spikes-container">
+        <div class="spike s1"></div>
+        <div class="spike s2"></div>
+        <div class="spike s3"></div>
+        <div class="spike s4"></div>
+        <div class="spike s5"></div>
+        <div class="spike s6"></div>
+        <div class="spike s7"></div>
+    </div>
+</main>
+{% endblock %}

--- a/ferrofluid/templates/page.html
+++ b/ferrofluid/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main class="page-container">
+    <article class="article">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="page-content">
+            {{ page.content | safe }}
+        </div>
+    </article>
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds a new 'ferrofluid' Hwaro example site featuring a dark, bold, and elegant magnetic fluid design. The visual effects are achieved using pure CSS, solid colors, text-shadows, and an SVG filter for the gooey liquid effect, fully adhering to the constraints of no gradients, no emojis, and not modifying tags.json.

---
*PR created automatically by Jules for task [3266404647580594315](https://jules.google.com/task/3266404647580594315) started by @hahwul*