### PR TITLE
Add 'anaglyph' theme

### DIFF
--- a/anaglyph/config.toml
+++ b/anaglyph/config.toml
@@ -1,0 +1,9 @@
+title = "Anaglyph"
+description = "A bold and elegant 3D anaglyph aesthetic utilizing stereoscopic cyan and red color channels."
+base_url = "https://example.com"
+compile_sass = false
+minify_html = true
+default_language = "en"
+
+[extra]
+author = "Hwaro"

--- a/anaglyph/content/_index.md
+++ b/anaglyph/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Stereoscopic Vision"
++++
+The anaglyph aesthetic leverages the visual offset of two distinct colors, traditionally cyan and red, to create a sense of depth and three-dimensionality on a flat plane.
+
+In this digital iteration, we explore the stark contrast and visual tension created by shifting these color channels. The result is a bold, creative, and elegant design that commands attention and plays with perception, entirely without the use of complex gradients or emojis.

--- a/anaglyph/static/css/style.css
+++ b/anaglyph/static/css/style.css
@@ -1,0 +1,253 @@
+:root {
+    --bg-color: #f0f0f0;
+    --text-color: #111111;
+    --cyan: #00ffff;
+    --red: #ff0000;
+    --offset-x: 4px;
+    --offset-y: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #050505;
+        --text-color: #ffffff;
+        --cyan: #0ff;
+        --red: #f00;
+    }
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Inter', sans-serif;
+    line-height: 1.6;
+    overflow-x: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.anaglyph-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 4rem 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+.site-header {
+    margin-bottom: 4rem;
+    text-align: center;
+}
+
+h1, h2, h3 {
+    font-family: 'Syncopate', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+h1 {
+    font-size: 4rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+h2 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid var(--text-color);
+    box-shadow: 0 4px 0 var(--cyan), 0 8px 0 var(--red);
+}
+
+.subtitle {
+    font-size: 1.2rem;
+    max-width: 600px;
+    margin: 0 auto;
+    opacity: 0.9;
+}
+
+.content-box {
+    background: transparent;
+    padding: 3rem;
+    border: 4px solid var(--text-color);
+    /* The core anaglyph box shadow */
+    box-shadow:
+        var(--offset-x) var(--offset-y) 0 var(--cyan),
+        calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red);
+    position: relative;
+    transition: transform 0.3s ease;
+}
+
+.content-box:hover {
+    transform: translate(-2px, -1px);
+    box-shadow:
+        calc(var(--offset-x) * 1.5) calc(var(--offset-y) * 1.5) 0 var(--cyan),
+        calc(var(--offset-x) * -1.5) calc(var(--offset-y) * -1.5) 0 var(--red);
+}
+
+.prose {
+    font-size: 1.1rem;
+    margin-bottom: 3rem;
+}
+
+.prose p {
+    margin-bottom: 1.5rem;
+}
+
+/* The core anaglyph text effect */
+.anaglyph-text {
+    position: relative;
+    display: inline-block;
+    color: var(--text-color);
+    text-shadow:
+        var(--offset-x) var(--offset-y) 0 rgba(0, 255, 255, 0.7),
+        calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 rgba(255, 0, 0, 0.7);
+}
+
+/* Subtle effect for secondary text */
+.anaglyph-text-sub {
+    text-shadow:
+        2px 1px 0 rgba(0, 255, 255, 0.5),
+        -2px -1px 0 rgba(255, 0, 0, 0.5);
+}
+
+/* Abstract visual elements */
+.visual-elements {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    margin-top: 4rem;
+    padding-top: 3rem;
+    border-top: 2px solid var(--text-color);
+    box-shadow: inset 0 4px 0 var(--cyan), inset 0 8px 0 var(--red);
+}
+
+.shape {
+    width: 60px;
+    height: 60px;
+    background-color: var(--text-color);
+    /* Anaglyph box shadow for shapes */
+    box-shadow:
+        var(--offset-x) var(--offset-y) 0 var(--cyan),
+        calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red);
+    transition: all 0.3s ease;
+}
+
+.circle {
+    border-radius: 50%;
+}
+
+.triangle {
+    background-color: transparent;
+    width: 0;
+    height: 0;
+    border-left: 35px solid transparent;
+    border-right: 35px solid transparent;
+    border-bottom: 60px solid var(--text-color);
+    box-shadow: none;
+    /* Simulate anaglyph for triangle using filter since box-shadow on border trick doesn't work well */
+    filter: drop-shadow(var(--offset-x) var(--offset-y) 0 var(--cyan)) drop-shadow(calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red));
+}
+
+.shape:hover {
+    transform: scale(1.1) rotate(5deg);
+}
+
+.site-footer {
+    margin-top: 5rem;
+    text-align: center;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+/* Glitch animation for title */
+@keyframes glitch-anim {
+    0% {
+        text-shadow:
+            var(--offset-x) var(--offset-y) 0 var(--cyan),
+            calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red);
+    }
+    20% {
+        text-shadow:
+            calc(var(--offset-x) * 1.5) calc(var(--offset-y) * -0.5) 0 var(--cyan),
+            calc(var(--offset-x) * -1.5) calc(var(--offset-y) * 0.5) 0 var(--red);
+    }
+    40% {
+        text-shadow:
+            calc(var(--offset-x) * -0.5) calc(var(--offset-y) * 1.5) 0 var(--cyan),
+            calc(var(--offset-x) * 0.5) calc(var(--offset-y) * -1.5) 0 var(--red);
+    }
+    60% {
+        text-shadow:
+            var(--offset-x) var(--offset-y) 0 var(--cyan),
+            calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red);
+    }
+    80% {
+        text-shadow:
+            calc(var(--offset-x) * 2) 0 0 var(--cyan),
+            calc(var(--offset-x) * -2) 0 0 var(--red);
+    }
+    100% {
+        text-shadow:
+            var(--offset-x) var(--offset-y) 0 var(--cyan),
+            calc(var(--offset-x) * -1) calc(var(--offset-y) * -1) 0 var(--red);
+    }
+}
+
+.glitch-effect:hover {
+    animation: glitch-anim 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+}
+
+/* Add some dynamic displacement using pseudo-elements */
+.glitch-effect::before,
+.glitch-effect::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.8;
+}
+
+.glitch-effect::before {
+    color: var(--cyan);
+    z-index: -1;
+    transform: translate(var(--offset-x), var(--offset-y));
+    mix-blend-mode: multiply;
+}
+
+.glitch-effect::after {
+    color: var(--red);
+    z-index: -2;
+    transform: translate(calc(var(--offset-x) * -1), calc(var(--offset-y) * -1));
+    mix-blend-mode: multiply;
+}
+
+@media (prefers-color-scheme: dark) {
+    .glitch-effect::before,
+    .glitch-effect::after {
+        mix-blend-mode: screen;
+    }
+}
+
+@media (max-width: 768px) {
+    h1 {
+        font-size: 2.5rem;
+    }
+    h2 {
+        font-size: 1.8rem;
+    }
+    .content-box {
+        padding: 1.5rem;
+    }
+}

--- a/anaglyph/templates/index.html
+++ b/anaglyph/templates/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if section.title %}{{ section.title }} - {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Syncopate:wght@400;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="anaglyph-container">
+        <header class="site-header">
+            <h1 class="anaglyph-text glitch-effect" data-text="{{ config.title }}">{{ config.title }}</h1>
+            <p class="subtitle anaglyph-text-sub">{{ config.description }}</p>
+        </header>
+
+        <main class="site-content">
+            <article class="content-box">
+                <h2 class="anaglyph-text" data-text="{{ section.title }}">{{ section.title }}</h2>
+                <div class="prose">
+                    {{ section.content | safe }}
+                </div>
+
+                <div class="visual-elements">
+                    <div class="shape circle anaglyph-box"></div>
+                    <div class="shape square anaglyph-box"></div>
+                    <div class="shape triangle anaglyph-box"></div>
+                </div>
+            </article>
+        </main>
+
+        <footer class="site-footer">
+            <p class="anaglyph-text-sub">Designed by {{ config.extra.author }}</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Adds the `anaglyph` theme with a stereoscopic 3D design using text-shadow and box-shadow, adhering to all design constraints including no gradients and no emojis.

---
*PR created automatically by Jules for task [15030863641684115639](https://jules.google.com/task/15030863641684115639) started by @hahwul*