### PR TITLE
Add 'Terracotta Tiles' example site

### DIFF
--- a/terracotta-tiles/AGENTS.md
+++ b/terracotta-tiles/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/terracotta-tiles/config.toml
+++ b/terracotta-tiles/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Terracotta Tiles"
+description = "Earthy, warm, and repetitive geometric clay patterns."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/terracotta-tiles/content/about.md
+++ b/terracotta-tiles/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About Terracotta Tiles"
++++
+
+## Inspiration
+
+This theme was designed to capture the essence of handcrafted clay tiles. It avoids gradients for depth and instead relies on solid colors, subtle opacity layers, and repetitive CSS-generated patterns to create texture.
+
+The design is bold yet grounded, offering an artistic approach to web presentation that feels tactile and warm.
+
+### The Palette
+
+- **Clay Base (`#d27b53`)**: The primary brand color.
+- **Clay Light (`#e8a584`)**: Used for highlights and blockquotes.
+- **Clay Dark (`#a95632`)**: Used for text emphasis and borders.
+- **Sand Background (`#f9f4ef`)**: A soft, off-white base that complements the warmth of the clay.

--- a/terracotta-tiles/content/index.md
+++ b/terracotta-tiles/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Terracotta Tiles"
++++
+
+Welcome to a world of warm, repetitive geometric clay patterns. This theme is inspired by traditional terracotta tiling, with an earthy and structural aesthetic.
+
+## The Aesthetic of Clay
+
+Terracotta, Italian for "baked earth", has been used throughout history for sculpture, pottery, and architecture. Its characteristic reddish-brown color comes from the iron content in the clay reacting with oxygen during firing.
+
+> "To work with clay is to work with the earth itself."
+
+### Key Features of this Theme
+
+1.  **Earthy Palette**: Utilizing shades of baked clay, mortar, and sand.
+2.  **Geometric Patterns**: Repetitive tile-like backgrounds using CSS gradients.
+3.  **Structural Layout**: Blocky, solid elements with distinct borders and shadows reminiscent of masonry.
+4.  **Warm Typography**: Serif fonts paired with italic accents to soften the structural rigidity.
+
+Explore the [Patterns](/posts/) section to see the tile grid layout in action, or read [About](/about/) the inspiration behind this design.

--- a/terracotta-tiles/content/posts/_index.md
+++ b/terracotta-tiles/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Patterns"
+template = "section"
++++

--- a/terracotta-tiles/content/posts/basketweave.md
+++ b/terracotta-tiles/content/posts/basketweave.md
@@ -1,0 +1,7 @@
++++
+title = "Basketweave"
+date = "2024-05-15"
+summary = "Interlocking pairs of tiles creating a woven effect."
++++
+
+The basketweave pattern creates a visual effect of strands woven over and under each other. When made with terracotta clay, it gives a rustic, handcrafted feel to patios and walkways.

--- a/terracotta-tiles/content/posts/herringbone.md
+++ b/terracotta-tiles/content/posts/herringbone.md
@@ -1,0 +1,9 @@
++++
+title = "Herringbone"
+date = "2024-05-10"
+summary = "A classic arrangement of rectangular tiles."
++++
+
+The herringbone pattern is an arrangement of rectangles used for floor tilings and road pavement, so named for a fancied resemblance to the bones of a fish such as a herring.
+
+It provides excellent structural integrity, making it a popular choice for brickwork and clay tiles.

--- a/terracotta-tiles/content/posts/running-bond.md
+++ b/terracotta-tiles/content/posts/running-bond.md
@@ -1,0 +1,7 @@
++++
+title = "Running Bond"
+date = "2024-05-20"
+summary = "The standard brickwork pattern, offset by half."
++++
+
+The running bond is the simplest and most common brick pattern. Each row is offset by half the width of the tile below it, creating a strong, straightforward geometric flow.

--- a/terracotta-tiles/templates/404.html
+++ b/terracotta-tiles/templates/404.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article style="text-align: center;">
+    <header class="section-header">
+        <h1>404 Not Found</h1>
+    </header>
+    <div class="content">
+        <p>The page you are looking for does not exist.</p>
+        <p style="margin-top: 2rem;"><a href="{{ base_url }}/" style="padding: 10px 20px; background-color: var(--clay-base); color: var(--text-light); text-decoration: none; border-radius: 4px;">Return to Home</a></p>
+    </div>
+</article>
+{% endblock content %}

--- a/terracotta-tiles/templates/base.html
+++ b/terracotta-tiles/templates/base.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page is defined %}{% if page.title %}{{ page.title }} | {% endif %}{% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page is defined %}{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}{% else %}{{ site.description }}{% endif %}">
+    <style>
+        :root {
+            /* Terracotta palette */
+            --clay-light: #e8a584;
+            --clay-base: #d27b53;
+            --clay-dark: #a95632;
+            --clay-shadow: #7a3c22;
+            --clay-highlight: #f3c2ab;
+            --sand-bg: #f9f4ef;
+            --sand-dark: #e6dfd6;
+            --mortar: #e0d8cc;
+            --text-dark: #3a2218;
+            --text-light: #f9f4ef;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Georgia', serif;
+            background-color: var(--sand-bg);
+            color: var(--text-dark);
+            line-height: 1.6;
+            /* Geometric clay pattern background */
+            background-image:
+                linear-gradient(45deg, var(--mortar) 25%, transparent 25%),
+                linear-gradient(-45deg, var(--mortar) 25%, transparent 25%),
+                linear-gradient(45deg, transparent 75%, var(--mortar) 75%),
+                linear-gradient(-45deg, transparent 75%, var(--mortar) 75%);
+            background-size: 40px 40px;
+            background-position: 0 0, 0 20px, 20px -20px, -20px 0px;
+        }
+
+        /* Overlay to soften the background pattern */
+        body::before {
+            content: "";
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background-color: rgba(249, 244, 239, 0.85); /* var(--sand-bg) with opacity */
+            z-index: -1;
+        }
+
+        header.site-header {
+            background-color: var(--clay-base);
+            color: var(--text-light);
+            padding: 2rem 1rem;
+            text-align: center;
+            border-bottom: 8px solid var(--clay-dark);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            /* Tile pattern for header */
+            background-image:
+                radial-gradient(circle at center, var(--clay-highlight) 2px, transparent 2px),
+                radial-gradient(circle at center, var(--clay-shadow) 2px, transparent 2px);
+            background-size: 20px 20px;
+            background-position: 0 0, 10px 10px;
+            position: relative;
+        }
+
+        header.site-header h1 {
+            margin: 0;
+            font-size: 3rem;
+            font-weight: normal;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            text-shadow: 2px 2px 0px var(--clay-shadow);
+        }
+
+        header.site-header p {
+            font-size: 1.2rem;
+            margin-top: 0.5rem;
+            font-style: italic;
+            opacity: 0.9;
+        }
+
+        nav {
+            margin-top: 1.5rem;
+        }
+
+        nav a {
+            color: var(--text-light);
+            text-decoration: none;
+            margin: 0 1rem;
+            font-size: 1.1rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.3s ease;
+        }
+
+        nav a:hover {
+            border-bottom-color: var(--clay-highlight);
+        }
+
+        main {
+            max-width: 800px;
+            margin: 3rem auto;
+            padding: 2rem;
+            background-color: var(--sand-bg);
+            border: 1px solid var(--sand-dark);
+            box-shadow:
+                0 10px 30px rgba(0,0,0,0.05),
+                inset 0 0 40px rgba(210, 123, 83, 0.05); /* subtle clay tint */
+        }
+
+        article {
+            padding: 2rem 0;
+            border-bottom: 2px solid var(--sand-dark);
+        }
+
+        article:last-child {
+            border-bottom: none;
+        }
+
+        h1, h2, h3 {
+            color: var(--clay-dark);
+            font-weight: normal;
+        }
+
+        h2 {
+            font-size: 2.2rem;
+            margin-bottom: 1rem;
+            position: relative;
+            display: inline-block;
+        }
+
+        /* Decorative underline for h2 */
+        h2::after {
+            content: "";
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 100%;
+            height: 4px;
+            background: repeating-linear-gradient(
+                45deg,
+                var(--clay-base),
+                var(--clay-base) 10px,
+                transparent 10px,
+                transparent 20px
+            );
+        }
+
+        a {
+            color: var(--clay-dark);
+            text-decoration: underline;
+            text-decoration-color: var(--clay-light);
+            text-decoration-thickness: 2px;
+            text-underline-offset: 4px;
+            transition: all 0.2s ease;
+        }
+
+        a:hover {
+            color: var(--clay-base);
+            text-decoration-color: var(--clay-base);
+        }
+
+        .meta {
+            font-size: 0.9rem;
+            color: var(--clay-shadow);
+            opacity: 0.8;
+            font-style: italic;
+            margin-bottom: 1.5rem;
+        }
+
+        /* Styling blocks of text like clay tablets */
+        blockquote {
+            margin: 2rem 0;
+            padding: 1.5rem 2rem;
+            background-color: var(--clay-light);
+            color: var(--text-dark);
+            border-left: 8px solid var(--clay-dark);
+            border-radius: 4px 12px 12px 4px;
+            box-shadow: inset 2px 2px 5px rgba(255,255,255,0.3),
+                        3px 3px 10px rgba(0,0,0,0.1);
+            font-style: italic;
+        }
+
+        /* Themed list items */
+        ul {
+            list-style-type: none;
+            padding-left: 1.5rem;
+        }
+
+        ul li {
+            position: relative;
+            margin-bottom: 0.5rem;
+        }
+
+        ul li::before {
+            content: "◆";
+            color: var(--clay-base);
+            position: absolute;
+            left: -1.5rem;
+            font-size: 0.8rem;
+            top: 0.2rem;
+        }
+
+        footer {
+            text-align: center;
+            padding: 2rem;
+            margin-top: 4rem;
+            background-color: var(--text-dark);
+            color: var(--sand-dark);
+            font-size: 0.9rem;
+            border-top: 4px solid var(--clay-dark);
+        }
+
+        /* Terracotta Tile Grid component for lists/galleries */
+        .tile-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+            gap: 20px;
+            margin: 2rem 0;
+        }
+
+        .tile {
+            background-color: var(--clay-base);
+            color: var(--text-light);
+            padding: 1.5rem;
+            border-radius: 8px;
+            box-shadow:
+                4px 4px 0px var(--clay-dark),
+                inset 2px 2px 5px rgba(255,255,255,0.2),
+                inset -2px -2px 5px rgba(0,0,0,0.1);
+            transition: transform 0.2s, box-shadow 0.2s;
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .tile::before {
+            content: "";
+            position: absolute;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background-image:
+                linear-gradient(45deg, rgba(255,255,255,0.05) 25%, transparent 25%),
+                linear-gradient(-45deg, rgba(255,255,255,0.05) 25%, transparent 25%);
+            background-size: 20px 20px;
+            pointer-events: none;
+        }
+
+        .tile:hover {
+            transform: translate(2px, 2px);
+            box-shadow:
+                2px 2px 0px var(--clay-dark),
+                inset 2px 2px 5px rgba(255,255,255,0.2),
+                inset -2px -2px 5px rgba(0,0,0,0.1);
+        }
+
+        .tile h3 {
+            color: var(--text-light);
+            margin-top: 0;
+            font-size: 1.4rem;
+            border-bottom: 2px solid rgba(255,255,255,0.2);
+            padding-bottom: 0.5rem;
+        }
+
+        .tile a {
+            color: var(--text-light);
+            text-decoration: none;
+        }
+
+        .tile a:hover {
+            color: var(--clay-highlight);
+        }
+
+        .tile a::after {
+            content: " →";
+        }
+
+        /* Section layout specific */
+        .section-header {
+            text-align: center;
+            margin-bottom: 3rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px dashed var(--clay-base);
+        }
+
+        .section-header h1 {
+            color: var(--clay-dark);
+            margin-bottom: 0.5rem;
+        }
+
+        .post-list {
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+        }
+
+        .post-item {
+            background-color: var(--sand-bg);
+            padding: 1.5rem;
+            border-radius: 2px;
+            box-shadow: 2px 2px 10px rgba(0,0,0,0.05);
+            border-left: 6px solid var(--clay-light);
+            transition: border-color 0.3s;
+        }
+
+        .post-item:hover {
+            border-left-color: var(--clay-dark);
+        }
+
+        .post-item h2 {
+            margin-top: 0;
+            font-size: 1.5rem;
+        }
+
+        .post-item h2::after {
+            display: none; /* remove underline for list items */
+        }
+
+        .post-item a {
+            text-decoration: none;
+        }
+
+        .pagination {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 3rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--sand-dark);
+        }
+    </style>
+</head>
+<body>
+    {% include "header.html" %}
+    <main>
+        {% block content %}
+        {% endblock content %}
+    </main>
+    {% include "footer.html" %}
+</body>
+</html>

--- a/terracotta-tiles/templates/footer.html
+++ b/terracotta-tiles/templates/footer.html
@@ -1,0 +1,4 @@
+<footer>
+    <p>&copy; {{ site.title }} - Geometric Clay Aesthetics</p>
+    <p>Powered by <a href="https://hwaro.hahwul.com" style="color: var(--clay-highlight);">Hwaro</a></p>
+</footer>

--- a/terracotta-tiles/templates/header.html
+++ b/terracotta-tiles/templates/header.html
@@ -1,0 +1,9 @@
+<header class="site-header">
+    <h1><a href="{{ site.base_url }}/" style="color: inherit; text-decoration: none;">{{ site.title }}</a></h1>
+    <p>{{ site.description }}</p>
+    <nav>
+        <a href="{{ site.base_url }}/">Home</a>
+        <a href="{{ site.base_url }}/about/">About</a>
+        <a href="{{ site.base_url }}/posts/">Patterns</a>
+    </nav>
+</header>

--- a/terracotta-tiles/templates/page.html
+++ b/terracotta-tiles/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article>
+    <header class="section-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="meta">{{ page.date | date(format="%B %d, %Y") }}</div>
+        {% endif %}
+    </header>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock content %}

--- a/terracotta-tiles/templates/section.html
+++ b/terracotta-tiles/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header">
+    <h1>{{ section.title | default(value="Patterns") }}</h1>
+    {% if section.description %}
+    <p class="meta">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+<div class="tile-grid">
+    {% for post in section.pages %}
+    <div class="tile">
+        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        {% if post.date %}
+        <p class="meta" style="color: rgba(255,255,255,0.7);">{{ post.date | date(format="%B %d, %Y") }}</p>
+        {% endif %}
+        {% if post.summary %}
+        <p>{{ post.summary }}</p>
+        {% endif %}
+    </div>
+    {% endfor %}
+</div>
+{% endblock content %}

--- a/terracotta-tiles/templates/shortcodes/alert.html
+++ b/terracotta-tiles/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/terracotta-tiles/templates/taxonomy.html
+++ b/terracotta-tiles/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header">
+    <h1>{{ page.title | e }}</h1>
+    <p class="meta">Browse all terms in this taxonomy:</p>
+</div>
+
+<div class="content">
+    {{ content }}
+</div>
+{% endblock content %}

--- a/terracotta-tiles/templates/taxonomy_term.html
+++ b/terracotta-tiles/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header">
+    <h1>{{ page.title | e }}</h1>
+    <p class="meta">Posts tagged with this term:</p>
+</div>
+
+<div class="content">
+    {{ content }}
+</div>
+{% endblock content %}


### PR DESCRIPTION
This PR introduces the 'Terracotta Tiles' example site to the Hwaro repository. 

The theme focuses on a grounded, "baked earth" aesthetic featuring warm colors and repetitive geometric layouts inspired by masonry and tiling. CSS `linear-gradient` is strictly used for pattern generation, not blending, aligning with an earthy design language.

Tested locally, successfully built with `hwaro build`, and verified visually via Playwright. No modifications were made to `tags.json` as requested.

---
*PR created automatically by Jules for task [3298021880036605141](https://jules.google.com/task/3298021880036605141) started by @hahwul*