### PR TITLE
feat: Add X-Ray Vision theme example site

### DIFF
--- a/x-ray/config.toml
+++ b/x-ray/config.toml
@@ -1,0 +1,9 @@
+title = "X-Ray Vision"
+description = "Transparent UI showing internal mechanical or skeletal components."
+base_url = "https://example.com"
+compile_sass = false
+minify_html = true
+default_language = "en"
+
+[extra]
+author = "Hwaro"

--- a/x-ray/content/_index.md
+++ b/x-ray/content/_index.md
@@ -1,0 +1,15 @@
++++
+title = "Project X-Ray"
++++
+
+Welcome to the internal structure overview. This transparent interface reveals the underlying mechanical skeleton driving our systems. We aim to expose the beauty of the inner workings, laying bare the gears, circuitry, and core components usually hidden beneath a sleek exterior.
+
+### Diagnostics
+
+*   **Core Temp:** Stable (32°C)
+*   **Power Flow:** Optimal
+*   **Data Link:** Secured and Active
+
+### System Overview
+
+Our mechanical skeleton provides the robust foundation necessary for high-performance operations. Each joint and gear is meticulously engineered for maximum efficiency.

--- a/x-ray/static/css/style.css
+++ b/x-ray/static/css/style.css
@@ -1,0 +1,238 @@
+/* Reset and Base Styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --xray-bg: #050a10;
+    --xray-core: #00e5ff;
+    --xray-glow: rgba(0, 229, 255, 0.6);
+    --xray-panel-bg: rgba(5, 15, 25, 0.5);
+    --xray-border: rgba(0, 229, 255, 0.3);
+    --xray-text: #e0f7fa;
+    --xray-muted: #80deea;
+    --font-mono: 'Courier New', Courier, monospace;
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+body {
+    background-color: var(--xray-bg);
+    color: var(--xray-text);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--xray-core);
+    text-shadow: 0 0 8px var(--xray-glow);
+    margin-bottom: 1rem;
+}
+
+p {
+    margin-bottom: 1rem;
+}
+
+ul {
+    margin-bottom: 1rem;
+    padding-left: 2rem;
+    list-style-type: square;
+    color: var(--xray-muted);
+}
+
+/* Background Skeleton */
+.xray-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -2;
+    pointer-events: none;
+}
+
+/* SVG Animations */
+@keyframes pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+}
+
+@keyframes rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.joint-inner {
+    transform-origin: 300px 300px;
+    animation: rotate 20s linear infinite;
+}
+
+.joint-core {
+    animation: pulse 2s ease-in-out infinite;
+}
+
+/* Scanning Line Effect */
+.xray-scanner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    pointer-events: none;
+    background: linear-gradient(to bottom,
+        transparent 0%,
+        rgba(0, 229, 255, 0.05) 50%,
+        rgba(0, 229, 255, 0.2) 51%,
+        transparent 100%);
+    background-size: 100% 200%;
+    animation: scan 8s linear infinite;
+}
+
+@keyframes scan {
+    0% { background-position: 0 -100vh; }
+    100% { background-position: 0 100vh; }
+}
+
+/* Transparent UI Panels */
+.xray-panel {
+    background: var(--xray-panel-bg);
+    border: 1px solid var(--xray-border);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-radius: 4px;
+    box-shadow:
+        inset 0 0 20px rgba(0, 229, 255, 0.05),
+        0 0 15px rgba(0, 0, 0, 0.5),
+        0 0 2px var(--xray-glow);
+    position: relative;
+    overflow: hidden;
+}
+
+/* Panel Corner Accents (Medical/Sci-Fi UI feel) */
+.xray-panel::before,
+.xray-panel::after {
+    content: '';
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    border: 2px solid var(--xray-core);
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.xray-panel::before {
+    top: -1px;
+    left: -1px;
+    border-right: none;
+    border-bottom: none;
+}
+
+.xray-panel::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: none;
+    border-top: none;
+}
+
+/* Layout */
+.site-header {
+    margin: 2rem auto;
+    padding: 2rem;
+    max-width: 800px;
+    width: 90%;
+    text-align: center;
+}
+
+.site-title {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.site-description {
+    font-family: var(--font-mono);
+    color: var(--xray-muted);
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+}
+
+.site-main {
+    flex-grow: 1;
+    max-width: 800px;
+    width: 90%;
+    margin: 0 auto 2rem auto;
+}
+
+.content-panel {
+    padding: 2rem;
+}
+
+.content-header {
+    border-bottom: 1px solid var(--xray-border);
+    padding-bottom: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.xray-meta-bar {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--xray-muted);
+    margin-top: 0.5rem;
+}
+
+.xray-status {
+    color: #00ff66;
+    text-shadow: 0 0 5px rgba(0, 255, 102, 0.5);
+}
+
+.site-footer {
+    margin: auto auto 2rem auto;
+    padding: 1rem;
+    max-width: 800px;
+    width: 90%;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+
+/* Links */
+a {
+    color: var(--xray-core);
+    text-decoration: none;
+    position: relative;
+    transition: all 0.3s ease;
+}
+
+a:hover {
+    text-shadow: 0 0 8px var(--xray-glow);
+}
+
+a::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background-color: var(--xray-core);
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.3s ease;
+}
+
+a:hover::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}

--- a/x-ray/templates/base.html
+++ b/x-ray/templates/base.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% elif section.title %}{{ section.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ get_url(path="css/style.css") }}">
+</head>
+<body>
+    <div class="xray-background">
+        <!-- Abstract mechanical/skeletal SVG background -->
+        <svg class="mechanical-skeleton" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                    <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(0, 255, 255, 0.15)" stroke-width="1"/>
+                </pattern>
+                <pattern id="circuit" width="100" height="100" patternUnits="userSpaceOnUse">
+                    <circle cx="20" cy="20" r="3" fill="rgba(0, 255, 255, 0.3)" />
+                    <circle cx="80" cy="50" r="4" fill="none" stroke="rgba(0, 255, 255, 0.4)" stroke-width="2"/>
+                    <path d="M 20 20 L 50 20 L 80 50" fill="none" stroke="rgba(0, 255, 255, 0.2)" stroke-width="2"/>
+                    <path d="M 80 50 L 80 90" fill="none" stroke="rgba(0, 255, 255, 0.2)" stroke-width="2"/>
+                    <rect x="70" y="80" width="20" height="10" fill="rgba(0, 255, 255, 0.1)" stroke="rgba(0, 255, 255, 0.3)"/>
+                </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill="url(#grid)" />
+            <rect width="100%" height="100%" fill="url(#circuit)" />
+
+            <!-- Large abstract "bones" or structural elements -->
+            <path class="bone" d="M -50 200 C 150 150, 300 400, 500 350 S 800 100, 1200 200" fill="none" stroke="rgba(0, 200, 255, 0.1)" stroke-width="40" stroke-linecap="round" />
+            <path class="bone-core" d="M -50 200 C 150 150, 300 400, 500 350 S 800 100, 1200 200" fill="none" stroke="rgba(255, 255, 255, 0.3)" stroke-width="10" stroke-linecap="round" />
+
+            <circle class="joint" cx="300" cy="300" r="60" fill="none" stroke="rgba(0, 255, 255, 0.15)" stroke-width="15" />
+            <circle class="joint-inner" cx="300" cy="300" r="40" fill="none" stroke="rgba(255, 255, 255, 0.4)" stroke-width="4" stroke-dasharray="10 5" />
+            <circle class="joint-core" cx="300" cy="300" r="10" fill="rgba(0, 255, 255, 0.6)" />
+
+            <!-- Spine-like structure -->
+            <g class="spine" transform="translate(80%, 0)">
+                <line x1="0" y1="0" x2="0" y2="1000" stroke="rgba(0, 200, 255, 0.2)" stroke-width="20" />
+                <line x1="0" y1="0" x2="0" y2="1000" stroke="rgba(255, 255, 255, 0.4)" stroke-width="4" stroke-dasharray="20 40" />
+                <path d="M -30 100 L 30 100 M -40 200 L 40 200 M -35 300 L 35 300 M -45 400 L 45 400" stroke="rgba(0, 255, 255, 0.3)" stroke-width="6" />
+            </g>
+        </svg>
+    </div>
+
+    <div class="xray-scanner"></div>
+
+    <header class="site-header xray-panel">
+        <h1 class="site-title">{{ site.title }}</h1>
+        {% if site.description %}
+            <p class="site-description">{{ site.description }}</p>
+        {% endif %}
+    </header>
+
+    <main class="site-main">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer xray-panel">
+        <p>&copy; {{ site.extra.author }}</p>
+    </footer>
+</body>
+</html>

--- a/x-ray/templates/index.html
+++ b/x-ray/templates/index.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="xray-panel content-panel">
+    <header class="content-header">
+        <h2 class="content-title">{{ section.title }}</h2>
+        <div class="xray-meta-bar">
+            <span class="xray-status">[STATUS: NOMINAL]</span>
+            <span class="xray-id">ID: 0xXRY-{{ section.title | length }}</span>
+        </div>
+    </header>
+    <div class="content-body">
+        {{ section.content | safe }}
+    </div>
+</article>
+{% endblock content %}

--- a/x-ray/templates/page.html
+++ b/x-ray/templates/page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="xray-panel content-panel">
+    <header class="content-header">
+        <h2 class="content-title">{{ page.title }}</h2>
+        <div class="xray-meta-bar">
+            {% if page.date %}
+            <span class="xray-date">LOG DATE: {{ page.date | date(format="%Y-%m-%d") }}</span>
+            {% endif %}
+            <span class="xray-status">[STATUS: SECURE]</span>
+        </div>
+    </header>
+    <div class="content-body">
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Added a new Hwaro example site titled "X-Ray Vision" in the `x-ray` directory.
The design uses `backdrop-filter` for translucent UI panels and an intricate inline SVG background with CSS animations to simulate mechanical joints and circuits underneath the UI, paired with a glowing scanning line.
Ensured all configuration files, templates, and content use correct Zola/Hwaro conventions.
Explicitly left `tags.json` untouched to meet the strict requirement.

---
*PR created automatically by Jules for task [8491472534740131733](https://jules.google.com/task/8491472534740131733) started by @hahwul*