### PR TITLE
feat: add topographic-sand example site

### DIFF
--- a/topographic-sand/AGENTS.md
+++ b/topographic-sand/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/topographic-sand/config.toml
+++ b/topographic-sand/config.toml
@@ -1,0 +1,245 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Topographic Sand"
+description = "A 'Zen garden' feel with sand-ripple patterns and stones."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+# =============================================================================
+# Highlight
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/topographic-sand/content/about.md
+++ b/topographic-sand/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About"
+date = "2023-10-25"
++++
+
+This theme is designed for those who appreciate minimalism and structure. The elements represent stones resting on rippling sand.
+
+It is ideal for essays, poetry, or thoughts that require a calm, uninterrupted environment.

--- a/topographic-sand/content/index.md
+++ b/topographic-sand/content/index.md
@@ -1,0 +1,21 @@
++++
+title = "A Zen Garden Experience"
+description = "Find peace and tranquility in the topographic sand patterns."
+date = "2023-10-25"
++++
+
+Welcome to Topographic Sand. This is a place of reflection and digital mindfulness.
+
+The design utilizes a procedural topographic background resembling raked sand in a traditional Japanese Zen garden. The typography is clean and elegant, providing a serene reading experience.
+
+Here are a few principles of this digital garden:
+
+1. **Simplicity:** Remove what is unnecessary.
+2. **Asymmetry:** Balance without exact replication.
+3. **Naturalness:** Forms that feel organic and unforced.
+
+> "Nature does not hurry, yet everything is accomplished." - Lao Tzu
+
+### Contemplating the Stones
+
+The aesthetic uses dark, smooth stones for structure and visual anchoring. They sit atop the rippled sand, creating a grounded sensation in the layout.

--- a/topographic-sand/content/posts/_index.md
+++ b/topographic-sand/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/topographic-sand/content/posts/raking-sand.md
+++ b/topographic-sand/content/posts/raking-sand.md
@@ -1,0 +1,11 @@
++++
+title = "The Art of Raking Sand"
+description = "Understanding the patterns in the Zen garden."
+date = "2023-10-26"
++++
+
+In a traditional karesansui (dry landscape) garden, the act of raking sand or gravel into patterns is a meditative practice. The patterns often represent water, with concentric circles around rocks mimicking ripples from a stone dropped in a pond, and straight lines representing calm currents.
+
+This theme attempts to capture that essence digitally. The background uses a generated SVG topographic pattern that gently shifts, representing the continuous but slow change of nature.
+
+The structural elements are designed to feel heavy and solid, like the carefully placed stones in a real garden. Contrast this with the light, airy sand background.

--- a/topographic-sand/templates/404.html
+++ b/topographic-sand/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main>
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/topographic-sand/templates/footer.html
+++ b/topographic-sand/templates/footer.html
@@ -1,0 +1,6 @@
+        <footer>
+            <p>&copy; {{ current_year }} {{ site.title }}. Designed with serenity.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/topographic-sand/templates/header.html
+++ b/topographic-sand/templates/header.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site.title }} - {{ page.title | default(value=site.description) }}</title>
+    <meta name="description" content="{{ site.description }}">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,400&family=Lato:wght@300;400&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            /* Sand Colors */
+            --sand-light: #f5f2eb;
+            --sand-base: #e8e3d3;
+            --sand-dark: #d8d1bc;
+            --sand-shadow: #c5bba1;
+
+            /* Stone Colors */
+            --stone-dark: #2c2f33;
+            --stone-medium: #4a4e54;
+            --stone-light: #6a6f78;
+
+            /* Typography */
+            --font-heading: 'Cormorant Garamond', serif;
+            --font-body: 'Lato', sans-serif;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--sand-base);
+            color: var(--stone-dark);
+            font-family: var(--font-body);
+            line-height: 1.7;
+            font-weight: 300;
+            overflow-x: hidden;
+
+            /* Topographic Sand Pattern Background (SVG Data URI) */
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.005' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.25 0'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 1'/%3E%3C/feComponentTransfer%3E%3CfeGaussianBlur stdDeviation='2'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='linear' slope='2' intercept='-0.5'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23e8e3d3'/%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' fill='%23d8d1bc' opacity='0.4'/%3E%3C/svg%3E");
+            background-attachment: fixed;
+            background-size: cover;
+        }
+
+        /* Better ripple pattern via CSS masks */
+        .sand-ripple {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            pointer-events: none;
+            z-index: -1;
+            opacity: 0.15;
+            background-image:
+                radial-gradient(circle at 50% 50%, transparent 20%, var(--sand-dark) 21%, transparent 22%),
+                radial-gradient(circle at 50% 50%, transparent 30%, var(--sand-dark) 31%, transparent 32%),
+                radial-gradient(circle at 50% 50%, transparent 40%, var(--sand-dark) 41%, transparent 42%),
+                radial-gradient(circle at 50% 50%, transparent 50%, var(--sand-dark) 51%, transparent 52%),
+                radial-gradient(circle at 50% 50%, transparent 60%, var(--sand-dark) 61%, transparent 62%),
+                radial-gradient(circle at 50% 50%, transparent 70%, var(--sand-dark) 71%, transparent 72%),
+                radial-gradient(circle at 50% 50%, transparent 80%, var(--sand-dark) 81%, transparent 82%),
+                radial-gradient(circle at 50% 50%, transparent 90%, var(--sand-dark) 91%, transparent 92%);
+            background-size: 150vw 150vw;
+            background-position: center;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+        }
+
+        /* The Stone Header */
+        .site-header {
+            background-color: var(--stone-dark);
+            color: var(--sand-light);
+            padding: 60px 40px;
+            margin-bottom: 60px;
+            border-radius: 40px 4px 40px 4px; /* Organic stone-like shape */
+            box-shadow:
+                10px 10px 20px rgba(0, 0, 0, 0.1),
+                -5px -5px 15px rgba(255, 255, 255, 0.1) inset,
+                5px 5px 15px rgba(0, 0, 0, 0.5) inset;
+            position: relative;
+        }
+
+        /* Subtle texture on the stone */
+        .site-header::after {
+            content: "";
+            position: absolute;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
+            border-radius: inherit;
+            pointer-events: none;
+        }
+
+        .site-header h1 {
+            color: var(--sand-light);
+            font-family: var(--font-heading);
+            font-size: 3rem;
+            font-weight: 300;
+            margin: 0 0 10px 0;
+            letter-spacing: 2px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .site-header p {
+            margin: 0;
+            font-size: 1.1rem;
+            color: var(--sand-shadow);
+            position: relative;
+            z-index: 1;
+        }
+
+        nav {
+            margin-top: 30px;
+            position: relative;
+            z-index: 1;
+        }
+
+        nav a {
+            color: var(--sand-base);
+            text-decoration: none;
+            margin-right: 20px;
+            font-size: 0.9rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            border-bottom: 1px solid transparent;
+            transition: all 0.3s ease;
+        }
+
+        nav a:hover {
+            color: white;
+            border-bottom: 1px solid var(--sand-light);
+        }
+
+        /* Content Area */
+        main {
+            background-color: rgba(255, 255, 255, 0.6);
+            backdrop-filter: blur(5px);
+            padding: 50px;
+            border-radius: 2px 20px 2px 20px;
+            box-shadow:
+                5px 5px 15px rgba(0, 0, 0, 0.05),
+                -5px -5px 15px rgba(255, 255, 255, 0.5);
+            position: relative;
+        }
+
+        /* A smaller "stone" acting as an accent */
+        main::before {
+            content: "";
+            position: absolute;
+            top: -20px;
+            right: 40px;
+            width: 40px;
+            height: 30px;
+            background-color: var(--stone-medium);
+            border-radius: 60% 40% 50% 50% / 50% 50% 40% 60%;
+            box-shadow:
+                3px 5px 8px rgba(0,0,0,0.2),
+                inset -2px -3px 5px rgba(0,0,0,0.4),
+                inset 2px 3px 5px rgba(255,255,255,0.1);
+        }
+
+        h1, h2, h3 {
+            font-family: var(--font-heading);
+            color: var(--stone-dark);
+            font-weight: 400;
+        }
+
+        .post-header h1 {
+            color: var(--stone-dark);
+        }
+
+        h2 {
+            font-size: 2.2rem;
+            margin-top: 40px;
+            border-bottom: 1px solid var(--sand-shadow);
+            padding-bottom: 10px;
+            display: inline-block;
+        }
+
+        a {
+            color: var(--stone-medium);
+            text-decoration: none;
+            border-bottom: 1px solid var(--sand-shadow);
+            transition: color 0.3s, border-color 0.3s;
+        }
+
+        a:hover {
+            color: var(--stone-dark);
+            border-color: var(--stone-dark);
+        }
+
+        blockquote {
+            margin: 40px 0;
+            padding: 20px 40px;
+            font-family: var(--font-heading);
+            font-size: 1.5rem;
+            font-style: italic;
+            color: var(--stone-medium);
+            border-left: 4px solid var(--stone-light);
+            background-color: rgba(245, 242, 235, 0.5);
+            border-radius: 0 10px 10px 0;
+        }
+
+        code {
+            background-color: var(--sand-light);
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 0.9em;
+            color: var(--stone-medium);
+        }
+
+        pre code {
+            display: block;
+            padding: 20px;
+            background-color: var(--stone-dark);
+            color: var(--sand-light);
+            border-radius: 8px;
+            overflow-x: auto;
+            box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+        }
+
+        ul, ol {
+            padding-left: 20px;
+        }
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        /* Posts List */
+        .post-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .post-item {
+            margin-bottom: 30px;
+            padding-bottom: 30px;
+            border-bottom: 1px solid rgba(0,0,0,0.05);
+        }
+
+        .post-item h2 {
+            margin-top: 0;
+            margin-bottom: 10px;
+            border-bottom: none;
+            padding-bottom: 0;
+        }
+
+        .post-meta {
+            font-size: 0.85rem;
+            color: var(--stone-light);
+            margin-bottom: 15px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        footer {
+            margin-top: 80px;
+            text-align: center;
+            padding: 40px 0;
+            color: var(--stone-light);
+            font-size: 0.9rem;
+            border-top: 1px solid var(--sand-shadow);
+        }
+    </style>
+</head>
+<body>
+    <div class="sand-ripple"></div>
+    <div class="container">
+        <header class="site-header">
+            <h1>{{ site.title }}</h1>
+            <p>{{ site.description }}</p>
+            <nav>
+                <a href="{{ site.base_url }}/">Home</a>
+                <a href="{{ site.base_url }}/posts">Posts</a>
+                <a href="{{ site.base_url }}/about">About</a>
+            </nav>
+        </header>

--- a/topographic-sand/templates/page.html
+++ b/topographic-sand/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<main>
+    <article>
+        <header class="post-header">
+            {% if page.title != "Posts" and page.title != "A Zen Garden Experience" and page.title != "About" %}
+                <h1>{{ page.title }}</h1>
+                {% if page.date %}
+                    <div class="post-meta">
+                        {{ page.date | date("%B %d, %Y") }}
+                    </div>
+                {% endif %}
+            {% else %}
+                <!-- Title hidden for specific pages as it's part of content or section -->
+            {% endif %}
+        </header>
+
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </article>
+</main>
+
+{% include "footer.html" %}

--- a/topographic-sand/templates/section.html
+++ b/topographic-sand/templates/section.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+
+<main>
+    <h1>{{ section.title }}</h1>
+
+    {% if content %}
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    {% endif %}
+
+    <ul class="post-list">
+        {% for post in section.pages %}
+        <li class="post-item">
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            {% if post.date %}
+                <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
+            {% endif %}
+            {% if post.summary %}
+                <p>{{ post.summary }}</p>
+            {% elif post.description %}
+                <p>{{ post.description }}</p>
+            {% else %}
+                <p>{{ post.content | strip_html | truncate(length=150) }}</p>
+            {% endif %}
+            <a href="{{ post.url }}" class="read-more">Read Contemplation &rarr;</a>
+        </li>
+        {% endfor %}
+    </ul>
+</main>
+
+{% include "footer.html" %}

--- a/topographic-sand/templates/taxonomy.html
+++ b/topographic-sand/templates/taxonomy.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/topographic-sand/templates/taxonomy_term.html
+++ b/topographic-sand/templates/taxonomy_term.html
@@ -1,0 +1,6 @@
+{% include "header.html" %}
+  <main>
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a new Hwaro example site called `topographic-sand`. It features a highly artistic "Zen garden" theme, utilizing procedural SVG noise and CSS radial-gradients for sand ripples, along with dark, smooth border-radius shapes to simulate stones. 

It contains the site skeleton generated by `hwaro init` along with custom content and templates. The `tags.json` file remains completely unmodified as requested.

---
*PR created automatically by Jules for task [11521220791539924256](https://jules.google.com/task/11521220791539924256) started by @hahwul*