### PR TITLE
Add Iridescent Oil theme

### DIFF
--- a/iridescent-oil/AGENTS.md
+++ b/iridescent-oil/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/iridescent-oil/config.toml
+++ b/iridescent-oil/config.toml
@@ -1,0 +1,31 @@
+title = "Iridescent Oil"
+description = "Swirling, multicolored oil-on-water textures for a psychedelic look."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/iridescent-oil/content/about.md
+++ b/iridescent-oil/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About This Theme"
+date = "2024-05-10"
++++
+
+This theme was built as a creative experiment to see how far we can push native web technologies like SVG and CSS to create art.
+
+The core of the effect lies in the `<feTurbulence>` and `<feDisplacementMap>` SVG filters. By generating a fractal noise pattern and applying it as a displacement map over CSS gradient blobs, we create the swirling, fluid motion characteristic of oil on water.
+
+### The Code
+
+We define the SVG filter hidden in the HTML, then apply it via CSS:
+
+```css
+.oil-background {
+    filter: url(#oil-swirl) contrast(1.5) saturate(2);
+}
+```
+
+The underlying blobs are animated using CSS `@keyframes`, which when distorted by the SVG filter, creates a continuous, organic fluid simulation.

--- a/iridescent-oil/content/index.md
+++ b/iridescent-oil/content/index.md
@@ -1,0 +1,18 @@
++++
+title = "Swirling Colors"
+date = "2024-05-10"
++++
+
+Welcome to **Iridescent Oil**.
+
+This site demonstrates a highly psychedelic, fluid aesthetic using complex **CSS mix-blend-mode** and **SVG feTurbulence** filters to create the illusion of an oil slick on water.
+
+The background is completely dynamic, animated purely through CSS and SVG filters. The text container uses a deep `backdrop-filter: blur()` effect to separate the content from the chaotic, shifting colors behind it, known as "glassmorphism".
+
+**Key Features:**
+*   Psychedelic dynamic background using SVG displacement.
+*   Glassmorphism UI elements for contrast and readability.
+*   Animated linear-gradient text effects for strong elements.
+*   A space-age typography approach using 'Space Grotesk'.
+
+Explore the chaotic beauty of fluid dynamics mapped into code.

--- a/iridescent-oil/static/css/style.css
+++ b/iridescent-oil/static/css/style.css
@@ -1,0 +1,188 @@
+:root {
+  --primary: #ffffff;
+  --bg-color: #050505;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--primary);
+  line-height: 1.6;
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Iridescent Oil Background setup */
+.oil-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  overflow: hidden;
+  background: black;
+  /* Complex gradient mix blending */
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 0, 150, 0.4), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(0, 255, 200, 0.5), transparent 50%),
+    radial-gradient(circle at 20% 80%, rgba(100, 50, 255, 0.5), transparent 50%);
+  filter: url(#oil-swirl) contrast(1.5) saturate(2);
+  animation: bgPulse 20s infinite alternate linear;
+}
+
+@keyframes bgPulse {
+  0% { transform: scale(1) translate(0, 0); }
+  50% { transform: scale(1.1) translate(2%, -2%); }
+  100% { transform: scale(1.2) translate(-2%, 2%); }
+}
+
+.blob {
+  position: absolute;
+  filter: blur(40px);
+  border-radius: 50%;
+  animation: float 20s infinite linear;
+  opacity: 0.8;
+  mix-blend-mode: screen;
+}
+
+.blob:nth-child(1) {
+  width: 60vw; height: 60vw;
+  background: linear-gradient(45deg, #ff0055, #ff00cc);
+  top: -20%; left: -10%;
+  animation-duration: 25s;
+}
+
+.blob:nth-child(2) {
+  width: 50vw; height: 50vw;
+  background: linear-gradient(135deg, #00ffcc, #0055ff);
+  bottom: -20%; right: -10%;
+  animation-duration: 30s;
+  animation-direction: reverse;
+}
+
+.blob:nth-child(3) {
+  width: 70vw; height: 70vw;
+  background: linear-gradient(225deg, #ccff00, #ff5500);
+  top: 20%; left: 30%;
+  animation-duration: 35s;
+}
+
+@keyframes float {
+  0% { transform: rotate(0deg) translate(50px) rotate(0deg); }
+  100% { transform: rotate(360deg) translate(50px) rotate(-360deg); }
+}
+
+/* Glassmorphism content container */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+  position: relative;
+  z-index: 1;
+}
+
+header {
+  margin-bottom: 4rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(255,255,255,0.2);
+  text-align: center;
+}
+
+header a {
+  text-decoration: none;
+  color: #fff;
+}
+
+.logo {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -1px;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 0 20px rgba(255,255,255,0.5);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.nav-links a {
+  font-size: 1.1rem;
+  font-weight: 500;
+  text-transform: lowercase;
+  opacity: 0.8;
+  transition: opacity 0.3s;
+}
+
+.nav-links a:hover {
+  opacity: 1;
+  text-shadow: 0 0 10px #fff;
+}
+
+.content {
+  background: rgba(10, 10, 10, 0.4);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 3rem;
+  border-radius: 20px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+}
+
+h1, h2, h3 {
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  line-height: 1.2;
+}
+
+h1 { font-size: 2.5rem; }
+h2 { font-size: 2rem; margin-top: 2rem; }
+
+p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  opacity: 0.9;
+}
+
+a {
+  color: #fff;
+  text-decoration: underline;
+  text-decoration-color: rgba(255,255,255,0.5);
+  text-underline-offset: 4px;
+}
+
+a:hover {
+  text-decoration-color: #fff;
+}
+
+footer {
+  margin-top: 4rem;
+  text-align: center;
+  padding: 2rem;
+  font-size: 0.9rem;
+  opacity: 0.6;
+}
+
+/* Custom iridescent text effect for strong tags */
+strong {
+  background: linear-gradient(45deg, #ff0055, #00ffcc, #ccff00);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-size: 200% auto;
+  animation: shine 3s linear infinite;
+}
+
+@keyframes shine {
+  to { background-position: 200% center; }
+}

--- a/iridescent-oil/templates/404.html
+++ b/iridescent-oil/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/iridescent-oil/templates/footer.html
+++ b/iridescent-oil/templates/footer.html
@@ -1,0 +1,6 @@
+      <footer>
+          &copy; {{ current_year }} {{ site.title }}. Designed for Hwaro Examples.
+      </footer>
+    </div>
+</body>
+</html>

--- a/iridescent-oil/templates/header.html
+++ b/iridescent-oil/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- SVG Filter for the oil texture effect -->
+    <svg style="display: none;">
+      <defs>
+        <filter id="oil-swirl">
+          <feTurbulence type="fractalNoise" baseFrequency="0.015" numOctaves="3" result="noise">
+            <animate attributeName="baseFrequency" values="0.015;0.010;0.015" dur="30s" repeatCount="indefinite" />
+          </feTurbulence>
+          <feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -5" in="noise" result="coloredNoise" />
+          <feDisplacementMap in="SourceGraphic" in2="coloredNoise" scale="100" xChannelSelector="R" yChannelSelector="G" result="displacement" />
+          <feGaussianBlur in="displacement" stdDeviation="5" result="blur" />
+          <feComposite in="blur" in2="SourceGraphic" operator="over" />
+        </filter>
+      </defs>
+    </svg>
+
+    <div class="oil-background">
+      <div class="blob"></div>
+      <div class="blob"></div>
+      <div class="blob"></div>
+    </div>
+
+    <div class="container">
+      <header>
+          <a href="{{ site.base_url }}/"><div class="logo">{{ site.title }}</div></a>
+          <div class="nav-links">
+              <a href="{{ site.base_url }}/">Home</a>
+              <a href="{{ site.base_url }}/about/">About</a>
+          </div>
+      </header>

--- a/iridescent-oil/templates/page.html
+++ b/iridescent-oil/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<main class="content">
+    {% if page is defined and page.title %}
+      <h1>{{ page.title }}</h1>
+    {% endif %}
+    {{ content | safe }}
+</main>
+
+{% include "footer.html" %}

--- a/iridescent-oil/templates/section.html
+++ b/iridescent-oil/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<main class="content">
+    {% if section is defined and section.title %}
+      <h1>{{ section.title }}</h1>
+    {% endif %}
+
+    {{ content | safe }}
+
+    <div class="post-list">
+        {% if section is defined and section.pages %}
+            {% for post in section.pages %}
+            <article class="post-item" style="margin-bottom: 2rem; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 1rem;">
+                <h2 style="margin-bottom: 0.5rem;"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+                {% if post.date %}
+                <div class="meta" style="font-size: 0.9rem; opacity: 0.7; margin-bottom: 1rem;">{{ post.date | date(format="%B %d, %Y") }}</div>
+                {% endif %}
+                <p>{{ post.summary | default(value="Read more about "~post.title) }}</p>
+            </article>
+            {% endfor %}
+        {% endif %}
+    </div>
+</main>
+
+{% include "footer.html" %}

--- a/iridescent-oil/templates/shortcodes/alert.html
+++ b/iridescent-oil/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/iridescent-oil/templates/taxonomy.html
+++ b/iridescent-oil/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/iridescent-oil/templates/taxonomy_term.html
+++ b/iridescent-oil/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds the `iridescent-oil` theme to the Hwaro examples repository.

The theme demonstrates an artistic fluid aesthetic utilizing native web technologies:
- `feTurbulence` and `feDisplacementMap` SVG filters for organic distortion.
- CSS `mix-blend-mode` for blending gradient blobs.
- Glassmorphism (`backdrop-filter: blur`) UI to float above the chaotic background.
- Animated `linear-gradient` text effects.

No changes were made to the `tags.json` file, strictly following the project constraints. The implementation is isolated entirely within the `iridescent-oil/` directory.

---
*PR created automatically by Jules for task [1820783646397452818](https://jules.google.com/task/1820783646397452818) started by @hahwul*