### PR TITLE
feat: add Oscilloscope Trace theme example site

### DIFF
--- a/oscilloscope/AGENTS.md
+++ b/oscilloscope/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/oscilloscope/config.toml
+++ b/oscilloscope/config.toml
@@ -1,0 +1,8 @@
+base_url = "https://example.com"
+title = "Oscilloscope Trace"
+description = "Green phosphorescent wave-lines on a dark, curved CRT screen effect."
+default_language = "en"
+
+[extra]
+author = "Jules"
+theme_color = "#151515"

--- a/oscilloscope/content/about.md
+++ b/oscilloscope/content/about.md
@@ -1,0 +1,14 @@
++++
+title: "ABOUT CALIBRATION"
+description: "Calibration instructions"
+date: "1970-01-01"
++++
+
+### INSTRUMENT CALIBRATION
+
+To properly calibrate this instrument, connect a 1 kHz square wave from the internal oscillator to CH1 input. Adjust the V/DIV and TIME/DIV knobs until a stable trace is displayed.
+
+The graticule provides a reference grid. The primary divisions are 1 cm apart, while the subdivisions provide 0.2 cm increments for accurate reading.
+
+* **PROBE COMPENSATION:** Adjust the probe capacitor to achieve perfectly square corners on the reference waveform.
+* **FOCUS & INTENSITY:** Keep intensity as low as possible while still maintaining a visible trace to prevent burning the phosphor coating on the screen.

--- a/oscilloscope/content/index.md
+++ b/oscilloscope/content/index.md
@@ -1,0 +1,19 @@
++++
+title: "SYSTEM INITIALIZED"
+description: "Welcome to the oscilloscope interface"
+date: "1970-01-01"
++++
+
+### SIGNAL LOCK ESTABLISHED
+
+The oscilloscope is a type of electronic test instrument that graphically displays varying signal voltages, usually as a calibrated two-dimensional plot of one or more signals as a function of time.
+
+This theme features a **curved CRT effect**, a persistent phosphorescent glow, and simulated scanlines—all achieved without using CSS gradients to maintain pure rendering speed.
+
+#### KEY FEATURES
+* No Gradients (SVG Patterns used instead)
+* Pure HTML/CSS/SVG
+* High contrast green-on-black UI
+* Simulated CRT flicker and scanlines
+
+> `WARNING: HIGH VOLTAGE INSIDE CRT ENCLOSURE. DO NOT OPEN.`

--- a/oscilloscope/static/css/style.css
+++ b/oscilloscope/static/css/style.css
@@ -1,0 +1,203 @@
+:root {
+    --bg-color: #050a05;
+    --phosphor-green: #00ff00;
+    --phosphor-glow: rgba(0, 255, 0, 0.6);
+    --phosphor-dim: #005500;
+    --bezel-color: #1a1a1a;
+    --bezel-shadow: #000;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #111;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    font-family: 'Courier New', Courier, monospace;
+    color: var(--phosphor-green);
+}
+
+.crt-bezel {
+    width: 90vw;
+    max-width: 1200px;
+    height: 85vh;
+    background-color: var(--bezel-color);
+    border-radius: 40px;
+    padding: 30px;
+    box-shadow:
+        inset 0 0 20px #000,
+        0 10px 30px rgba(0,0,0,0.8),
+        0 0 0 5px #222;
+    position: relative;
+    overflow: hidden;
+}
+
+.crt-screen {
+    width: 100%;
+    height: 100%;
+    background-color: var(--bg-color);
+    border-radius: 20px;
+    position: relative;
+    overflow: hidden;
+    box-shadow:
+        inset 0 0 50px rgba(0,255,0,0.1),
+        0 0 20px rgba(0,255,0,0.2);
+    /* simulate curvature without gradients: inset solid box-shadows */
+    box-shadow:
+        inset 0px 0px 80px 20px rgba(0,0,0,0.9),
+        0 0 20px var(--phosphor-dim);
+}
+
+/* Base text styling */
+h1, h2, h3, h4, h5, h6 {
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    text-shadow: 0 0 5px var(--phosphor-glow), 0 0 10px var(--phosphor-glow);
+    margin-bottom: 20px;
+}
+
+a {
+    color: var(--phosphor-green);
+    text-decoration: none;
+    text-shadow: 0 0 5px var(--phosphor-glow);
+    border-bottom: 1px dashed var(--phosphor-dim);
+    transition: all 0.2s;
+}
+
+a:hover {
+    color: #fff;
+    background-color: var(--phosphor-dim);
+    text-shadow: 0 0 8px #fff;
+}
+
+/* Animations */
+@keyframes flicker {
+    0% { opacity: 0.95; }
+    5% { opacity: 0.85; }
+    10% { opacity: 0.95; }
+    15% { opacity: 1; }
+    100% { opacity: 1; }
+}
+
+.flicker {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,255,0,0.02);
+    pointer-events: none;
+    animation: flicker 0.15s infinite alternate;
+    z-index: 15;
+}
+
+@keyframes trace-anim {
+    from { stroke-dashoffset: 2000; }
+    to { stroke-dashoffset: 0; }
+}
+
+.grid-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    pointer-events: none;
+}
+
+.trace, .trace-glow {
+    stroke-dasharray: 2000;
+    animation: trace-anim 4s linear infinite;
+}
+
+/* Content layout */
+.screen-content {
+    position: relative;
+    z-index: 20;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 20px;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 2px solid var(--phosphor-dim);
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+.status-bar {
+    display: flex;
+    gap: 20px;
+    font-weight: bold;
+}
+
+.blink {
+    animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+nav {
+    display: flex;
+    gap: 15px;
+}
+
+main {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 15px;
+}
+
+/* Scrollbar styling */
+main::-webkit-scrollbar {
+    width: 10px;
+}
+main::-webkit-scrollbar-track {
+    background: rgba(0, 50, 0, 0.2);
+    border-left: 1px solid var(--phosphor-dim);
+}
+main::-webkit-scrollbar-thumb {
+    background: var(--phosphor-dim);
+}
+
+footer {
+    border-top: 2px solid var(--phosphor-dim);
+    padding-top: 10px;
+    margin-top: 20px;
+}
+
+.footer-info {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9em;
+}
+
+.page-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+.page-list li {
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+}
+
+.timestamp {
+    color: var(--phosphor-dim);
+    margin-right: 15px;
+}
+
+/* Selection */
+::selection {
+    background-color: var(--phosphor-green);
+    color: #000;
+}

--- a/oscilloscope/templates/404.html
+++ b/oscilloscope/templates/404.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Not Found | {{ site.title }}</title>
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+</head>
+<body>
+    <div class="crt-bezel">
+        <div class="crt-screen">
+            <svg class="grid-overlay" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(0, 255, 0, 0.2)" stroke-width="1"/>
+                        <path d="M 20 0 L 20 40 M 0 20 L 40 20" fill="none" stroke="rgba(0, 255, 0, 0.1)" stroke-width="0.5" stroke-dasharray="2,2"/>
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#grid)" />
+                <path class="trace" d="M -100 200 L 100 200 L 150 100 L 200 300 L 250 200 L 1500 200" fill="none" stroke="#f00" stroke-width="3" />
+            </svg>
+            <div class="screen-content">
+                {% include "header.html" %}
+                <main style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
+                    <h1 style="font-size: 4em; color: #f00; text-shadow: 0 0 10px #f00;">ERR 404</h1>
+                    <p>SIGNAL LOST. NO TRACE DETECTED AT THIS COORDINATE.</p>
+                </main>
+                {% include "footer.html" %}
+            </div>
+            <svg class="scanlines" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none; position: absolute; top: 0; left: 0; z-index: 10;">
+                <defs>
+                    <pattern id="scanlines" width="4" height="4" patternUnits="userSpaceOnUse">
+                        <rect width="4" height="2" fill="rgba(0,0,0,0.3)" />
+                        <rect y="2" width="4" height="2" fill="transparent" />
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#scanlines)" />
+            </svg>
+            <div class="flicker"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/oscilloscope/templates/footer.html
+++ b/oscilloscope/templates/footer.html
@@ -1,0 +1,7 @@
+<footer>
+    <div class="footer-info">
+        <span>FREQ: 1.000 kHz</span>
+        <span>VPP: 4.80 V</span>
+        <span>&copy; {{ site.title }}</span>
+    </div>
+</footer>

--- a/oscilloscope/templates/header.html
+++ b/oscilloscope/templates/header.html
@@ -1,0 +1,11 @@
+<header>
+    <div class="status-bar">
+        <span>CH1: 2V/DIV</span>
+        <span>TIME: 5ms/DIV</span>
+        <span class="blink">TRIG'D</span>
+    </div>
+    <nav>
+        <a href="/">HOME</a>
+        <a href="/about/">ABOUT</a>
+    </nav>
+</header>

--- a/oscilloscope/templates/page.html
+++ b/oscilloscope/templates/page.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page is defined %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+</head>
+<body>
+    <div class="crt-bezel">
+        <div class="crt-screen">
+            <svg class="grid-overlay" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(0, 255, 0, 0.2)" stroke-width="1"/>
+                        <path d="M 20 0 L 20 40 M 0 20 L 40 20" fill="none" stroke="rgba(0, 255, 0, 0.1)" stroke-width="0.5" stroke-dasharray="2,2"/>
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#grid)" />
+                <path class="trace" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="#0f0" stroke-width="3" />
+                <path class="trace-glow" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="rgba(0, 255, 0, 0.5)" stroke-width="8" filter="blur(4px)" />
+            </svg>
+
+            <div class="screen-content">
+                {% include "header.html" %}
+                <main>
+                    {% if page is defined and page.title is defined %}
+                        <article>
+                            <h1>{{ page.title | default(value="UNTITLED") }}</h1>
+                            <div class="content">
+                                {{ page.content | safe }}
+                            </div>
+                        </article>
+                    {% elif section is defined %}
+                        <div class="section-content">
+                            <h1>{{ section.title | default(value="UNTITLED SECTION") }}</h1>
+                            {% if section.content %}
+                                {{ section.content | safe }}
+                            {% endif %}
+                            <ul class="page-list">
+                            {% for p in section.pages %}
+                                <li>
+                                    <span class="timestamp">[{{ p.date | default(value="00-00-00") }}]</span>
+                                    <a href="/{{ p.path }}">{{ p.title }}</a>
+                                </li>
+                            {% endfor %}
+                            </ul>
+                        </div>
+                    {% else %}
+                        {{ content | safe }}
+                    {% endif %}
+                </main>
+                {% include "footer.html" %}
+            </div>
+
+            <!-- Scanlines simulated using SVG instead of gradient -->
+            <svg class="scanlines" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none; position: absolute; top: 0; left: 0; z-index: 10;">
+                <defs>
+                    <pattern id="scanlines" width="4" height="4" patternUnits="userSpaceOnUse">
+                        <rect width="4" height="2" fill="rgba(0,0,0,0.3)" />
+                        <rect y="2" width="4" height="2" fill="transparent" />
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#scanlines)" />
+            </svg>
+            <div class="flicker"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/oscilloscope/templates/shortcodes/alert.html
+++ b/oscilloscope/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="border: 2px solid #0f0; background-color: rgba(0, 255, 0, 0.1); padding: 10px; margin: 20px 0; box-shadow: inset 0 0 10px rgba(0, 255, 0, 0.2); text-shadow: 0 0 5px #0f0;">
+    {{ body | safe }}
+</div>

--- a/oscilloscope/templates/taxonomy.html
+++ b/oscilloscope/templates/taxonomy.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(value="Taxonomy") }} | {{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+</head>
+<body>
+    <div class="crt-bezel">
+        <div class="crt-screen">
+            <svg class="grid-overlay" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(0, 255, 0, 0.2)" stroke-width="1"/>
+                        <path d="M 20 0 L 20 40 M 0 20 L 40 20" fill="none" stroke="rgba(0, 255, 0, 0.1)" stroke-width="0.5" stroke-dasharray="2,2"/>
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#grid)" />
+                <path class="trace" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="#0f0" stroke-width="3" />
+                <path class="trace-glow" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="rgba(0, 255, 0, 0.5)" stroke-width="8" filter="blur(4px)" />
+            </svg>
+
+            <div class="screen-content">
+                {% include "header.html" %}
+                <main class="site-main">
+                    <h1>{{ page.title | default(value="TAXONOMY") }}</h1>
+                    <p class="taxonomy-desc">>_ BROWSE ALL TERMS:</p>
+                    <div class="content">
+                        {{ content | safe }}
+                    </div>
+                </main>
+                {% include "footer.html" %}
+            </div>
+
+            <!-- Scanlines simulated using SVG instead of gradient -->
+            <svg class="scanlines" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none; position: absolute; top: 0; left: 0; z-index: 10;">
+                <defs>
+                    <pattern id="scanlines" width="4" height="4" patternUnits="userSpaceOnUse">
+                        <rect width="4" height="2" fill="rgba(0,0,0,0.3)" />
+                        <rect y="2" width="4" height="2" fill="transparent" />
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#scanlines)" />
+            </svg>
+            <div class="flicker"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/oscilloscope/templates/taxonomy_term.html
+++ b/oscilloscope/templates/taxonomy_term.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(value="Term") }} | {{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+</head>
+<body>
+    <div class="crt-bezel">
+        <div class="crt-screen">
+            <svg class="grid-overlay" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(0, 255, 0, 0.2)" stroke-width="1"/>
+                        <path d="M 20 0 L 20 40 M 0 20 L 40 20" fill="none" stroke="rgba(0, 255, 0, 0.1)" stroke-width="0.5" stroke-dasharray="2,2"/>
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#grid)" />
+                <path class="trace" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="#0f0" stroke-width="3" />
+                <path class="trace-glow" d="M -100 200 Q 100 50 300 200 T 700 200 T 1100 200 T 1500 200" fill="none" stroke="rgba(0, 255, 0, 0.5)" stroke-width="8" filter="blur(4px)" />
+            </svg>
+
+            <div class="screen-content">
+                {% include "header.html" %}
+                <main class="site-main">
+                    <h1>{{ page.title | default(value="TERM") }}</h1>
+                    <p class="taxonomy-desc">>_ POSTS TAGGED WITH THIS TERM:</p>
+                    <div class="content">
+                        {{ content | safe }}
+                    </div>
+                </main>
+                {% include "footer.html" %}
+            </div>
+
+            <!-- Scanlines simulated using SVG instead of gradient -->
+            <svg class="scanlines" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" style="pointer-events: none; position: absolute; top: 0; left: 0; z-index: 10;">
+                <defs>
+                    <pattern id="scanlines" width="4" height="4" patternUnits="userSpaceOnUse">
+                        <rect width="4" height="2" fill="rgba(0,0,0,0.3)" />
+                        <rect y="2" width="4" height="2" fill="transparent" />
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#scanlines)" />
+            </svg>
+            <div class="flicker"></div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds the `oscilloscope` example site to demonstrate an artistic CRT oscilloscope UI in Hwaro. It includes templates, styling, and dummy content while specifically avoiding changes to tags.json and gradients.

Key features:
- CRT bezel and curvature via CSS.
- SVG based phosphor grid overlay and waveform trace.
- CSS text and box shadow based phosphor glow.
- Scanline overlay and slight flicker animation.

---
*PR created automatically by Jules for task [18427495299553722272](https://jules.google.com/task/18427495299553722272) started by @hahwul*