### PR TITLE
feat: Add Prism Refraction example site

### DIFF
--- a/hwaro.log
+++ b/hwaro.log
@@ -1,0 +1,11 @@
+Performing initial build...
+Building site...
+  Found 4 pages.
+  Generated sitemap with 4 URLs.
+  Generated robots.txt
+  Generated llms.txt
+Build complete! Generated 4 pages in 18.68ms.
+Serving site at http://127.0.0.1:3000
+Press Ctrl+C to stop.
+Error: Could not bind to '127.0.0.1:3000': Address in use
+Watching for changes in content/, templates/, static/ and config.toml...

--- a/prism-refraction/AGENTS.md
+++ b/prism-refraction/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/prism-refraction/config.toml
+++ b/prism-refraction/config.toml
@@ -1,0 +1,181 @@
+title = "Prism Refraction"
+description = "UI elements that bend and split light and background colors like a prism."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/prism-refraction/content/_index.md
+++ b/prism-refraction/content/_index.md
@@ -1,0 +1,19 @@
++++
+title = "Refracted Light"
+description = "Welcome to Prism Refraction."
+template = "home"
++++
+
+We explore UI elements that bend and split light and background colors.
+
+<!-- more -->
+
+This theme uses CSS `backdrop-filter`, `mix-blend-mode`, and offset color shadows to create a prismatic effect, separating the RGB channels of typical borders and text shadows to simulate a glass prism breaking light.
+
+## Bold, Creative, and Elegant
+
+- **Translucent Glass:** Layers interact with animated background lights.
+- **Chromatic Aberration:** Text and boxes feature offset red/cyan and green/magenta shadows.
+- **Clean Layout:** Despite the complex effects, the typography remains sharp and legible.
+
+Check out the [Articles](/posts/) section to see more.

--- a/prism-refraction/content/about.md
+++ b/prism-refraction/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/prism-refraction/content/posts/_index.md
+++ b/prism-refraction/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Articles"
+template = "section"
++++

--- a/prism-refraction/content/posts/physics-of-light.md
+++ b/prism-refraction/content/posts/physics-of-light.md
@@ -1,0 +1,37 @@
++++
+title = "The Physics of Light in CSS"
+date = "2025-01-28"
+tags = ["css", "design", "physics"]
++++
+
+Simulating physical light phenomena in a 2D browser environment is a challenge. By layering box shadows and manipulating text shadows, we can approximate the look of chromatic aberration and refraction.
+
+<!-- more -->
+
+### The Chromatic Effect
+
+By using standard offset coordinates for text shadow, we separate the colors.
+
+```css
+.site-title {
+    text-shadow:
+        3px 0 0 var(--prism-red),
+        -3px 0 0 var(--prism-cyan);
+    mix-blend-mode: screen;
+}
+```
+
+This creates an illusion that the white text is being split at its edges into component wavelengths. We use a dark background so `mix-blend-mode: screen` works nicely.
+
+### Glassmorphism
+
+To complete the prism effect, the cards need to look like physical objects that light passes through.
+
+```css
+.prism-card {
+    background: rgba(25, 25, 30, 0.4);
+    backdrop-filter: blur(20px) saturate(150%);
+}
+```
+
+When floating abstract light shapes pass underneath these cards, they become blurred and vibrant, acting as the light source that the prism then refracts at its edges.

--- a/prism-refraction/static/css/style.css
+++ b/prism-refraction/static/css/style.css
@@ -1,0 +1,389 @@
+:root {
+    --bg-color: #0b0c10;
+    --text-primary: #f8f8f2;
+    --text-secondary: #a9a9b3;
+
+    /* Prism Colors */
+    --prism-red: rgba(255, 60, 60, 0.7);
+    --prism-green: rgba(60, 255, 60, 0.7);
+    --prism-blue: rgba(60, 60, 255, 0.7);
+    --prism-magenta: rgba(255, 60, 255, 0.7);
+    --prism-cyan: rgba(60, 255, 255, 0.7);
+    --prism-yellow: rgba(255, 255, 60, 0.7);
+
+    /* Glass Effect */
+    --glass-bg: rgba(25, 25, 30, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Background gradient for refraction interaction */
+body::before {
+    content: '';
+    position: fixed;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle at 50% 50%, rgba(20, 20, 30, 1) 0%, rgba(11, 12, 16, 1) 100%);
+    z-index: -2;
+}
+
+/* Abstract light shapes to interact with glass */
+.bg-light {
+    position: fixed;
+    border-radius: 50%;
+    filter: blur(80px);
+    z-index: -1;
+    opacity: 0.6;
+    animation: float 20s infinite ease-in-out alternate;
+}
+.bg-light-1 {
+    top: 20%; left: 10%; width: 300px; height: 300px; background: var(--prism-magenta);
+}
+.bg-light-2 {
+    bottom: 10%; right: 20%; width: 400px; height: 400px; background: var(--prism-blue); animation-delay: -5s;
+}
+.bg-light-3 {
+    top: 40%; right: 10%; width: 250px; height: 250px; background: var(--prism-yellow); animation-delay: -10s;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(50px, 50px) scale(1.2); }
+}
+
+a {
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+a:hover {
+    color: #fff;
+    text-shadow: 2px 0 0 var(--prism-red), -2px 0 0 var(--prism-cyan);
+}
+
+.site-header {
+    padding: 2rem 5%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    z-index: 10;
+}
+
+.site-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.05em;
+    text-transform: uppercase;
+    position: relative;
+    display: inline-block;
+}
+
+/* Prismatic text effect */
+.site-title {
+    text-shadow:
+        3px 0 0 var(--prism-red),
+        -3px 0 0 var(--prism-cyan);
+    mix-blend-mode: screen;
+}
+
+.site-nav a {
+    margin-left: 2rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.9rem;
+}
+
+main {
+    flex: 1;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 5%;
+    position: relative;
+    z-index: 5;
+}
+
+/* The Core Prism Component */
+.prism-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 3rem;
+    margin-bottom: 3rem;
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(20px) saturate(150%);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    transition: transform 0.4s ease, border-color 0.4s ease;
+}
+
+/* Simulate light splitting through the glass edges */
+.prism-card::before,
+.prism-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-radius: 16px;
+    z-index: -1;
+    transition: all 0.4s ease;
+}
+
+.prism-card::before {
+    box-shadow:
+        inset 5px 0 15px -5px var(--prism-red),
+        inset -5px 0 15px -5px var(--prism-cyan);
+    opacity: 0.5;
+}
+
+.prism-card::after {
+    box-shadow:
+        inset 0 5px 15px -5px var(--prism-green),
+        inset 0 -5px 15px -5px var(--prism-magenta);
+    opacity: 0.5;
+}
+
+.prism-card:hover {
+    transform: translateY(-5px);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.prism-card:hover::before {
+    box-shadow:
+        inset 10px 0 20px -5px var(--prism-red),
+        inset -10px 0 20px -5px var(--prism-cyan);
+    opacity: 0.8;
+}
+
+.prism-card:hover::after {
+    box-shadow:
+        inset 0 10px 20px -5px var(--prism-green),
+        inset 0 -10px 20px -5px var(--prism-magenta);
+    opacity: 0.8;
+}
+
+/* Typography inside Prism */
+h1, h2, h3 {
+    margin-bottom: 1rem;
+    line-height: 1.2;
+}
+
+.page-title {
+    font-size: 3.5rem;
+    font-weight: 900;
+    margin-bottom: 1.5rem;
+    letter-spacing: -0.03em;
+    position: relative;
+    display: inline-block;
+}
+
+/* A dramatic split text effect */
+.page-title::before,
+.page-title::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.7;
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.page-title::before {
+    color: var(--prism-red);
+    transform: translateX(-4px) translateY(-2px);
+    z-index: -1;
+}
+
+.page-title::after {
+    color: var(--prism-cyan);
+    transform: translateX(4px) translateY(2px);
+    z-index: -2;
+}
+
+.post-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    list-style: none;
+}
+
+.post-card {
+    display: block;
+    height: 100%;
+    padding: 2rem;
+}
+
+.post-card h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-date {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.post-card p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.content-body {
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.content-body p {
+    margin-bottom: 1.5rem;
+}
+
+.content-body h2, .content-body h3 {
+    margin-top: 3rem;
+    color: #fff;
+}
+
+/* Image Refraction */
+.content-body img {
+    max-width: 100%;
+    border-radius: 8px;
+    margin: 2rem 0;
+    filter: drop-shadow(5px 5px 0 var(--prism-red)) drop-shadow(-5px -5px 0 var(--prism-cyan));
+}
+
+.content-body pre {
+    background: rgba(0, 0, 0, 0.5) !important;
+    padding: 1.5rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 2px 2px 0 var(--prism-magenta), -2px -2px 0 var(--prism-blue);
+    margin: 2rem 0;
+}
+
+/* Prismatic Buttons */
+.btn {
+    display: inline-block;
+    padding: 0.8rem 1.5rem;
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.2);
+    color: #fff;
+    border-radius: 30px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.85rem;
+    font-weight: 600;
+    backdrop-filter: blur(10px);
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+}
+
+.btn::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: linear-gradient(90deg, var(--prism-red), var(--prism-yellow), var(--prism-green), var(--prism-cyan), var(--prism-blue), var(--prism-magenta), var(--prism-red));
+    background-size: 400%;
+    z-index: -1;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.btn:hover::before {
+    opacity: 0.5;
+    animation: rainbow 5s linear infinite;
+}
+
+.btn:hover {
+    border-color: transparent;
+    text-shadow: none;
+}
+
+@keyframes rainbow {
+    0% { background-position: 0% 50%; }
+    100% { background-position: 100% 50%; }
+}
+
+.site-footer {
+    text-align: center;
+    padding: 3rem 5%;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    position: relative;
+    z-index: 10;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 3rem;
+}
+
+/* Tags */
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+}
+
+.tag {
+    font-size: 0.8rem;
+    padding: 0.3rem 0.8rem;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary);
+}
+
+.tag:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    box-shadow: 0 0 10px var(--prism-cyan);
+}
+
+@media (max-width: 768px) {
+    .site-header {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .page-title {
+        font-size: 2.5rem;
+    }
+    .prism-card {
+        padding: 2rem;
+    }
+}

--- a/prism-refraction/templates/404.html
+++ b/prism-refraction/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/prism-refraction/templates/footer.html
+++ b/prism-refraction/templates/footer.html
@@ -1,0 +1,6 @@
+    </main>
+    <footer class="site-footer">
+        <p>&copy; {{ current_year }} {{ site.title }}. Refracting light and code.</p>
+    </footer>
+</body>
+</html>

--- a/prism-refraction/templates/header.html
+++ b/prism-refraction/templates/header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(val=site.title) }}</title>
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800;900&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="bg-light bg-light-1"></div>
+    <div class="bg-light bg-light-2"></div>
+    <div class="bg-light bg-light-3"></div>
+
+    <header class="site-header">
+        <a href="{{ site.base_url }}/" class="site-title">{{ site.title }}</a>
+        <nav class="site-nav">
+            <a href="{{ site.base_url }}/">Home</a>
+            <a href="{{ site.base_url }}/posts/">Articles</a>
+            <a href="{{ site.base_url }}/about/">About</a>
+        </nav>
+    </header>
+    <main>

--- a/prism-refraction/templates/home.html
+++ b/prism-refraction/templates/home.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+
+<article class="prism-card">
+    <div class="content-body">
+        {{ page.content | safe }}
+
+        <br>
+        <br>
+        <a href="{{ site.base_url }}/posts/" class="btn">Read Articles</a>
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/prism-refraction/templates/page.html
+++ b/prism-refraction/templates/page.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+
+<article class="prism-card">
+    <h1 class="page-title" data-text="{{ page.title }}">{{ page.title }}</h1>
+
+    {% if page.date %}
+    <time class="post-date">{{ page.date | date(format="%B %d, %Y") }}</time>
+    {% endif %}
+
+    <div class="content-body">
+        {{ page.content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/prism-refraction/templates/section.html
+++ b/prism-refraction/templates/section.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+
+<div class="prism-card">
+    {% if section is defined and section.title %}
+        <h1 class="page-title" data-text="{{ section.title }}">{{ section.title }}</h1>
+        {% if section.content %}
+            <div class="content-body">{{ section.content | safe }}</div>
+        {% endif %}
+    {% elif taxonomy_term is defined %}
+        <h1 class="page-title" data-text="{{ taxonomy_term }}">{{ taxonomy_term }}</h1>
+    {% elif taxonomy_name is defined %}
+        <h1 class="page-title" data-text="{{ taxonomy_name }}">{{ taxonomy_name }}</h1>
+    {% else %}
+        <h1 class="page-title" data-text="Archive">Archive</h1>
+    {% endif %}
+</div>
+
+<div class="post-list">
+    {% set items = section.pages | default(val=taxonomy_pages | default(val=site.pages)) %}
+    {% for post in items %}
+    <a href="{{ post.url }}" class="prism-card post-card">
+        <h2>{{ post.title }}</h2>
+        {% if post.date %}
+        <time class="post-date">{{ post.date | date(format="%B %d, %Y") }}</time>
+        {% endif %}
+        {% if post.summary %}
+        <p>{{ post.summary | strip_html | truncate_words(n=30) }}</p>
+        {% endif %}
+    </a>
+    {% endfor %}
+</div>
+
+{% include "footer.html" %}

--- a/prism-refraction/templates/shortcodes/alert.html
+++ b/prism-refraction/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/prism-refraction/templates/taxonomy.html
+++ b/prism-refraction/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/prism-refraction/templates/taxonomy_term.html
+++ b/prism-refraction/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This pull request adds a new Hwaro example site named `prism-refraction`. The theme features a bold, creative, and elegant design utilizing CSS `backdrop-filter`, `mix-blend-mode`, and chromatic aberration effects (`box-shadow`, `text-shadow`) to simulate UI elements bending and splitting light and background colors like a prism. The implementation strictly avoids modifying `tags.json` and uses the standard Hwaro directory structure.

---
*PR created automatically by Jules for task [9480712900591045651](https://jules.google.com/task/9480712900591045651) started by @hahwul*