### PR TITLE
feat: add kinetic-typography example site

### DIFF
--- a/kinetic-typography/config.toml
+++ b/kinetic-typography/config.toml
@@ -1,0 +1,186 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Kinetic Typography"
+description = "The text itself is the primary visual and navigation element."
+base_url = "http://localhost:3000"
+
+default_language = "en"
+
+[languages.en]
+language_name = "English"
+weight = 1
+
+[languages.ko]
+language_name = "한국어"
+weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+# =============================================================================
+# Permalinks
+# =============================================================================
+
+[permalinks]
+projects = "work"
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+
+[[taxonomies]]
+name = "skills"
+
+# =============================================================================
+# SEO
+# =============================================================================
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+# =============================================================================
+# Feeds
+# =============================================================================
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 20
+
+# =============================================================================
+# Markdown
+# =============================================================================
+
+[markdown]
+safe = false
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)

--- a/kinetic-typography/content/_index.md
+++ b/kinetic-typography/content/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Home"
+sort_by = "date"
+template = "index.html"
++++

--- a/kinetic-typography/content/first-post.md
+++ b/kinetic-typography/content/first-post.md
@@ -1,0 +1,21 @@
++++
+title = "THE SHAPE OF WORDS"
+date = 2023-10-25
+description = "Exploring typography as a structural element in web design."
+template = "page.html"
++++
+
+When we strip away images, illustrations, and complex background elements, what remains? The text.
+
+But text doesn't have to be passive. In kinetic typography, words become physical objects. They possess weight, dimension, and momentum. They can stack like bricks, scroll like tickers, or shatter upon interaction.
+
+### The Grid is Dead, Long Live the Grid
+
+Traditional web layouts use text to fill containers. Kinetic design uses text *as* the container. A giant headline isn't just announcing the content below it; it is the primary visual anchor of the viewport.
+
+* By utilizing viewport units (`vw`, `vh`), text scales fluidly with the screen, ensuring the composition remains intact whether on a mobile phone or an ultrawide monitor.
+* CSS functions like `clamp()` allow for precise control over this scaling, setting hard limits so the typography never becomes unreadable or broken.
+
+> "Typography is two-dimensional architecture." - Hermann Zapf
+
+In this theme, we utilize `Anton` for its brutalist, blocky presence, contrasting it with the sophisticated curves of `Syne` and the condensed utility of `Oswald`. The resulting hierarchy is clear, loud, and uncompromising.

--- a/kinetic-typography/content/second-post.md
+++ b/kinetic-typography/content/second-post.md
@@ -1,0 +1,18 @@
++++
+title = "MOTION IS MEANING"
+date = 2023-10-28
+description = "Why static text is no longer enough for modern interfaces."
+template = "page.html"
++++
+
+A word standing still is a statement. A word in motion is a conversation.
+
+The marquees running across the top and bottom of this site aren't just decorative; they frame the experience, creating a boundary that feels alive. They suggest that the site extends beyond the edges of your screen, a continuous stream of information.
+
+### Interaction as Animation
+
+Hover states are where kinetic typography truly shines. When a user interacts with a text element, the element should respond.
+
+In this theme, navigation links reveal a secondary color layer on hover, sliding in smoothly. Titles shift from solid fills to stark outlines with heavy drop shadows, simulating a sudden jump off the page.
+
+These micro-interactions turn reading into an active, tactile experience. You aren't just looking at the words; you're playing with them.

--- a/kinetic-typography/static/css/style.css
+++ b/kinetic-typography/static/css/style.css
@@ -1,0 +1,308 @@
+:root {
+    --bg-color: #0f0f0f;
+    --text-color: #f0f0f0;
+    --accent-color: #ff3366;
+    --font-heading: 'Anton', sans-serif;
+    --font-body: 'Syne', sans-serif;
+    --font-nav: 'Oswald', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    overflow-x: hidden;
+}
+
+/* Typography Scale */
+h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(4rem, 15vw, 15rem);
+    text-transform: uppercase;
+    line-height: 0.85;
+    letter-spacing: -0.02em;
+    margin-bottom: 2rem;
+    transition: color 0.3s ease, -webkit-text-stroke 0.3s ease;
+}
+
+h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(3rem, 10vw, 8rem);
+    text-transform: uppercase;
+    line-height: 0.9;
+    margin-bottom: 1.5rem;
+}
+
+h3 {
+    font-family: var(--font-nav);
+    font-size: clamp(2rem, 5vw, 4rem);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+p {
+    font-size: clamp(1.1rem, 2vw, 1.5rem);
+    max-width: 800px;
+    margin-bottom: 1.5rem;
+}
+
+/* Marquee Styles */
+.marquee {
+    position: fixed;
+    width: 100%;
+    background: var(--text-color);
+    color: var(--bg-color);
+    overflow: hidden;
+    padding: 0.5rem 0;
+    z-index: 100;
+    font-family: var(--font-nav);
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.top-marquee { top: 0; }
+.bottom-marquee { bottom: 0; }
+
+.marquee-inner {
+    display: inline-block;
+    animation: marquee 20s linear infinite;
+}
+
+.marquee-inner.reverse {
+    animation: marquee-reverse 20s linear infinite;
+}
+
+.marquee-inner span {
+    display: inline-block;
+    padding-right: 2rem;
+}
+
+@keyframes marquee {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+}
+
+@keyframes marquee-reverse {
+    0% { transform: translateX(-50%); }
+    100% { transform: translateX(0); }
+}
+
+/* Layout */
+.site-header {
+    padding: 6rem 2rem 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.nav-links {
+    display: flex;
+    gap: clamp(1rem, 4vw, 4rem);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.nav-item {
+    font-family: var(--font-nav);
+    font-size: clamp(2rem, 6vw, 4rem);
+    font-weight: 700;
+    color: transparent;
+    -webkit-text-stroke: 1px var(--text-color);
+    text-decoration: none;
+    text-transform: uppercase;
+    position: relative;
+    transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.nav-item::before {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 100%;
+    color: var(--accent-color);
+    -webkit-text-stroke: 0px transparent;
+    overflow: hidden;
+    transition: width 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    white-space: nowrap;
+}
+
+.nav-item:hover::before {
+    width: 100%;
+}
+
+.content-wrapper {
+    padding: 2rem 2rem 8rem;
+    max-width: 1600px;
+    margin: 0 auto;
+}
+
+/* Kinetic Blocks */
+.kinetic-block {
+    margin: 8rem 0;
+    position: relative;
+}
+
+.kinetic-block:nth-child(even) {
+    text-align: right;
+}
+
+.kinetic-title {
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+}
+
+.kinetic-title:hover {
+    color: var(--bg-color);
+    -webkit-text-stroke: 2px var(--accent-color);
+    text-shadow: 10px 10px 0 var(--accent-color),
+                 -10px -10px 0 var(--text-color);
+}
+
+.stacked-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.stacked-text span {
+    display: block;
+    line-height: 0.8;
+}
+
+.stacked-text span:nth-child(2) {
+    padding-left: 20%;
+    color: transparent;
+    -webkit-text-stroke: 2px var(--text-color);
+}
+
+.stacked-text span:nth-child(3) {
+    padding-left: 40%;
+    color: var(--accent-color);
+}
+
+.scrolling-text-block {
+    overflow: hidden;
+    white-space: nowrap;
+    margin: 4rem 0;
+}
+
+.scrolling-text-block h2 {
+    display: inline-block;
+    animation: scroll-left 15s linear infinite;
+    padding-right: 2rem;
+}
+
+@keyframes scroll-left {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+}
+
+/* Staggered Grid for Content */
+.text-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 4rem;
+    margin-top: 4rem;
+}
+
+.grid-item h3 {
+    border-bottom: 4px solid var(--text-color);
+    padding-bottom: 0.5rem;
+    display: inline-block;
+    transition: border-color 0.3s, color 0.3s;
+}
+
+.grid-item:hover h3 {
+    color: var(--accent-color);
+    border-color: var(--accent-color);
+}
+
+/* Animated Underline */
+.hover-underline {
+    position: relative;
+    text-decoration: none;
+    color: var(--text-color);
+}
+
+.hover-underline::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 4px;
+    bottom: -4px;
+    left: 0;
+    background-color: var(--accent-color);
+    transform: scaleX(0);
+    transform-origin: bottom right;
+    transition: transform 0.3s ease-out;
+}
+
+.hover-underline:hover::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+}
+
+/* Split Text Effect */
+.split-text {
+    position: relative;
+    display: inline-block;
+}
+
+.split-text::after {
+    content: attr(data-text);
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    color: var(--accent-color);
+    z-index: -1;
+    opacity: 0;
+    transition: all 0.3s ease;
+}
+
+.split-text:hover::after {
+    left: 10px;
+    top: 10px;
+    opacity: 1;
+}
+
+/* Post List */
+.post-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.post-list-item a {
+    text-decoration: none;
+    display: block;
+    padding: 2rem;
+    border: 2px solid var(--text-color);
+    transition: all 0.3s ease;
+}
+
+.post-list-item h2 {
+    font-size: clamp(2rem, 5vw, 4rem);
+    margin-bottom: 0.5rem;
+    color: var(--text-color);
+}
+
+.post-list-item:hover {
+    background: var(--text-color);
+    transform: translateX(20px);
+}
+
+.post-list-item:hover h2,
+.post-list-item:hover p {
+    color: var(--bg-color);
+}

--- a/kinetic-typography/templates/base.html
+++ b/kinetic-typography/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Syne:wght@400;700;800&family=Oswald:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="marquee top-marquee">
+        <div class="marquee-inner">
+            <span>KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY </span>
+            <span>KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY KINETIC TYPOGRAPHY </span>
+        </div>
+    </div>
+    <header class="site-header">
+        <nav class="nav-links">
+            <a href="{{ site.base_url }}/" class="nav-item" data-text="HOME">HOME</a>
+            <a href="{{ site.base_url }}/about" class="nav-item" data-text="ABOUT">ABOUT</a>
+            <a href="{{ site.base_url }}/work" class="nav-item" data-text="WORK">WORK</a>
+            <a href="{{ site.base_url }}/contact" class="nav-item" data-text="CONTACT">CONTACT</a>
+        </nav>
+    </header>
+    <main class="content-wrapper">
+        {% block content %}{% endblock content %}
+    </main>
+    <div class="marquee bottom-marquee">
+        <div class="marquee-inner reverse">
+            <span>SCROLL TO EXPLORE SCROLL TO EXPLORE SCROLL TO EXPLORE SCROLL TO EXPLORE </span>
+            <span>SCROLL TO EXPLORE SCROLL TO EXPLORE SCROLL TO EXPLORE SCROLL TO EXPLORE </span>
+        </div>
+    </div>
+</body>
+</html>

--- a/kinetic-typography/templates/index.html
+++ b/kinetic-typography/templates/index.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="kinetic-block">
+    <h1 class="kinetic-title stacked-text">
+        <span>WORDS</span>
+        <span>ARE</span>
+        <span>POWER</span>
+    </h1>
+</div>
+
+<div class="scrolling-text-block">
+    <h2>
+        <span class="split-text" data-text="DESIGN IS HOW IT WORKS">DESIGN IS HOW IT WORKS</span> &nbsp;&mdash;&nbsp;
+        <span class="split-text" data-text="NOT JUST HOW IT LOOKS">NOT JUST HOW IT LOOKS</span> &nbsp;&mdash;&nbsp;
+        <span class="split-text" data-text="DESIGN IS HOW IT WORKS">DESIGN IS HOW IT WORKS</span> &nbsp;&mdash;&nbsp;
+        <span class="split-text" data-text="NOT JUST HOW IT LOOKS">NOT JUST HOW IT LOOKS</span>
+    </h2>
+</div>
+
+<div class="kinetic-block">
+    <h1 class="kinetic-title" style="text-align: right; width: 100%;">
+        BOLD<br>
+        <span style="color: transparent; -webkit-text-stroke: 2px var(--accent-color);">STATEMENT</span>
+    </h1>
+</div>
+
+<div class="text-grid">
+    <div class="grid-item">
+        <h3>TYPOGRAPHY</h3>
+        <p>In this theme, the letters themselves form the architecture of the page. Scale, weight, and motion guide the eye.</p>
+        <a href="#" class="hover-underline">READ MORE</a>
+    </div>
+    <div class="grid-item">
+        <h3>MOTION</h3>
+        <p>Kinetic energy translates to digital space through scrolling marquees, hover reveals, and shifting outlines.</p>
+        <a href="#" class="hover-underline">DISCOVER</a>
+    </div>
+    <div class="grid-item">
+        <h3>CONTRAST</h3>
+        <p>Stark black and white contrasted with vibrant pink creates a dynamic tension that demands attention.</p>
+        <a href="#" class="hover-underline">EXPLORE</a>
+    </div>
+</div>
+
+<div class="kinetic-block" style="margin-top: 10rem;">
+    <h2>LATEST THOUGHTS</h2>
+    <ul class="post-list">
+        {% set section = get_section(path="_index.md") %}
+        {% for page in section.pages %}
+        <li class="post-list-item">
+            <a href="{{ page.permalink }}">
+                <h2>{{ page.title }}</h2>
+                <p>{{ page.description }}</p>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock content %}

--- a/kinetic-typography/templates/page.html
+++ b/kinetic-typography/templates/page.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="kinetic-block" style="margin-top: 4rem; text-align: left;">
+    <h1 class="kinetic-title" style="font-size: clamp(3rem, 8vw, 8rem); line-height: 1;">{{ page.title }}</h1>
+
+    {% if page.date %}
+    <p style="font-family: var(--font-nav); font-size: 1.5rem; color: var(--accent-color); margin-bottom: 4rem;">
+        {{ page.date | date(format="%Y.%m.%d") }}
+    </p>
+    {% endif %}
+
+    <div style="max-width: 900px; margin: 0 auto; font-size: 1.2rem; line-height: 1.8;">
+        {{ page.content | safe }}
+    </div>
+</article>
+
+<div style="text-align: center; margin-top: 8rem;">
+    <a href="{{ site.base_url }}/" class="nav-item" data-text="BACK TO HOME" style="font-size: 3rem;">BACK TO HOME</a>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Adds a new Hwaro example site demonstrating the 'Kinetic Typography' theme. The design treats text as the primary visual and navigation element, utilizing CSS animations like scrolling marquees, hover reveals, and split-text effects. The `tags.json` file is explicitly unmodified as per instructions.

---
*PR created automatically by Jules for task [9575203075374795005](https://jules.google.com/task/9575203075374795005) started by @hahwul*