### PR TITLE
feat(theme): add japanese-industrial theme

### DIFF
--- a/japanese-industrial/AGENTS.md
+++ b/japanese-industrial/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/japanese-industrial/config.toml
+++ b/japanese-industrial/config.toml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Japanese Industrial Theme - Site Configuration
+# =============================================================================
+# Clean lines, exposed concrete textures, and bold red/black/white.
+
+title = "Japanese Industrial"
+description = "Clean lines, exposed concrete textures, and bold red/black/white."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github-dark"
+use_cdn = true
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/japanese-industrial/content/_index.md
+++ b/japanese-industrial/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Japanese Industrial"
+date = "2024-05-20"
+description = "Clean lines, exposed concrete textures, and bold red/black/white."
+template = "index"
++++
+
+This is the homepage of the Japanese Industrial theme. Experience clean lines, raw concrete textures, and bold contrasts.

--- a/japanese-industrial/content/about.md
+++ b/japanese-industrial/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About Industrial"
+date = "2024-05-20"
+description = "Learn more about the Japanese Industrial design philosophy."
+template = "page"
++++
+
+# About Japanese Industrial Design
+
+Japanese Industrial design emphasizes raw materials, minimal ornamentation, and high functionality. This theme brings that aesthetic to the web.
+
+## Core Principles
+
+*   **Clean Lines:** Structural elements are sharply defined.
+*   **Raw Textures:** Exposed concrete and metal are celebrated.
+*   **Bold Contrasts:** Red, black, and white create a striking visual hierarchy.
+*   **Function First:** Form follows function, leading to elegant simplicity.
+
+Experience the brutal yet refined aesthetic.

--- a/japanese-industrial/templates/base.html
+++ b/japanese-industrial/templates/base.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ page.description | default(site.description) }}">
+    <style>
+        /* Japanese Industrial Theme CSS */
+        :root {
+            --color-bg: #f4f4f4; /* Light concrete */
+            --color-text: #111111; /* Almost black */
+            --color-accent: #e60000; /* Bold Red */
+            --color-white: #ffffff;
+            --color-black: #000000;
+            --color-concrete: #dcdcdc;
+            --color-concrete-dark: #aaaaaa;
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            src: url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700;900&display=swap');
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: var(--color-bg);
+            color: var(--color-text);
+            line-height: 1.6;
+
+            /* Concrete texture using SVG background */
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
+            background-attachment: fixed;
+        }
+
+        /* Structural lines */
+        .grid-container {
+            display: grid;
+            grid-template-columns: 300px 1fr;
+            min-height: 100vh;
+            border-left: 10px solid var(--color-accent);
+        }
+
+        @media (max-width: 768px) {
+            .grid-container {
+                grid-template-columns: 1fr;
+                border-left: none;
+                border-top: 10px solid var(--color-accent);
+            }
+        }
+
+        /* Sidebar / Header */
+        .sidebar {
+            background-color: var(--color-white);
+            border-right: 2px solid var(--color-black);
+            padding: 3rem 2rem;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+            z-index: 10;
+        }
+
+        .site-title {
+            font-size: 2.5rem;
+            font-weight: 900;
+            text-transform: uppercase;
+            letter-spacing: -1px;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            color: var(--color-black);
+            line-height: 1.1;
+        }
+
+        .site-description {
+            font-size: 0.9rem;
+            color: var(--color-concrete-dark);
+            margin-bottom: 3rem;
+            font-weight: 400;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        nav a {
+            display: block;
+            color: var(--color-text);
+            text-decoration: none;
+            font-size: 1.2rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s ease, color 0.2s ease;
+            text-transform: uppercase;
+        }
+
+        nav a:hover {
+            color: var(--color-accent);
+            border-bottom: 2px solid var(--color-accent);
+        }
+
+        /* Main Content */
+        .main-content {
+            padding: 4rem;
+            max-width: 900px;
+            background-color: transparent;
+        }
+
+        @media (max-width: 768px) {
+            .main-content {
+                padding: 2rem;
+            }
+        }
+
+        h1 {
+            font-size: 4rem;
+            font-weight: 900;
+            text-transform: uppercase;
+            margin-top: 0;
+            margin-bottom: 2rem;
+            letter-spacing: -2px;
+            color: var(--color-black);
+            position: relative;
+        }
+
+        /* Red accent square on h1 */
+        h1::before {
+            content: '';
+            position: absolute;
+            left: -4rem;
+            top: 0.5rem;
+            width: 1.5rem;
+            height: 1.5rem;
+            background-color: var(--color-accent);
+        }
+
+        @media (max-width: 768px) {
+            h1::before {
+                left: -2rem;
+            }
+            h1 {
+                font-size: 2.5rem;
+            }
+        }
+
+        h2 {
+            font-size: 2rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            border-bottom: 4px solid var(--color-black);
+            padding-bottom: 0.5rem;
+            margin-top: 3rem;
+        }
+
+        p {
+            font-size: 1.1rem;
+            font-weight: 300;
+            margin-bottom: 1.5rem;
+            max-width: 70ch;
+        }
+
+        /* Exposed concrete block styling for emphasis */
+        .concrete-block {
+            background-color: var(--color-concrete);
+            padding: 2rem;
+            border: 2px solid var(--color-black);
+            margin: 2rem 0;
+            position: relative;
+            box-shadow: 10px 10px 0 var(--color-black); /* Solid shadow */
+        }
+
+        .concrete-block::after {
+             content: '';
+             position: absolute;
+             bottom: -12px;
+             right: -12px;
+             width: 20px;
+             height: 20px;
+             background-color: var(--color-accent);
+        }
+
+        a {
+            color: var(--color-accent);
+            text-decoration: underline;
+            text-underline-offset: 4px;
+            text-decoration-thickness: 2px;
+            font-weight: 700;
+        }
+
+        a:hover {
+            color: var(--color-black);
+            text-decoration-color: var(--color-black);
+        }
+
+        /* Technical / Monospace elements */
+        code, pre {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+            background-color: var(--color-black);
+            color: var(--color-white);
+            padding: 0.2rem 0.4rem;
+            font-size: 0.9em;
+        }
+
+        pre {
+            padding: 1.5rem;
+            border-left: 5px solid var(--color-accent);
+            overflow-x: auto;
+        }
+
+        /* Industrial decorative elements */
+        .decor-line {
+            height: 2px;
+            background-color: var(--color-black);
+            width: 100%;
+            margin: 4rem 0;
+            position: relative;
+        }
+
+        .decor-line::before {
+            content: '///';
+            position: absolute;
+            right: 0;
+            top: -10px;
+            background: var(--color-bg);
+            padding-left: 10px;
+            font-weight: 900;
+            color: var(--color-accent);
+            letter-spacing: 2px;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="grid-container">
+        <aside class="sidebar">
+            <h1 class="site-title">{{ site.title }}</h1>
+            <div class="site-description">{{ site.description }}</div>
+            <nav>
+                <a href="{{ site.base_url | default('.') }}/">Home</a>
+                <a href="{{ site.base_url | default('.') }}/about">About</a>
+            </nav>
+            <div style="flex-grow: 1;"></div>
+            <div style="font-size: 0.8rem; font-weight: 700; text-transform: uppercase; color: var(--color-concrete-dark);">
+                SYS.REQ // 2024
+            </div>
+        </aside>
+
+        <main class="main-content">
+            {% block content %}{% endblock content %}
+        </main>
+    </div>
+</body>
+</html>

--- a/japanese-industrial/templates/index.html
+++ b/japanese-industrial/templates/index.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="concrete-block">
+        <h1 style="font-size: 2.5rem; margin-bottom: 1rem;">{{ page.title | default(site.title) }}</h1>
+        <p style="font-size: 1.2rem; font-weight: 700; margin-bottom: 0;">{{ page.description | default(site.description) }}</p>
+    </div>
+
+    <div class="decor-line"></div>
+
+    <div class="page-content">
+        {% if page is defined %}
+            {{ page.content | safe }}
+        {% else %}
+            <p>Welcome to the industrial zone. Structure. Material. Function.</p>
+
+            <h2>Design Ethos</h2>
+            <p>We believe in the power of raw materials. The internet does not need to be soft. It can be built like a factory: robust, clear, and uncompromising.</p>
+
+            <div class="concrete-block" style="background-color: var(--color-black); color: var(--color-white);">
+                <h3 style="color: var(--color-accent); text-transform: uppercase; margin-top: 0;">Notice</h3>
+                <p>This structure is load-bearing. Do not remove essential components.</p>
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/japanese-industrial/templates/page.html
+++ b/japanese-industrial/templates/page.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <article>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+            <div style="font-family: monospace; font-size: 0.9rem; color: var(--color-accent); margin-bottom: 2rem; border-bottom: 1px solid var(--color-black); padding-bottom: 0.5rem; display: inline-block;">
+                DATE_LOG: {{ page.date }}
+            </div>
+        {% endif %}
+
+        <div class="page-content">
+            {{ page.content | safe }}
+        </div>
+    </article>
+
+    <div class="decor-line"></div>
+    <a href="{{ site.base_url }}/" style="text-transform: uppercase; font-size: 0.9rem;">&lt;&lt; Return to Base</a>
+{% endblock content %}


### PR DESCRIPTION
This PR adds a new Hwaro example site using the 'Japanese Industrial' aesthetic. It relies on sharp geometric structures, solid drop shadows, raw colors (concrete grey, deep red, black, white), and an SVG fractal noise filter to simulate an exposed concrete texture. It deliberately avoids gradients, gradients, and emojis, maintaining an elegant, stark style. No modifications were made to `tags.json`.

---
*PR created automatically by Jules for task [13821657776062912559](https://jules.google.com/task/13821657776062912559) started by @hahwul*