### PR TITLE
Add Ethereal Vapor theme

### DIFF
--- a/ethereal-vapor/config.toml
+++ b/ethereal-vapor/config.toml
@@ -1,0 +1,9 @@
+base_url = "https://example.com"
+title = "Ethereal Vapor"
+description = "Soft, cloudy textures and translucent UI that feels like it's floating."
+default_language = "en"
+compile_sass = false
+
+[extra]
+author = "Jules"
+footer_text = "Drift in the vapor."

--- a/ethereal-vapor/content/_index.md
+++ b/ethereal-vapor/content/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Floating Above"
+date = 2023-11-20
++++
+
+Welcome to a world of weightless design. Here, the boundaries blur between structure and atmosphere. Our thoughts drift like vapor, carried by gentle currents of air.
+
+Explore the layers of translucency and let your mind wander through the clouds.
+
+- **Weightlessness**: Disconnect from the heavy constraints of reality.
+- **Translucency**: See beyond the surface.
+- **Serenity**: Find peace in soft textures and muted contrasts.
+
+Embrace the Ethereal Vapor.

--- a/ethereal-vapor/content/about.md
+++ b/ethereal-vapor/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About the Vapor"
+date = 2023-11-21
++++
+
+## The Concept
+
+The *Ethereal Vapor* aesthetic is born from a desire for digital softness. In a world full of hard edges and high contrasts, we seek a sanctuary of blurred boundaries and floating elements.
+
+We rely on subtle box shadows, backdrop blurs, and soft, cloudy textures created entirely with SVG filters and CSS properties.
+
+Join us in creating interfaces that breathe.

--- a/ethereal-vapor/static/css/style.css
+++ b/ethereal-vapor/static/css/style.css
@@ -1,0 +1,283 @@
+/* Base variables - Ethereal Vapor palette */
+:root {
+    --bg-color: #f2f7fb;
+    --text-main: #3a4b5c;
+    --text-muted: #6b829b;
+    --accent: #a3c2e0;
+
+    --glass-bg: rgba(255, 255, 255, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.7);
+    --glass-shadow: rgba(139, 162, 186, 0.15);
+
+    --font-heading: 'Cormorant Garamond', serif;
+    --font-body: 'Montserrat', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-body);
+    color: var(--text-main);
+    background-color: var(--bg-color);
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
+    line-height: 1.7;
+    font-weight: 300;
+}
+
+/* Background textures and floating elements */
+.vapor-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -2;
+    background-color: var(--bg-color);
+    /* Filter for texture applied to the entire background */
+    filter: url(#cloudy-texture);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+/* Clouds / Floating Blobs */
+.cloud {
+    position: fixed;
+    border-radius: 50%;
+    background-color: #ffffff;
+    filter: blur(80px);
+    z-index: -1;
+    opacity: 0.7;
+    animation: float 20s infinite ease-in-out alternate;
+    pointer-events: none;
+}
+
+.cloud-1 {
+    width: 600px;
+    height: 600px;
+    top: -200px;
+    left: -100px;
+    background-color: rgba(255, 255, 255, 0.8);
+    animation-duration: 25s;
+}
+
+.cloud-2 {
+    width: 800px;
+    height: 500px;
+    bottom: -150px;
+    right: -200px;
+    background-color: rgba(215, 235, 250, 0.6);
+    animation-duration: 22s;
+    animation-delay: -5s;
+}
+
+.cloud-3 {
+    width: 400px;
+    height: 400px;
+    top: 40%;
+    left: 60%;
+    background-color: rgba(240, 248, 255, 0.7);
+    animation-duration: 18s;
+    animation-delay: -10s;
+}
+
+@keyframes float {
+    0% {
+        transform: translate(0, 0) scale(1);
+    }
+    50% {
+        transform: translate(30px, -50px) scale(1.05);
+    }
+    100% {
+        transform: translate(-20px, 20px) scale(0.95);
+    }
+}
+
+/* Layout */
+.page-wrapper {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Glassmorphism utility */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 8px 32px 0 var(--glass-shadow),
+                inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+    border-radius: 24px;
+}
+
+/* Header */
+.glass-header {
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border);
+    border-radius: 50px;
+    padding: 1rem 2.5rem;
+    margin-bottom: 4rem;
+    box-shadow: 0 8px 32px 0 var(--glass-shadow);
+    /* Subtle floating animation */
+    animation: gentle-float 6s ease-in-out infinite alternate;
+}
+
+@keyframes gentle-float {
+    0% { transform: translateY(0); }
+    100% { transform: translateY(-5px); }
+}
+
+nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    font-family: var(--font-heading);
+    font-size: 1.8rem;
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text-main);
+    text-decoration: none;
+    letter-spacing: 1px;
+}
+
+.nav-links a {
+    color: var(--text-muted);
+    text-decoration: none;
+    margin-left: 2rem;
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    transition: color 0.3s ease;
+}
+
+.nav-links a:hover {
+    color: var(--text-main);
+}
+
+/* Main Content */
+main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 0;
+}
+
+.glass-card {
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--glass-border);
+    border-radius: 30px;
+    padding: 4rem;
+    width: 100%;
+    max-width: 800px;
+    box-shadow: 0 20px 50px -10px var(--glass-shadow),
+                inset 0 2px 10px rgba(255, 255, 255, 0.8);
+    position: relative;
+    /* Extra floaty shadow using SVG filter from base.html if we want, or just box-shadow */
+    filter: url(#float-shadow);
+    transition: transform 0.5s ease;
+}
+
+.glass-card:hover {
+    transform: translateY(-10px);
+}
+
+.card-content {
+    position: relative;
+    z-index: 1;
+}
+
+.ethereal-title {
+    font-family: var(--font-heading);
+    font-size: 4rem;
+    font-weight: 300;
+    color: var(--text-main);
+    margin-bottom: 2rem;
+    text-align: center;
+    line-height: 1.1;
+    letter-spacing: -0.5px;
+}
+
+/* Typography and Prose */
+.prose {
+    font-size: 1.1rem;
+    color: var(--text-main);
+}
+
+.prose p {
+    margin-bottom: 1.5rem;
+}
+
+.prose h2 {
+    font-family: var(--font-heading);
+    font-size: 2.5rem;
+    font-weight: 300;
+    margin: 3rem 0 1.5rem 0;
+    color: var(--text-main);
+}
+
+.prose ul {
+    margin-bottom: 1.5rem;
+    padding-left: 1.5rem;
+    list-style-type: none;
+}
+
+.prose li {
+    margin-bottom: 0.8rem;
+    position: relative;
+}
+
+.prose li::before {
+    content: "∘";
+    position: absolute;
+    left: -1.5rem;
+    color: var(--accent);
+    font-size: 1.2rem;
+}
+
+.prose strong {
+    font-weight: 500;
+    color: var(--text-main);
+}
+
+/* Footer */
+.glass-footer {
+    text-align: center;
+    padding: 2rem;
+    margin-top: 4rem;
+    font-family: var(--font-heading);
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 1.2rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .glass-card {
+        padding: 2rem;
+    }
+
+    .ethereal-title {
+        font-size: 3rem;
+    }
+
+    .glass-header {
+        padding: 1rem 1.5rem;
+    }
+}

--- a/ethereal-vapor/templates/base.html
+++ b/ethereal-vapor/templates/base.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <link rel="stylesheet" href="{{ config.base_url }}/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Montserrat:wght@200;300;400;500&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- SVG filter for cloudy texture -->
+    <svg style="display: none;">
+        <filter id="cloudy-texture">
+            <feTurbulence type="fractalNoise" baseFrequency="0.015" numOctaves="4" result="noise" />
+            <feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 0.1 0" in="noise" result="coloredNoise" />
+            <feComposite operator="in" in="coloredNoise" in2="SourceGraphic" result="composite" />
+            <feBlend mode="multiply" in="composite" in2="SourceGraphic" />
+        </filter>
+        <filter id="float-shadow">
+            <feDropShadow dx="0" dy="20" stdDeviation="25" flood-color="#8ba2ba" flood-opacity="0.3"/>
+        </filter>
+    </svg>
+
+    <div class="vapor-background"></div>
+    <div class="cloud cloud-1"></div>
+    <div class="cloud cloud-2"></div>
+    <div class="cloud cloud-3"></div>
+
+    <div class="page-wrapper">
+        <header class="glass-header">
+            <nav>
+                <a href="{{ config.base_url }}/" class="logo">{{ config.title }}</a>
+                <div class="nav-links">
+                    <a href="{{ config.base_url }}/about">About</a>
+                </div>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock content %}
+        </main>
+
+        <footer class="glass-footer">
+            <p>{{ config.extra.footer_text }}</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/ethereal-vapor/templates/index.html
+++ b/ethereal-vapor/templates/index.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-card hero-card">
+    <div class="card-content">
+        <h1 class="ethereal-title">{{ section.title | default("Ethereal Vapor") }}</h1>
+        <div class="prose">
+            {{ section.content | safe }}
+        </div>
+    </div>
+</article>
+{% endblock content %}

--- a/ethereal-vapor/templates/page.html
+++ b/ethereal-vapor/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-card page-card">
+    <div class="card-content">
+        <h1 class="ethereal-title">{{ page.title }}</h1>
+        <div class="prose">
+            {{ page.content | safe }}
+        </div>
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Adds a new Hwaro example site named 'Ethereal Vapor'. The theme implements a soft, cloudy texture using SVG filters, and a translucent UI utilizing glassmorphism and subtle floating animations. No gradients or emojis were used. The tags.json file was not modified.

---
*PR created automatically by Jules for task [1878254618321034128](https://jules.google.com/task/1878254618321034128) started by @hahwul*