### PR TITLE
feat: add Art Nouveau 2.0 theme example

### DIFF
--- a/artnouveau/config.toml
+++ b/artnouveau/config.toml
@@ -1,0 +1,41 @@
+title = "Art Nouveau 2.0"
+description = "Sinuous curves and botanical motifs with a modern flat-design twist."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/artnouveau/content/index.md
+++ b/artnouveau/content/index.md
@@ -1,0 +1,12 @@
++++
+title = "The Elegant Curve"
+date = "2025-01-15"
+description = "Embracing the beauty of nature."
++++
+
+Welcome to Art Nouveau 2.0. This site demonstrates a modern interpretation of the classic Art Nouveau style. We use sinuous curves, organic botanical motifs, and a refined flat-design color palette.
+
+The aesthetic is characterized by its use of a long, sinuous, organic line and was employed most often in architecture, interior design, jewelry and glass design, posters, and illustration.
+
+### Botanical Themes
+Drawing inspiration from nature, you will find floral borders, vines, and curved frames.

--- a/artnouveau/content/posts/_index.md
+++ b/artnouveau/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Articles"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
++++

--- a/artnouveau/content/posts/flowing-forms.md
+++ b/artnouveau/content/posts/flowing-forms.md
@@ -1,0 +1,12 @@
++++
+title = "Flowing Forms in UI Design"
+date = "2025-02-01"
+description = "Applying sinuous curves to modern interfaces."
+tags = ["design", "art-nouveau"]
++++
+
+Art Nouveau's defining feature is its undulating, asymmetrical line, often taking the form of flower stalks and buds, vine tendrils, insect wings, and other delicate and sinuous natural objects.
+
+In modern flat design, these motifs can be simplified into bold, colored vectors, creating a striking contrast against rigid grid layouts.
+
+Instead of heavy 3D shading, **Art Nouveau 2.0** uses flat, solid colors—like deep forest green, muted mustard yellow, and rose—with sharp vector boundaries.

--- a/artnouveau/static/css/style.css
+++ b/artnouveau/static/css/style.css
@@ -1,0 +1,357 @@
+:root {
+    /* Art Nouveau 2.0 Color Palette */
+    --color-bg: #FDFBF7; /* Creamy off-white */
+    --color-primary: #1F4529; /* Deep Forest Green */
+    --color-secondary: #D4A373; /* Mustard/Gold */
+    --color-accent: #B05B5A; /* Muted Rose / Terracotta */
+    --color-text: #2B2B2B; /* Soft black */
+    --color-text-light: #5A5A5A;
+
+    /* Typography */
+    --font-heading: 'Cinzel', serif;
+    --font-subheading: 'Playfair Display', serif;
+    --font-body: 'Outfit', sans-serif;
+
+    --curve-radius: 40px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    padding: 2rem;
+    position: relative;
+    overflow-x: hidden;
+}
+
+/* Background Botanical Pattern (Subtle) */
+body::before {
+    content: '';
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    opacity: 0.03;
+    pointer-events: none;
+    z-index: -1;
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M30 0 C45 20, 60 30, 60 30 C45 30, 30 45, 30 60 C15 45, 0 30, 0 30 C15 20, 30 0, 30 0 Z' fill='%231F4529' fill-rule='evenodd'/%3E%3C/svg%3E");
+    background-size: 120px 120px;
+}
+
+/* Main Frame */
+.frame-container {
+    width: 100%;
+    max-width: 900px;
+    background: var(--color-bg);
+    position: relative;
+    border: 2px solid var(--color-primary);
+    border-radius: var(--curve-radius);
+    padding: 3rem;
+    box-shadow: 12px 12px 0px rgba(31, 69, 41, 0.1);
+}
+
+/* Corner Decorations */
+.corner-decoration {
+    position: absolute;
+    width: 60px;
+    height: 60px;
+}
+
+.top-left { top: -2px; left: -2px; }
+.top-right { top: -2px; right: -2px; }
+.bottom-left { bottom: -2px; left: -2px; }
+.bottom-right { bottom: -2px; right: -2px; }
+
+/* Header */
+.site-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.site-title {
+    font-family: var(--font-heading);
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+.brand a {
+    text-decoration: none;
+}
+
+.site-nav {
+    margin: 1.5rem 0;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+}
+
+.site-nav a {
+    font-family: var(--font-subheading);
+    font-size: 1.1rem;
+    font-weight: 600;
+    font-style: italic;
+    color: var(--color-primary);
+    text-decoration: none;
+    position: relative;
+    transition: color 0.3s ease;
+}
+
+.site-nav a:hover {
+    color: var(--color-accent);
+}
+
+.site-nav a::after {
+    content: '';
+    position: absolute;
+    bottom: -4px;
+    left: 50%;
+    width: 0;
+    height: 2px;
+    background-color: var(--color-accent);
+    transition: all 0.3s ease;
+    transform: translateX(-50%);
+    border-radius: 50%;
+}
+
+.site-nav a:hover::after {
+    width: 100%;
+    border-radius: 0;
+}
+
+.header-divider, .footer-divider {
+    margin: 2rem 0;
+    opacity: 0.7;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+p {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+}
+
+a {
+    color: var(--color-accent);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Page Content */
+.page-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.page-title {
+    font-size: 2.5rem;
+    color: var(--color-primary);
+}
+
+.page-meta {
+    font-family: var(--font-subheading);
+    font-style: italic;
+    color: var(--color-secondary);
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+}
+
+.page-tags {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.tag {
+    background-color: var(--color-primary);
+    color: var(--color-bg);
+    padding: 0.3rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-family: var(--font-subheading);
+    font-style: italic;
+    text-decoration: none;
+    transition: background-color 0.3s ease;
+}
+
+.tag:hover {
+    background-color: var(--color-accent);
+    color: var(--color-bg);
+    text-decoration: none;
+}
+
+/* Prose (Markdown Content) */
+.prose {
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.prose h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    color: var(--color-primary);
+    border-bottom: 1px solid var(--color-secondary);
+    padding-bottom: 0.5rem;
+}
+
+.prose h3 {
+    font-size: 1.4rem;
+    margin-top: 2rem;
+    color: var(--color-accent);
+}
+
+.prose blockquote {
+    font-family: var(--font-subheading);
+    font-style: italic;
+    font-size: 1.3rem;
+    color: var(--color-primary);
+    border-left: 4px solid var(--color-secondary);
+    padding-left: 1.5rem;
+    margin: 2rem 0;
+    background: rgba(212, 163, 115, 0.1);
+    padding: 1.5rem;
+    border-radius: 0 20px 20px 0;
+}
+
+.prose ul, .prose ol {
+    margin-bottom: 1.5rem;
+    padding-left: 1.5rem;
+}
+
+.prose li {
+    margin-bottom: 0.5rem;
+}
+
+.prose img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 20px;
+    border: 2px solid var(--color-primary);
+    margin: 2rem 0;
+}
+
+/* Post List */
+.post-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.post-card {
+    padding: 2rem;
+    background: white;
+    border: 1px solid rgba(31, 69, 41, 0.2);
+    border-radius: 20px;
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 0;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.post-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0;
+    width: 4px;
+    height: 100%;
+    background-color: var(--color-secondary);
+}
+
+.post-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 8px 8px 0px rgba(212, 163, 115, 0.2);
+}
+
+.post-card .post-title {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-card .post-title a {
+    color: var(--color-primary);
+}
+
+.post-card .post-title a:hover {
+    color: var(--color-accent);
+    text-decoration: none;
+}
+
+.post-card .post-meta {
+    font-family: var(--font-subheading);
+    font-style: italic;
+    color: var(--color-text-light);
+    margin-bottom: 1rem;
+}
+
+.read-more {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--font-subheading);
+    font-weight: 600;
+    font-style: italic;
+    color: var(--color-accent);
+    margin-top: 1rem;
+}
+
+.read-more .arrow {
+    margin-left: 0.5rem;
+    transition: transform 0.3s ease;
+}
+
+.read-more:hover .arrow {
+    transform: translateX(5px);
+}
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    margin-top: 4rem;
+    font-family: var(--font-subheading);
+    color: var(--color-text-light);
+}
+
+.botanical-text {
+    font-style: italic;
+    color: var(--color-secondary);
+    margin-top: 0.5rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .frame-container {
+        padding: 2rem 1.5rem;
+        border-radius: 20px;
+    }
+
+    .site-title {
+        font-size: 2rem;
+    }
+
+    .corner-decoration {
+        width: 40px;
+        height: 40px;
+    }
+}

--- a/artnouveau/templates/footer.html
+++ b/artnouveau/templates/footer.html
@@ -1,0 +1,14 @@
+        </main>
+        <footer class="site-footer">
+            <div class="footer-divider">
+                <svg viewBox="0 0 200 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" width="100%" height="20">
+                    <path d="M 0 10 C 50 30, 150 -10, 200 10" stroke="var(--color-primary)" stroke-width="2" fill="none"/>
+                    <circle cx="100" cy="10" r="4" fill="var(--color-accent)"/>
+                </svg>
+            </div>
+            <p>&copy; {{ current_year | default("2025") }} {{ site.title }}</p>
+            <p class="botanical-text">Inspired by nature, crafted with curves.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/artnouveau/templates/header.html
+++ b/artnouveau/templates/header.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default("en") }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="stylesheet" href="{{ config.base_url }}/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Outfit:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="frame-container">
+        <div class="corner-decoration top-left">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 0 L 100 0 C 40 0 0 40 0 100 Z" fill="var(--color-accent)"/>
+                <path d="M 10 10 C 10 50 50 90 90 90" stroke="var(--color-bg)" stroke-width="2" fill="none"/>
+                <circle cx="25" cy="25" r="5" fill="var(--color-bg)"/>
+            </svg>
+        </div>
+        <div class="corner-decoration top-right">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 100 0 L 0 0 C 60 0 100 40 100 100 Z" fill="var(--color-accent)"/>
+                <path d="M 90 10 C 90 50 50 90 10 90" stroke="var(--color-bg)" stroke-width="2" fill="none"/>
+                <circle cx="75" cy="25" r="5" fill="var(--color-bg)"/>
+            </svg>
+        </div>
+        <div class="corner-decoration bottom-left">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 0 100 L 100 100 C 40 100 0 60 0 0 Z" fill="var(--color-accent)"/>
+                <path d="M 10 90 C 10 50 50 10 90 10" stroke="var(--color-bg)" stroke-width="2" fill="none"/>
+                <circle cx="25" cy="75" r="5" fill="var(--color-bg)"/>
+            </svg>
+        </div>
+        <div class="corner-decoration bottom-right">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <path d="M 100 100 L 0 100 C 60 100 100 60 100 0 Z" fill="var(--color-accent)"/>
+                <path d="M 90 90 C 90 50 50 10 10 10" stroke="var(--color-bg)" stroke-width="2" fill="none"/>
+                <circle cx="75" cy="75" r="5" fill="var(--color-bg)"/>
+            </svg>
+        </div>
+
+        <header class="site-header">
+            <div class="brand">
+                <a href="{{ config.base_url }}/">
+                    <span class="site-title">{{ site.title }}</span>
+                </a>
+            </div>
+            <nav class="site-nav">
+                <a href="{{ config.base_url }}/">Home</a>
+                <a href="{{ config.base_url }}/posts/">Articles</a>
+                <a href="{{ config.base_url }}/tags/">Tags</a>
+            </nav>
+            <div class="header-divider">
+                <svg viewBox="0 0 200 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" width="100%" height="20">
+                    <path d="M 0 10 C 50 -10, 150 30, 200 10" stroke="var(--color-primary)" stroke-width="2" fill="none"/>
+                    <circle cx="100" cy="10" r="4" fill="var(--color-accent)"/>
+                </svg>
+            </div>
+        </header>
+        <main class="content">

--- a/artnouveau/templates/page.html
+++ b/artnouveau/templates/page.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<article class="page-content">
+    {% if page.title %}
+    <header class="page-header">
+        <h1 class="page-title">{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="page-meta">
+            <time datetime="{{ page.date | date("%Y-%m-%d") }}">{{ page.date | date("%B %d, %Y") }}</time>
+        </div>
+        {% endif %}
+        {% if page.tags %}
+        <div class="page-tags">
+            {% for tag in page.tags %}
+            <a href="{{ config.base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    <div class="prose">
+        {{ content | safe }}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/artnouveau/templates/section.html
+++ b/artnouveau/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+
+<div class="section-container">
+    <header class="section-header">
+        <h1 class="section-title">{% if section.title %}{{ section.title }}{% else %}{{ page.title | default("Articles") }}{% endif %}</h1>
+        {% if section.description %}
+        <p class="section-description">{{ section.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="post-list">
+        {% set posts = section.pages | default(site.pages) %}
+        {% for post in posts %}
+        {% if not post.draft %}
+        <article class="post-card">
+            <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">
+                {% if post.date %}
+                <time datetime="{{ post.date | date("%Y-%m-%d") }}">{{ post.date | date("%B %d, %Y") }}</time>
+                {% endif %}
+            </div>
+            <div class="post-summary">
+                {% if post.description %}
+                    <p>{{ post.description }}</p>
+                {% elif post.summary %}
+                    <p>{{ post.summary | strip_html | truncate_words(30) }}</p>
+                {% endif %}
+            </div>
+            <a href="{{ post.url }}" class="read-more">Read More <span class="arrow">→</span></a>
+        </article>
+        {% endif %}
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/artnouveau/templates/taxonomy.html
+++ b/artnouveau/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+
+<div class="taxonomy-container">
+    <header class="section-header">
+        <h1 class="section-title">Tags</h1>
+    </header>
+
+    <div class="tags-cloud">
+        {% for term in taxonomy_terms %}
+        <a href="{{ term.url }}" class="tag-cloud-item">{{ term.name }} <span class="count">({{ term.pages | length }})</span></a>
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}

--- a/artnouveau/templates/taxonomy_term.html
+++ b/artnouveau/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+
+<div class="section-container">
+    <header class="section-header">
+        <h1 class="section-title">Tag: {{ taxonomy_term.name }}</h1>
+    </header>
+
+    <div class="post-list">
+        {% for post in taxonomy_pages %}
+        {% if not post.draft %}
+        <article class="post-card">
+            <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">
+                {% if post.date %}
+                <time datetime="{{ post.date | date("%Y-%m-%d") }}">{{ post.date | date("%B %d, %Y") }}</time>
+                {% endif %}
+            </div>
+            <a href="{{ post.url }}" class="read-more">Read More <span class="arrow">→</span></a>
+        </article>
+        {% endif %}
+        {% endfor %}
+    </div>
+</div>
+
+{% include "footer.html" %}


### PR DESCRIPTION
Adds the 'Art Nouveau 2.0' theme to the Hwaro examples repository. This theme features sinuous curves, botanical motifs with a modern flat-design twist, elegant serif typography, and a refined color palette. The implementation adheres to the constraint of not modifying the tags.json file.

---
*PR created automatically by Jules for task [15829364274371621991](https://jules.google.com/task/15829364274371621991) started by @hahwul*