### PR TITLE
Add Monolithic Dark theme

### DIFF
--- a/monolithic-dark/config.toml
+++ b/monolithic-dark/config.toml
@@ -1,0 +1,7 @@
+base_url = "https://example.com"
+title = "Monolithic Dark"
+description = "A bold, creative, and elegant monolithic theme."
+default_language = "en"
+
+[extra]
+author = "Hwaro User"

--- a/monolithic-dark/content/_index.md
+++ b/monolithic-dark/content/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Home"
+sort_by = "date"
++++
+
+Welcome to the monolithic architecture of the future.

--- a/monolithic-dark/content/foundation.md
+++ b/monolithic-dark/content/foundation.md
@@ -1,0 +1,6 @@
++++
+title = "The Foundation"
+date = 2024-05-15
++++
+
+A massive block of carved stone forming the bedrock of modern aesthetics. Its weight implies permanence, while its texture tells the story of centuries of endurance against the elements.

--- a/monolithic-dark/static/css/style.css
+++ b/monolithic-dark/static/css/style.css
@@ -1,0 +1,178 @@
+:root {
+    --bg-color: #0d0d0f; /* Extremely dark grey, almost black */
+    --block-color: #1a1a1c; /* Dark stone color */
+    --block-border-light: #2c2c30; /* Highlight on the top/left edges */
+    --block-border-dark: #050505; /* Shadow on bottom/right edges */
+    --text-primary: #8a8a93; /* Recessed, muted text */
+    --text-highlight: #d1d1d6; /* Slightly brighter text for titles */
+    --text-recessed-shadow: 1px 1px 2px rgba(0,0,0,0.8), -1px -1px 1px rgba(255,255,255,0.05);
+
+    --font-heading: 'Cinzel', serif;
+    --font-body: 'Inter', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    display: flex;
+    justify-content: center;
+    min-height: 100vh;
+}
+
+.page-container {
+    width: 100%;
+    max-width: 1200px;
+    padding: 40px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6, .site-title {
+    font-family: var(--font-heading);
+    color: var(--text-highlight);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 400;
+}
+
+a {
+    color: var(--text-highlight);
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+a:hover {
+    color: #fff;
+}
+
+/* Monolithic Block Container */
+.block-container {
+    background-color: var(--block-color);
+    /* Creates the 3D block effect */
+    border-top: 2px solid var(--block-border-light);
+    border-left: 2px solid var(--block-border-light);
+    border-bottom: 4px solid var(--block-border-dark);
+    border-right: 4px solid var(--block-border-dark);
+    /* Solid shadow to ground the block */
+    box-shadow: 10px 10px 0px rgba(0,0,0,0.5);
+    padding: 60px;
+    margin-bottom: 40px;
+}
+
+/* Recessed text inside the blocks */
+.block-content h1,
+.block-content h2,
+.block-content p,
+.block-content time {
+    text-shadow: var(--text-recessed-shadow);
+}
+
+/* Header */
+.monolith-header {
+    margin-bottom: 20px;
+}
+
+.site-title {
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: 4px;
+    text-shadow: var(--text-recessed-shadow);
+}
+
+/* Hero Section */
+.hero-block {
+    text-align: center;
+    padding: 100px 40px;
+}
+
+.hero-title {
+    font-size: 4rem;
+    margin-bottom: 20px;
+    letter-spacing: 6px;
+}
+
+.hero-desc {
+    font-size: 1.2rem;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+/* Posts Grid */
+.posts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px;
+}
+
+.post-block {
+    padding: 40px;
+    margin-bottom: 0; /* Override generic margin */
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post-block:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 12px 12px 0px rgba(0,0,0,0.6);
+}
+
+.post-title {
+    font-size: 1.5rem;
+    margin-bottom: 10px;
+}
+
+.post-date {
+    font-size: 0.9rem;
+    color: #5a5a60;
+    font-family: var(--font-body);
+}
+
+/* Single Page */
+.single-page {
+    padding: 80px;
+}
+
+.page-header {
+    margin-bottom: 40px;
+    border-bottom: 1px solid var(--block-border-dark);
+    padding-bottom: 20px;
+}
+
+.page-title {
+    font-size: 3rem;
+    margin-bottom: 10px;
+}
+
+.page-date {
+    font-size: 1rem;
+    color: #5a5a60;
+}
+
+.page-body {
+    font-size: 1.1rem;
+    line-height: 1.8;
+}
+
+.page-body p {
+    margin-bottom: 20px;
+}
+
+/* Footer */
+.monolith-footer {
+    text-align: center;
+    padding: 40px 0;
+    border-top: 2px solid var(--block-border-dark);
+    color: #5a5a60;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}

--- a/monolithic-dark/templates/base.html
+++ b/monolithic-dark/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+    <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page-container">
+        <header class="monolith-header">
+            <div class="header-inner">
+                <a href="{{ config.base_url }}" class="site-title">{{ config.title }}</a>
+                <nav class="main-nav">
+                    <!-- Navigation items if any -->
+                </nav>
+            </div>
+        </header>
+
+        <main class="monolith-main">
+            {% block content %}{% endblock content %}
+        </main>
+
+        <footer class="monolith-footer">
+            <div class="footer-inner">
+                <p>&copy; {{ config.title }}. Carved in stone.</p>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/monolithic-dark/templates/index.html
+++ b/monolithic-dark/templates/index.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="index-layout">
+    <section class="hero-block block-container">
+        <div class="block-content">
+            <h1 class="hero-title">{{ config.title }}</h1>
+            {% if config.description %}
+            <p class="hero-desc">{{ config.description }}</p>
+            {% endif %}
+        </div>
+    </section>
+
+    <section class="posts-grid">
+        {% for page in section.pages %}
+        <article class="post-block block-container">
+            <div class="block-content">
+                <h2 class="post-title"><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                {% if page.date %}
+                <time class="post-date" datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time>
+                {% endif %}
+            </div>
+        </article>
+        {% endfor %}
+    </section>
+</div>
+{% endblock content %}

--- a/monolithic-dark/templates/page.html
+++ b/monolithic-dark/templates/page.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+
+{% block content %}
+<article class="single-page block-container">
+    <div class="block-content">
+        <header class="page-header">
+            <h1 class="page-title">{{ page.title }}</h1>
+            {% if page.date %}
+            <time class="page-date" datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time>
+            {% endif %}
+        </header>
+
+        <div class="page-body">
+            {{ page.content | safe }}
+        </div>
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
This PR introduces the `monolithic-dark` theme to the Hwaro examples. It features a bold, creative, and elegant design defined by giant stone-like blocks (created via box-shadows and borders) and minimal recessed text (created via text-shadows) on an extremely dark background. It correctly sets up Zola components including config, templates, static assets, and content front matter.

---
*PR created automatically by Jules for task [11021382000198633572](https://jules.google.com/task/11021382000198633572) started by @hahwul*