### PR TITLE
feat: add solar-punk bright theme

### DIFF
--- a/solar-punk/config.toml
+++ b/solar-punk/config.toml
@@ -1,0 +1,47 @@
+title = "Solar-Punk Bright"
+description = "Vibrant greens, sun-bleached whites, and sustainable tech aesthetics."
+base_url = "http://localhost:3000"
+default_language = "en"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+[extra]
+author = "Solari"
+social_twitter = "solarpunk"
+social_github = "solarpunk"

--- a/solar-punk/content/index.md
+++ b/solar-punk/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Solar-Punk Bright"
+description = "A sustainable tech aesthetic featuring vibrant greens and sun-bleached whites."
+template = "index"
++++
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 2rem; margin-top: 2rem;">
+    <div class="post-card">
+        <h3>Harmony with Nature</h3>
+        <p>Designing systems that integrate seamlessly with the natural world, fostering growth rather than extraction.</p>
+    </div>
+    <div class="post-card">
+        <h3>Renewable Energy</h3>
+        <p>Harnessing the power of the sun, wind, and water to power our digital infrastructures and communities.</p>
+    </div>
+    <div class="post-card">
+        <h3>Community Tech</h3>
+        <p>Building localized, resilient networks that empower individuals and communities over centralized control.</p>
+    </div>
+</div>

--- a/solar-punk/content/posts/_index.md
+++ b/solar-punk/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "The Solarpunk Manifesto"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+transparent = false
++++

--- a/solar-punk/content/posts/embracing-solarpunk.md
+++ b/solar-punk/content/posts/embracing-solarpunk.md
@@ -1,0 +1,36 @@
++++
+title = "Embracing the Solar-Punk Aesthetic"
+date = "2025-04-10"
+description = "How to integrate sustainable design principles into modern web interfaces."
+tags = ["design", "solarpunk", "aesthetic"]
+[extra]
+author = "Solari"
++++
+
+Solarpunk is not just a visual aesthetic; it's a movement towards a sustainable and equitable future. In web design, this translates to utilizing colors that evoke nature—vibrant greens, sun-bleached whites, and earthy tones—while maintaining a clean, technological edge.
+
+## The Core Elements
+
+1. **Vibrant Greens**: Symbolizing life, growth, and the integration of nature into our daily lives.
+2. **Sun-bleached Whites**: Providing a clean, bright canvas that reflects the energy of the sun.
+3. **Sustainable Tech**: Utilizing efficient code and lightweight assets to minimize the carbon footprint of our digital creations.
+
+### Code Example
+
+Here is a quick example of a lightweight, energy-efficient CSS snippet:
+
+```css
+:root {
+  --primary: #00e676;
+  --bg: #fffaf0;
+  --text: #1b4d3e;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+}
+```
+
+By prioritizing simplicity and efficiency, we not only create beautiful interfaces but also contribute to a more sustainable web.

--- a/solar-punk/content/posts/resilient-communities.md
+++ b/solar-punk/content/posts/resilient-communities.md
@@ -1,0 +1,22 @@
++++
+title = "Building Resilient Digital Communities"
+date = "2025-04-12"
+description = "Exploring decentralized networks and community-driven technology."
+tags = ["community", "technology", "decentralization"]
+[extra]
+author = "Lyra"
++++
+
+In the solarpunk vision, technology serves the community rather than exploiting it. This post explores the rise of decentralized networks, localized internets, and open-source software that empowers individuals.
+
+## Localized Networks
+
+Mesh networks allow neighborhoods to share internet access, creating a resilient infrastructure that is less dependent on centralized ISPs.
+
+## Open-Source Software
+
+By contributing to and utilizing open-source projects, we ensure that the tools we rely on remain accessible to everyone, preventing corporate monopolies on essential technology.
+
+> "Technology should be a tool for liberation, not a mechanism for control."
+
+Let's continue to build systems that uplift and connect us all, grounded in the principles of equity and sustainability.

--- a/solar-punk/templates/404.html
+++ b/solar-punk/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<article class="page-content" style="text-align: center; padding: 5rem 3rem;">
+    <h1 style="font-size: 5rem; color: var(--primary-color); margin-bottom: 0;">404</h1>
+    <h2 style="font-size: 2rem; margin-bottom: 2rem;">Signal Lost</h2>
+    <p>The node you are looking for has been reclaimed by nature or never existed.</p>
+    <a href="{{ config.base_url }}/" class="tag" style="display: inline-block; margin-top: 2rem; padding: 0.8rem 2rem; font-size: 1.1rem;">Return to the Grid</a>
+</article>
+
+{% include "footer.html" %}

--- a/solar-punk/templates/footer.html
+++ b/solar-punk/templates/footer.html
@@ -1,0 +1,38 @@
+        </main>
+
+        <style>
+            .site-footer {
+                margin-top: 5rem;
+                padding: 2rem 0;
+                border-top: 1px dashed var(--border-color);
+                text-align: center;
+                color: #558b2f;
+                font-size: 0.9rem;
+            }
+            .tech-accent {
+                display: flex;
+                justify-content: center;
+                gap: 5px;
+                margin-top: 1rem;
+            }
+            .tech-dot {
+                width: 8px;
+                height: 8px;
+                background-color: var(--secondary-color);
+                border-radius: 50%;
+            }
+            .tech-dot:nth-child(2) { background-color: var(--primary-color); }
+            .tech-dot:nth-child(3) { background-color: var(--accent-color); }
+        </style>
+
+        <footer class="site-footer">
+            <p>&copy; {{ current_year | default(value=2025) }} {{ config.title }}. Powered by Sun and Wind.</p>
+            <div class="tech-accent">
+                <div class="tech-dot"></div>
+                <div class="tech-dot"></div>
+                <div class="tech-dot"></div>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/solar-punk/templates/header.html
+++ b/solar-punk/templates/header.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="{{ config.default_language | default(value='en') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{% if page is defined and page.description %}{{ page.description }}{% else %}{{ config.description }}{% endif %}">
+
+    <style>
+        :root {
+            --bg-color: #fffaf0; /* Sun-bleached white */
+            --text-color: #1b4d3e; /* Deep forest green */
+            --primary-color: #00e676; /* Vibrant green */
+            --secondary-color: #aeea00; /* Vibrant lime */
+            --accent-color: #ffab00; /* Sun yellow/orange accent */
+            --card-bg: #ffffff;
+            --border-color: #b2dfdb;
+            --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
+            --font-serif: 'Georgia', serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: var(--font-sans);
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+            background-image:
+                radial-gradient(circle at 10% 20%, rgba(174, 234, 0, 0.05) 0%, transparent 50%),
+                radial-gradient(circle at 90% 80%, rgba(0, 230, 118, 0.05) 0%, transparent 50%);
+        }
+
+        /* Container */
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 0 2rem;
+        }
+
+        /* Header Navigation */
+        .site-header {
+            padding: 2rem 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 2px solid var(--primary-color);
+            margin-bottom: 3rem;
+        }
+
+        .site-title {
+            font-family: var(--font-serif);
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--text-color);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .site-title::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background-color: var(--primary-color);
+            border-radius: 50% 0 50% 50%; /* Leaf shape */
+            transform: rotate(45deg);
+        }
+
+        .site-nav a {
+            color: var(--text-color);
+            text-decoration: none;
+            margin-left: 1.5rem;
+            font-weight: 500;
+            transition: color 0.2s, box-shadow 0.2s;
+            padding-bottom: 2px;
+        }
+
+        .site-nav a:hover {
+            color: var(--primary-color);
+            box-shadow: inset 0 -2px 0 var(--primary-color);
+        }
+
+        /* Content Areas */
+        main {
+            min-height: 60vh;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-serif);
+            margin-bottom: 1rem;
+            color: var(--text-color);
+            line-height: 1.3;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            position: relative;
+            display: inline-block;
+        }
+
+        h1::after {
+            content: '';
+            position: absolute;
+            bottom: 4px;
+            left: 0;
+            width: 100%;
+            height: 8px;
+            background-color: rgba(0, 230, 118, 0.3);
+            z-index: -1;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+        }
+
+        a {
+            color: var(--primary-color);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Post Cards */
+        .post-list {
+            list-style: none;
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 2rem;
+        }
+
+        .post-card {
+            background-color: var(--card-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 12px 12px 12px 0; /* Tech but organic */
+            padding: 2rem;
+            box-shadow: 4px 4px 0 rgba(0, 230, 118, 0.1);
+            transition: transform 0.2s, box-shadow 0.2s;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .post-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background-color: var(--primary-color);
+        }
+
+        .post-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 8px 8px 0 rgba(0, 230, 118, 0.2);
+        }
+
+        .post-card h2 {
+            margin-bottom: 0.5rem;
+            font-size: 1.8rem;
+        }
+
+        .post-card h2 a {
+            color: var(--text-color);
+        }
+
+        .post-card h2 a:hover {
+            text-decoration: none;
+            color: var(--primary-color);
+        }
+
+        .post-meta {
+            font-size: 0.9rem;
+            color: #558b2f;
+            margin-bottom: 1rem;
+            display: flex;
+            gap: 1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .post-summary {
+            color: #33691e;
+        }
+
+        /* Tags */
+        .tags {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .tag {
+            background-color: var(--secondary-color);
+            color: var(--text-color);
+            padding: 0.2rem 0.8rem;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .tag:hover {
+            background-color: var(--primary-color);
+            color: white;
+            text-decoration: none;
+        }
+
+        /* Tech Element styling for code blocks */
+        pre {
+            background-color: #f1f8e9;
+            border: 1px solid var(--border-color);
+            border-left: 4px solid var(--secondary-color);
+            padding: 1rem;
+            border-radius: 4px;
+            overflow-x: auto;
+            margin-bottom: 1.5rem;
+            font-family: 'Courier New', Courier, monospace;
+        }
+
+        code {
+            background-color: #f1f8e9;
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.9em;
+            color: var(--text-color);
+        }
+
+        pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+
+        /* Page styling */
+        .page-content {
+            background-color: var(--card-bg);
+            padding: 3rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.03);
+            border: 1px solid var(--border-color);
+            position: relative;
+        }
+
+        .page-header {
+            margin-bottom: 2rem;
+            text-align: center;
+        }
+
+        .page-header h1 {
+            font-size: 3rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .page-header h1::after {
+            left: 50%;
+            transform: translateX(-50%);
+            width: 60px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header class="site-header">
+            <a href="{{ config.base_url }}/" class="site-title">{{ config.title }}</a>
+            <nav class="site-nav">
+                <a href="{{ config.base_url }}/">Home</a>
+                <a href="{{ config.base_url }}/posts/">Manifesto</a>
+            </nav>
+        </header>
+        <main>

--- a/solar-punk/templates/index.html
+++ b/solar-punk/templates/index.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+
+<div class="hero" style="text-align: center; margin: 4rem 0;">
+    <h1>{{ page.title | default(value=config.title) }}</h1>
+    <p style="font-size: 1.2rem; color: #558b2f; max-width: 600px; margin: 1rem auto;">
+        {{ page.description | default(value=config.description) }}
+    </p>
+</div>
+
+{% if page is defined and page.content %}
+<div class="page-content" style="margin-bottom: 3rem; background: transparent; box-shadow: none; border: none; padding: 0;">
+    {{ page.content | safe }}
+</div>
+{% endif %}
+
+{% if section is defined and section.pages %}
+<ul class="post-list">
+    {% for post in section.pages %}
+    <li class="post-card">
+        <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div class="post-meta">
+            {% if post.date %}
+            <span>{{ post.date | date(format="%B %d, %Y") }}</span>
+            {% endif %}
+            {% if post.extra and post.extra.author %}
+            <span>&bull; {{ post.extra.author }}</span>
+            {% endif %}
+        </div>
+        {% if post.summary %}
+        <p class="post-summary">{{ post.summary }}</p>
+        {% elif post.description %}
+        <p class="post-summary">{{ post.description }}</p>
+        {% endif %}
+
+        {% if post.tags %}
+        <div class="tags">
+            {% for tag in post.tags %}
+            <span class="tag">{{ tag }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% include "footer.html" %}

--- a/solar-punk/templates/page.html
+++ b/solar-punk/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<article class="page-content">
+    <header class="page-header">
+        <h1>{{ page.title }}</h1>
+        <div class="post-meta" style="justify-content: center;">
+            {% if page.date %}
+            <span>{{ page.date | date(format="%B %d, %Y") }}</span>
+            {% endif %}
+            {% if page.extra and page.extra.author %}
+            <span>&bull; {{ page.extra.author }}</span>
+            {% endif %}
+        </div>
+    </header>
+
+    <div class="content">
+        {{ page.content | safe }}
+    </div>
+
+    {% if page.tags %}
+    <div class="tags" style="margin-top: 3rem; border-top: 1px solid var(--border-color); padding-top: 1.5rem;">
+        <span style="color: var(--text-color); font-weight: 600; margin-right: 0.5rem;">Tags:</span>
+        {% for tag in page.tags %}
+        <a href="{{ config.base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/solar-punk/templates/section.html
+++ b/solar-punk/templates/section.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+
+<div class="hero" style="text-align: center; margin: 3rem 0;">
+    <h1>{{ section.title | default(value="Posts") }}</h1>
+    {% if section.description %}
+    <p style="font-size: 1.2rem; color: #558b2f; max-width: 600px; margin: 1rem auto;">
+        {{ section.description }}
+    </p>
+    {% endif %}
+</div>
+
+{% if section.pages %}
+<ul class="post-list">
+    {% for post in section.pages %}
+    <li class="post-card">
+        <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div class="post-meta">
+            {% if post.date %}
+            <span>{{ post.date | date(format="%B %d, %Y") }}</span>
+            {% endif %}
+        </div>
+        {% if post.summary %}
+        <p class="post-summary">{{ post.summary }}</p>
+        {% elif post.description %}
+        <p class="post-summary">{{ post.description }}</p>
+        {% endif %}
+
+        {% if post.tags %}
+        <div class="tags">
+            {% for tag in post.tags %}
+            <span class="tag">{{ tag }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% include "footer.html" %}


### PR DESCRIPTION
Added the "Solar-Punk Bright" example site theme to the hwaro-examples repository.

This theme features a bright, sustainable tech aesthetic incorporating sun-bleached whites (`#fffaf0`), vibrant greens (`#00e676`), and organic-yet-technological UI elements. It provides a complete, isolated Hwaro directory structure with templates, config, and example markdown content.

**Changes included:**
*   Created the `solar-punk/` directory structure.
*   Added `config.toml` with appropriate metadata.
*   Implemented core HTML templates (`header.html`, `footer.html`, `index.html`, `page.html`, `section.html`, `404.html`) using inline CSS.
*   Provided sample markdown content (`content/index.md`, `content/posts/`) showcasing the aesthetic.
*   Ensured Jinja2/Tera template filters use named arguments to prevent build issues.

As requested, the `tags.json` file was strictly not modified during this task.

---
*PR created automatically by Jules for task [3773575674010040553](https://jules.google.com/task/3773575674010040553) started by @hahwul*