### PR TITLE
Add Abstract Calligraphy Theme Example

### DIFF
--- a/calligraphy/config.toml
+++ b/calligraphy/config.toml
@@ -1,0 +1,39 @@
+title = "Abstract Calligraphy"
+description = "Huge, expressive ink strokes used as structural elements."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/calligraphy/content/index.md
+++ b/calligraphy/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Home"
+template = "index"
++++
+Welcome to a realm where ink and digital spaces merge. Abstract calligraphy uses bold, unrestrained strokes to define the canvas.
+
+Explore our collection of thoughts and expressions.

--- a/calligraphy/content/posts/_index.md
+++ b/calligraphy/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Expressions"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "section"
+generate_feeds = true
+transparent = false
++++
+A collection of our most expressive moments in ink.

--- a/calligraphy/content/posts/first-stroke.md
+++ b/calligraphy/content/posts/first-stroke.md
@@ -1,0 +1,17 @@
++++
+title = "The First Stroke"
+date = "2025-01-01"
+description = "Every masterpiece begins with a single, unhesitating stroke."
+tags = ["ink", "philosophy"]
+categories = ["thoughts"]
++++
+The blank page is not empty; it is full of potential. The brush does not mark the paper, it reveals what was already there waiting to be seen.
+
+When we approach the canvas, our minds must be as fluid as the ink. Rigidity breeds fragile forms. The stroke must be confident, flowing from the shoulder, not just the wrist.
+
+<!-- more -->
+
+### The Weight of Black
+Black ink against white paper creates an absolute duality. The white space is not simply background; it is negative space, carrying as much structural weight as the ink itself. In abstract calligraphy, we do not aim for legibility, but for emotion.
+
+> "The stroke is the mind made visible."

--- a/calligraphy/templates/footer.html
+++ b/calligraphy/templates/footer.html
@@ -1,0 +1,8 @@
+    </main>
+
+    <footer class="mt-24 py-12 border-t border-ink/10 text-center text-ash text-sm">
+        <p class="font-serif italic mb-2">The stroke is eternal.</p>
+        <p>&copy; {{ current_year | default("2025") }} {{ site.title }}</p>
+    </footer>
+</body>
+</html>

--- a/calligraphy/templates/header.html
+++ b/calligraphy/templates/header.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="{{ site.language_code | default("en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <!-- Minimal setup for Tailwind via CDN to save time, with custom config for our typography/colors -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        ink: '#111111',
+                        paper: '#f9f8f4',
+                        redseal: '#ba2311',
+                        ash: '#888888',
+                    },
+                    fontFamily: {
+                        sans: ['"Helvetica Neue"', 'Helvetica', 'Arial', 'sans-serif'],
+                        serif: ['"Playfair Display"', '"Bodoni MT"', 'Didot', '"Times New Roman"', 'serif'],
+                    }
+                }
+            }
+        }
+    </script>
+
+    <!-- Google Fonts for the elegant serif -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --ink-stroke: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path fill="%23111111" opacity="0.05" d="M0,50 Q25,30 50,50 T100,50 Q75,70 50,50 T0,50 Z"/></svg>');
+        }
+
+        body {
+            background-color: theme('colors.paper');
+            color: theme('colors.ink');
+            position: relative;
+            overflow-x: hidden;
+            font-family: theme('fontFamily.sans');
+        }
+
+        /* Abstract structural ink strokes */
+        .ink-stroke-vertical {
+            position: fixed;
+            top: -10%;
+            left: 10%;
+            width: 20vw;
+            height: 120vh;
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 800" preserveAspectRatio="none"><path d="M40,0 Q60,200 45,400 T50,800 L0,800 Q10,400 20,0 Z" fill="%23111111" opacity="0.03"/></svg>');
+            background-size: 100% 100%;
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        .ink-stroke-horizontal {
+            position: fixed;
+            top: 30%;
+            right: -5%;
+            width: 60vw;
+            height: 30vh;
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 100" preserveAspectRatio="none"><path d="M0,40 Q200,60 400,45 T800,50 L800,0 Q400,10 0,20 Z" fill="%23111111" opacity="0.04"/></svg>');
+            background-size: 100% 100%;
+            z-index: -1;
+            transform: rotate(-10deg);
+            pointer-events: none;
+        }
+
+        .ink-splatter {
+            position: absolute;
+            width: 400px;
+            height: 400px;
+            top: -50px;
+            right: -50px;
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="%23111111" opacity="0.02" filter="url(%23displacementFilter)"/><defs><filter id="displacementFilter"><feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="3" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="20" xChannelSelector="R" yChannelSelector="G"/></filter></defs></svg>');
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6, .font-serif {
+            font-family: theme('fontFamily.serif');
+        }
+
+        .brush-title {
+            position: relative;
+            display: inline-block;
+        }
+
+        .brush-title::after {
+            content: '';
+            position: absolute;
+            bottom: 10%;
+            left: -5%;
+            width: 110%;
+            height: 40%;
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 Q25,0 50,10 T100,10 Q75,20 50,10 T0,10 Z" fill="%23ba2311" opacity="0.2"/></svg>');
+            z-index: -1;
+        }
+
+        /* Nav */
+        .nav-link {
+            position: relative;
+            transition: color 0.3s ease;
+        }
+
+        .nav-link:hover {
+            color: theme('colors.redseal');
+        }
+
+        /* Content Markdown Styling */
+        .content-area p {
+            margin-bottom: 1.5rem;
+            line-height: 1.8;
+            font-size: 1.125rem;
+            color: theme('colors.ink');
+        }
+
+        .content-area a {
+            color: theme('colors.redseal');
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.3s;
+        }
+
+        .content-area a:hover {
+            border-bottom-color: theme('colors.redseal');
+        }
+
+        .content-area h2 {
+            font-size: 2.25rem;
+            margin-top: 3rem;
+            margin-bottom: 1.5rem;
+            font-weight: 700;
+        }
+
+        .content-area h3 {
+            font-size: 1.75rem;
+            margin-top: 2.5rem;
+            margin-bottom: 1rem;
+            font-weight: 700;
+        }
+
+        .content-area blockquote {
+            border-left: 4px solid theme('colors.ink');
+            padding-left: 1.5rem;
+            margin-left: 0;
+            margin-right: 0;
+            font-style: italic;
+            font-size: 1.25rem;
+            color: theme('colors.ash');
+            font-family: theme('fontFamily.serif');
+        }
+
+        /* The seal */
+        .seal {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            border: 2px solid theme('colors.redseal');
+            color: theme('colors.redseal');
+            font-family: theme('fontFamily.serif');
+            font-weight: bold;
+            font-size: 0.8rem;
+            border-radius: 4px;
+            transform: rotate(-5deg);
+        }
+    </style>
+</head>
+<body class="antialiased">
+    <div class="ink-stroke-vertical"></div>
+    <div class="ink-stroke-horizontal"></div>
+
+    <header class="py-12 px-6 md:px-12 max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center relative">
+        <div class="ink-splatter"></div>
+        <a href="{{ site.base_url }}/" class="text-4xl font-serif font-bold tracking-tight mb-6 md:mb-0 text-ink flex items-center gap-4 hover:opacity-80 transition-opacity">
+            <span>{{ site.title }}</span>
+            <span class="seal text-redseal border-redseal">AC</span>
+        </a>
+
+        <nav class="flex gap-8 text-sm uppercase tracking-widest font-bold">
+            <a href="{{ site.base_url }}/" class="nav-link">Home</a>
+            <a href="{{ site.base_url }}/posts/" class="nav-link">Expressions</a>
+            <a href="{{ site.base_url }}/tags/" class="nav-link">Tags</a>
+        </nav>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-6 md:px-12 py-12 min-h-[60vh]">

--- a/calligraphy/templates/index.html
+++ b/calligraphy/templates/index.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+
+<article class="relative">
+    <div class="content-area">
+        <h1 class="text-5xl font-bold font-serif mb-8 brush-title">{{ page.title | default("Home") }}</h1>
+        <div class="text-xl leading-relaxed text-ink/90 font-serif mb-12 border-l-4 border-redseal pl-6">
+            {{ content | safe }}
+        </div>
+
+        <div class="mt-16 text-center">
+            <a href="{{ site.base_url }}/posts/" class="inline-block border-2 border-ink text-ink hover:bg-ink hover:text-paper font-bold uppercase tracking-widest px-8 py-4 transition-colors">
+                View Expressions
+            </a>
+        </div>
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/calligraphy/templates/page.html
+++ b/calligraphy/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+
+<article class="relative">
+    <header class="mb-16 text-center">
+        <h1 class="text-5xl md:text-7xl font-bold brush-title mb-6 leading-tight">{{ page.title }}</h1>
+        {% if page.date %}
+            <p class="text-ash tracking-widest uppercase text-sm mb-4">{{ page.date | date("%B %d, %Y") }}</p>
+        {% endif %}
+        {% if page.description %}
+            <p class="text-xl md:text-2xl font-serif text-ash italic max-w-2xl mx-auto mt-8 border-l-4 border-redseal pl-6 text-left">{{ page.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="content-area">
+        {{ content | safe }}
+    </div>
+
+    {% if page.tags %}
+    <div class="mt-16 pt-8 border-t border-ink/10 flex gap-4">
+        <span class="text-ash uppercase tracking-widest text-sm font-bold">Tags:</span>
+        {% for tag in page.tags %}
+            <a href="{{ site.base_url }}/tags/{{ tag | slugify }}/" class="text-redseal hover:text-ink transition-colors text-sm uppercase tracking-widest">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/calligraphy/templates/section.html
+++ b/calligraphy/templates/section.html
@@ -1,0 +1,37 @@
+{% include "header.html" %}
+
+<div class="mb-16">
+    <h1 class="text-5xl font-bold font-serif mb-4 brush-title">{{ section.title | default("Section") }}</h1>
+    {% if section.description %}
+        <p class="text-xl text-ash italic font-serif">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+<div class="space-y-16">
+    {% for post in section.pages %}
+        <article class="group">
+            <a href="{{ post.url | default(site.base_url ~ post.path) }}" class="block">
+                <header class="mb-4">
+                    {% if post.date %}
+                        <span class="text-xs text-ash tracking-widest uppercase mb-2 block">{{ post.date | date("%Y-%m-%d") }}</span>
+                    {% endif %}
+                    <h2 class="text-3xl font-bold font-serif group-hover:text-redseal transition-colors">{{ post.title }}</h2>
+                </header>
+                <div class="text-lg text-ink/80 font-serif italic mb-4 border-l-2 border-transparent group-hover:border-redseal pl-4 transition-all">
+                    {% if post.description %}
+                        {{ post.description }}
+                    {% elif post.summary %}
+                        {{ post.summary | strip_html | safe }}
+                    {% else %}
+                        {{ post.content | strip_html | truncate_words(30) | safe }}
+                    {% endif %}
+                </div>
+            </a>
+            <a href="{{ post.url | default(site.base_url ~ post.path) }}" class="text-sm uppercase tracking-widest text-redseal font-bold flex items-center gap-2 group-hover:gap-4 transition-all">
+                Read Expression <span class="text-lg">&rarr;</span>
+            </a>
+        </article>
+    {% endfor %}
+</div>
+
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds the 'Abstract Calligraphy' example theme to showcase bold, expressive SVG ink strokes as structural elements, creating an elegant, artistic design. The tags.json file was explicitly left untouched as requested.

---
*PR created automatically by Jules for task [6606840254399147533](https://jules.google.com/task/6606840254399147533) started by @hahwul*