### PR TITLE
feat: add paper-art hwaro example site

### DIFF
--- a/paper-art/config.toml
+++ b/paper-art/config.toml
@@ -1,0 +1,41 @@
+title = "Paper Texture Art"
+description = "Realistic layered paper textures, like a high-end physical collage."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/paper-art/content/_index.md
+++ b/paper-art/content/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Gallery"
+sort_by = "date"
+reverse = true
+paginate = 10
+template = "index.html"
+generate_feeds = true
++++

--- a/paper-art/content/post-1.md
+++ b/paper-art/content/post-1.md
@@ -1,0 +1,10 @@
++++
+title = "The Art of Layering"
+date = "2024-05-10"
+description = "Exploring the depth and shadows of paper art."
+tags = ["paper", "art", "collage"]
+categories = ["design"]
++++
+In the realm of physical collage, the interplay of light and shadow is paramount. Each layer of paper adds a new dimension, creating a tactile experience that transcends the flat surface. By carefully cutting, tearing, and arranging these layers, artists can evoke emotions and tell stories in a uniquely organic way.
+
+The texture of the paper itself—its grain, thickness, and color—plays a crucial role in the final piece. Some papers are smooth and translucent, casting soft shadows, while others are rough and opaque, demanding attention with sharp, dramatic edges.

--- a/paper-art/content/post-2.md
+++ b/paper-art/content/post-2.md
@@ -1,0 +1,10 @@
++++
+title = "Shadow Play"
+date = "2024-05-15"
+description = "How slight elevations change the perspective."
+tags = ["shadows", "technique"]
+categories = ["design"]
++++
+Elevation is the secret ingredient in paper texture art. Even a millimeter of space between layers can drastically alter how the artwork is perceived. This technique relies heavily on the environment's lighting; as the light source shifts, the shadows dance across the surface, bringing the collage to life.
+
+We often use small foam pads or thick glue dots to achieve this separation. The result is a dynamic piece that changes its appearance throughout the day, offering new details to discover with every glance.

--- a/paper-art/static/css/style.css
+++ b/paper-art/static/css/style.css
@@ -1,0 +1,307 @@
+:root {
+    --bg-color: #d8d3c5; /* Neutral warm grey/beige for the background mat */
+    --paper-white: #f4f1ea;
+    --paper-cream: #eeeadd;
+    --paper-dark: #2c2b28;
+    --paper-accent: #8b3a3a;
+    --text-main: #33312e;
+    --text-light: #5a5751;
+
+    /* Shadows for depth */
+    --shadow-1: 0 2px 5px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-2: 0 4px 10px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1);
+    --shadow-3: 0 8px 20px rgba(0, 0, 0, 0.2), 0 4px 8px rgba(0, 0, 0, 0.15);
+    --shadow-float: 0 15px 35px rgba(0, 0, 0, 0.25), 0 5px 15px rgba(0, 0, 0, 0.15);
+
+    --font-serif: 'Playfair Display', serif;
+    --font-serif-body: 'Cormorant Garamond', serif;
+    --font-sans: 'Source Sans Pro', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.08'/%3E%3C/svg%3E");
+    color: var(--text-main);
+    font-family: var(--font-serif-body);
+    font-size: 20px;
+    line-height: 1.6;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+a {
+    color: var(--paper-accent);
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+a:hover {
+    color: var(--text-main);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-serif);
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.5em;
+    color: var(--paper-dark);
+}
+
+/* Layer System */
+.layer {
+    background-color: var(--paper-white);
+    position: relative;
+    filter: url(#paper-texture);
+}
+
+/* Base Canvas */
+.canvas {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 40px 20px;
+    position: relative;
+}
+
+/* Header Layer */
+.header-layer {
+    background-color: var(--paper-cream);
+    padding: 60px 40px;
+    margin-bottom: 60px;
+    box-shadow: var(--shadow-2);
+    transform: rotate(-1deg);
+    z-index: 10;
+    text-align: center;
+    border: 1px solid rgba(0,0,0,0.05);
+}
+
+.header-content {
+    transform: rotate(1deg); /* Counter-rotate content */
+}
+
+.header-layer h1 {
+    font-size: 3.5rem;
+    letter-spacing: 1px;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+}
+
+.header-layer h1 a {
+    color: var(--paper-dark);
+}
+
+.subtitle {
+    font-family: var(--font-sans);
+    font-size: 1.1rem;
+    color: var(--text-light);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+/* Post Grid for Index */
+.post-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 40px;
+    margin-bottom: 60px;
+}
+
+/* Individual Cards */
+.post-card {
+    padding: 30px;
+    box-shadow: var(--shadow-1);
+    transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+    cursor: pointer;
+    border: 1px solid rgba(0,0,0,0.03);
+    z-index: 5;
+}
+
+.post-card:hover {
+    box-shadow: var(--shadow-float);
+    transform: translateY(-5px) scale(1.02) !important;
+    z-index: 20;
+}
+
+.tilt-0 { transform: rotate(1.5deg); }
+.tilt-1 { transform: rotate(-2deg); background-color: var(--paper-cream); }
+.tilt-2 { transform: rotate(0.5deg); }
+
+.card-inner {
+    /* Counter rotation is difficult with dynamic tilts, we'll keep the text slightly tilted for realism */
+}
+
+.post-title {
+    font-size: 1.8rem;
+    margin-bottom: 10px;
+}
+
+.post-meta {
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    color: var(--text-light);
+    margin-bottom: 20px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-bottom: 1px dashed rgba(0,0,0,0.1);
+    padding-bottom: 10px;
+    display: inline-block;
+}
+
+.post-description {
+    margin-bottom: 25px;
+    font-size: 1.1rem;
+}
+
+/* Small Button Layer */
+.button-layer {
+    display: inline-block;
+    padding: 8px 20px;
+    background-color: var(--paper-dark);
+    color: var(--paper-white) !important;
+    font-family: var(--font-sans);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 0.85rem;
+    box-shadow: var(--shadow-1);
+    transform: rotate(-1deg);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.button-layer:hover {
+    transform: rotate(1deg) translateY(-2px);
+    box-shadow: var(--shadow-2);
+}
+
+/* Full Post Page */
+.full-post {
+    padding: 60px 80px;
+    background-color: var(--paper-white);
+    box-shadow: var(--shadow-3);
+    margin-bottom: 60px;
+    z-index: 15;
+    border: 1px solid rgba(0,0,0,0.04);
+}
+
+.post-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.full-post .post-title {
+    font-size: 3rem;
+}
+
+.post-body p {
+    margin-bottom: 1.5em;
+    font-size: 1.25rem;
+}
+
+/* Footer */
+.footer-layer {
+    padding: 30px;
+    text-align: center;
+    background-color: var(--paper-dark);
+    color: var(--paper-white);
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    box-shadow: var(--shadow-2);
+    transform: rotate(1deg);
+    z-index: 10;
+}
+
+/* Realistic Details */
+
+/* Masking Tape */
+.tape {
+    position: absolute;
+    width: 100px;
+    height: 30px;
+    background-color: rgba(255, 255, 240, 0.6);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    backdrop-filter: blur(2px);
+    z-index: 50;
+    /* Ragged edges using clip-path */
+    clip-path: polygon(
+        0% 5%, 5% 0%, 15% 8%, 25% 0%, 35% 5%, 45% 0%, 55% 10%, 65% 0%, 75% 5%, 85% 0%, 95% 8%, 100% 0%,
+        100% 95%, 95% 100%, 85% 92%, 75% 100%, 65% 95%, 55% 100%, 45% 90%, 35% 100%, 25% 95%, 15% 100%, 5% 92%, 0% 100%
+    );
+    opacity: 0.85;
+}
+
+/* Texture for the tape itself */
+.tape::after {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.15'/%3E%3C/svg%3E");
+    pointer-events: none;
+}
+
+.tape.top-left {
+    top: -15px;
+    left: -20px;
+    transform: rotate(-45deg);
+}
+
+.tape.top-right {
+    top: -15px;
+    right: -20px;
+    transform: rotate(45deg);
+}
+
+.tape.bottom-center {
+    bottom: -15px;
+    left: 50%;
+    transform: translateX(-50%) rotate(-2deg);
+    width: 150px;
+}
+
+/* Paper Clip */
+.paper-clip {
+    position: absolute;
+    top: 20px;
+    left: 30px;
+    width: 15px;
+    height: 60px;
+    border: 3px solid #a0a0a0;
+    border-radius: 10px;
+    transform: rotate(15deg);
+    box-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+    z-index: 40;
+    border-bottom: none;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+.paper-clip::before {
+    content: '';
+    position: absolute;
+    top: -3px;
+    left: 3px;
+    width: 3px;
+    height: 45px;
+    border: 3px solid #a0a0a0;
+    border-radius: 10px;
+    border-top: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    box-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .full-post {
+        padding: 40px 20px;
+    }
+
+    .header-layer h1 {
+        font-size: 2.5rem;
+    }
+}

--- a/paper-art/templates/base.html
+++ b/paper-art/templates/base.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default(config.title) }}</title>
+    <link rel="stylesheet" href="{{ config.base_url }}/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Source+Sans+Pro:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <!-- SVG Noise Filter for Paper Texture -->
+    <svg style="display:none;">
+        <filter id="paper-texture">
+            <feTurbulence type="fractalNoise" baseFrequency="0.04" result="noise" />
+            <feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 0.05 0" in="noise" result="coloredNoise" />
+            <feComposite operator="in" in="coloredNoise" in2="SourceGraphic" result="composite" />
+            <feBlend mode="multiply" in="composite" in2="SourceGraphic" />
+        </filter>
+    </svg>
+
+    <div class="canvas">
+        <header class="layer header-layer">
+            <div class="header-content">
+                <h1><a href="{{ config.base_url }}/">{{ config.title }}</a></h1>
+                <p class="subtitle">{{ config.description }}</p>
+            </div>
+            <div class="tape top-left"></div>
+            <div class="tape top-right"></div>
+        </header>
+
+        <main class="main-content">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="layer footer-layer">
+            <p>&copy; 2024 {{ config.title }}</p>
+            <div class="tape bottom-center"></div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/paper-art/templates/index.html
+++ b/paper-art/templates/index.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="post-grid">
+    {% for post in section.pages %}
+    <article class="layer post-card tilt-{{ loop.index0 % 3 }}">
+        <div class="card-inner">
+            <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">
+                <span class="date">{{ post.date | date("%B %d, %Y") }}</span>
+            </div>
+            <p class="post-description">{{ post.description }}</p>
+            <a href="{{ post.url }}" class="read-more layer button-layer">Read More</a>
+        </div>
+        <!-- Torn edge effect elements -->
+        <div class="torn-edge top"></div>
+        <div class="torn-edge bottom"></div>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/paper-art/templates/page.html
+++ b/paper-art/templates/page.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="layer full-post">
+    <div class="post-header">
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta">
+            <span class="date">{{ page.date | date("%B %d, %Y") }}</span>
+        </div>
+    </div>
+    <div class="post-body">
+        {{ page.content | safe }}
+    </div>
+
+    <div class="paper-clip"></div>
+</article>
+{% endblock %}


### PR DESCRIPTION
Created the `paper-art` theme directory for the Hwaro project. This PR includes:
- Directory structure: `content`, `templates`, and `static/css`.
- `config.toml` setup for the new example site.
- HTML templates (`base.html`, `index.html`, `page.html`) establishing semantic layouts with specific classes for paper layering effects.
- `style.css` implementing the "Realistic layered paper textures, like a high-end physical collage" aesthetic using CSS shadows, rotations, SVG-based noise filters, and pseudo-elements (e.g., masking tape and paperclips).
- Sample markdown content showcasing the layout.
- The `tags.json` file is explicitly left untouched as requested.

---
*PR created automatically by Jules for task [10726218135404206919](https://jules.google.com/task/10726218135404206919) started by @hahwul*