### PR TITLE
fix: cobblestone theme broken templates

### DIFF
--- a/cobblestone/templates/header.html
+++ b/cobblestone/templates/header.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
-  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ config.description }}{% endif %}">
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">

--- a/cobblestone/templates/home.html
+++ b/cobblestone/templates/home.html
@@ -11,7 +11,7 @@
 
   <main class="wide-container">
     <section class="timeline">
-      {% for post in pages %}
+      {% for post in site.pages | sort(attribute="date") | reverse %}
       <article class="timeline-item">
         <div class="timeline-date">
           <span class="day">{{ post.date | date(format="%d") }}</span>
@@ -23,9 +23,9 @@
           {% if post.description %}
           <p class="excerpt">{{ post.description }}</p>
           {% endif %}
-          {% if post.taxonomies.tags %}
+          {% if post.tags %}
           <ul class="tag-list">
-            {% for tag in post.taxonomies.tags %}
+            {% for tag in post.tags %}
             <li><a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-pill">{{ tag }}</a></li>
             {% endfor %}
           </ul>

--- a/cobblestone/templates/page.html
+++ b/cobblestone/templates/page.html
@@ -6,9 +6,9 @@
       {% if page.date %}
       <p class="post-meta">{{ page.date | date(format="%B %d, %Y") }}</p>
       {% endif %}
-      {% if page.taxonomies.tags %}
+      {% if page.tags %}
       <ul class="tag-list" style="justify-content: center; margin-top: 1rem;">
-        {% for tag in page.taxonomies.tags %}
+        {% for tag in page.tags %}
         <li><a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-pill">{{ tag }}</a></li>
         {% endfor %}
       </ul>

--- a/cobblestone/templates/section.html
+++ b/cobblestone/templates/section.html
@@ -23,9 +23,9 @@
           {% if post.description %}
           <p class="excerpt">{{ post.description }}</p>
           {% endif %}
-          {% if post.taxonomies.tags %}
+          {% if post.tags %}
           <ul class="tag-list">
-            {% for tag in post.taxonomies.tags %}
+            {% for tag in post.tags %}
             <li><a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-pill">{{ tag }}</a></li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
## Summary
- Fixed cobblestone site rendering as a blank page due to incorrect template variable names
- `config.title`/`config.description` → `site.title`/`site.description` (header.html)
- `pages` → `site.pages | sort(attribute="date") | reverse` (home.html) — posts were not listed
- `post.taxonomies.tags`/`page.taxonomies.tags` → `post.tags`/`page.tags` (home, section, page templates)

## Test plan
- [x] `hwaro build` completes with no warnings
- [x] All 8 pages generated with non-zero file sizes
- [ ] Verify https://examples.hwaro.hahwul.com/cobblestone/ renders correctly after deploy