### PR TITLE
Add Spectra Example Site

### DIFF
--- a/spectra/AGENTS.md
+++ b/spectra/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/spectra/config.toml
+++ b/spectra/config.toml
@@ -1,0 +1,66 @@
+title = "Spectra: Full Spectrum Analysis"
+description = "A data science visualization site for full spectrum color analysis."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+
+[llms]
+enabled = true
+filename = "llms.txt"
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+[extra]
+author = "Spectral Lab"
+theme_color = "#0a0a0a"
+lab_id = "L-380-700"
+spectral_range = "380nm - 700nm"

--- a/spectra/content/about.md
+++ b/spectra/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/spectra/content/analysis/_index.md
+++ b/spectra/content/analysis/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Spectral Analysis Repository"
+sort_by = "date"
+reverse = true
++++
+
+This repository contains the latest data science visualizations and spectral decomposition reports from the laboratory.

--- a/spectra/content/analysis/helium.md
+++ b/spectra/content/analysis/helium.md
@@ -1,0 +1,34 @@
++++
+title = "Elemental Signature: HELIUM"
+date = "2025-01-23"
+slug = "analysis-he2"
+description = "Analysis of Helium emission spectrum."
+tags = ["data-science", "analysis", "elemental"]
++++
+
+<div class="spectrogram-box" style="border-color: #ffff00;">
+    <div class="spectrogram-data" style="background: repeating-linear-gradient(90deg, transparent, transparent 15%, rgba(255, 255, 0, 0.05) 15%, rgba(255, 255, 0, 0.05) 16%);">
+        <div style="width: 100%; position: relative; height: 100%;">
+            <div style="position: absolute; left: 90%; width: 2px; height: 100%; background: #aa0000; box-shadow: 0 0 10px #aa0000;"></div> <!-- 706.5nm Deep Red -->
+            <div style="position: absolute; left: 80%; width: 2px; height: 100%; background: #ff0000; box-shadow: 0 0 10px #ff0000;"></div> <!-- 667.8nm Red -->
+            <div style="position: absolute; left: 65%; width: 2px; height: 100%; background: #ffff00; box-shadow: 0 0 10px #ffff00;"></div> <!-- 587.6nm Yellow (D3) -->
+            <div style="position: absolute; left: 40%; width: 2px; height: 100%; background: #00ff00; box-shadow: 0 0 10px #00ff00;"></div> <!-- 501.6nm Green -->
+            <div style="position: absolute; left: 35%; width: 2px; height: 100%; background: #00ffff; box-shadow: 0 0 10px #00ffff;"></div> <!-- 487.8nm Cyan -->
+            <div style="position: absolute; left: 20%; width: 2px; height: 100%; background: #0000ff; box-shadow: 0 0 10px #0000ff;"></div> <!-- 447.1nm Blue -->
+        </div>
+    </div>
+</div>
+
+### HELIUM SPECTRUM SCAN
+
+The characteristic **Helium** D3 line at 587.6nm (Yellow) is the dominant spectral marker in our recent observations. This line is crucial for distinguishing Helium from other alkali metals in various stellar atmospheres.
+
+#### PRIMARY MARKERS
+*   **D3 Yellow:** 587.6 nm
+*   **Prominent Green:** 501.6 nm
+*   **Strong Blue:** 447.1 nm
+*   **Deep Red Marker:** 706.5 nm
+
+<div class="spectral-divider"></div>
+
+Correlation with Laboratory Reference (Ref-He-Solar) remains stable at 99.7%. This scan represents a high-density, low-temperature plasma state consistent with theoretical models.

--- a/spectra/content/analysis/hydrogen.md
+++ b/spectra/content/analysis/hydrogen.md
@@ -1,0 +1,33 @@
++++
+title = "Elemental Signature: HYDROGEN"
+date = "2025-01-22"
+slug = "analysis-h1"
+description = "Analysis of Hydrogen emission spectrum."
+tags = ["data-science", "analysis", "elemental"]
++++
+
+<div class="spectrogram-box" style="border-color: #00ffff;">
+    <div class="spectrogram-data" style="background: repeating-linear-gradient(90deg, transparent, transparent 20%, rgba(0, 255, 255, 0.05) 20%, rgba(0, 255, 255, 0.05) 21%);">
+        <!-- Balmers: 656.3nm, 486.1nm, 434.0nm, 410.2nm -->
+        <div style="width: 100%; position: relative; height: 100%;">
+            <div style="position: absolute; left: 85%; width: 2px; height: 100%; background: #ff0000; box-shadow: 0 0 10px #ff0000;"></div> <!-- 656.3nm -->
+            <div style="position: absolute; left: 30%; width: 2px; height: 100%; background: #00ffff; box-shadow: 0 0 10px #00ffff;"></div> <!-- 486.1nm -->
+            <div style="position: absolute; left: 15%; width: 2px; height: 100%; background: #0000ff; box-shadow: 0 0 10px #0000ff;"></div> <!-- 434.0nm -->
+            <div style="position: absolute; left: 5%; width: 2px; height: 100%; background: #440044; box-shadow: 0 0 10px #440044;"></div>  <!-- 410.2nm -->
+        </div>
+    </div>
+</div>
+
+### OBSERVATION DATA
+
+The scan above illustrates the classic Balmer series for **Hydrogen**. The characteristic red line at 656.3nm provides the primary identification marker in most stellar observations.
+
+#### SPECTRAL PEAKS
+1.  **H-alpha:** 656.3 nm (Primary Red)
+2.  **H-beta:** 486.1 nm (Secondary Cyan)
+3.  **H-gamma:** 434.0 nm (Tertiary Blue)
+4.  **H-delta:** 410.2 nm (Quaternary Violet)
+
+<div class="spectral-divider"></div>
+
+Data suggests a concentration of 75% in the observed gaseous nebula sample. Correlation with existing database (DB-H1) is 99.8%.

--- a/spectra/content/index.md
+++ b/spectra/content/index.md
@@ -1,0 +1,39 @@
++++
+title = "SYSTEM STATUS: OPERATIONAL"
+date = "2025-01-20"
+description = "Full spectrum color analysis and data visualization dashboard."
++++
+
+<div class="spectrogram-box">
+    <div class="spectrogram-data">
+        <div class="spectral-peak" style="height: 40%; background: #440044;"></div>
+        <div class="spectral-peak" style="height: 60%; background: #0000ff;"></div>
+        <div class="spectral-peak" style="height: 30%; background: #00ffff;"></div>
+        <div class="spectral-peak" style="height: 80%; background: #00ff00;"></div>
+        <div class="spectral-peak" style="height: 20%; background: #ffff00;"></div>
+        <div class="spectral-peak" style="height: 90%; background: #ff0000;"></div>
+        <div class="spectral-peak" style="height: 50%; background: #aa0000;"></div>
+        <!-- More peaks for visual effect -->
+        <div class="spectral-peak" style="height: 75%; background: var(--accent-color);"></div>
+        <div class="spectral-peak" style="height: 35%; background: var(--accent-color);"></div>
+        <div class="spectral-peak" style="height: 65%; background: var(--accent-color);"></div>
+    </div>
+</div>
+
+## LABORATORY OVERVIEW
+
+Welcome to the **Spectra Analysis Lab**. This facility is dedicated to the high-precision decomposition and visualization of the visible light spectrum. Our systems process data from 380nm to 700nm with nanometer accuracy.
+
+### CURRENT CAPABILITIES
+
+*   **Decomposition:** Breakdown of complex light sources into constituent wavelengths.
+*   **Visualization:** Real-time spectrogram generation with "Prism" sectioning.
+*   **Mapping:** Correlation of categorical data to specific spectral signatures.
+
+<div class="spectral-divider"></div>
+
+### SYSTEM LOG: RECENT SCANS
+
+Check our latest [Spectral Analysis](/analysis/) reports for detailed breakdowns of elemental signatures and color profiles.
+
+> "In every beam of light, there is a hidden language of data waiting to be decoded."

--- a/spectra/templates/404.html
+++ b/spectra/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/spectra/templates/footer.html
+++ b/spectra/templates/footer.html
@@ -1,0 +1,11 @@
+    </main>
+    <footer style="margin-top: 5rem; border-top: 1px solid #333; padding: 2rem; background: rgba(0,0,0,0.8);">
+        <div class="container" style="display: flex; justify-content: space-between; align-items: center;">
+            <div style="font-size: 0.8rem; color: #666;">
+                © {{ current_year }} Spectral Lab | DATA ANALYTICS HUB
+            </div>
+            <div style="height: 12px; width: 150px; background: var(--spectrum-gradient); border-radius: 6px;"></div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/spectra/templates/header.html
+++ b/spectra/templates/header.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_title }}{% if page_title %} | {{ page_title }}{% endif %}</title>
+    <meta name="description" content="{{ page.description | default(value=site_description) }}">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;700&display=swap">
+    <style>
+        :root {
+            --bg-color: #0a0a0a;
+            --text-color: #e0e0e0;
+            --accent-color: #00ff41; /* Lab green */
+            --grid-color: rgba(0, 255, 65, 0.05);
+            --spectrum-gradient: linear-gradient(to right,
+                #440044 0%,   /* 380nm */
+                #0000ff 15%,  /* 440nm */
+                #00ffff 30%,  /* 490nm */
+                #00ff00 45%,  /* 510nm */
+                #ffff00 65%,  /* 580nm */
+                #ff0000 85%,  /* 645nm */
+                #aa0000 100%  /* 700nm */
+            );
+            --font-mono: 'JetBrains Mono', 'Courier New', monospace;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: var(--font-mono);
+            line-height: 1.6;
+            background-image:
+                linear-gradient(var(--grid-color) 1px, transparent 1px),
+                linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+            background-size: 20px 20px;
+            overflow-x: hidden;
+        }
+
+        header {
+            padding: 2rem;
+            border-bottom: 2px solid var(--accent-color);
+            position: relative;
+        }
+
+        .spectrum-bar {
+            height: 8px;
+            width: 100%;
+            background: var(--spectrum-gradient);
+            position: absolute;
+            bottom: 0;
+            left: 0;
+        }
+
+        .lab-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 1rem;
+        }
+
+        .lab-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--accent-color);
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .lab-info {
+            font-size: 0.8rem;
+            color: #666;
+            text-align: right;
+        }
+
+        nav {
+            margin-top: 1rem;
+        }
+
+        nav a {
+            color: var(--text-color);
+            text-decoration: none;
+            margin-right: 1.5rem;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav a:hover {
+            color: var(--accent-color);
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        a {
+            color: var(--accent-color);
+        }
+
+        h1, h2, h3 {
+            margin-bottom: 1.5rem;
+            color: var(--accent-color);
+            text-transform: uppercase;
+        }
+
+        .spectral-divider {
+            height: 4px;
+            background: var(--spectrum-gradient);
+            margin: 2rem 0;
+            border-radius: 2px;
+        }
+
+        /* Prism Divider */
+        .prism-divider {
+            height: 60px;
+            background:
+                linear-gradient(135deg, transparent 45%, var(--accent-color) 45%, var(--accent-color) 55%, transparent 55%),
+                linear-gradient(45deg, transparent 45%, var(--accent-color) 45%, var(--accent-color) 55%, transparent 55%);
+            background-size: 20px 20px;
+            opacity: 0.3;
+            margin: 3rem 0;
+        }
+
+        .spectrogram-box {
+            border: 1px solid var(--accent-color);
+            padding: 1.5rem;
+            background: rgba(0, 0, 0, 0.5);
+            position: relative;
+            margin-bottom: 2rem;
+        }
+
+        .spectrogram-box::before {
+            content: "SCANNING...";
+            position: absolute;
+            top: -10px;
+            left: 20px;
+            background: var(--bg-color);
+            padding: 0 10px;
+            font-size: 0.7rem;
+            color: var(--accent-color);
+        }
+
+        .spectrogram-data {
+            height: 150px;
+            background: repeating-linear-gradient(
+                90deg,
+                transparent,
+                transparent 10px,
+                rgba(0, 255, 65, 0.1) 10px,
+                rgba(0, 255, 65, 0.1) 11px
+            );
+            border-bottom: 1px solid var(--accent-color);
+            display: flex;
+            align-items: flex-end;
+            gap: 2px;
+            padding: 0 10px;
+        }
+
+        .spectral-peak {
+            background: var(--accent-color);
+            width: 4px;
+            min-height: 10px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="lab-header">
+                <div class="lab-title">{{ site_title }}</div>
+                <div class="lab-info">
+                    UNIT: L-380-700<br>
+                    RANGE: 380nm - 700nm
+                </div>
+            </div>
+            <nav>
+                <a href="{{ base_url }}/">HOME</a>
+                <a href="{{ base_url }}/analysis/">ANALYSIS</a>
+                <a href="{{ base_url }}/about/">LAB INFO</a>
+            </nav>
+        </div>
+        <div class="spectrum-bar"></div>
+    </header>
+    <main class="container">

--- a/spectra/templates/page.html
+++ b/spectra/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<article class="page-content">
+    <div style="margin-bottom: 3rem;">
+        <h1 style="border-left: 10px solid var(--accent-color); padding-left: 20px; font-size: 3rem; line-height: 1;">{{ page.title }}</h1>
+        <div class="spectral-divider"></div>
+        <div style="font-size: 0.8rem; color: #888; display: flex; gap: 20px;">
+            <span>DATE: {{ page.date | default(value="SYSTEM_TIME") }}</span>
+            <span>ID: {{ page.slug | upper | default(value="UNREGISTERED") }}</span>
+        </div>
+    </div>
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+
+    <div class="prism-divider"></div>
+</article>
+
+{% include "footer.html" %}

--- a/spectra/templates/section.html
+++ b/spectra/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<section>
+    <div style="margin-bottom: 3rem;">
+        <h1 style="border-left: 10px solid var(--accent-color); padding-left: 20px; font-size: 3rem; line-height: 1;">{{ section.title }}</h1>
+        <div class="spectral-divider"></div>
+        <p style="color: #888; font-size: 0.9rem;">ENTRIES FOUND: {{ section.pages | length }}</p>
+    </div>
+
+    <div class="analysis-list">
+        {% for post in section.pages %}
+        <div class="spectrogram-box" style="margin-bottom: 3rem; border-color: rgba(0, 255, 65, 0.3);">
+            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 1rem;">
+                <h2 style="font-size: 1.5rem; margin: 0;"><a href="{{ post.permalink }}" style="text-decoration: none;">{{ post.title }}</a></h2>
+                <span style="font-size: 0.8rem; color: #666;">DATE: {{ post.date | default(value="SYSTEM_TIME") }}</span>
+            </div>
+
+            <div style="margin-bottom: 1.5rem; font-size: 0.9rem; color: #ccc;">
+                {{ post.summary | strip_html | truncate_words(30) }}
+            </div>
+
+            <div class="spectral-divider" style="height: 2px; opacity: 0.5;"></div>
+
+            <a href="{{ post.permalink }}" style="font-size: 0.8rem; text-decoration: none; color: var(--accent-color);">[ VIEW DETAILED ANALYSIS ]</a>
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+{% include "footer.html" %}

--- a/spectra/templates/shortcodes/alert.html
+++ b/spectra/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/spectra/templates/taxonomy.html
+++ b/spectra/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/spectra/templates/taxonomy_term.html
+++ b/spectra/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1397,6 +1397,12 @@
     "seasonal",
     "time-based"
   ],
+  "spectra": [
+    "dark",
+    "data-science",
+    "spectrum",
+    "rainbow"
+  ],
   "spectrum": [
     "light",
     "blog",


### PR DESCRIPTION
Added a new Hwaro example site 'spectra' featuring a dark-themed spectroscopy lab aesthetic with full-spectrum rainbow gradients and data science visualizations. The implementation includes custom templates for a lab monitor vibe, elemental signature pages for Hydrogen and Helium, and an updated global tags.json.

Fixes #508

---
*PR created automatically by Jules for task [13269412002310820631](https://jules.google.com/task/13269412002310820631) started by @hahwul*