### PR TITLE
Fix design and configuration for lithograph example

### DIFF
--- a/lithograph/config.toml
+++ b/lithograph/config.toml
@@ -1,6 +1,6 @@
 title = "Lithograph"
 description = "A bold, creative, and elegant lithograph print aesthetic."
-base_url = "http://localhost:1111"
+base_url = "http://localhost:3000"
 
 # The language code. Default is 'en'
 default_language = "en"
@@ -14,7 +14,7 @@ build_search_index = false
 [markdown]
 highlight_code = true
 highlight_theme = "base16-ocean-dark"
-render_emoji = false
+emoji = false
 
 [[taxonomies]]
 name = "tags"
@@ -26,3 +26,204 @@ feed = true
 
 [extra]
 author = "Publisher"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/lithograph/content/posts/_index.md
+++ b/lithograph/content/posts/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Archive of Prints"
 sort_by = "date"
-template = "section.html"
-page_template = "page.html"
+template = "section"
+page_template = "page"
 +++

--- a/lithograph/static/css/style.css
+++ b/lithograph/static/css/style.css
@@ -1,10 +1,10 @@
 :root {
-  /* Lithograph color palette */
-  --bg-color: #f4f1ea; /* Creamy paper */
-  --text-color: #1a1a1a; /* Charcoal black ink */
+  /* Lithograph dark color palette */
+  --bg-color: #1a1a1a; /* Dark background */
+  --text-color: #f4f1ea; /* Creamy text */
   --accent-color: #c93b22; /* Classic lithograph red */
-  --border-color: #1a1a1a;
-  --secondary-bg: #e8e4d9; /* Slightly darker paper for contrast */
+  --border-color: #f4f1ea;
+  --secondary-bg: #2a2a2a; /* Slightly lighter background for contrast */
 
   --font-body: 'Georgia', serif;
   --font-heading: 'Playfair Display', 'Times New Roman', serif;
@@ -25,9 +25,6 @@ body {
   font-family: var(--font-body);
   line-height: 1.6;
   font-size: 18px;
-  /* Add texture using repeating linear but we are strictly avoiding any gradients,
-     so we use an SVG pattern or just solid background */
-  background-image: url('data:image/svg+xml;utf8,<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h40v40H0V0zm20 20h20v20H20V20z" fill="%23e8e4d9" fill-opacity="0.2" fill-rule="evenodd"/></svg>');
 }
 
 /* Typography */

--- a/lithograph/templates/page.html
+++ b/lithograph/templates/page.html
@@ -10,11 +10,11 @@
                 Printed on {{ page.date | date(format="%B %d, %Y") }}
             {% endif %}
 
-            {% if page.taxonomies.tags %}
+            {% if page.taxonomies is defined and page.taxonomies.tags is defined and page.taxonomies.tags %}
                 <ul class="tags" style="justify-content: center; margin-top: 0.5rem;">
-                {% if page.taxonomies is defined and page.taxonomies.tags is defined %}{% for tag in page.taxonomies.tags %}
+                {% for tag in page.taxonomies.tags %}
                     <li><a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a></li>
-                {% endfor %}{% endif %}
+                {% endfor %}
                 </ul>
             {% endif %}
         </div>

--- a/lithograph/templates/section.html
+++ b/lithograph/templates/section.html
@@ -26,11 +26,11 @@
                 <p class="post-summary">{{ page.description }}</p>
             {% endif %}
 
-            {% if page.taxonomies.tags %}
+            {% if page.taxonomies is defined and page.taxonomies.tags is defined and page.taxonomies.tags %}
                 <ul class="tags">
-                {% if page.taxonomies is defined and page.taxonomies.tags is defined %}{% for tag in page.taxonomies.tags %}
+                {% for tag in page.taxonomies.tags %}
                     <li><a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a></li>
-                {% endfor %}{% endif %}
+                {% endfor %}
                 </ul>
             {% endif %}
         </li>

--- a/tags.json
+++ b/tags.json
@@ -2444,5 +2444,11 @@
     "gallery",
     "escher",
     "pattern-art"
+  ],
+  "lithograph": [
+    "dark",
+    "blog",
+    "lithograph",
+    "printmaking"
   ]
 }


### PR DESCRIPTION
This PR implements the requested dark, bold, clean, and elegant design for the `lithograph` example site as per issue #649. It ensures no gradients and no emojis are used, and fixes the template missing variables.

---
*PR created automatically by Jules for task [17093756330862977036](https://jules.google.com/task/17093756330862977036) started by @chei-l*