### PR TITLE
feat: add masquerade example site

### DIFF
--- a/example-sites/masquerade/config.toml
+++ b/example-sites/masquerade/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Masquerade"
+description = "A glamorous and elegant experience."
+base_url = "http://127.0.0.1:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/example-sites/masquerade/content/about.md
+++ b/example-sites/masquerade/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "The Mystery"
+template = "page"
++++
+
+A masquerade ball is a dance of hidden identities. It is a tradition steeped in elegance, where velvet and gold adorn the unseen.
+
+The essence of the night lies in the unknown. Behind every intricate mask is a story untold, waiting to be discovered under the dim glow of the chandeliers.

--- a/example-sites/masquerade/content/index.md
+++ b/example-sites/masquerade/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Welcome to the Masquerade"
+template = "index"
++++
+
+Step into a world of mystery, velvet, and elegance. The grand hall is softly illuminated by flickering candlelight, casting long shadows across ornate masks and heavy drapes.
+
+This is a night to remember, a fleeting moment of glamour and secrecy. Please, enjoy the revelry.
+
+[Discover the Mystery](/about/)

--- a/example-sites/masquerade/templates/404.html
+++ b/example-sites/masquerade/templates/404.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h2>404 - Not Found</h2>
+    <p>The masquerade ball has moved. This room is empty.</p>
+    <p><a href="/">Return to the main hall</a></p>
+{% endblock %}

--- a/example-sites/masquerade/templates/base.html
+++ b/example-sites/masquerade/templates/base.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page and page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <style>
+        :root {
+            --bg-color: #0d0008;
+            --text-color: #e5d8d9;
+            --accent-color: #8b002a;
+            --gold-color: #d4af37;
+            --glow-shadow: 0 0 15px rgba(212, 175, 55, 0.4);
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-family: "Georgia", serif;
+            line-height: 1.6;
+        }
+
+        header {
+            padding: 40px 20px;
+            text-align: center;
+            border-bottom: 2px solid var(--gold-color);
+            box-shadow: var(--glow-shadow);
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 3rem;
+            color: var(--gold-color);
+            font-weight: normal;
+            text-shadow: 0 0 10px rgba(212, 175, 55, 0.6);
+            letter-spacing: 2px;
+        }
+
+        header p {
+            margin: 10px 0 0 0;
+            font-size: 1.2rem;
+            color: #b09e9f;
+            font-style: italic;
+        }
+
+        main {
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 20px;
+            background-color: rgba(139, 0, 42, 0.1);
+            border: 1px solid var(--accent-color);
+            box-shadow: 0 0 20px rgba(139, 0, 42, 0.3);
+        }
+
+        a {
+            color: var(--gold-color);
+            text-decoration: none;
+            transition: color 0.3s, text-shadow 0.3s;
+        }
+
+        a:hover {
+            color: #ffdf00;
+            text-shadow: 0 0 8px rgba(255, 223, 0, 0.6);
+        }
+
+        h2, h3 {
+            color: var(--gold-color);
+            font-weight: normal;
+            border-bottom: 1px solid var(--accent-color);
+            padding-bottom: 5px;
+        }
+
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        footer {
+            text-align: center;
+            padding: 20px;
+            margin-top: 40px;
+            border-top: 1px solid var(--accent-color);
+            font-size: 0.9rem;
+            color: #7a6e6f;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>{{ site.title }}</h1>
+        <p>{{ site.description }}</p>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <p>&copy; 2026 {{ site.title }}. All rights reserved in mystery.</p>
+    </footer>
+</body>
+</html>

--- a/example-sites/masquerade/templates/index.html
+++ b/example-sites/masquerade/templates/index.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+
+    {% if section and section.pages %}
+        <h3>Recent Revelries</h3>
+        <ul class="page-list">
+        {% for p in section.pages %}
+            <li><a href="{{ p.permalink }}">{{ p.title }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/example-sites/masquerade/templates/page.html
+++ b/example-sites/masquerade/templates/page.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h2>{{ page.title }}</h2>
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/example-sites/masquerade/templates/section.html
+++ b/example-sites/masquerade/templates/section.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h2>{{ page.title }}</h2>
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+
+    {% if section.pages %}
+        <ul class="page-list">
+        {% for p in section.pages %}
+            <li><a href="{{ p.permalink }}">{{ p.title }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/example-sites/masquerade/templates/shortcodes/alert.html
+++ b/example-sites/masquerade/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/example-sites/masquerade/templates/taxonomy.html
+++ b/example-sites/masquerade/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h2>Taxonomy: {{ taxonomy_name }}</h2>
+    {% if taxonomy_terms %}
+        <ul class="taxonomy-terms">
+        {% for term in taxonomy_terms %}
+            <li><a href="/{{ taxonomy_name }}/{{ term | lower }}/">{{ term }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/example-sites/masquerade/templates/taxonomy_term.html
+++ b/example-sites/masquerade/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h2>Pages tagged with "{{ taxonomy_name }}"</h2>
+    {% if taxonomy_pages %}
+        <ul class="taxonomy-pages">
+        {% for p in taxonomy_pages %}
+            <li><a href="{{ p.permalink }}">{{ p.title }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1416,6 +1416,13 @@
     "geometric",
     "minimal"
   ],
+  "masquerade": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "luxury",
+    "mystery"
+  ],
   "matrix": [
     "light",
     "docs",


### PR DESCRIPTION
Resolves #819.

This PR adds the requested `masquerade` example site. It adheres to the design direction emphasizing an elegant theme (velvet dark reds/purples and golds), but strictly conforms to the user's specific constraint of avoiding gradients and emojis. Glowing effects are implemented purely via CSS `box-shadow` and solid colors.

Tasks completed:
* Created site directory with `hwaro init` in `example-sites/`.
* Cleaned up default artifacts (e.g., deleted `AGENTS.md`).
* Refactored templates to use a single elegant `base.html` shell.
* Replaced dummy content with mysterious narrative copy.
* Updated `tags.json` to include `"masquerade"`.

---
*PR created automatically by Jules for task [12613763257445916066](https://jules.google.com/task/12613763257445916066) started by @chei-l*