### PR TITLE
Add festival example site

### DIFF
--- a/example-sites/festival/config.toml
+++ b/example-sites/festival/config.toml
@@ -1,0 +1,182 @@
+title = "Festival"
+description = "Glamorous and trendy music festival example"
+base_url = "http://127.0.0.1:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/example-sites/festival/content/about.md
+++ b/example-sites/festival/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About Festival"
+date = "2026-04-10"
++++
+
+Festival is the premier electronic music and arts festival, bringing together the best artists from around the world for a weekend of pure magic.
+
+Born from a love of sound and spectacle, we push the boundaries of what a live event can be.

--- a/example-sites/festival/content/index.md
+++ b/example-sites/festival/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Welcome to Festival"
+date = "2026-04-10"
++++
+
+Welcome to the ultimate music festival experience. Get ready for an unforgettable night of music, lights, and energy.
+
+Check out our [Lineup](/posts/) to see who's performing this year.
+
+Don't forget to grab your tickets before they sell out!

--- a/example-sites/festival/content/posts/_index.md
+++ b/example-sites/festival/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Lineup"
+template = "section"
+sort_by = "date"
+reverse = true
++++
+
+Discover the incredible artists performing at this year's festival.

--- a/example-sites/festival/content/posts/dj-neon.md
+++ b/example-sites/festival/content/posts/dj-neon.md
@@ -1,0 +1,13 @@
++++
+title = "Headliner: DJ Neon"
+date = "2026-04-10"
+tags = ["headliner", "electronic", "mainstage"]
++++
+
+Get ready for an explosive set by DJ Neon, closing out the mainstage on Saturday night.
+
+Expect heavy bass, incredible visuals, and a light show that will blow your mind.
+
+<!-- more -->
+
+DJ Neon has been dominating the electronic music scene for the past decade, and we are thrilled to have them headline this year's festival. Their high-energy performances are legendary, and this is a set you won't want to miss.

--- a/example-sites/festival/templates/404.html
+++ b/example-sites/festival/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="text-align: center; padding: 5rem 0;">
+    <h1 style="font-size: 5rem; margin-bottom: 0; color: var(--accent-color); text-shadow: 0 0 20px rgba(255, 0, 85, 0.5);">404</h1>
+    <h2 style="font-size: 2rem; margin-top: 0; text-transform: uppercase;">Lost in the crowd?</h2>
+    <p style="color: #aaa; margin-bottom: 3rem;">The stage you're looking for doesn't exist or has been moved.</p>
+    <a href="{{ base_url }}/" class="button">Return to Main Stage</a>
+</div>
+{% endblock %}

--- a/example-sites/festival/templates/base.html
+++ b/example-sites/festival/templates/base.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <style>
+        :root {
+            --bg-color: #0d0d0d;
+            --text-color: #f0f0f0;
+            --accent-color: #ff0055;
+            --secondary-color: #00e5ff;
+            --glow-spread: 15px;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            line-height: 1.6;
+        }
+
+        a {
+            color: var(--secondary-color);
+            text-decoration: none;
+            transition: all 0.3s ease;
+            position: relative;
+        }
+
+        a:hover {
+            color: var(--accent-color);
+            text-shadow: 0 0 var(--glow-spread) rgba(255, 0, 85, 0.7);
+        }
+
+        header {
+            padding: 2rem;
+            text-align: center;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 3rem;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            font-weight: 900;
+        }
+
+        header h1 a {
+            color: var(--text-color);
+        }
+
+        header h1 a:hover {
+            color: var(--accent-color);
+        }
+
+        nav {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+        }
+
+        nav a {
+            font-size: 1.2rem;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        main {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 3rem 1rem;
+        }
+
+        .card {
+            background-color: #1a1a1a;
+            border-radius: 12px;
+            padding: 2rem;
+            margin-bottom: 2rem;
+            box-shadow: 0 0 20px rgba(0, 229, 255, 0.1);
+            transition: box-shadow 0.3s ease, transform 0.3s ease;
+        }
+
+        .card:hover {
+            box-shadow: 0 0 30px rgba(255, 0, 85, 0.3);
+            transform: translateY(-5px);
+        }
+
+        .card-title {
+            margin-top: 0;
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .card-meta {
+            font-size: 0.9rem;
+            color: #888;
+            margin-bottom: 1.5rem;
+        }
+
+        .button {
+            display: inline-block;
+            padding: 0.8rem 1.5rem;
+            background-color: transparent;
+            color: var(--secondary-color);
+            border: 2px solid var(--secondary-color);
+            border-radius: 30px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.2);
+            transition: all 0.3s ease;
+        }
+
+        .button:hover {
+            background-color: var(--accent-color);
+            color: #fff;
+            border-color: var(--accent-color);
+            box-shadow: 0 0 25px rgba(255, 0, 85, 0.6);
+        }
+
+        .tags {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .tag {
+            font-size: 0.8rem;
+            padding: 0.3rem 0.8rem;
+            background-color: rgba(255, 255, 255, 0.05);
+            border-radius: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            transition: all 0.2s ease;
+        }
+
+        .tag:hover {
+            background-color: rgba(0, 229, 255, 0.2);
+            border-color: var(--secondary-color);
+            box-shadow: 0 0 10px rgba(0, 229, 255, 0.4);
+        }
+
+        footer {
+            text-align: center;
+            padding: 2rem;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            font-size: 0.9rem;
+            color: #666;
+            margin-top: 2rem;
+        }
+
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+        }
+
+        pre {
+            background-color: #111;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+        }
+
+        code {
+            font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+            background-color: #111;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+            font-size: 0.9em;
+        }
+
+        pre code {
+            padding: 0;
+            background-color: transparent;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1><a href="{{ base_url }}/">{{ site.title }}</a></h1>
+        <nav>
+            <a href="{{ base_url }}/">Home</a>
+            <a href="{{ base_url }}/about/">About</a>
+            <a href="{{ base_url }}/posts/">Lineup</a>
+        </nav>
+    </header>
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <p>&copy; {{ current_year }} {{ site.title }}. Example for Hwaro.</p>
+    </footer>
+</body>
+</html>

--- a/example-sites/festival/templates/page.html
+++ b/example-sites/festival/templates/page.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="card">
+    <h1 class="card-title">{{ page.title }}</h1>
+    {% if page.date %}
+    <div class="card-meta">
+        {{ page.date | date("%B %d, %Y") }}
+    </div>
+    {% endif %}
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies and page.taxonomies.tags %}
+    <div class="tags">
+        {% for tag in page.taxonomies.tags %}
+        <a href="{{ base_url }}/tags/{{ tag }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endblock %}

--- a/example-sites/festival/templates/section.html
+++ b/example-sites/festival/templates/section.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header" style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="font-size: 2.5rem; text-transform: uppercase; letter-spacing: 2px;">{{ section.title | default("Lineup") }}</h1>
+    {% if section.description %}
+    <p style="color: #aaa; font-size: 1.2rem;">{{ section.description }}</p>
+    {% endif %}
+    {% if content %}
+    <div class="content" style="margin-top: 1rem;">
+        {{ content | safe }}
+    </div>
+    {% endif %}
+</div>
+
+<div class="posts-list">
+    {% for post in section.pages %}
+    <article class="card">
+        <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.date %}
+        <div class="card-meta">{{ post.date | date("%B %d, %Y") }}</div>
+        {% endif %}
+
+        {% if post.summary %}
+        <p>{{ post.summary | safe }}</p>
+        {% endif %}
+
+        <div style="margin-top: 1.5rem;">
+            <a href="{{ post.url }}" class="button">Read More</a>
+        </div>
+    </article>
+    {% endfor %}
+</div>
+
+{% if paginator %}
+<div class="pagination" style="display: flex; justify-content: space-between; margin-top: 3rem;">
+    {% if paginator.previous %}
+    <a href="{{ paginator.previous }}" class="button">&larr; Previous</a>
+    {% else %}
+    <div></div>
+    {% endif %}
+
+    {% if paginator.next %}
+    <a href="{{ paginator.next }}" class="button">Next &rarr;</a>
+    {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/example-sites/festival/templates/taxonomy.html
+++ b/example-sites/festival/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="card">
+    <h1 class="card-title" style="text-transform: uppercase;">{{ taxonomy_name | capitalize }}</h1>
+
+    <div class="tags" style="margin-top: 2rem;">
+        {% for term in taxonomy_terms %}
+        <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term }}/" class="tag" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
+            {{ term }}
+        </a>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/example-sites/festival/templates/taxonomy_term.html
+++ b/example-sites/festival/templates/taxonomy_term.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header" style="text-align: center; margin-bottom: 3rem;">
+    <h1 style="font-size: 2.5rem; text-transform: uppercase; letter-spacing: 2px;">
+        {{ taxonomy_name | capitalize }}: <span style="color: var(--secondary-color); text-shadow: 0 0 15px rgba(0, 229, 255, 0.4);">{{ taxonomy_term }}</span>
+    </h1>
+</div>
+
+<div class="posts-list">
+    {% for post in taxonomy_pages %}
+    <article class="card">
+        <h2 class="card-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        {% if post.date %}
+        <div class="card-meta">{{ post.date | date("%B %d, %Y") }}</div>
+        {% endif %}
+
+        <div style="margin-top: 1.5rem;">
+            <a href="{{ post.url }}" class="button">Read More</a>
+        </div>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -839,6 +839,13 @@
     "ferrofluid",
     "magnetic"
   ],
+  "festival": [
+    "dark",
+    "event",
+    "elegant",
+    "glow",
+    "bold"
+  ],
   "filigree": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #820

Adds the new `festival` example site. The design embraces a glamorous aesthetic with a dark theme and glowing elements (achieved with `box-shadow` and `rgba` colors, strict adherence to avoiding gradients). Emojis are disabled in configuration to follow strict design instructions. All templates were properly integrated using a shared `base.html` template. `tags.json` was updated.

---
*PR created automatically by Jules for task [9225578225952759880](https://jules.google.com/task/9225578225952759880) started by @chei-l*