### PR TITLE
Add mardi-gras example site

### DIFF
--- a/mardi-gras/config.toml
+++ b/mardi-gras/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Mardi Gras"
+description = "Welcome to my new Hwaro site."
+base_url = "http://127.0.0.1:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/mardi-gras/content/about.md
+++ b/mardi-gras/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About Mardi Gras Design"
+date = "2026-04-09"
++++
+
+This example site was created to demonstrate how to build a striking, glamorous design using the Hwaro static site generator without relying on excessive elements like emojis or standard gradients.
+
+### Design Principles
+
+*   **Vibrant Palette:** Utilizing the traditional Mardi Gras colors: Purple (Justice), Gold (Power), and Green (Faith).
+*   **Subtle Glows:** Instead of gradients, this design employs layered CSS `box-shadow` properties with `rgba` values to create a sense of depth, luminescence, and energy.
+*   **High Contrast:** A dark background ensures the primary colors pop, creating an immediate visual impact.
+*   **Clean Typography:** Solid, sans-serif fonts ensure that the content remains readable despite the bold surroundings.
+
+This template is perfect for event pages, portfolios, or any site that needs to make a loud, unforgettable statement.

--- a/mardi-gras/content/index.md
+++ b/mardi-gras/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Welcome to Mardi Gras"
+date = "2026-04-09"
++++
+
+Welcome to the **Mardi Gras** example site!
+
+Experience the glamorous and trendy atmosphere inspired by the world-famous festival. This design showcases a bold, eye-catching aesthetic with maximum visual impact, featuring a classic palette of purple, gold, and green.
+
+Enjoy the vibrant colors, rich textures, and dynamic visual effects that capture the spirit of the celebration, all while maintaining perfect readability and usability.
+
+### Let the good times roll
+
+Explore our sections to discover more about this extravagant design.
+
+```python
+def celebrate(festival="Mardi Gras"):
+    print(f"Welcome to {festival}!")
+    return ["purple", "gold", "green"]
+```

--- a/mardi-gras/static/style.css
+++ b/mardi-gras/static/style.css
@@ -1,0 +1,181 @@
+/* Mardi Gras Theme - Glamorous & Trendy (No Gradients) */
+
+:root {
+    /* Color Palette */
+    --purple: #800080;
+    --gold: #FFD700;
+    --green: #008000;
+    --dark-purple: #4B0082;
+    --dark-bg: #121212;
+    --text-color: #E0E0E0;
+
+    /* Glow Effects */
+    --glow-purple: rgba(128, 0, 128, 0.6);
+    --glow-gold: rgba(255, 215, 0, 0.6);
+    --glow-green: rgba(0, 128, 0, 0.6);
+}
+
+body {
+    background-color: var(--dark-bg);
+    color: var(--text-color);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.header-container {
+    background-color: var(--dark-purple);
+    padding: 20px 40px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 4px solid var(--gold);
+    box-shadow: 0 4px 15px var(--glow-purple);
+}
+
+h1 {
+    margin: 0;
+    font-size: 2.5em;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+h1 a {
+    color: var(--gold);
+    text-decoration: none;
+    text-shadow: 0 0 10px var(--glow-gold);
+}
+
+nav a {
+    color: var(--text-color);
+    text-decoration: none;
+    margin-left: 20px;
+    font-weight: bold;
+    text-transform: uppercase;
+    transition: color 0.3s ease;
+}
+
+nav a:hover {
+    color: var(--green);
+    text-shadow: 0 0 8px var(--glow-green);
+}
+
+.content-container {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 215, 0, 0.3);
+    border-radius: 8px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5), inset 0 0 10px var(--glow-purple);
+}
+
+h2 {
+    color: var(--purple);
+    border-bottom: 2px solid var(--green);
+    padding-bottom: 10px;
+    margin-top: 0;
+    text-shadow: 0 0 8px var(--glow-purple);
+}
+
+h3 {
+    color: var(--gold);
+}
+
+a {
+    color: var(--gold);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+    color: var(--purple);
+}
+
+.post-item {
+    background-color: #1A1A1A;
+    padding: 20px;
+    margin-bottom: 20px;
+    border-left: 5px solid var(--green);
+    border-radius: 4px;
+    box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.5);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post-item:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 5px 15px var(--glow-green);
+}
+
+.post-title a {
+    color: var(--purple);
+    text-shadow: none;
+}
+
+.post-title a:hover {
+    color: var(--gold);
+    text-shadow: 0 0 5px var(--glow-gold);
+}
+
+.meta {
+    font-size: 0.9em;
+    color: #888;
+    margin-bottom: 15px;
+}
+
+.btn, .read-more {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: var(--purple);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: bold;
+    text-transform: uppercase;
+    border: 1px solid var(--gold);
+    box-shadow: 0 0 10px var(--glow-purple);
+    transition: all 0.3s ease;
+}
+
+.btn:hover, .read-more:hover {
+    background-color: var(--green);
+    border-color: var(--gold);
+    color: white;
+    box-shadow: 0 0 15px var(--glow-green);
+}
+
+.footer-container {
+    text-align: center;
+    padding: 20px;
+    background-color: var(--dark-purple);
+    border-top: 4px solid var(--gold);
+    color: var(--text-color);
+    box-shadow: 0 -4px 15px var(--glow-purple);
+    margin-top: 40px;
+}
+
+.tags {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px dashed rgba(255, 215, 0, 0.5);
+}
+
+.tag {
+    display: inline-block;
+    background-color: var(--green);
+    color: white;
+    padding: 5px 10px;
+    margin-right: 10px;
+    border-radius: 20px;
+    font-size: 0.85em;
+    font-weight: bold;
+    box-shadow: 0 0 5px var(--glow-green);
+}
+
+.tag:hover {
+    background-color: var(--gold);
+    color: var(--dark-bg);
+    text-decoration: none;
+    box-shadow: 0 0 8px var(--glow-gold);
+}

--- a/mardi-gras/templates/404.html
+++ b/mardi-gras/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-page">
+    <h2>404 - Page Not Found</h2>
+    <p>The page you are looking for does not exist.</p>
+    <a href="{{ site.base_url }}/" class="btn">Return Home</a>
+</div>
+{% endblock %}

--- a/mardi-gras/templates/base.html
+++ b/mardi-gras/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page and page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+</head>
+<body>
+    <header>
+        <div class="header-container">
+            <h1><a href="{{ site.base_url }}/">{{ site.title }}</a></h1>
+            <nav>
+                <a href="{{ site.base_url }}/">Home</a>
+                <a href="{{ site.base_url }}/about.html">About</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="content-container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+        <div class="footer-container">
+            <p>&copy; 2026 {{ site.title }}. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/mardi-gras/templates/page.html
+++ b/mardi-gras/templates/page.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page">
+    {% if page.title %}
+    <header class="page-header">
+        <h2>{{ page.title }}</h2>
+        {% if page.date %}
+        <div class="meta">
+            <time datetime="{{ page.date }}">{{ page.date }}</time>
+        </div>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies and page.taxonomies.tags %}
+    <footer class="page-footer">
+        <div class="tags">
+            <strong>Tags:</strong>
+            {% for tag in page.taxonomies.tags %}
+            <a href="{{ site.base_url }}/tags/{{ tag }}.html" class="tag">{{ tag }}</a>
+            {% endfor %}
+        </div>
+    </footer>
+    {% endif %}
+</article>
+{% endblock %}

--- a/mardi-gras/templates/section.html
+++ b/mardi-gras/templates/section.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section">
+    {% if page.title %}
+    <header class="section-header">
+        <h2>{{ page.title }}</h2>
+    </header>
+    {% endif %}
+
+    <div class="section-content">
+        {{ content | safe }}
+    </div>
+
+    {% if section.pages %}
+    <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-item">
+            <h3 class="post-title"><a href="{{ site.base_url }}/{{ post.path }}">{{ post.title }}</a></h3>
+            {% if post.date %}
+            <div class="meta">
+                <time datetime="{{ post.date }}">{{ post.date }}</time>
+            </div>
+            {% endif %}
+            {% if post.description %}
+            <p class="post-description">{{ post.description }}</p>
+            {% endif %}
+            <a href="{{ site.base_url }}/{{ post.path }}" class="read-more">Read more</a>
+        </article>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/mardi-gras/templates/shortcodes/alert.html
+++ b/mardi-gras/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/mardi-gras/templates/taxonomy.html
+++ b/mardi-gras/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy">
+    <header class="taxonomy-header">
+        <h2>{{ taxonomy_name | capitalize }}</h2>
+    </header>
+
+    <div class="term-list">
+        {% for term in taxonomy_terms %}
+        <a href="{{ site.base_url }}/{{ taxonomy_name }}/{{ term }}.html" class="term-link">{{ term }}</a>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/mardi-gras/templates/taxonomy_term.html
+++ b/mardi-gras/templates/taxonomy_term.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-term">
+    <header class="term-header">
+        <h2>Pages tagged with "{{ taxonomy_term }}"</h2>
+    </header>
+
+    <div class="post-list">
+        {% for post in taxonomy_pages %}
+        <article class="post-item">
+            <h3 class="post-title"><a href="{{ site.base_url }}/{{ post.path }}">{{ post.title }}</a></h3>
+            {% if post.date %}
+            <div class="meta">
+                <time datetime="{{ post.date }}">{{ post.date }}</time>
+            </div>
+            {% endif %}
+            <a href="{{ site.base_url }}/{{ post.path }}" class="read-more">Read more</a>
+        </article>
+        {% endfor %}
+    </div>
+
+    <a href="{{ site.base_url }}/{{ taxonomy_name }}.html" class="back-link">&larr; All {{ taxonomy_name }}</a>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1405,6 +1405,14 @@
     "marbled",
     "paper"
   ],
+  "mardi-gras": [
+    "glamorous",
+    "trendy",
+    "bold",
+    "purple",
+    "gold",
+    "green"
+  ],
   "marketplace": [
     "light",
     "store",


### PR DESCRIPTION
Resolves #818 by introducing the `mardi-gras` example site. 
The site adheres to the requested color theme (purple, gold, green) but implements the explicit user instruction to be "elegant" by strictly omitting gradients and emojis, utilizing dark backgrounds and `rgba` box-shadows for glowing effects instead.

---
*PR created automatically by Jules for task [3991148637685627339](https://jules.google.com/task/3991148637685627339) started by @chei-l*