### PR TITLE
feat: add synthwave example site

### DIFF
--- a/example-sites/synthwave/config.toml
+++ b/example-sites/synthwave/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Synthwave"
+description = "A glamorous and trendy retro-futuristic example site"
+base_url = "http://127.0.0.1:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/example-sites/synthwave/content/about.md
+++ b/example-sites/synthwave/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+description = "Information about this example"
+template = "page"
++++
+
+This is the Synthwave example for Hwaro. It is an exploration of retro-futuristic aesthetics using modern web technologies while adhering strictly to specific design constraints: no heavy gradients and no emojis.
+
+Instead of overwhelming the user with massive gradient backgrounds, we rely on a sophisticated color palette—deep blacks, neon cyan, and magenta—combined with transparent overlays and precise `box-shadow` applications to achieve the desired "glow."

--- a/example-sites/synthwave/content/index.md
+++ b/example-sites/synthwave/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "The Grid"
+description = "Welcome to the Synthwave."
+template = "page"
++++
+
+Welcome to the future as seen from 1984. The chrome is polished, the neon is humming, and the grid awaits.
+
+This example site demonstrates a glamorous, elegant aesthetic built entirely without excessive background gradients. We use carefully crafted CSS `box-shadow` techniques combined with `rgba` to produce striking, luminescent neon effects that stay true to the 80s electronic retro-futurism without being overwhelming.
+
+### Key Elements
+* **Grid Topography:** A subtle, perspective-shifted background grid sets the tone.
+* **Neon Glows:** Text shadows and box shadows provide the characteristic luminescence.
+* **Sleek Typography:** *Syncopate* for headings and *Space Grotesk* for body text.
+
+Navigate to [Posts](/posts/) to explore further transmissions.

--- a/example-sites/synthwave/content/posts/_index.md
+++ b/example-sites/synthwave/content/posts/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Posts"
+template = "section"
+paginate = 10
+sort_by = "date"
+reverse = true
++++
+
+Transmissions from the neon grid.

--- a/example-sites/synthwave/content/posts/first-post.md
+++ b/example-sites/synthwave/content/posts/first-post.md
@@ -1,0 +1,11 @@
++++
+title = "Initial Transmission"
+date = "2026-04-09"
+description = "First connection to the mainframe established."
+template = "page"
+taxonomies = { tags = ["retro", "system"] }
++++
+
+Connection established at 2400 baud.
+
+The neon lights are flickering on. The grid has been compiled and is running smoothly. This post serves as the initial test of the system's broadcasting capabilities. Everything appears nominal.

--- a/example-sites/synthwave/static/style.css
+++ b/example-sites/synthwave/static/style.css
@@ -1,0 +1,181 @@
+:root {
+    --bg-color: #0b0c10;
+    --text-color: #c5c6c7;
+    --accent-color-1: #66fcf1; /* Neon cyan */
+    --accent-color-2: #45a29e; /* Darker cyan */
+    --accent-color-3: #c3073f; /* Deep pink/red */
+    --accent-color-4: #950740;
+    --grid-color: rgba(102, 252, 241, 0.1);
+
+    --font-heading: 'Syncopate', sans-serif;
+    --font-body: 'Space Grotesk', sans-serif;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    position: relative;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+/* Elegant Grid Background instead of heavy gradients */
+.grid-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-image:
+        linear-gradient(to right, var(--grid-color) 1px, transparent 1px),
+        linear-gradient(to bottom, var(--grid-color) 1px, transparent 1px);
+    background-size: 50px 50px;
+    z-index: -1;
+    transform: perspective(500px) rotateX(60deg) translateY(-100px) scale(3);
+    transform-origin: top center;
+    opacity: 0.4;
+}
+
+.content-wrapper {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+    color: var(--accent-color-1);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    /* Subtle glow effect without gradients */
+    text-shadow: 0 0 10px rgba(102, 252, 241, 0.3), 0 0 20px rgba(102, 252, 241, 0.1);
+}
+
+a {
+    color: var(--accent-color-3);
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+a:hover {
+    color: var(--accent-color-1);
+    text-shadow: 0 0 8px rgba(102, 252, 241, 0.5);
+}
+
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    border-bottom: 1px solid var(--accent-color-4);
+    padding-bottom: 1rem;
+    margin-bottom: 3rem;
+}
+
+.site-title {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.site-title a {
+    color: #fff;
+    text-shadow: 0 0 5px rgba(255, 255, 255, 0.5), 0 0 15px rgba(102, 252, 241, 0.8);
+}
+
+.site-title a:hover {
+    color: var(--accent-color-1);
+}
+
+.site-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 1.5rem;
+}
+
+.site-nav a {
+    font-family: var(--font-heading);
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+    color: var(--text-color);
+}
+
+.site-nav a:hover {
+    color: var(--accent-color-1);
+}
+
+.site-main {
+    min-height: 50vh;
+}
+
+.post-item {
+    margin-bottom: 2rem;
+    padding: 1.5rem;
+    background-color: rgba(11, 12, 16, 0.8);
+    border: 1px solid rgba(195, 7, 63, 0.3);
+    border-radius: 4px;
+    /* Elegant box shadow for glow effect */
+    box-shadow: 0 4px 15px rgba(195, 7, 63, 0.15), inset 0 0 20px rgba(195, 7, 63, 0.05);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.post-item:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 25px rgba(102, 252, 241, 0.2), inset 0 0 20px rgba(102, 252, 241, 0.1);
+    border-color: rgba(102, 252, 241, 0.5);
+}
+
+.post-item h2 {
+    margin-top: 0;
+    font-size: 1.5rem;
+}
+
+.post-meta {
+    font-size: 0.85rem;
+    color: var(--accent-color-2);
+    margin-bottom: 1rem;
+    font-family: var(--font-heading);
+    letter-spacing: 1px;
+}
+
+.site-footer {
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--accent-color-4);
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--accent-color-2);
+}
+
+code {
+    background-color: rgba(195, 7, 63, 0.1);
+    color: var(--accent-color-1);
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-family: monospace;
+}
+
+pre {
+    background-color: #050508 !important;
+    padding: 1.5rem;
+    border-radius: 4px;
+    border: 1px solid rgba(102, 252, 241, 0.2);
+    box-shadow: 0 0 15px rgba(102, 252, 241, 0.05);
+    overflow-x: auto;
+}
+
+blockquote {
+    border-left: 4px solid var(--accent-color-1);
+    margin: 0;
+    padding-left: 1.5rem;
+    font-style: italic;
+    color: #a0a0a0;
+}

--- a/example-sites/synthwave/templates/404.html
+++ b/example-sites/synthwave/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}404 - Not Found - {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="not-found" style="text-align: center; margin-top: 4rem;">
+    <h1 style="font-size: 5rem; margin-bottom: 1rem;">404</h1>
+    <p>The page you are looking for does not exist in this grid.</p>
+    <a href="{{ site.base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.8rem 2rem; border: 1px solid var(--accent-color-1); border-radius: 4px; font-family: var(--font-heading);">Return to Base</a>
+</div>
+{% endblock %}

--- a/example-sites/synthwave/templates/base.html
+++ b/example-sites/synthwave/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="stylesheet" href="{{ site.base_url }}/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;600&family=Syncopate:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="grid-background"></div>
+    <div class="content-wrapper">
+        <header class="site-header">
+            <h1 class="site-title"><a href="{{ site.base_url }}/">{{ site.title }}</a></h1>
+            <nav class="site-nav">
+                <ul>
+                    <li><a href="{{ site.base_url }}/">Home</a></li>
+                    <li><a href="{{ site.base_url }}/about/">About</a></li>
+                    <li><a href="{{ site.base_url }}/posts/">Posts</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <main class="site-main">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="site-footer">
+            <p>&copy; 2026 {{ site.title }}. <a href="https://github.com/hahwul/hwaro">Built with Hwaro</a></p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/example-sites/synthwave/templates/page.html
+++ b/example-sites/synthwave/templates/page.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}
+{% endblock %}
+
+{% block content %}
+<article class="post">
+    <header class="post-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="post-meta">
+            <time datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time>
+        </div>
+        {% endif %}
+    </header>
+    <div class="post-content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/example-sites/synthwave/templates/section.html
+++ b/example-sites/synthwave/templates/section.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {% if section.title %}{{ section.title }} - {% endif %}{{ site.title }}
+{% endblock %}
+
+{% block content %}
+<div class="section">
+    <header class="section-header">
+        <h1>{% if section.title %}{{ section.title }}{% else %}Posts{% endif %}</h1>
+        {{ content | safe }}
+    </header>
+
+    <div class="post-list">
+        {% for page in section.pages %}
+        <article class="post-item">
+            <h2><a href="{{ site.base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.date %}
+            <div class="post-meta">
+                <time datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time>
+            </div>
+            {% endif %}
+            <div class="post-summary">
+                {% if page.description %}
+                    <p>{{ page.description }}</p>
+                {% else %}
+                    {{ page.summary | safe }}
+                {% endif %}
+            </div>
+            <a class="read-more" href="{{ site.base_url }}{{ page.permalink }}">Read more &rarr;</a>
+        </article>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/example-sites/synthwave/templates/shortcodes/alert.html
+++ b/example-sites/synthwave/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/example-sites/synthwave/templates/taxonomy.html
+++ b/example-sites/synthwave/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}{{ taxonomy_name | capitalize }} - {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="taxonomy">
+    <h1>{{ taxonomy_name | capitalize }}</h1>
+    <ul class="taxonomy-list">
+        {% for term in taxonomy_terms %}
+        <li><a href="{{ site.base_url }}/{{ taxonomy_name }}/{{ term }}/">{{ term }}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/example-sites/synthwave/templates/taxonomy_term.html
+++ b/example-sites/synthwave/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block title %}{{ term }} - {{ taxonomy_name }} - {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="taxonomy-term">
+    <h1>{{ taxonomy_name | capitalize }}: {{ term }}</h1>
+
+    <div class="post-list">
+        {% for page in taxonomy_pages %}
+        <article class="post-item">
+            <h2><a href="{{ site.base_url }}{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.date %}
+            <div class="post-meta">
+                <time datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time>
+            </div>
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2344,6 +2344,12 @@
     "blog",
     "community"
   ],
+  "synthwave": [
+    "dark",
+    "retro",
+    "glamorous",
+    "trendy"
+  ],
   "tactile-fabric": [
     "light",
     "blog",


### PR DESCRIPTION
Adds a new "synthwave" example site inside `example-sites/` directory per #829.

It implements a retro-futuristic theme that achieves a glamorous look without breaking the explicit constraints: it avoids emojis (`emoji = false` configured) and eschews heavy, overwhelming background gradients in favor of refined neon glow effects created via precise `box-shadow` properties against a dark, minimal grid background. Templates were updated to use inheritance properly, and `tags.json` was updated.

---
*PR created automatically by Jules for task [9705405859646770915](https://jules.google.com/task/9705405859646770915) started by @chei-l*