### PR TITLE
Add new example site: hyperpop

### DIFF
--- a/example-sites/hyperpop/config.toml
+++ b/example-sites/hyperpop/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Hyperpop"
+description = "A glamorous and trendy example site."
+base_url = "http://127.0.0.1:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/example-sites/hyperpop/content/about.md
+++ b/example-sites/hyperpop/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About Hyperpop"
+tags = ["about", "vision"]
+categories = ["pages"]
++++
+
+# About the Hyperpop Concept
+
+The Hyperpop design concept is all about pushing boundaries while maintaining an elegant structure. We achieve the "wow-factor" through carefully selected color contrasts, bold typography, and strategic glowing effects.
+
+## Why this design?
+
+We wanted to showcase how a site can be incredibly vibrant and engaging without falling back on the common tropes of excessive background gradients or distracting emojis.
+
+*   **Bold Accents**: Colors like vibrant pink and electric blue.
+*   **Deep Backgrounds**: Almost-black backgrounds to make the colors pop.
+*   **Subtle Glows**: Using CSS box-shadows to create a neon-like luminescence.
+
+Join us in redefining digital aesthetics.

--- a/example-sites/hyperpop/content/index.md
+++ b/example-sites/hyperpop/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Welcome to Hyperpop"
+tags = ["glamour", "trend", "hyperpop"]
++++
+
+# Embrace the Glow
+
+Welcome to the **Hyperpop** example site. This design concept embraces glamorous and trendy visuals with striking colors and subtle luminescent effects, without relying on excessive gradients.
+
+## Design Direction
+
+- **Visual Impact**: Bold color palettes and rich visual layers.
+- **Dynamic Elements**: Elegant box-shadows and vibrant accents.
+- **Balance**: High contrast maintained with high readability.
+
+## Experience the Aesthetic
+
+Feel the energy of the hyperpop aesthetic in every interaction. Explore the depths of digital excess combined with elegant typography.
+
+[Learn more about our vision](/about/)

--- a/example-sites/hyperpop/templates/404.html
+++ b/example-sites/hyperpop/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="error-content" style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 4rem; color: var(--accent-color); text-shadow: 0 0 20px var(--accent-glow);">404</h1>
+    <p>Page Not Found</p>
+    <a href="{{ site.base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.5rem 1rem; border: 1px solid var(--secondary-color); border-radius: 4px; box-shadow: 0 0 10px var(--secondary-glow);">Return Home</a>
+  </div>
+{% endblock %}

--- a/example-sites/hyperpop/templates/base.html
+++ b/example-sites/hyperpop/templates/base.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="{{ site.default_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {% if site.description %}
+  <meta name="description" content="{{ site.description }}">
+  {% endif %}
+  <style>
+    :root {
+      --bg-color: #0d0d0d;
+      --text-color: #e0e0e0;
+      --accent-color: #ff2a6d;
+      --accent-glow: rgba(255, 42, 109, 0.6);
+      --secondary-color: #05d9e8;
+      --secondary-glow: rgba(5, 217, 232, 0.4);
+      --container-bg: #111111;
+      --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      font-family: var(--font-family);
+      line-height: 1.6;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      padding: 2rem 0;
+      text-align: center;
+      border-bottom: 1px solid #222;
+      box-shadow: 0 4px 20px var(--secondary-glow);
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 3rem;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: #fff;
+      text-shadow: 0 0 10px var(--accent-glow), 0 0 20px var(--accent-glow);
+    }
+
+    header a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    nav {
+      margin-top: 1rem;
+    }
+
+    nav a {
+      color: var(--secondary-color);
+      text-decoration: none;
+      margin: 0 1rem;
+      font-weight: bold;
+      letter-spacing: 1px;
+      transition: text-shadow 0.3s ease;
+    }
+
+    nav a:hover {
+      text-shadow: 0 0 8px var(--secondary-glow);
+    }
+
+    main {
+      flex: 1;
+      max-width: 800px;
+      margin: 3rem auto;
+      padding: 2rem;
+      background-color: var(--container-bg);
+      border-radius: 8px;
+      box-shadow: 0 0 15px var(--accent-glow);
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      color: #fff;
+    }
+
+    a {
+      color: var(--accent-color);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+      text-shadow: 0 0 5px var(--accent-glow);
+    }
+
+    ul, ol {
+      padding-left: 1.5rem;
+    }
+
+    .post-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    .post-item {
+      margin-bottom: 1.5rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid #333;
+    }
+
+    .post-item h2 {
+      margin: 0 0 0.5rem 0;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 0;
+      font-size: 0.9rem;
+      color: #666;
+      border-top: 1px solid #222;
+    }
+
+    pre {
+      background-color: #1a1a1a;
+      padding: 1rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+    }
+
+    code {
+      font-family: "Courier New", Courier, monospace;
+      color: var(--secondary-color);
+    }
+
+    /* Subtle glow for images */
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+      box-shadow: 0 0 10px var(--secondary-glow);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1><a href="{{ site.base_url }}/">{{ site.title }}</a></h1>
+    <nav>
+      <a href="{{ site.base_url }}/">Home</a>
+      <a href="{{ site.base_url }}/about/">About</a>
+    </nav>
+  </header>
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer>
+    <p>&copy; {{ site.title }}. Built with Hwaro.</p>
+  </footer>
+</body>
+</html>

--- a/example-sites/hyperpop/templates/page.html
+++ b/example-sites/hyperpop/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <article class="page-content">
+    {% if page.title %}
+      <h1>{{ page.title }}</h1>
+    {% endif %}
+    {{ content | safe }}
+  </article>
+{% endblock %}

--- a/example-sites/hyperpop/templates/section.html
+++ b/example-sites/hyperpop/templates/section.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="section-content">
+    {% if section.title %}
+      <h1>{{ section.title }}</h1>
+    {% endif %}
+
+    {% if content %}
+      <div class="section-body">
+        {{ content | safe }}
+      </div>
+    {% endif %}
+
+    {% if section.pages %}
+      <ul class="post-list">
+        {% for p in section.pages %}
+          <li class="post-item">
+            <h2><a href="{{ site.base_url }}{{ p.path }}">{{ p.title }}</a></h2>
+            {% if p.description %}
+              <p>{{ p.description }}</p>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/example-sites/hyperpop/templates/shortcodes/alert.html
+++ b/example-sites/hyperpop/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/example-sites/hyperpop/templates/taxonomy.html
+++ b/example-sites/hyperpop/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="taxonomy-content">
+    <h1>{{ taxonomy_name | capitalize }}</h1>
+
+    {% if taxonomy_terms %}
+      <ul class="post-list">
+        {% for term in taxonomy_terms %}
+          <li class="post-item">
+            <h2><a href="{{ site.base_url }}/{{ taxonomy_name }}/{{ term }}/">{{ term }}</a></h2>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/example-sites/hyperpop/templates/taxonomy_term.html
+++ b/example-sites/hyperpop/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="taxonomy-term-content">
+    <h1>{{ taxonomy_name | capitalize }}: {{ term }}</h1>
+
+    {% if taxonomy_pages %}
+      <ul class="post-list">
+        {% for p in taxonomy_pages %}
+          <li class="post-item">
+            <h2><a href="{{ site.base_url }}{{ p.path }}">{{ p.title }}</a></h2>
+            {% if p.description %}
+              <p>{{ p.description }}</p>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1110,6 +1110,13 @@
     "3d",
     "wireframe"
   ],
+  "hyperpop": [
+    "dark",
+    "glamorous",
+    "neon",
+    "trendy",
+    "elegant"
+  ],
   "igloo": [
     "light",
     "blog",


### PR DESCRIPTION
Fixes #828 by adding the new `hyperpop` example site.

- Disabled emojis in `config.toml`
- Designed an elegant dark theme using CSS variables and `box-shadow` for glowing accents.
- Refactored templates to extend a unified `base.html`.
- Appended `hyperpop` to `tags.json` registry.

---
*PR created automatically by Jules for task [16448313655189465829](https://jules.google.com/task/16448313655189465829) started by @chei-l*