### PR TITLE
feat: add new carnival example site (#815)

### DIFF
--- a/example-sites/carnival/config.toml
+++ b/example-sites/carnival/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Carnival"
+description = "A glamorous and trendy example site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/example-sites/carnival/content/about.md
+++ b/example-sites/carnival/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About Carnival"
+description = "The philosophy behind our glamorous theme."
++++
+
+Carnival is designed to evoke the feeling of a grand festival without the visual clutter often associated with it.
+
+### Elegant Design
+
+We strictly prohibit the use of excessive gradients and emojis. Instead, we rely on:
+
+1.  **Bold Typography:** Using Cormorant Garamond for headings provides a classic, authoritative feel.
+2.  **Subtle Glows:** Achieved through refined `box-shadow` techniques rather than overwhelming gradients.
+3.  **High Contrast:** A deep, dark background (`#0a0a0c`) contrasted with golden accents (`#d4af37`) and subtle magenta/cyan highlights.
+
+The result is a design that is both spectacular and highly readable.

--- a/example-sites/carnival/content/index.md
+++ b/example-sites/carnival/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "Home"
+description = "Welcome to Carnival, where elegance meets celebration."
+template = "index"
++++
+
+<div class="hero">
+  <h1 class="hero-title">Carnival</h1>
+  <p class="hero-subtitle">A celebration of design, color, and elegant typography. Step into a world of visual splendor.</p>
+  <a href="{{ base_url }}/about/" class="btn">Explore Now</a>
+</div>
+
+<div class="features">
+  <div class="feature-card">
+    <h3 class="feature-title">Glamorous</h3>
+    <p>Elegant typography combined with subtle, luminous accents creates a feeling of luxury and festivity.</p>
+  </div>
+  <div class="feature-card">
+    <h3 class="feature-title">Dramatic</h3>
+    <p>High contrast, deep backgrounds, and carefully placed highlights ensure a dramatic and memorable visual experience.</p>
+  </div>
+  <div class="feature-card">
+    <h3 class="feature-title">Refined</h3>
+    <p>Using structural layouts that maintain readability while pushing the boundaries of traditional blog design.</p>
+  </div>
+</div>

--- a/example-sites/carnival/content/posts/_index.md
+++ b/example-sites/carnival/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Journal"
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/example-sites/carnival/content/posts/first-post.md
+++ b/example-sites/carnival/content/posts/first-post.md
@@ -1,0 +1,19 @@
++++
+title = "The Art of Celebration"
+date = "2025-01-01"
+description = "A deep dive into the aesthetics of joy and grandeur."
++++
+
+Welcome to our first entry.
+
+The essence of the carnival is not just in its vibrant colors, but in the elegant structure that holds the chaos together. It is a harmonious blend of shadow and light, silence and music.
+
+### The Contrast
+
+In design, as in life, contrast provides focus. By using deep, dark backgrounds, we allow our golden accents to truly shine, much like fireworks against a night sky.
+
+* Elegant typography sets the tone
+* Subtle glows replace harsh gradients
+* Structural spacing gives room to breathe
+
+We hope you enjoy the spectacle.

--- a/example-sites/carnival/static/css/style.css
+++ b/example-sites/carnival/static/css/style.css
@@ -1,0 +1,373 @@
+:root {
+  --color-bg: #0a0a0c;
+  --color-text: #f0f0f5;
+  --color-primary: #d4af37;
+  --color-secondary: #8b005d;
+  --color-accent: #00d2ff;
+  --color-surface: rgba(255, 255, 255, 0.03);
+  --color-border: rgba(212, 175, 55, 0.2);
+
+  --font-heading: 'Cormorant Garamond', serif;
+  --font-body: 'Montserrat', sans-serif;
+
+  --shadow-glow: 0 0 20px rgba(212, 175, 55, 0.3), 0 0 40px rgba(139, 0, 93, 0.2);
+  --shadow-card: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  overflow-x: hidden;
+  position: relative;
+}
+
+.spotlight {
+  position: fixed;
+  top: -20vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  height: 60vh;
+  background: radial-gradient(ellipse at bottom, rgba(139, 0, 93, 0.15) 0%, rgba(10, 10, 12, 0) 70%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+  color: var(--color-text);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--color-accent);
+  text-shadow: 0 0 8px rgba(0, 210, 255, 0.5);
+}
+
+/* Header */
+.site-header {
+  padding: 2rem 0;
+  border-bottom: 1px solid var(--color-border);
+  background: rgba(10, 10, 12, 0.8);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(212, 175, 55, 0.4);
+}
+
+.logo:hover {
+  color: var(--color-text);
+  text-shadow: var(--shadow-glow);
+}
+
+.main-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.main-nav a {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--color-text);
+  position: relative;
+}
+
+.main-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background-color: var(--color-primary);
+  transition: width 0.3s ease;
+  box-shadow: 0 0 5px var(--color-primary);
+}
+
+.main-nav a:hover::after {
+  width: 100%;
+}
+
+/* Hero Section */
+.hero {
+  padding: 8rem 0 6rem;
+  text-align: center;
+  position: relative;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 300px;
+  height: 300px;
+  background: rgba(212, 175, 55, 0.05);
+  border-radius: 50%;
+  filter: blur(40px);
+  z-index: -1;
+}
+
+.hero-title {
+  font-size: 5rem;
+  margin-bottom: 1.5rem;
+  color: var(--color-primary);
+  text-shadow: 0 0 30px rgba(212, 175, 55, 0.2);
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  font-weight: 300;
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  color: rgba(240, 240, 245, 0.8);
+}
+
+.btn {
+  display: inline-block;
+  padding: 1rem 2.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--color-bg);
+  background-color: var(--color-primary);
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+  box-shadow: 0 0 15px rgba(212, 175, 55, 0.5);
+  transition: all 0.3s ease;
+}
+
+.btn:hover {
+  background-color: #f3e5ab;
+  color: var(--color-bg);
+  box-shadow: 0 0 25px rgba(212, 175, 55, 0.8);
+  transform: translateY(-2px);
+  text-shadow: none;
+}
+
+/* Content Area */
+.page-content {
+  padding: 4rem 0;
+  min-height: 60vh;
+}
+
+.page-title {
+  font-size: 3.5rem;
+  text-align: center;
+  margin-bottom: 0.5rem;
+  color: var(--color-primary);
+}
+
+.page-meta {
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(240, 240, 245, 0.6);
+  margin-bottom: 3rem;
+  font-family: var(--font-heading);
+  font-style: italic;
+}
+
+.content {
+  font-size: 1.1rem;
+  color: rgba(240, 240, 245, 0.9);
+}
+
+.content p {
+  margin-bottom: 1.5rem;
+}
+
+.content h2 {
+  font-size: 2.2rem;
+  margin: 3rem 0 1.5rem;
+  color: var(--color-primary);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.5rem;
+  display: inline-block;
+}
+
+/* Features Grid */
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin: 4rem 0;
+}
+
+.feature-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 2.5rem;
+  text-align: center;
+  transition: all 0.4s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.feature-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at center, rgba(139, 0, 93, 0.1) 0%, transparent 70%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-10px);
+  box-shadow: var(--shadow-glow);
+  border-color: rgba(212, 175, 55, 0.5);
+}
+
+.feature-card:hover::before {
+  opacity: 1;
+}
+
+.feature-icon {
+  font-size: 2.5rem;
+  margin-bottom: 1.5rem;
+  display: inline-block;
+  color: var(--color-primary);
+}
+
+.feature-title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+/* Post List */
+.post-list {
+  list-style: none;
+}
+
+.post-item {
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.post-link {
+  display: block;
+}
+
+.post-item-title {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-text);
+  transition: color 0.3s ease;
+}
+
+.post-link:hover .post-item-title {
+  color: var(--color-primary);
+}
+
+.post-item-meta {
+  font-size: 0.85rem;
+  color: rgba(240, 240, 245, 0.5);
+  margin-bottom: 1rem;
+  font-family: var(--font-heading);
+  font-style: italic;
+}
+
+.post-summary {
+  color: rgba(240, 240, 245, 0.8);
+}
+
+/* Footer */
+.site-footer {
+  padding: 4rem 0 2rem;
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  margin-top: 4rem;
+  position: relative;
+}
+
+.site-footer::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 50%;
+  height: 1px;
+  background: var(--color-primary);
+  opacity: 0.5;
+}
+
+.footer-nav {
+  margin-bottom: 2rem;
+}
+
+.footer-nav a {
+  margin: 0 1rem;
+  color: rgba(240, 240, 245, 0.6);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.footer-nav a:hover {
+  color: var(--color-primary);
+}
+
+.copyright {
+  font-size: 0.85rem;
+  color: rgba(240, 240, 245, 0.4);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 3.5rem;
+  }
+
+  .main-nav {
+    display: none;
+  }
+}

--- a/example-sites/carnival/templates/404.html
+++ b/example-sites/carnival/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/example-sites/carnival/templates/footer.html
+++ b/example-sites/carnival/templates/footer.html
@@ -1,0 +1,12 @@
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-nav">
+                <a href="{{ site.base_url }}/">Home</a>
+                <a href="{{ site.base_url }}/about/">About</a>
+                <a href="{{ site.base_url }}/posts/">Journal</a>
+            </div>
+            <p class="copyright">&copy; {{ current_year }} {{ site.title }}. Designed with Hwaro.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/example-sites/carnival/templates/header.html
+++ b/example-sites/carnival/templates/header.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=Montserrat:wght@300;400;600;800&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="{{ site.base_url }}/css/style.css">
+</head>
+<body>
+    <div class="spotlight"></div>
+    <header class="site-header">
+        <div class="container header-inner">
+            <a href="{{ site.base_url }}/" class="logo">{{ site.title }}</a>
+            <nav class="main-nav">
+                <a href="{{ site.base_url }}/">Home</a>
+                <a href="{{ site.base_url }}/about/">About</a>
+                <a href="{{ site.base_url }}/posts/">Journal</a>
+            </nav>
+        </div>
+    </header>

--- a/example-sites/carnival/templates/index.html
+++ b/example-sites/carnival/templates/index.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+<main class="container page-content">
+  {{ content | safe }}
+</main>
+
+{% include "footer.html" %}

--- a/example-sites/carnival/templates/page.html
+++ b/example-sites/carnival/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<main class="container page-content">
+  <article>
+    <header class="page-header">
+      <h1 class="page-title">{{ page.title }}</h1>
+      {% if page.date %}
+      <div class="page-meta">
+        <time datetime="{{ page.date | date('%Y-%m-%d') }}">{{ page.date | date('%B %d, %Y') }}</time>
+      </div>
+      {% endif %}
+    </header>
+
+    <div class="content">
+      {{ content | safe }}
+    </div>
+  </article>
+</main>
+
+{% include "footer.html" %}

--- a/example-sites/carnival/templates/section.html
+++ b/example-sites/carnival/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+
+<main class="container page-content">
+  <header class="page-header">
+    <h1 class="page-title">{{ section.title }}</h1>
+    {% if section.description %}
+    <p class="page-meta">{{ section.description }}</p>
+    {% endif %}
+  </header>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+
+  <ul class="post-list">
+    {% for post in section.pages %}
+    <li class="post-item">
+      <a href="{{ post.url }}" class="post-link">
+        <h2 class="post-item-title">{{ post.title }}</h2>
+        <div class="post-item-meta">
+          <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>
+        </div>
+        {% if post.description %}
+        <p class="post-summary">{{ post.description }}</p>
+        {% elif post.summary %}
+        <div class="post-summary">{{ post.summary | strip_html | truncate_words(30) }}</div>
+        {% endif %}
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</main>
+
+{% include "footer.html" %}

--- a/example-sites/carnival/templates/shortcodes/alert.html
+++ b/example-sites/carnival/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/example-sites/carnival/templates/taxonomy.html
+++ b/example-sites/carnival/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/example-sites/carnival/templates/taxonomy_term.html
+++ b/example-sites/carnival/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -357,6 +357,12 @@
     "blog",
     "outdoor"
   ],
+  "carnival": [
+    "dark",
+    "blog",
+    "glamorous",
+    "event"
+  ],
   "cartograph": [
     "dark",
     "docs",


### PR DESCRIPTION
Fixes #815.

This PR introduces the `carnival` example site, fulfilling the design constraints specified in the issue.

### Changes Made:
- **Design:** Implemented an elegant, high-contrast UI replacing typical loud gradients with sophisticated CSS `box-shadow` glows and refined dark backgrounds (`#0a0a0c`). Typography emphasizes classic lines with `Cormorant Garamond` and `Montserrat`.
- **Constraint Compliance:** Emojis have been strictly omitted from UI elements and deliberately disabled via `config.toml` (`emoji = false`). Excessive gradients were entirely avoided in favor of solid backgrounds and precise shading.
- **Templates:** Overrode the base scaffold templates (`index.html`, `page.html`, `section.html`, etc.) for seamless inclusion of the structural header and footer.
- **Content:** Added example content that matches the sophisticated tone and explains the theme's design philosophy.
- **Registry:** Successfully appended the `carnival` entry with its relevant tags (`dark`, `blog`, `glamorous`, `event`) to the main `tags.json` registry file, keeping the list alphabetically sorted.

All configurations were verified using `hwaro doctor --fix` and a local `hwaro build` to ensure the project meets the expected standards for deployment in the showcase.

---
*PR created automatically by Jules for task [12358485895025489248](https://jules.google.com/task/12358485895025489248) started by @chei-l*