### PR TITLE
feat: add neo-deco example site

### DIFF
--- a/neo-deco/config.toml
+++ b/neo-deco/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Neo Deco"
+description = "Neo Art Deco modern reinterpretation with geometric luxury, gold lines, and bold symmetry"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/neo-deco/content/index.md
+++ b/neo-deco/content/index.md
@@ -1,0 +1,19 @@
++++
+title = "Neo Deco"
+description = "A modern reinterpretation of Art Deco, featuring geometric luxury, dark atmospheres, and subtle glowing gold accents."
+template = "index"
++++
+
+Welcome to the **Neo Deco** example site. This template demonstrates how to build an elegant, high-impact design using the Hwaro static site generator.
+
+The design philosophy emphasizes bold symmetry, stark contrasts, and refined typography. We rely on strategic `box-shadow` techniques rather than gradients to achieve a sense of luminescence that feels sophisticated and timeless.
+
+## Core Principles
+
+*   **Geometric Precision**: Layouts guided by structured, symmetric frames.
+*   **Luxurious Palette**: Deep blacks and charcoal grays contrasted with varied shades of gold.
+*   **Typography**: A pairing of the classic *Cormorant Garamond* for headings and the modern *Montserrat* for body text.
+
+> "Elegance is not about being noticed, it's about being remembered."
+
+Explore the [Journal](/posts/) for a demonstration of how this design scales to long-form content and article listings.

--- a/neo-deco/content/posts/_index.md
+++ b/neo-deco/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Journal"
+description = "Thoughts, updates, and articles in the Neo Deco style."
+sort_by = "date"
+reverse = true
+template = "section"
++++

--- a/neo-deco/content/posts/hello-world.md
+++ b/neo-deco/content/posts/hello-world.md
@@ -1,0 +1,33 @@
++++
+title = "The Architecture of Elegance"
+date = "2026-04-10"
+description = "Exploring the structural beauty of geometric design in modern web interfaces."
+tags = ["design", "architecture", "web"]
++++
+
+Art Deco is characterized by its emphasis on strong lines, symmetrical layouts, and an inherent sense of opulence. When translating this to a modern web interface, the challenge is maintaining the luxury without overwhelming the user.
+
+<!-- more -->
+
+## The Role of Symmetry
+
+In digital design, symmetry offers a sense of stability and order. The eye naturally seeks balance, and by explicitly defining spatial relationships with bordered frames and corner accents, we guide the user's attention deliberately.
+
+```css
+.deco-frame {
+  position: relative;
+  padding: 3rem;
+  border: 1px solid var(--color-gold-dark);
+  text-align: center;
+}
+```
+
+## Glowing Accents over Gradients
+
+A common modern pitfall is the overuse of gradients to simulate light. In this design, we strictly prohibit gradients. Instead, we use solid colors and carefully calibrated `box-shadow` properties using `rgba()` to create a sense of light that emanates from the structural elements themselves.
+
+*   Subtle glows for interactive states
+*   Stronger glows to highlight primary architecture
+*   Consistent color palette rooted in deep backgrounds
+
+By adhering to these constraints, we ensure the design remains sharp, clean, and definitively *Neo Deco*.

--- a/neo-deco/static/css/style.css
+++ b/neo-deco/static/css/style.css
@@ -1,0 +1,481 @@
+/* ==========================================================================
+   Neo Deco - Modern Art Deco Reinterpretation
+   ========================================================================== */
+
+:root {
+  /* Color Palette - strictly no gradients */
+  --color-bg: #0a0a0c;
+  --color-text: #e0e0e0;
+  --color-gold: #d4af37;
+  --color-gold-light: #f3e5ab;
+  --color-gold-dark: #aa7c11;
+  --color-border: #333333;
+  --color-accent: #111115;
+
+  /* Typography */
+  --font-serif: 'Cormorant Garamond', serif;
+  --font-sans: 'Montserrat', sans-serif;
+
+  /* Glowing Box Shadows - no gradients */
+  --glow-subtle: 0 0 10px rgba(212, 175, 55, 0.15);
+  --glow-medium: 0 0 20px rgba(212, 175, 55, 0.3);
+  --glow-strong: 0 0 30px rgba(212, 175, 55, 0.5);
+}
+
+/* Base Styles */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  font-size: 16px;
+  font-weight: 300;
+  overflow-x: hidden;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  color: var(--color-gold);
+  letter-spacing: 2px;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+a {
+  color: var(--color-gold-light);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--color-gold);
+  text-shadow: var(--glow-subtle);
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* Site Layout */
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  border-left: 2px solid var(--color-gold-dark);
+  border-right: 2px solid var(--color-gold-dark);
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+  background-color: var(--color-bg);
+}
+
+.site-wrapper::before,
+.site-wrapper::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 100%;
+  top: 0;
+  border-left: 1px solid var(--color-gold-dark);
+  border-right: 1px solid var(--color-gold-dark);
+  pointer-events: none;
+  opacity: 0.3;
+}
+
+.site-wrapper::before {
+  left: 10px;
+}
+
+.site-wrapper::after {
+  right: 10px;
+}
+
+/* Header */
+.site-header {
+  padding: 2.5rem 0;
+  border-bottom: 2px solid var(--color-gold-dark);
+  text-align: center;
+  position: relative;
+}
+
+.site-header::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: var(--color-gold-dark);
+  opacity: 0.5;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-gold);
+  letter-spacing: 5px;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: 1.5rem;
+}
+
+.site-title:hover {
+  color: var(--color-gold-light);
+  text-shadow: var(--glow-medium);
+}
+
+.site-nav {
+  display: flex;
+  justify-content: center;
+  gap: 2.5rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 0.9rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.site-nav a {
+  position: relative;
+  padding-bottom: 5px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background-color: var(--color-gold);
+  transition: width 0.3s ease;
+  box-shadow: var(--glow-subtle);
+}
+
+.site-nav a:hover::after {
+  width: 100%;
+}
+
+/* Main Content */
+.site-main {
+  flex: 1;
+  padding: 4rem 0;
+}
+
+/* Deco Frames & Corners */
+.deco-frame {
+  position: relative;
+  padding: 3rem;
+  border: 1px solid var(--color-gold-dark);
+  text-align: center;
+  margin-bottom: 3rem;
+  background-color: var(--color-accent);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.deco-frame::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  border: 1px solid var(--color-gold-dark);
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.deco-corner {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  border: 2px solid var(--color-gold);
+}
+
+.top-left {
+  top: -2px;
+  left: -2px;
+  border-right: none;
+  border-bottom: none;
+  box-shadow: -2px -2px 10px rgba(212, 175, 55, 0.2);
+}
+
+.top-right {
+  top: -2px;
+  right: -2px;
+  border-left: none;
+  border-bottom: none;
+  box-shadow: 2px -2px 10px rgba(212, 175, 55, 0.2);
+}
+
+.bottom-left {
+  bottom: -2px;
+  left: -2px;
+  border-right: none;
+  border-top: none;
+  box-shadow: -2px 2px 10px rgba(212, 175, 55, 0.2);
+}
+
+.bottom-right {
+  bottom: -2px;
+  right: -2px;
+  border-left: none;
+  border-top: none;
+  box-shadow: 2px 2px 10px rgba(212, 175, 55, 0.2);
+}
+
+/* Hero Section */
+.home-hero {
+  margin-bottom: 4rem;
+}
+
+.hero-title {
+  font-size: 3.5rem;
+  margin-bottom: 1rem;
+  text-shadow: var(--glow-medium);
+}
+
+.hero-subtitle {
+  font-family: var(--font-sans);
+  font-size: 1.1rem;
+  letter-spacing: 2px;
+  color: var(--color-text);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.8;
+}
+
+/* Page Content */
+.page-content {
+  font-size: 1.1rem;
+  line-height: 1.8;
+}
+
+.page-content p {
+  margin-bottom: 1.5rem;
+}
+
+.page-content h2 {
+  font-size: 2rem;
+  margin-top: 3rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.5rem;
+  display: inline-block;
+}
+
+.page-content ul, .page-content ol {
+  margin-bottom: 1.5rem;
+  padding-left: 2rem;
+}
+
+.page-content li {
+  margin-bottom: 0.5rem;
+}
+
+.page-content blockquote {
+  border-left: 3px solid var(--color-gold);
+  padding-left: 1.5rem;
+  margin: 2rem 0;
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-style: italic;
+  color: var(--color-gold-light);
+}
+
+/* Posts List */
+.post-list {
+  margin-top: 2rem;
+}
+
+.post-item {
+  margin-bottom: 3rem;
+  position: relative;
+}
+
+.post-item-title {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-item-meta {
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  color: #888;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 1.5rem;
+}
+
+.post-item-summary {
+  margin-bottom: 1.5rem;
+}
+
+.read-more {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  padding: 0.5rem 1.5rem;
+  border: 1px solid var(--color-gold);
+  color: var(--color-gold);
+  transition: all 0.3s ease;
+}
+
+.read-more:hover {
+  background-color: var(--color-gold);
+  color: var(--color-bg);
+  box-shadow: var(--glow-medium);
+}
+
+.post-item-divider {
+  width: 50px;
+  height: 2px;
+  background-color: var(--color-gold-dark);
+  margin-top: 3rem;
+}
+
+/* Page Header */
+.page-header {
+  margin-bottom: 3rem;
+}
+
+.page-title {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.page-meta {
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  color: #888;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.page-tags {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  border: 1px solid var(--color-border);
+  padding: 0.2rem 0.8rem;
+  color: #aaa;
+}
+
+.tag:hover {
+  border-color: var(--color-gold);
+  color: var(--color-gold);
+}
+
+/* Taxonomy Terms */
+.terms-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-top: 3rem;
+}
+
+.term-link {
+  display: block;
+  padding: 1rem 2rem;
+  border: 1px solid var(--color-gold-dark);
+  background-color: var(--color-accent);
+  transition: all 0.3s ease;
+}
+
+.term-link:hover {
+  border-color: var(--color-gold);
+  box-shadow: var(--glow-medium);
+  transform: translateY(-2px);
+}
+
+.term-name {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-gold);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+/* Footer */
+.site-footer {
+  padding: 3rem 0;
+  text-align: center;
+  border-top: 2px solid var(--color-gold-dark);
+  position: relative;
+  font-size: 0.9rem;
+  color: #888;
+  letter-spacing: 1px;
+}
+
+.site-footer::before {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: var(--color-gold-dark);
+  opacity: 0.5;
+}
+
+.footer-deco-line {
+  width: 30px;
+  height: 30px;
+  border-left: 1px solid var(--color-gold);
+  border-bottom: 1px solid var(--color-gold);
+  transform: rotate(-45deg);
+  margin: 0 auto 2rem;
+  opacity: 0.5;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .site-wrapper {
+    border: none;
+  }
+
+  .site-wrapper::before,
+  .site-wrapper::after {
+    display: none;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .page-title {
+    font-size: 2rem;
+  }
+
+  .site-nav {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .deco-frame {
+    padding: 2rem 1rem;
+  }
+}

--- a/neo-deco/templates/404.html
+++ b/neo-deco/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="deco-frame">
+  <div class="deco-corner top-left"></div>
+  <div class="deco-corner top-right"></div>
+  <h1 class="hero-title">404</h1>
+  <p class="hero-subtitle">The page you are looking for does not exist in this geometry.</p>
+  <div class="post-item-divider" style="margin: 2rem auto; width: 100px;"></div>
+  <a href="{{ base_url }}/" class="read-more">Return to Home</a>
+  <div class="deco-corner bottom-left"></div>
+  <div class="deco-corner bottom-right"></div>
+</div>
+{% endblock %}

--- a/neo-deco/templates/base.html
+++ b/neo-deco/templates/base.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page and page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{% if page and page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Montserrat:wght@300;400;500;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+
+  {{ auto_includes | safe }}
+  {{ og_all_tags | safe }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <div class="container">
+        <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+        <nav class="site-nav">
+          <a href="{{ base_url }}/">Home</a>
+          <a href="{{ base_url }}/about/">About</a>
+          <a href="{{ base_url }}/posts/">Journal</a>
+          <a href="{{ base_url }}/tags/">Tags</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="site-main">
+      <div class="container">
+        {% block content %}{% endblock %}
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="footer-deco-line"></div>
+        <p>&copy; {{ current_year }} {{ site.title }}. <br>Geometric luxury, bold symmetry.</p>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/neo-deco/templates/index.html
+++ b/neo-deco/templates/index.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="home-hero">
+  <div class="deco-frame">
+    <div class="deco-corner top-left"></div>
+    <div class="deco-corner top-right"></div>
+    <h1 class="hero-title">{{ site.title }}</h1>
+    <p class="hero-subtitle">{{ site.description }}</p>
+    <div class="deco-corner bottom-left"></div>
+    <div class="deco-corner bottom-right"></div>
+  </div>
+</div>
+
+<div class="page-content">
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/neo-deco/templates/page.html
+++ b/neo-deco/templates/page.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-container">
+  <header class="page-header deco-frame">
+    <div class="deco-corner top-left"></div>
+    <div class="deco-corner top-right"></div>
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% if page.date %}
+      <div class="page-meta">
+        <time datetime="{{ page.date | date('%Y-%m-%d') }}">{{ page.date | date('%B %d, %Y') }}</time>
+      </div>
+    {% endif %}
+    {% if page.taxonomies and page.taxonomies.tags %}
+      <div class="page-tags">
+        {% for tag in page.taxonomies.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
+    <div class="deco-corner bottom-left"></div>
+    <div class="deco-corner bottom-right"></div>
+  </header>
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/neo-deco/templates/section.html
+++ b/neo-deco/templates/section.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-container">
+  <header class="section-header deco-frame">
+    <div class="deco-corner top-left"></div>
+    <div class="deco-corner top-right"></div>
+    <h1 class="section-title">{{ section.title | default("Journal") }}</h1>
+    {% if section.description %}
+      <p class="section-description">{{ section.description }}</p>
+    {% endif %}
+    <div class="deco-corner bottom-left"></div>
+    <div class="deco-corner bottom-right"></div>
+  </header>
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+
+  <div class="post-list">
+    {% for post in section.pages %}
+      <article class="post-item">
+        <h2 class="post-item-title">
+          <a href="{{ post.url }}">{{ post.title }}</a>
+        </h2>
+        {% if post.date %}
+          <div class="post-item-meta">
+            <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>
+          </div>
+        {% endif %}
+        {% if post.summary %}
+          <div class="post-item-summary">
+            {{ post.summary | strip_html }}
+          </div>
+        {% endif %}
+        <a href="{{ post.url }}" class="read-more">Read More</a>
+        <div class="post-item-divider"></div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/neo-deco/templates/shortcodes/alert.html
+++ b/neo-deco/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/neo-deco/templates/taxonomy.html
+++ b/neo-deco/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-container">
+  <header class="section-header deco-frame">
+    <div class="deco-corner top-left"></div>
+    <div class="deco-corner top-right"></div>
+    <h1 class="section-title">All {{ taxonomy_name | title }}</h1>
+    <div class="deco-corner bottom-left"></div>
+    <div class="deco-corner bottom-right"></div>
+  </header>
+
+  <div class="terms-list">
+    {% for term in taxonomy_terms %}
+      <a href="{{ base_url }}/{{ taxonomy_name | slugify }}/{{ term | slugify }}/" class="term-link">
+        <span class="term-name">{{ term }}</span>
+      </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/neo-deco/templates/taxonomy_term.html
+++ b/neo-deco/templates/taxonomy_term.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-term-container">
+  <header class="section-header deco-frame">
+    <div class="deco-corner top-left"></div>
+    <div class="deco-corner top-right"></div>
+    <h1 class="section-title">{{ taxonomy_name | title }}: {{ taxonomy_term }}</h1>
+    <div class="deco-corner bottom-left"></div>
+    <div class="deco-corner bottom-right"></div>
+  </header>
+
+  <div class="post-list">
+    {% for post in taxonomy_pages %}
+      <article class="post-item">
+        <h2 class="post-item-title">
+          <a href="{{ post.url }}">{{ post.title }}</a>
+        </h2>
+        {% if post.date %}
+          <div class="post-item-meta">
+            <time datetime="{{ post.date | date('%Y-%m-%d') }}">{{ post.date | date('%B %d, %Y') }}</time>
+          </div>
+        {% endif %}
+        <a href="{{ post.url }}" class="read-more">Read More</a>
+        <div class="post-item-divider"></div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1594,6 +1594,12 @@
     "space",
     "ethereal"
   ],
+  "neo-deco": [
+    "dark",
+    "portfolio",
+    "artdeco",
+    "elegant"
+  ],
   "neo-memphis-dark": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR implements issue #830 by introducing the `neo-deco` example site. 

The site showcases an elegant Neo Art Deco style focusing on:
- Geometric layouts and bold symmetry
- Dark backgrounds and gold highlights using `box-shadow` for subtle luminescence. 
- Strict adherence to the constraint prohibiting gradients and emojis.
- Full responsive design built over the Hwaro simple scaffold, restructured to use `base.html` inheritance.
- Updated `tags.json` alphabetically.

Verified locally with `hwaro build` and visually tested via Playwright.

---
*PR created automatically by Jules for task [17767597260291359061](https://jules.google.com/task/17767597260291359061) started by @chei-l*