### PR TITLE
feat: add 10 new example sites

### DIFF
--- a/byzantine/config.toml
+++ b/byzantine/config.toml
@@ -1,0 +1,41 @@
+title = "Byzantine"
+description = "A blog inspired by the golden mosaics and imperial grandeur of Byzantine art"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/byzantine/content/about.md
+++ b/byzantine/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Byzantine"
++++
+
+# About Byzantine
+
+Byzantine is a blog theme for Hwaro inspired by the golden mosaics and imperial art of the Byzantine Empire. The design uses deep purples, gold accents, and mosaic-inspired patterns to create a sense of sacred grandeur.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/byzantine
+```

--- a/byzantine/content/index.md
+++ b/byzantine/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Byzantine"
+template = "home"
++++
+
+A blog inspired by the golden mosaics and imperial grandeur of Byzantine art

--- a/byzantine/content/posts/_index.md
+++ b/byzantine/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/byzantine/content/posts/golden-mosaics.md
+++ b/byzantine/content/posts/golden-mosaics.md
@@ -1,0 +1,27 @@
++++
+title = "Golden Mosaics"
+date = "2026-02-20"
+description = "The techniques and symbolism behind Byzantine mosaic masterpieces."
+tags = ["mosaic", "art"]
+template = "post"
++++
+
+The techniques and symbolism behind Byzantine mosaic masterpieces.
+
+## Introduction
+
+This post explores the fundamental concepts behind Golden Mosaics. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/byzantine/content/posts/hagia-sophia.md
+++ b/byzantine/content/posts/hagia-sophia.md
@@ -1,0 +1,33 @@
++++
+title = "The Architecture of Hagia Sophia"
+date = "2026-03-08"
+description = "Exploring the architectural innovations of the Hagia Sophia."
+tags = ["architecture", "history"]
+template = "post"
++++
+
+Exploring the architectural innovations of the Hagia Sophia.
+
+## Overview
+
+Exploring the nuances of The Architecture of Hagia Sophia reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/byzantine/content/posts/iconography.md
+++ b/byzantine/content/posts/iconography.md
@@ -1,0 +1,26 @@
++++
+title = "Byzantine Iconography in Modern Design"
+date = "2026-03-25"
+description = "How Byzantine visual language informs contemporary graphic design."
+tags = ["design", "iconography"]
+template = "post"
++++
+
+How Byzantine visual language informs contemporary graphic design.
+
+## The Creative Process
+
+Byzantine Iconography in Modern Design represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/byzantine/static/css/style.css
+++ b/byzantine/static/css/style.css
@@ -1,0 +1,285 @@
+:root {
+  --purple: #4a0e4e;
+  --purple-light: #7b1fa2;
+  --gold: #d4af37;
+  --gold-light: #f0d060;
+  --deep-blue: #1a237e;
+  --mosaic-red: #b71c1c;
+  --ivory: #faf3e0;
+  --dark: #0d0d1a;
+  --text-primary: #1a0a1e;
+  --text-secondary: #4a3a52;
+  --text-muted: #7a6a82;
+  --border: rgba(74, 14, 78, 0.15);
+  --shadow: rgba(74, 14, 78, 0.12);
+  --font-display: 'Cinzel', 'Georgia', serif;
+  --font-body: 'Lora', 'Georgia', serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--ivory);
+}
+
+a { color: var(--purple); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--gold); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--dark);
+  letter-spacing: 0.03em;
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(74, 14, 78, 0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--purple);
+}
+
+pre {
+  background: var(--dark);
+  color: var(--ivory);
+  padding: 1.25rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  border: 2px solid var(--gold);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--gold);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(212, 175, 55, 0.08);
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 4px; border: 2px solid var(--border); }
+
+hr {
+  border: none;
+  height: 3px;
+  background: linear-gradient(90deg, var(--gold), var(--purple), var(--gold));
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 3px double var(--gold);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--purple);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-brand:hover { color: var(--gold); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--gold);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--purple); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--purple);
+  color: var(--purple);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  overflow: hidden;
+  background: linear-gradient(160deg, var(--purple) 0%, var(--deep-blue) 50%, var(--dark) 100%);
+  border: 3px double var(--gold);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.2) 0%, transparent 50%),
+    radial-gradient(circle at 20% 80%, rgba(183, 28, 28, 0.1) 0%, transparent 40%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--gold);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(250, 243, 224, 0.8);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--gold);
+  color: var(--dark);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 2px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.3); color: var(--dark); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--gold);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 2px solid rgba(212, 175, 55, 0.5);
+  border-radius: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(212, 175, 55, 0.1); border-color: var(--gold); color: var(--gold); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.4rem; text-align: center; margin-bottom: 2rem; letter-spacing: 0.05em; text-transform: uppercase; }
+.section-title { font-family: var(--font-display); font-size: 1.8rem; margin-bottom: 1.5rem; color: var(--purple); letter-spacing: 0.05em; }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-top: 3px solid var(--gold);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-2px); box-shadow: 0 6px 24px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.2rem; margin: 0.4rem 0; letter-spacing: 0.02em; }
+.post-card .post-title a { color: var(--dark); }
+.post-card .post-title a:hover { color: var(--purple); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.6rem; background: rgba(74, 14, 78, 0.08); color: var(--purple); font-size: 0.75rem; font-weight: 600; border-radius: 2px; letter-spacing: 0.03em; text-transform: uppercase; }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 3px double var(--gold); }
+.post-header .post-title { font-size: 2rem; margin: 0 0 0.75rem; color: var(--purple); letter-spacing: 0.03em; }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--gold); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--purple); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 3px double var(--gold); }
+.post-nav a { font-family: var(--font-display); font-size: 0.85rem; padding: 0.5rem 1rem; border: 1px solid var(--border); transition: border-color 0.2s, background 0.2s; letter-spacing: 0.03em; }
+.post-nav a:hover { border-color: var(--gold); background: rgba(212, 175, 55, 0.06); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--purple); letter-spacing: 0.03em; }
+
+.taxonomy-list a { color: var(--purple); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: #fff; border: 1px solid var(--border); transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 12px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--gold); }
+.error-page h1 { font-size: 5rem; color: var(--purple); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 4px solid var(--purple); background: rgba(74, 14, 78, 0.05); }
+.alert-warning { border-left-color: var(--gold); background: rgba(212, 175, 55, 0.08); }
+.alert-error { border-left-color: var(--mosaic-red); background: rgba(183, 28, 28, 0.05); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 3px double var(--gold); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--purple); }
+.site-footer a:hover { color: var(--gold); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/byzantine/templates/404.html
+++ b/byzantine/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[+]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/footer.html
+++ b/byzantine/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/byzantine/templates/header.html
+++ b/byzantine/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/byzantine/templates/home.html
+++ b/byzantine/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/page.html
+++ b/byzantine/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/post.html
+++ b/byzantine/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/section.html
+++ b/byzantine/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/shortcodes/alert.html
+++ b/byzantine/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/byzantine/templates/taxonomy.html
+++ b/byzantine/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/byzantine/templates/taxonomy_term.html
+++ b/byzantine/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/config.toml
+++ b/chinoiserie/config.toml
@@ -1,0 +1,41 @@
+title = "Chinoiserie"
+description = "A blog inspired by the elegant blue-and-white porcelain tradition and Chinese decorative arts"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/chinoiserie/content/about.md
+++ b/chinoiserie/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Chinoiserie"
++++
+
+# About Chinoiserie
+
+Chinoiserie is a blog theme for Hwaro inspired by Chinese decorative arts, particularly the blue-and-white porcelain tradition. The design combines porcelain blues with silk cream backgrounds and refined serif typography.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/chinoiserie
+```

--- a/chinoiserie/content/index.md
+++ b/chinoiserie/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Chinoiserie"
+template = "home"
++++
+
+A blog inspired by the elegant blue-and-white porcelain tradition and Chinese decorative arts

--- a/chinoiserie/content/posts/_index.md
+++ b/chinoiserie/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/chinoiserie/content/posts/blue-and-white.md
+++ b/chinoiserie/content/posts/blue-and-white.md
@@ -1,0 +1,27 @@
++++
+title = "Blue and White Porcelain"
+date = "2026-02-12"
+description = "The timeless beauty and cultural significance of blue-and-white porcelain."
+tags = ["porcelain", "art"]
+template = "post"
++++
+
+The timeless beauty and cultural significance of blue-and-white porcelain.
+
+## Introduction
+
+This post explores the fundamental concepts behind Blue and White Porcelain. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/chinoiserie/content/posts/modern-chinoiserie.md
+++ b/chinoiserie/content/posts/modern-chinoiserie.md
@@ -1,0 +1,26 @@
++++
+title = "Modern Chinoiserie"
+date = "2026-03-22"
+description = "The revival of chinoiserie in contemporary interior and graphic design."
+tags = ["modern", "interior"]
+template = "post"
++++
+
+The revival of chinoiserie in contemporary interior and graphic design.
+
+## The Creative Process
+
+Modern Chinoiserie represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/chinoiserie/content/posts/silk-road-aesthetics.md
+++ b/chinoiserie/content/posts/silk-road-aesthetics.md
@@ -1,0 +1,33 @@
++++
+title = "Silk Road Aesthetics"
+date = "2026-03-03"
+description = "How the Silk Road shaped the exchange of artistic ideas across civilizations."
+tags = ["history", "design"]
+template = "post"
++++
+
+How the Silk Road shaped the exchange of artistic ideas across civilizations.
+
+## Overview
+
+Exploring the nuances of Silk Road Aesthetics reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/chinoiserie/static/css/style.css
+++ b/chinoiserie/static/css/style.css
@@ -1,0 +1,276 @@
+:root {
+  --blue: #1565c0;
+  --blue-light: #42a5f5;
+  --blue-pale: #e3f2fd;
+  --red: #c62828;
+  --ink: #1a1a1a;
+  --silk: #faf6f0;
+  --jade: #2e7d32;
+  --white: #ffffff;
+  --text-primary: #1a1a2e;
+  --text-secondary: #4a4a5e;
+  --text-muted: #7a7a8e;
+  --border: rgba(21, 101, 192, 0.12);
+  --shadow: rgba(21, 101, 192, 0.1);
+  --font-display: 'Cormorant Garamond', 'Georgia', serif;
+  --font-body: 'Open Sans', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--silk);
+}
+
+a { color: var(--blue); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--red); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--ink);
+}
+
+h1 { font-size: 2.4rem; }
+h2 { font-size: 1.7rem; }
+h3 { font-size: 1.3rem; }
+p { margin: 1em 0; }
+
+code {
+  background: var(--blue-pale);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--blue);
+}
+
+pre {
+  background: var(--ink);
+  color: var(--silk);
+  padding: 1.25rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--blue);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: var(--blue-pale);
+  border-radius: 0 8px 8px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 8px; }
+
+hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--blue), transparent);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--blue);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--blue);
+  letter-spacing: 0.02em;
+}
+
+.site-brand:hover { color: var(--red); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--red);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--blue); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--blue);
+  color: var(--blue);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 12px;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--blue) 0%, #0d47a1 60%, var(--ink) 100%);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.08) 0%, transparent 50%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3.2rem;
+  font-weight: 700;
+  color: var(--white);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.8);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--white);
+  color: var(--blue);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  border-radius: 50px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.2); color: var(--blue); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--white);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  border-radius: 50px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(255, 255, 255, 0.1); border-color: var(--white); color: var(--white); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.6rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--blue); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 8px 30px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.3rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--ink); }
+.post-card .post-title a:hover { color: var(--blue); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: var(--blue-pale); color: var(--blue); font-size: 0.75rem; font-weight: 600; border-radius: 50px; }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 2px solid var(--blue); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--blue); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--blue-light); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--blue); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 2px solid var(--blue); }
+.post-nav a { font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 50px; transition: border-color 0.2s, background 0.2s; }
+.post-nav a:hover { border-color: var(--blue); background: var(--blue-pale); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--blue); }
+
+.taxonomy-list a { color: var(--blue); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--white); border: 1px solid var(--border); border-radius: 8px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 15px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--blue); }
+.error-page h1 { font-size: 5rem; color: var(--blue); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 8px; margin: 1.5rem 0; border-left: 4px solid var(--blue); background: var(--blue-pale); }
+.alert-warning { border-left-color: #f9a825; background: #fff8e1; }
+.alert-error { border-left-color: var(--red); background: #ffebee; }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 2px solid var(--blue); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--blue); }
+.site-footer a:hover { color: var(--red); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2.2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/chinoiserie/templates/404.html
+++ b/chinoiserie/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[青]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/footer.html
+++ b/chinoiserie/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/chinoiserie/templates/header.html
+++ b/chinoiserie/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,700;1,400&family=Open+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/chinoiserie/templates/home.html
+++ b/chinoiserie/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/page.html
+++ b/chinoiserie/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/post.html
+++ b/chinoiserie/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/section.html
+++ b/chinoiserie/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/shortcodes/alert.html
+++ b/chinoiserie/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/chinoiserie/templates/taxonomy.html
+++ b/chinoiserie/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/chinoiserie/templates/taxonomy_term.html
+++ b/chinoiserie/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/config.toml
+++ b/jugendstil/config.toml
@@ -1,0 +1,41 @@
+title = "Jugendstil"
+description = "A blog inspired by the organic curves and natural forms of German Art Nouveau"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/jugendstil/content/about.md
+++ b/jugendstil/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Jugendstil"
++++
+
+# About Jugendstil
+
+Jugendstil is a blog theme for Hwaro inspired by the German Art Nouveau movement. The design features sage greens, warm golds, and organic curves that echo the natural forms celebrated by Jugendstil artists.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/jugendstil
+```

--- a/jugendstil/content/index.md
+++ b/jugendstil/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Jugendstil"
+template = "home"
++++
+
+A blog inspired by the organic curves and natural forms of German Art Nouveau

--- a/jugendstil/content/posts/_index.md
+++ b/jugendstil/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/jugendstil/content/posts/nature-in-design.md
+++ b/jugendstil/content/posts/nature-in-design.md
@@ -1,0 +1,26 @@
++++
+title = "Nature as Muse"
+date = "2026-03-24"
+description = "The role of natural motifs in Art Nouveau and their influence on modern design."
+tags = ["nature", "motifs"]
+template = "post"
++++
+
+The role of natural motifs in Art Nouveau and their influence on modern design.
+
+## The Creative Process
+
+Nature as Muse represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/jugendstil/content/posts/organic-forms.md
+++ b/jugendstil/content/posts/organic-forms.md
@@ -1,0 +1,27 @@
++++
+title = "Organic Forms in Design"
+date = "2026-02-18"
+description = "Exploring the flowing organic forms that define the Jugendstil movement."
+tags = ["art", "organic"]
+template = "post"
++++
+
+Exploring the flowing organic forms that define the Jugendstil movement.
+
+## Introduction
+
+This post explores the fundamental concepts behind Organic Forms in Design. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/jugendstil/content/posts/typography-as-art.md
+++ b/jugendstil/content/posts/typography-as-art.md
@@ -1,0 +1,33 @@
++++
+title = "Typography as Art"
+date = "2026-03-06"
+description = "How Jugendstil elevated letterforms into decorative art."
+tags = ["typography", "design"]
+template = "post"
++++
+
+How Jugendstil elevated letterforms into decorative art.
+
+## Overview
+
+Exploring the nuances of Typography as Art reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/jugendstil/static/css/style.css
+++ b/jugendstil/static/css/style.css
@@ -1,0 +1,275 @@
+:root {
+  --sage: #6b8e6b;
+  --sage-light: #8fbc8f;
+  --gold: #b8860b;
+  --gold-light: #daa520;
+  --cream: #faf8f0;
+  --forest: #1a2e1a;
+  --copper: #b87333;
+  --warm-white: #fff8f0;
+  --text-primary: #1a2a1a;
+  --text-secondary: #4a5a4a;
+  --text-muted: #7a8a7a;
+  --border: rgba(107, 142, 107, 0.2);
+  --shadow: rgba(107, 142, 107, 0.12);
+  --font-display: 'Abril Fatface', 'Georgia', serif;
+  --font-body: 'Raleway', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--cream);
+}
+
+a { color: var(--sage); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--gold); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  line-height: 1.2;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--forest);
+}
+
+h1 { font-size: 2.5rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.3rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(107, 142, 107, 0.08);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--forest);
+}
+
+pre {
+  background: var(--forest);
+  color: var(--cream);
+  padding: 1.25rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  border: 2px solid var(--sage);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--gold);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(184, 134, 11, 0.06);
+  border-radius: 0 12px 12px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 12px; }
+
+hr {
+  border: none;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--sage), var(--gold), var(--sage), transparent);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--sage);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--forest);
+}
+
+.site-brand:hover { color: var(--gold); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--gold);
+  transition: width 0.3s;
+  border-radius: 2px;
+}
+
+.site-nav a:hover { color: var(--sage); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--sage);
+  color: var(--sage);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 20px;
+  overflow: hidden;
+  background: linear-gradient(160deg, var(--sage) 0%, var(--forest) 100%);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 30% 70%, rgba(184, 134, 11, 0.2) 0%, transparent 50%),
+    radial-gradient(ellipse at 70% 20%, rgba(143, 188, 143, 0.15) 0%, transparent 40%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3.2rem;
+  color: var(--warm-white);
+  margin: 0 0 0.75rem;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(255, 248, 240, 0.8);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--warm-white);
+  color: var(--forest);
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 50px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.2); color: var(--forest); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--warm-white);
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid rgba(255, 248, 240, 0.4);
+  border-radius: 50px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(255, 248, 240, 0.1); border-color: var(--warm-white); color: var(--warm-white); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.6rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--sage); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--warm-white);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 8px 30px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.3rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--forest); }
+.post-card .post-title a:hover { color: var(--sage); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: rgba(107, 142, 107, 0.1); color: var(--sage); font-size: 0.75rem; font-weight: 600; border-radius: 50px; }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 2px solid var(--sage); }
+.post-header .post-title { font-size: 2.4rem; margin: 0 0 0.75rem; color: var(--sage); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--sage-light); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--sage); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 2px solid var(--sage); }
+.post-nav a { font-family: var(--font-body); font-weight: 700; font-size: 0.9rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 50px; transition: border-color 0.2s, background 0.2s; }
+.post-nav a:hover { border-color: var(--sage); background: rgba(107, 142, 107, 0.06); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--sage); }
+
+.taxonomy-list a { color: var(--sage); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--warm-white); border: 1px solid var(--border); border-radius: 12px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 15px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--sage); }
+.error-page h1 { font-size: 5rem; color: var(--sage); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 12px; margin: 1.5rem 0; border-left: 4px solid var(--sage); background: rgba(107, 142, 107, 0.06); }
+.alert-warning { border-left-color: var(--gold); background: rgba(184, 134, 11, 0.06); }
+.alert-error { border-left-color: #c62828; background: rgba(198, 40, 40, 0.05); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 2px solid var(--sage); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--sage); }
+.site-footer a:hover { color: var(--gold); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2.2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.8rem; }
+}

--- a/jugendstil/templates/404.html
+++ b/jugendstil/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[~]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/footer.html
+++ b/jugendstil/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/jugendstil/templates/header.html
+++ b/jugendstil/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Raleway:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/jugendstil/templates/home.html
+++ b/jugendstil/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/page.html
+++ b/jugendstil/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/post.html
+++ b/jugendstil/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/section.html
+++ b/jugendstil/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/shortcodes/alert.html
+++ b/jugendstil/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/jugendstil/templates/taxonomy.html
+++ b/jugendstil/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/jugendstil/templates/taxonomy_term.html
+++ b/jugendstil/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/config.toml
+++ b/madhubani/config.toml
@@ -1,0 +1,41 @@
+title = "Madhubani"
+description = "A blog inspired by the vibrant geometric patterns and bold colors of Indian Madhubani folk art"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/madhubani/content/about.md
+++ b/madhubani/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Madhubani"
++++
+
+# About Madhubani
+
+Madhubani is a blog theme for Hwaro inspired by the vibrant folk art tradition of Madhubani painting from Bihar, India. The design uses bold primary colors, geometric borders, and high-contrast patterns.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/madhubani
+```

--- a/madhubani/content/index.md
+++ b/madhubani/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Madhubani"
+template = "home"
++++
+
+A blog inspired by the vibrant geometric patterns and bold colors of Indian Madhubani folk art

--- a/madhubani/content/posts/_index.md
+++ b/madhubani/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/madhubani/content/posts/folk-art-traditions.md
+++ b/madhubani/content/posts/folk-art-traditions.md
@@ -1,0 +1,27 @@
++++
+title = "Folk Art Traditions"
+date = "2026-02-22"
+description = "The living tradition of Madhubani painting and its cultural roots in Bihar."
+tags = ["folk-art", "tradition"]
+template = "post"
++++
+
+The living tradition of Madhubani painting and its cultural roots in Bihar.
+
+## Introduction
+
+This post explores the fundamental concepts behind Folk Art Traditions. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/madhubani/content/posts/geometric-patterns.md
+++ b/madhubani/content/posts/geometric-patterns.md
@@ -1,0 +1,33 @@
++++
+title = "Geometry in Madhubani"
+date = "2026-03-10"
+description = "How geometric patterns create rhythm and meaning in Madhubani compositions."
+tags = ["patterns", "geometry"]
+template = "post"
++++
+
+How geometric patterns create rhythm and meaning in Madhubani compositions.
+
+## Overview
+
+Exploring the nuances of Geometry in Madhubani reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/madhubani/content/posts/natural-pigments.md
+++ b/madhubani/content/posts/natural-pigments.md
@@ -1,0 +1,26 @@
++++
+title = "Natural Pigments and Colors"
+date = "2026-03-28"
+description = "The use of natural pigments and their significance in Madhubani art."
+tags = ["colors", "craft"]
+template = "post"
++++
+
+The use of natural pigments and their significance in Madhubani art.
+
+## The Creative Process
+
+Natural Pigments and Colors represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/madhubani/static/css/style.css
+++ b/madhubani/static/css/style.css
@@ -1,0 +1,270 @@
+:root {
+  --vermillion: #e53935;
+  --ochre: #f9a825;
+  --deep-blue: #1565c0;
+  --forest: #2e7d32;
+  --black: #1a1a1a;
+  --off-white: #fff8e1;
+  --white: #ffffff;
+  --text-primary: #1a1a1a;
+  --text-secondary: #4a4a4a;
+  --text-muted: #7a7a7a;
+  --border: rgba(229, 57, 53, 0.15);
+  --shadow: rgba(229, 57, 53, 0.1);
+  --font-display: 'Yeseva One', 'Georgia', serif;
+  --font-body: 'Nunito', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--off-white);
+}
+
+a { color: var(--vermillion); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--deep-blue); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  line-height: 1.2;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--black);
+}
+
+h1 { font-size: 2.4rem; }
+h2 { font-size: 1.7rem; }
+h3 { font-size: 1.3rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(229, 57, 53, 0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--vermillion);
+}
+
+pre {
+  background: var(--black);
+  color: var(--off-white);
+  padding: 1.25rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  border: 3px solid var(--ochre);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 5px solid var(--ochre);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(249, 168, 37, 0.08);
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border: 3px solid var(--black); }
+
+hr {
+  border: none;
+  height: 3px;
+  background: repeating-linear-gradient(90deg, var(--vermillion) 0px, var(--vermillion) 8px, var(--ochre) 8px, var(--ochre) 16px, var(--deep-blue) 16px, var(--deep-blue) 24px, var(--forest) 24px, var(--forest) 32px);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 3px solid var(--vermillion);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--vermillion);
+}
+
+.site-brand:hover { color: var(--deep-blue); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 3px;
+  background: var(--ochre);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--vermillion); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--vermillion);
+  color: var(--vermillion);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  overflow: hidden;
+  background: var(--vermillion);
+  border: 4px solid var(--black);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 50%, rgba(249, 168, 37, 0.3) 0%, transparent 40%),
+    radial-gradient(circle at 80% 50%, rgba(21, 101, 192, 0.3) 0%, transparent 40%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  color: var(--off-white);
+  margin: 0 0 0.75rem;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(255, 248, 225, 0.9);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--ochre);
+  color: var(--black);
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid var(--black);
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 3px 3px 0 var(--black);
+}
+
+.btn-primary:hover { transform: translate(-2px, -2px); box-shadow: 5px 5px 0 var(--black); color: var(--black); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--off-white);
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid var(--off-white);
+  transition: background 0.2s;
+}
+
+.btn-outline:hover { background: rgba(255, 248, 225, 0.15); color: var(--off-white); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.6rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--vermillion); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--white);
+  border: 2px solid var(--black);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 3px 3px 0 var(--border);
+}
+
+.post-card:hover { transform: translate(-2px, -2px); box-shadow: 5px 5px 0 var(--vermillion); }
+
+.post-date { font-size: 0.8rem; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.3rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--black); }
+.post-card .post-title a:hover { color: var(--vermillion); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: var(--ochre); color: var(--black); font-size: 0.75rem; font-weight: 700; border: 1px solid var(--black); }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 3px solid var(--vermillion); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--vermillion); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--ochre); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 2px solid var(--border); }
+.content-body h3 { color: var(--deep-blue); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 3px solid var(--vermillion); }
+.post-nav a { font-family: var(--font-body); font-weight: 700; font-size: 0.9rem; padding: 0.5rem 1rem; border: 2px solid var(--black); transition: background 0.2s; }
+.post-nav a:hover { background: var(--ochre); color: var(--black); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2.2rem; margin-bottom: 1.5rem; color: var(--vermillion); }
+
+.taxonomy-list a { color: var(--vermillion); font-weight: 700; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--white); border: 2px solid var(--black); transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 3px 3px 0 var(--vermillion); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--ochre); }
+.error-page h1 { font-size: 5rem; color: var(--vermillion); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 5px solid var(--deep-blue); background: rgba(21, 101, 192, 0.06); border: 2px solid var(--black); border-left-width: 5px; }
+.alert-warning { border-left-color: var(--ochre); background: rgba(249, 168, 37, 0.08); }
+.alert-error { border-left-color: var(--vermillion); background: rgba(229, 57, 53, 0.06); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 3px solid var(--vermillion); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--vermillion); }
+.site-footer a:hover { color: var(--deep-blue); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 2px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/madhubani/templates/404.html
+++ b/madhubani/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[*]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/footer.html
+++ b/madhubani/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/madhubani/templates/header.html
+++ b/madhubani/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,400;0,700;1,400&family=Yeseva+One&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/madhubani/templates/home.html
+++ b/madhubani/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/page.html
+++ b/madhubani/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/post.html
+++ b/madhubani/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/section.html
+++ b/madhubani/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/shortcodes/alert.html
+++ b/madhubani/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/madhubani/templates/taxonomy.html
+++ b/madhubani/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/madhubani/templates/taxonomy_term.html
+++ b/madhubani/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/mughal/config.toml
+++ b/mughal/config.toml
@@ -1,0 +1,41 @@
+title = "Mughal"
+description = "A blog inspired by the grandeur of Mughal art, architecture, and miniature painting"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/mughal/content/about.md
+++ b/mughal/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Mughal"
++++
+
+# About Mughal
+
+Mughal is a blog theme for Hwaro inspired by the rich artistic traditions of the Mughal Empire. The design features emerald greens, deep golds, and ornate border treatments that echo the grandeur of Mughal architecture.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/mughal
+```

--- a/mughal/content/index.md
+++ b/mughal/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Mughal"
+template = "home"
++++
+
+A blog inspired by the grandeur of Mughal art, architecture, and miniature painting

--- a/mughal/content/posts/_index.md
+++ b/mughal/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/mughal/content/posts/gardens-of-paradise.md
+++ b/mughal/content/posts/gardens-of-paradise.md
@@ -1,0 +1,27 @@
++++
+title = "Gardens of Paradise"
+date = "2026-02-15"
+description = "Exploring the symbolic design of Mughal gardens and their influence on landscape architecture."
+tags = ["architecture", "gardens"]
+template = "post"
++++
+
+Exploring the symbolic design of Mughal gardens and their influence on landscape architecture.
+
+## Introduction
+
+This post explores the fundamental concepts behind Gardens of Paradise. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/mughal/content/posts/geometric-patterns.md
+++ b/mughal/content/posts/geometric-patterns.md
@@ -1,0 +1,26 @@
++++
+title = "Geometric Patterns in Islamic Art"
+date = "2026-03-18"
+description = "Understanding the mathematical precision behind Islamic geometric patterns."
+tags = ["patterns", "design"]
+template = "post"
++++
+
+Understanding the mathematical precision behind Islamic geometric patterns.
+
+## The Creative Process
+
+Geometric Patterns in Islamic Art represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/mughal/content/posts/miniature-painting.md
+++ b/mughal/content/posts/miniature-painting.md
@@ -1,0 +1,33 @@
++++
+title = "Miniature Painting Traditions"
+date = "2026-03-01"
+description = "The intricate world of Mughal miniature paintings and their storytelling traditions."
+tags = ["art", "painting"]
+template = "post"
++++
+
+The intricate world of Mughal miniature paintings and their storytelling traditions.
+
+## Overview
+
+Exploring the nuances of Miniature Painting Traditions reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/mughal/static/css/style.css
+++ b/mughal/static/css/style.css
@@ -1,0 +1,290 @@
+:root {
+  --emerald: #005f56;
+  --emerald-light: #00897b;
+  --gold: #d4a843;
+  --gold-light: #e8c975;
+  --deep-red: #8b1a1a;
+  --ivory: #fdf8f0;
+  --dark: #1a1a1a;
+  --warm-brown: #5c4033;
+  --text-primary: #2c1a0e;
+  --text-secondary: #5c4a3a;
+  --text-muted: #8a7a6a;
+  --border: rgba(0, 95, 86, 0.15);
+  --shadow: rgba(0, 95, 86, 0.12);
+  --font-display: 'Playfair Display', 'Georgia', serif;
+  --font-body: 'Source Sans 3', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--ivory);
+}
+
+a { color: var(--emerald); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--gold); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--dark);
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(0, 95, 86, 0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--emerald);
+}
+
+pre {
+  background: var(--dark);
+  color: var(--ivory);
+  padding: 1.25rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  border: 2px solid var(--gold);
+  border-top-width: 4px;
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--gold);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(212, 168, 67, 0.08);
+  border-radius: 0 8px 8px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 6px; }
+
+hr {
+  border: none;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--gold), transparent);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--gold);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 1.4rem;
+  color: var(--emerald);
+  letter-spacing: 0.02em;
+}
+
+.site-brand:hover { color: var(--gold); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--gold);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--emerald); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--emerald);
+  color: var(--emerald);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 12px;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--emerald) 0%, #004d40 60%, var(--dark) 100%);
+  border: 3px solid var(--gold);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 70%, rgba(212, 168, 67, 0.2) 0%, transparent 50%),
+    radial-gradient(circle at 70% 30%, rgba(212, 168, 67, 0.15) 0%, transparent 40%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  font-weight: 900;
+  color: var(--gold-light);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.03em;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(253, 248, 240, 0.85);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--gold);
+  color: var(--dark);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 6px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.25); color: var(--dark); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--gold-light);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid rgba(212, 168, 67, 0.5);
+  border-radius: 6px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(212, 168, 67, 0.15); border-color: var(--gold); color: var(--gold-light); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.5rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2rem; margin-bottom: 1.5rem; color: var(--emerald); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--gold);
+  border-radius: 8px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 6px 24px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--dark); }
+.post-card .post-title a:hover { color: var(--emerald); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+
+.tag-pill {
+  display: inline-block;
+  padding: 0.2rem 0.7rem;
+  background: rgba(0, 95, 86, 0.08);
+  color: var(--emerald);
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 50px;
+}
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 2px solid var(--gold); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--emerald); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--gold); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--emerald); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 2px solid var(--gold); }
+.post-nav a { font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 6px; transition: border-color 0.2s, background 0.2s; }
+.post-nav a:hover { border-color: var(--gold); background: rgba(212, 168, 67, 0.08); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--emerald); }
+
+.taxonomy-list a { color: var(--emerald); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: #fff; border: 1px solid var(--border); border-radius: 8px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 15px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--gold); }
+.error-page h1 { font-size: 5rem; color: var(--emerald); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 8px; margin: 1.5rem 0; border-left: 4px solid var(--emerald); background: rgba(0, 95, 86, 0.06); }
+.alert-warning { border-left-color: var(--gold); background: rgba(212, 168, 67, 0.08); }
+.alert-error { border-left-color: var(--deep-red); background: rgba(139, 26, 26, 0.06); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 2px solid var(--gold); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--emerald); }
+.site-footer a:hover { color: var(--gold); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/mughal/templates/404.html
+++ b/mughal/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[M]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/footer.html
+++ b/mughal/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/mughal/templates/header.html
+++ b/mughal/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&family=Source+Sans+3:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/mughal/templates/home.html
+++ b/mughal/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/page.html
+++ b/mughal/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/post.html
+++ b/mughal/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/section.html
+++ b/mughal/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/shortcodes/alert.html
+++ b/mughal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/mughal/templates/taxonomy.html
+++ b/mughal/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/mughal/templates/taxonomy_term.html
+++ b/mughal/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/config.toml
+++ b/particle-storm/config.toml
@@ -1,0 +1,41 @@
+title = "Particle Storm"
+description = "A dark blog theme inspired by dynamic particle systems and neon energy visuals"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/particle-storm/content/about.md
+++ b/particle-storm/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Particle Storm"
++++
+
+# About Particle Storm
+
+Particle Storm is a dark blog theme for Hwaro inspired by dynamic particle systems and energy visualizations. The design features electric magentas, neon greens, and plasma blues against a deep void background.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/particle-storm
+```

--- a/particle-storm/content/index.md
+++ b/particle-storm/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Particle Storm"
+template = "home"
++++
+
+A dark blog theme inspired by dynamic particle systems and neon energy visuals

--- a/particle-storm/content/posts/_index.md
+++ b/particle-storm/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/particle-storm/content/posts/energy-fields.md
+++ b/particle-storm/content/posts/energy-fields.md
@@ -1,0 +1,26 @@
++++
+title = "Visualizing Energy Fields"
+date = "2026-03-26"
+description = "Techniques for representing energy and force fields through visual design."
+tags = ["visualization", "energy"]
+template = "post"
++++
+
+Techniques for representing energy and force fields through visual design.
+
+## The Creative Process
+
+Visualizing Energy Fields represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/particle-storm/content/posts/generative-motion.md
+++ b/particle-storm/content/posts/generative-motion.md
@@ -1,0 +1,33 @@
++++
+title = "Generative Art and Motion"
+date = "2026-03-07"
+description = "Exploring the intersection of generative algorithms and motion design."
+tags = ["generative", "motion"]
+template = "post"
++++
+
+Exploring the intersection of generative algorithms and motion design.
+
+## Overview
+
+Exploring the nuances of Generative Art and Motion reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/particle-storm/content/posts/particle-physics.md
+++ b/particle-storm/content/posts/particle-physics.md
@@ -1,0 +1,27 @@
++++
+title = "Particle Systems in Graphics"
+date = "2026-02-16"
+description = "An introduction to particle systems and their role in computer graphics."
+tags = ["particles", "graphics"]
+template = "post"
++++
+
+An introduction to particle systems and their role in computer graphics.
+
+## Introduction
+
+This post explores the fundamental concepts behind Particle Systems in Graphics. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/particle-storm/static/css/style.css
+++ b/particle-storm/static/css/style.css
@@ -1,0 +1,292 @@
+:root {
+  --void: #050510;
+  --surface: #1a1a2e;
+  --magenta: #ff00ff;
+  --neon-green: #00ff88;
+  --plasma-blue: #0088ff;
+  --white: #f0f0ff;
+  --text-primary: #d0d0e0;
+  --text-secondary: #a0a0b0;
+  --text-muted: #707080;
+  --border: rgba(255, 0, 255, 0.15);
+  --shadow-magenta: rgba(255, 0, 255, 0.2);
+  --shadow-green: rgba(0, 255, 136, 0.15);
+  --font-display: 'Orbitron', 'Segoe UI', sans-serif;
+  --font-body: 'Exo 2', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--void);
+}
+
+a { color: var(--magenta); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--neon-green); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--white);
+  letter-spacing: 0.05em;
+}
+
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.15rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(255, 0, 255, 0.1);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--neon-green);
+}
+
+pre {
+  background: var(--surface);
+  color: var(--white);
+  padding: 1.25rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  box-shadow: 0 0 15px rgba(255, 0, 255, 0.05);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 3px solid var(--neon-green);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(0, 255, 136, 0.04);
+  border-radius: 0 8px 8px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 8px; }
+
+hr {
+  border: none;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--magenta), var(--neon-green), var(--plasma-blue), transparent);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--magenta);
+  text-shadow: 0 0 10px var(--shadow-magenta);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.site-brand:hover { color: var(--neon-green); text-shadow: 0 0 15px var(--shadow-green); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: linear-gradient(90deg, var(--magenta), var(--neon-green));
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--magenta); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--magenta);
+  color: var(--magenta);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 0 50px rgba(255, 0, 255, 0.06), 0 0 100px rgba(0, 136, 255, 0.04);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 0, 255, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 70% 70%, rgba(0, 255, 136, 0.1) 0%, transparent 40%),
+    radial-gradient(circle at 50% 50%, rgba(0, 136, 255, 0.08) 0%, transparent 50%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--white);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 0 30px var(--shadow-magenta);
+}
+
+.hero-tagline {
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: linear-gradient(135deg, var(--magenta), var(--plasma-blue));
+  color: var(--white);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 6px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 0 25px var(--shadow-magenta);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 0 40px var(--shadow-magenta); color: var(--white); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--neon-green);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(0, 255, 136, 0.4);
+  border-radius: 6px;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.btn-outline:hover { background: rgba(0, 255, 136, 0.06); border-color: var(--neon-green); box-shadow: 0 0 20px var(--shadow-green); color: var(--neon-green); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.3rem; text-align: center; margin-bottom: 2rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--white); }
+.section-title { font-family: var(--font-display); font-size: 1.6rem; margin-bottom: 1.5rem; color: var(--magenta); letter-spacing: 0.06em; text-shadow: 0 0 15px var(--shadow-magenta); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 0 30px var(--shadow-magenta); }
+
+.post-date { font-size: 0.75rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; font-family: var(--font-display); }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.1rem; margin: 0.4rem 0; letter-spacing: 0.03em; }
+.post-card .post-title a { color: var(--white); }
+.post-card .post-title a:hover { color: var(--magenta); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: rgba(255, 0, 255, 0.1); color: var(--magenta); font-size: 0.7rem; font-weight: 600; border-radius: 50px; border: 1px solid rgba(255, 0, 255, 0.2); letter-spacing: 0.05em; text-transform: uppercase; font-family: var(--font-display); }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
+.post-header .post-title { font-size: 1.8rem; margin: 0 0 0.75rem; color: var(--white); text-shadow: 0 0 20px var(--shadow-magenta); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--magenta); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--neon-green); text-shadow: 0 0 8px var(--shadow-green); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); }
+.post-nav a { font-family: var(--font-display); font-weight: 500; font-size: 0.8rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 6px; letter-spacing: 0.05em; transition: border-color 0.2s, box-shadow 0.2s; }
+.post-nav a:hover { border-color: var(--magenta); box-shadow: 0 0 12px var(--shadow-magenta); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 1.6rem; margin-bottom: 1.5rem; color: var(--magenta); letter-spacing: 0.05em; }
+
+.taxonomy-list a { color: var(--magenta); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 0 15px var(--shadow-magenta); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--magenta); text-shadow: 0 0 20px var(--shadow-magenta); }
+.error-page h1 { font-size: 4rem; color: var(--magenta); margin: 0; text-shadow: 0 0 40px var(--shadow-magenta); letter-spacing: 0.1em; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 6px; margin: 1.5rem 0; border-left: 3px solid var(--plasma-blue); background: rgba(0, 136, 255, 0.06); }
+.alert-warning { border-left-color: #fdd835; background: rgba(253, 216, 53, 0.06); }
+.alert-error { border-left-color: #ff1744; background: rgba(255, 23, 68, 0.06); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 1px solid var(--border); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--magenta); }
+.site-footer a:hover { color: var(--neon-green); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 1.8rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.4rem; }
+}

--- a/particle-storm/templates/404.html
+++ b/particle-storm/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[P]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/footer.html
+++ b/particle-storm/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/particle-storm/templates/header.html
+++ b/particle-storm/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,400;0,500;0,700;1,400&family=Orbitron:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/particle-storm/templates/home.html
+++ b/particle-storm/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/page.html
+++ b/particle-storm/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/post.html
+++ b/particle-storm/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/section.html
+++ b/particle-storm/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/shortcodes/alert.html
+++ b/particle-storm/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/particle-storm/templates/taxonomy.html
+++ b/particle-storm/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/particle-storm/templates/taxonomy_term.html
+++ b/particle-storm/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/config.toml
+++ b/persian-carpet/config.toml
@@ -1,0 +1,41 @@
+title = "Persian Carpet"
+description = "A blog inspired by the rich colors and intricate patterns of traditional Persian carpets"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/persian-carpet/content/about.md
+++ b/persian-carpet/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Persian Carpet"
++++
+
+# About Persian Carpet
+
+Persian Carpet is a blog theme for Hwaro inspired by the intricate beauty of traditional Persian rugs. The design features deep reds, navy blues, and gold accents with ornate border patterns that evoke the richness of hand-woven carpets.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/persian-carpet
+```

--- a/persian-carpet/content/index.md
+++ b/persian-carpet/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Persian Carpet"
+template = "home"
++++
+
+A blog inspired by the rich colors and intricate patterns of traditional Persian carpets

--- a/persian-carpet/content/posts/_index.md
+++ b/persian-carpet/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/persian-carpet/content/posts/art-of-weaving.md
+++ b/persian-carpet/content/posts/art-of-weaving.md
@@ -1,0 +1,27 @@
++++
+title = "The Art of Weaving"
+date = "2026-02-28"
+description = "Exploring the centuries-old techniques of Persian carpet weaving."
+tags = ["weaving", "craft"]
+template = "post"
++++
+
+Exploring the centuries-old techniques of Persian carpet weaving.
+
+## Introduction
+
+This post explores the fundamental concepts behind The Art of Weaving. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/persian-carpet/content/posts/color-and-dye.md
+++ b/persian-carpet/content/posts/color-and-dye.md
@@ -1,0 +1,26 @@
++++
+title = "Color and Natural Dye"
+date = "2026-04-01"
+description = "The tradition of natural dyes and their role in Persian carpet artistry."
+tags = ["color", "tradition"]
+template = "post"
++++
+
+The tradition of natural dyes and their role in Persian carpet artistry.
+
+## The Creative Process
+
+Color and Natural Dye represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/persian-carpet/content/posts/symbolic-motifs.md
+++ b/persian-carpet/content/posts/symbolic-motifs.md
@@ -1,0 +1,33 @@
++++
+title = "Symbolic Motifs"
+date = "2026-03-15"
+description = "Decoding the rich symbolism woven into traditional Persian carpet designs."
+tags = ["symbolism", "art"]
+template = "post"
++++
+
+Decoding the rich symbolism woven into traditional Persian carpet designs.
+
+## Overview
+
+Exploring the nuances of Symbolic Motifs reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/persian-carpet/static/css/style.css
+++ b/persian-carpet/static/css/style.css
@@ -1,0 +1,273 @@
+:root {
+  --deep-red: #8b0000;
+  --red-light: #b71c1c;
+  --navy: #1a237e;
+  --gold: #c9a227;
+  --gold-light: #e0c068;
+  --ivory: #faf3e0;
+  --burgundy: #5c0a0a;
+  --sand: #f5e6cc;
+  --text-primary: #2c1a0e;
+  --text-secondary: #5c3a2a;
+  --text-muted: #8a6a5a;
+  --border: rgba(139, 0, 0, 0.15);
+  --shadow: rgba(139, 0, 0, 0.1);
+  --font-display: 'Libre Baskerville', 'Georgia', serif;
+  --font-body: 'Karla', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--sand);
+}
+
+a { color: var(--deep-red); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--gold); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--burgundy);
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(139, 0, 0, 0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--deep-red);
+}
+
+pre {
+  background: var(--burgundy);
+  color: var(--ivory);
+  padding: 1.25rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  border: 2px solid var(--gold);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--gold);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(201, 162, 39, 0.08);
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border: 2px solid var(--border); }
+
+hr {
+  border: none;
+  height: 2px;
+  background: linear-gradient(90deg, var(--gold), var(--deep-red), var(--navy), var(--deep-red), var(--gold));
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--deep-red);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--deep-red);
+}
+
+.site-brand:hover { color: var(--gold); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--gold);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--deep-red); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--deep-red);
+  color: var(--deep-red);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--deep-red) 0%, var(--burgundy) 60%, var(--navy) 100%);
+  border: 3px double var(--gold);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(201, 162, 39, 0.15) 0%, transparent 50%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--gold-light);
+  margin: 0 0 0.75rem;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(250, 243, 224, 0.85);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--gold);
+  color: var(--burgundy);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 4px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.3); color: var(--burgundy); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--gold-light);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid rgba(201, 162, 39, 0.5);
+  border-radius: 4px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(201, 162, 39, 0.1); border-color: var(--gold); color: var(--gold-light); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.5rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2rem; margin-bottom: 1.5rem; color: var(--deep-red); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--ivory);
+  border: 1px solid var(--border);
+  border-top: 3px solid var(--deep-red);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-2px); box-shadow: 0 6px 24px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--burgundy); }
+.post-card .post-title a:hover { color: var(--deep-red); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.6rem; background: rgba(139, 0, 0, 0.08); color: var(--deep-red); font-size: 0.75rem; font-weight: 700; }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 2px solid var(--gold); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--deep-red); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--gold); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--navy); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 2px solid var(--gold); }
+.post-nav a { font-family: var(--font-display); font-size: 0.9rem; padding: 0.5rem 1rem; border: 1px solid var(--border); transition: border-color 0.2s, background 0.2s; }
+.post-nav a:hover { border-color: var(--gold); background: rgba(201, 162, 39, 0.06); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--deep-red); }
+
+.taxonomy-list a { color: var(--deep-red); font-weight: 700; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--ivory); border: 1px solid var(--border); transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 12px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--gold); }
+.error-page h1 { font-size: 5rem; color: var(--deep-red); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; margin: 1.5rem 0; border-left: 4px solid var(--navy); background: rgba(26, 35, 126, 0.05); }
+.alert-warning { border-left-color: var(--gold); background: rgba(201, 162, 39, 0.08); }
+.alert-error { border-left-color: var(--deep-red); background: rgba(139, 0, 0, 0.05); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 2px solid var(--deep-red); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--deep-red); }
+.site-footer a:hover { color: var(--gold); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/persian-carpet/templates/404.html
+++ b/persian-carpet/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[#]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/footer.html
+++ b/persian-carpet/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/persian-carpet/templates/header.html
+++ b/persian-carpet/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Karla:ital,wght@0,400;0,700;1,400&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/persian-carpet/templates/home.html
+++ b/persian-carpet/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/page.html
+++ b/persian-carpet/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/post.html
+++ b/persian-carpet/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/section.html
+++ b/persian-carpet/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/shortcodes/alert.html
+++ b/persian-carpet/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/persian-carpet/templates/taxonomy.html
+++ b/persian-carpet/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/persian-carpet/templates/taxonomy_term.html
+++ b/persian-carpet/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -353,6 +353,20 @@
     "charcoal",
     "texture"
   ],
+  "butterfly-wing": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "trendy",
+    "blog"
+  ],
+  "byzantine": [
+    "light",
+    "blog",
+    "byzantine",
+    "mosaic",
+    "imperial"
+  ],
   "cabaret": [
     "dark",
     "blog",
@@ -469,11 +483,24 @@
     "chiaroscuro",
     "contrast"
   ],
+  "chinoiserie": [
+    "light",
+    "blog",
+    "chinese",
+    "porcelain",
+    "elegant"
+  ],
   "chromatic": [
     "dark",
     "photoblog",
     "chromatic",
     "lens"
+  ],
+  "chromatic-wave": [
+    "dark",
+    "portfolio",
+    "glamorous",
+    "animation"
   ],
   "chromatophore": [
     "dark",
@@ -491,6 +518,12 @@
     "blog",
     "traditional",
     "serif"
+  ],
+  "chrysanthemum": [
+    "dark",
+    "blog",
+    "floral",
+    "glamorous"
   ],
   "cinder": [
     "dark",
@@ -623,6 +656,13 @@
     "documentary",
     "organic",
     "ocean"
+  ],
+  "coral-bloom": [
+    "dark",
+    "blog",
+    "elegant",
+    "marine",
+    "glamorous"
   ],
   "cosmos": [
     "dark",
@@ -929,6 +969,12 @@
     "blog",
     "travel"
   ],
+  "flamingo": [
+    "light",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
   "flowsync": [
     "dark",
     "landing"
@@ -1035,6 +1081,12 @@
     "blog",
     "editorial"
   ],
+  "generative-art": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "glamorous"
+  ],
   "geodesic": [
     "light",
     "landing",
@@ -1119,6 +1171,12 @@
     "docs",
     "guide"
   ],
+  "gunmetal": [
+    "dark",
+    "elegant",
+    "industrial",
+    "metallic"
+  ],
   "gyroscope": [
     "dark",
     "dashboard",
@@ -1182,6 +1240,12 @@
     "dark",
     "blog",
     "minimal"
+  ],
+  "hibiscus": [
+    "dark",
+    "blog",
+    "glamorous",
+    "tropical"
   ],
   "hologram": [
     "dark",
@@ -1316,6 +1380,13 @@
     "blog",
     "japanese",
     "industrial"
+  ],
+  "jugendstil": [
+    "light",
+    "blog",
+    "art-nouveau",
+    "organic",
+    "nature"
   ],
   "kaleidoscope": [
     "light",
@@ -1491,6 +1562,18 @@
     "snowflake",
     "crystalline"
   ],
+  "madhubani": [
+    "light",
+    "blog",
+    "indian",
+    "folk-art",
+    "geometric"
+  ],
+  "magenta-sunset": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
   "magma": [
     "dark",
     "dashboard",
@@ -1555,6 +1638,12 @@
     "light",
     "docs",
     "compatibility"
+  ],
+  "maximal-bloom": [
+    "elegant",
+    "floral",
+    "bold",
+    "glamorous"
   ],
   "maximalist": [
     "dark",
@@ -1729,6 +1818,13 @@
     "blog",
     "cozy"
   ],
+  "mughal": [
+    "light",
+    "blog",
+    "mughal",
+    "ornate",
+    "gold"
+  ],
   "mycelium": [
     "dark",
     "blog",
@@ -1877,6 +1973,12 @@
     "cartography",
     "vintage"
   ],
+  "op-art": [
+    "dark",
+    "blog",
+    "geometric",
+    "optical-illusion"
+  ],
   "opalescent": [
     "dark",
     "blog",
@@ -1893,6 +1995,12 @@
     "light",
     "blog",
     "food"
+  ],
+  "orchid": [
+    "dark",
+    "blog",
+    "glamorous",
+    "botanical"
   ],
   "origami": [
     "light",
@@ -1977,11 +2085,23 @@
     "parquetry",
     "woodwork"
   ],
+  "particle-storm": [
+    "dark",
+    "blog",
+    "neon",
+    "particles",
+    "energy"
+  ],
   "patina": [
     "dark",
     "blog",
     "minimal",
     "craft"
+  ],
+  "peacock": [
+    "elegant",
+    "glamorous",
+    "portfolio"
   ],
   "pendulum": [
     "dark",
@@ -2000,6 +2120,13 @@
     "archive",
     "ice",
     "frozen"
+  ],
+  "persian-carpet": [
+    "light",
+    "blog",
+    "persian",
+    "carpet",
+    "ornate"
   ],
   "petrified-wood": [
     "dark",
@@ -2096,6 +2223,13 @@
     "blog",
     "gallery"
   ],
+  "pop-surreal": [
+    "dark",
+    "glamorous",
+    "elegant",
+    "surreal",
+    "trendy"
+  ],
   "portfolio-blog": [
     "dark",
     "blog",
@@ -2142,6 +2276,12 @@
     "dark",
     "docs",
     "networking"
+  ],
+  "psychedelic": [
+    "dark",
+    "minimal",
+    "elegant",
+    "glamorous"
   ],
   "pulsar": [
     "dark",
@@ -2321,6 +2461,12 @@
     "light",
     "blog",
     "food"
+  ],
+  "sakura-storm": [
+    "dark",
+    "blog",
+    "glamorous",
+    "sakura"
   ],
   "sandcastle": [
     "light",
@@ -2558,6 +2704,13 @@
     "fabric",
     "textile"
   ],
+  "talavera": [
+    "light",
+    "blog",
+    "mexican",
+    "pottery",
+    "colorful"
+  ],
   "tale": [
     "light",
     "blog",
@@ -2738,6 +2891,11 @@
     "bold",
     "illusion"
   ],
+  "tropical-paradise": [
+    "elegant",
+    "vivid",
+    "botanical"
+  ],
   "tundra": [
     "dark",
     "blog",
@@ -2769,6 +2927,13 @@
     "magazine",
     "storm",
     "spiral"
+  ],
+  "ukiyo-e": [
+    "light",
+    "blog",
+    "japanese",
+    "woodblock",
+    "traditional"
   ],
   "ultraviolet": [
     "dark",
@@ -2857,6 +3022,13 @@
     "blog",
     "electric",
     "sparks"
+  ],
+  "volumetric": [
+    "dark",
+    "blog",
+    "3d",
+    "glow",
+    "atmospheric"
   ],
   "vortex": [
     "dark",
@@ -2953,107 +3125,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "coral-bloom": [
-    "dark",
-    "blog",
-    "elegant",
-    "marine",
-    "glamorous"
-  ],
-  "chromatic-wave": [
-    "dark",
-    "portfolio",
-    "glamorous",
-    "animation"
-  ],
-  "generative-art": [
-    "dark",
-    "portfolio",
-    "elegant",
-    "glamorous"
-  ],
-  "tropical-paradise": [
-    "elegant",
-    "vivid",
-    "botanical"
-  ],
-  "butterfly-wing": [
-    "dark",
-    "elegant",
-    "glamorous",
-    "trendy",
-    "blog"
-  ],
-  "pop-surreal": [
-    "dark",
-    "glamorous",
-    "elegant",
-    "surreal",
-    "trendy"
-  ],
-  "maximal-bloom": [
-    "elegant",
-    "floral",
-    "bold",
-    "glamorous"
-  ],
-  "psychedelic": [
-    "dark",
-    "minimal",
-    "elegant",
-    "glamorous"
-  ],
-  "peacock": [
-    "elegant",
-    "glamorous",
-    "portfolio"
-  ],
-  "gunmetal": [
-    "dark",
-    "elegant",
-    "industrial",
-    "metallic"
-  ],
-  "op-art": [
-    "dark",
-    "blog",
-    "geometric",
-    "optical-illusion"
-  ],
-  "magenta-sunset": [
-    "dark",
-    "blog",
-    "glamorous"
-  ],
-  "chrysanthemum": [
-    "dark",
-    "blog",
-    "floral",
-    "glamorous"
-  ],
-  "hibiscus": [
-    "dark",
-    "blog",
-    "glamorous",
-    "tropical"
-  ],
-  "orchid": [
-    "dark",
-    "blog",
-    "glamorous",
-    "botanical"
-  ],
-  "sakura-storm": [
-    "dark",
-    "blog",
-    "glamorous",
-    "sakura"
-  ],
-  "flamingo": [
-    "light",
-    "blog",
-    "glamorous",
-    "tropical"
   ]
 }

--- a/talavera/config.toml
+++ b/talavera/config.toml
@@ -1,0 +1,41 @@
+title = "Talavera"
+description = "A blog inspired by the cobalt blue and sun-yellow palette of Mexican Talavera pottery"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/talavera/content/about.md
+++ b/talavera/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Talavera"
++++
+
+# About Talavera
+
+Talavera is a blog theme for Hwaro inspired by the iconic Talavera pottery of Puebla, Mexico. The design features vibrant cobalt blues, sunshine yellows, and terracotta accents with tile-inspired decorative patterns.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/talavera
+```

--- a/talavera/content/index.md
+++ b/talavera/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Talavera"
+template = "home"
++++
+
+A blog inspired by the cobalt blue and sun-yellow palette of Mexican Talavera pottery

--- a/talavera/content/posts/_index.md
+++ b/talavera/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/talavera/content/posts/cobalt-blue.md
+++ b/talavera/content/posts/cobalt-blue.md
@@ -1,0 +1,33 @@
++++
+title = "Cobalt Blue in Mexican Art"
+date = "2026-03-12"
+description = "The enduring significance of cobalt blue in Mexican artistic traditions."
+tags = ["color", "art"]
+template = "post"
++++
+
+The enduring significance of cobalt blue in Mexican artistic traditions.
+
+## Overview
+
+Exploring the nuances of Cobalt Blue in Mexican Art reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/talavera/content/posts/history-of-talavera.md
+++ b/talavera/content/posts/history-of-talavera.md
@@ -1,0 +1,27 @@
++++
+title = "History of Talavera"
+date = "2026-02-25"
+description = "The origins and evolution of Talavera pottery from Puebla, Mexico."
+tags = ["history", "pottery"]
+template = "post"
++++
+
+The origins and evolution of Talavera pottery from Puebla, Mexico.
+
+## Introduction
+
+This post explores the fundamental concepts behind History of Talavera. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/talavera/content/posts/tile-patterns.md
+++ b/talavera/content/posts/tile-patterns.md
@@ -1,0 +1,26 @@
++++
+title = "Tile Pattern Design"
+date = "2026-03-30"
+description = "The art and mathematics behind Talavera tile pattern composition."
+tags = ["patterns", "design"]
+template = "post"
++++
+
+The art and mathematics behind Talavera tile pattern composition.
+
+## The Creative Process
+
+Tile Pattern Design represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/talavera/static/css/style.css
+++ b/talavera/static/css/style.css
@@ -1,0 +1,278 @@
+:root {
+  --cobalt: #1a47b8;
+  --cobalt-light: #3f6fd8;
+  --yellow: #fdd835;
+  --terracotta: #c75b39;
+  --white: #ffffff;
+  --navy: #0d1b3e;
+  --cream: #fef9e7;
+  --text-primary: #1a1a2e;
+  --text-secondary: #4a4a5e;
+  --text-muted: #7a7a8e;
+  --border: rgba(26, 71, 184, 0.15);
+  --shadow: rgba(26, 71, 184, 0.1);
+  --font-display: 'Merriweather', 'Georgia', serif;
+  --font-body: 'Inter', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--cream);
+}
+
+a { color: var(--cobalt); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--terracotta); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--navy);
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(26, 71, 184, 0.06);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--cobalt);
+}
+
+pre {
+  background: var(--navy);
+  color: var(--cream);
+  padding: 1.25rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 2px solid var(--cobalt);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 4px solid var(--yellow);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(253, 216, 53, 0.1);
+  border-radius: 0 8px 8px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 8px; }
+
+hr {
+  border: none;
+  height: 3px;
+  background: linear-gradient(90deg, var(--cobalt), var(--yellow), var(--terracotta), var(--yellow), var(--cobalt));
+  margin: 2.5rem 0;
+  border-radius: 3px;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 3px solid var(--cobalt);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--cobalt);
+}
+
+.site-brand:hover { color: var(--terracotta); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--yellow);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--cobalt); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 2px solid var(--cobalt);
+  color: var(--cobalt);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--cobalt) 0%, var(--navy) 100%);
+  border: 3px solid var(--yellow);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 25% 75%, rgba(253, 216, 53, 0.2) 0%, transparent 40%),
+    radial-gradient(circle at 75% 25%, rgba(199, 91, 57, 0.15) 0%, transparent 40%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--yellow);
+  margin: 0 0 0.75rem;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(254, 249, 231, 0.85);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--yellow);
+  color: var(--navy);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 25px rgba(0, 0, 0, 0.25); color: var(--navy); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--cream);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid rgba(254, 249, 231, 0.4);
+  border-radius: 8px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover { background: rgba(254, 249, 231, 0.1); border-color: var(--cream); color: var(--cream); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.5rem; text-align: center; margin-bottom: 2rem; }
+.section-title { font-family: var(--font-display); font-size: 2rem; margin-bottom: 1.5rem; color: var(--cobalt); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+  border-left: 4px solid var(--yellow);
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 8px 30px var(--shadow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--navy); }
+.post-card .post-title a:hover { color: var(--cobalt); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: rgba(26, 71, 184, 0.08); color: var(--cobalt); font-size: 0.75rem; font-weight: 600; border-radius: 50px; }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 3px solid var(--cobalt); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--cobalt); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--yellow); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--cobalt); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 3px solid var(--cobalt); }
+.post-nav a { font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 8px; transition: border-color 0.2s, background 0.2s; }
+.post-nav a:hover { border-color: var(--yellow); background: rgba(253, 216, 53, 0.08); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--cobalt); }
+
+.taxonomy-list a { color: var(--cobalt); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--white); border: 1px solid var(--border); border-radius: 8px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 4px 15px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--yellow); }
+.error-page h1 { font-size: 5rem; color: var(--cobalt); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 8px; margin: 1.5rem 0; border-left: 4px solid var(--cobalt); background: rgba(26, 71, 184, 0.05); }
+.alert-warning { border-left-color: var(--yellow); background: rgba(253, 216, 53, 0.1); }
+.alert-error { border-left-color: var(--terracotta); background: rgba(199, 91, 57, 0.06); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 3px solid var(--cobalt); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--cobalt); }
+.site-footer a:hover { color: var(--terracotta); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/talavera/templates/404.html
+++ b/talavera/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[*]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/footer.html
+++ b/talavera/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/talavera/templates/header.html
+++ b/talavera/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/talavera/templates/home.html
+++ b/talavera/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/page.html
+++ b/talavera/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/post.html
+++ b/talavera/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/section.html
+++ b/talavera/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/shortcodes/alert.html
+++ b/talavera/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/talavera/templates/taxonomy.html
+++ b/talavera/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/talavera/templates/taxonomy_term.html
+++ b/talavera/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/config.toml
+++ b/ukiyo-e/config.toml
@@ -1,0 +1,41 @@
+title = "Ukiyo-e"
+description = "A blog inspired by the Japanese woodblock print tradition of the floating world"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/ukiyo-e/content/about.md
+++ b/ukiyo-e/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Ukiyo-e"
++++
+
+# About Ukiyo-e
+
+Ukiyo-e is a blog theme for Hwaro inspired by the Japanese woodblock print tradition. The design draws on the muted earth tones, indigo blues, and vermillion reds of traditional ukiyo-e prints, combined with the texture of washi paper.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/ukiyo-e
+```

--- a/ukiyo-e/content/index.md
+++ b/ukiyo-e/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Ukiyo-e"
+template = "home"
++++
+
+A blog inspired by the Japanese woodblock print tradition of the floating world

--- a/ukiyo-e/content/posts/_index.md
+++ b/ukiyo-e/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/ukiyo-e/content/posts/digital-ukiyo-e.md
+++ b/ukiyo-e/content/posts/digital-ukiyo-e.md
@@ -1,0 +1,26 @@
++++
+title = "Digital Ukiyo-e"
+date = "2026-03-20"
+description = "How modern designers are reinterpreting the ukiyo-e aesthetic for digital media."
+tags = ["digital", "design"]
+template = "post"
++++
+
+How modern designers are reinterpreting the ukiyo-e aesthetic for digital media.
+
+## The Creative Process
+
+Digital Ukiyo-e represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/ukiyo-e/content/posts/the-floating-world.md
+++ b/ukiyo-e/content/posts/the-floating-world.md
@@ -1,0 +1,27 @@
++++
+title = "The Floating World"
+date = "2026-02-10"
+description = "Exploring the rich history and cultural significance of ukiyo-e woodblock prints."
+tags = ["art", "history"]
+template = "post"
++++
+
+Exploring the rich history and cultural significance of ukiyo-e woodblock prints.
+
+## Introduction
+
+This post explores the fundamental concepts behind The Floating World. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/ukiyo-e/content/posts/woodblock-techniques.md
+++ b/ukiyo-e/content/posts/woodblock-techniques.md
@@ -1,0 +1,33 @@
++++
+title = "Woodblock Printing Techniques"
+date = "2026-03-05"
+description = "A deep dive into the traditional techniques behind Japanese woodblock printing."
+tags = ["technique", "craft"]
+template = "post"
++++
+
+A deep dive into the traditional techniques behind Japanese woodblock printing.
+
+## Overview
+
+Exploring the nuances of Woodblock Printing Techniques reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/ukiyo-e/static/css/style.css
+++ b/ukiyo-e/static/css/style.css
@@ -1,0 +1,366 @@
+:root {
+  --indigo: #1a237e;
+  --indigo-light: #3949ab;
+  --vermillion: #c62828;
+  --sumi: #1a1a2e;
+  --washi: #faf3e0;
+  --cream: #f5f0e8;
+  --gold-muted: #b8860b;
+  --text-primary: #2c2416;
+  --text-secondary: #5c4d3c;
+  --text-muted: #8a7d6b;
+  --border: rgba(26, 35, 126, 0.15);
+  --shadow: rgba(26, 35, 126, 0.12);
+  --font-display: 'Noto Serif', 'Georgia', serif;
+  --font-body: 'Noto Sans', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--cream);
+}
+
+a { color: var(--indigo); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--vermillion); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--sumi);
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: var(--washi);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--indigo);
+}
+
+pre {
+  background: var(--sumi);
+  color: var(--washi);
+  padding: 1.25rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 3px solid var(--vermillion);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: var(--washi);
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 2px; }
+
+hr {
+  border: none;
+  height: 1px;
+  background: var(--border);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 780px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--sumi);
+  letter-spacing: 0.05em;
+}
+
+.site-brand:hover { color: var(--indigo); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--vermillion);
+  transition: width 0.3s;
+}
+
+.site-nav a:hover { color: var(--indigo); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--indigo);
+  color: var(--indigo);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  background: linear-gradient(180deg, var(--indigo) 0%, var(--sumi) 100%);
+  border: 1px solid var(--border);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 0%, rgba(184, 134, 11, 0.15) 0%, transparent 60%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--washi);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: rgba(250, 243, 224, 0.8);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+  line-height: 1.6;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.7rem 1.6rem;
+  background: var(--washi);
+  color: var(--indigo);
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-radius: 2px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  color: var(--indigo);
+}
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.7rem 1.6rem;
+  background: transparent;
+  color: var(--washi);
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 1px solid rgba(250, 243, 224, 0.4);
+  border-radius: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-outline:hover {
+  background: rgba(250, 243, 224, 0.1);
+  border-color: var(--washi);
+  color: var(--washi);
+}
+
+.section-heading {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  text-align: center;
+  margin-bottom: 2rem;
+  color: var(--sumi);
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  color: var(--indigo);
+}
+
+.posts-grid, .posts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.post-card {
+  background: var(--washi);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px var(--shadow);
+}
+
+.post-date {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.post-card .post-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--sumi); }
+.post-card .post-title a:hover { color: var(--indigo); }
+
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+
+.tag-pill {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  background: rgba(26, 35, 126, 0.08);
+  color: var(--indigo);
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 2px;
+  letter-spacing: 0.02em;
+}
+
+.post-content { max-width: 100%; }
+
+.post-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--indigo); }
+
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--border); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--indigo); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.post-nav a {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.post-nav a:hover { border-color: var(--indigo); background: var(--washi); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--indigo); }
+
+.taxonomy-list a { color: var(--indigo); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li {
+  margin-bottom: 0.6rem;
+  padding: 0.6rem 1rem;
+  background: var(--washi);
+  border: 1px solid var(--border);
+  transition: box-shadow 0.2s;
+}
+.taxonomy-list li:hover { box-shadow: 0 2px 10px var(--shadow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--indigo); }
+.error-page h1 { font-size: 5rem; color: var(--indigo); margin: 0; }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 2px;
+  margin: 1.5rem 0;
+  border-left: 3px solid var(--indigo);
+  background: var(--washi);
+  color: var(--text-primary);
+}
+.alert-warning { border-left-color: var(--gold-muted); background: #fdf6e3; }
+.alert-error { border-left-color: var(--vermillion); background: #fdf0f0; }
+
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--indigo); }
+.site-footer a:hover { color: var(--vermillion); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .hero-tagline { font-size: 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+  .site-wrapper { padding: 0 1rem; }
+}

--- a/ukiyo-e/templates/404.html
+++ b/ukiyo-e/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[浮]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/footer.html
+++ b/ukiyo-e/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/ukiyo-e/templates/header.html
+++ b/ukiyo-e/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;700&family=Noto+Serif:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/ukiyo-e/templates/home.html
+++ b/ukiyo-e/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/page.html
+++ b/ukiyo-e/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/post.html
+++ b/ukiyo-e/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/section.html
+++ b/ukiyo-e/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/shortcodes/alert.html
+++ b/ukiyo-e/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/ukiyo-e/templates/taxonomy.html
+++ b/ukiyo-e/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/ukiyo-e/templates/taxonomy_term.html
+++ b/ukiyo-e/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/config.toml
+++ b/volumetric/config.toml
@@ -1,0 +1,41 @@
+title = "Volumetric"
+description = "A dark blog theme inspired by 3D volumetric lighting and atmospheric glow effects"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true

--- a/volumetric/content/about.md
+++ b/volumetric/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "Learn more about Volumetric"
++++
+
+# About Volumetric
+
+Volumetric is a dark blog theme for Hwaro inspired by 3D volumetric lighting effects. The design uses deep blacks, glowing blues, and purple accents to create an atmospheric, immersive reading experience.
+
+## Features
+
+- Responsive layout for all devices
+- Custom color palette and typography
+- Clean post cards with hover effects
+- Tag-based content organization
+- RSS feed support
+
+## Getting Started
+
+```bash
+hwaro init my-site --scaffold https://github.com/hahwul/hwaro-examples/tree/main/volumetric
+```

--- a/volumetric/content/index.md
+++ b/volumetric/content/index.md
@@ -1,0 +1,6 @@
++++
+title = "Volumetric"
+template = "home"
++++
+
+A dark blog theme inspired by 3D volumetric lighting and atmospheric glow effects

--- a/volumetric/content/posts/_index.md
+++ b/volumetric/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
+sort_by = "date"
+template = "section"
++++

--- a/volumetric/content/posts/depth-perception.md
+++ b/volumetric/content/posts/depth-perception.md
@@ -1,0 +1,33 @@
++++
+title = "Depth Perception in Design"
+date = "2026-03-04"
+description = "Creating convincing depth through light, shadow, and atmospheric perspective."
+tags = ["depth", "design"]
+template = "post"
++++
+
+Creating convincing depth through light, shadow, and atmospheric perspective.
+
+## Overview
+
+Exploring the nuances of Depth Perception in Design reveals a rich tapestry of techniques and approaches that have evolved over centuries.
+
+## Techniques and Methods
+
+Artists and craftspeople have developed sophisticated methods:
+
+- **Material selection** plays a crucial role in the final result
+- **Layering and composition** create visual depth and harmony
+- **Color theory** guides palette choices across traditions
+
+### Traditional Approaches
+
+Traditional methods emphasize patience and precision. Each step builds upon the last, creating works of remarkable complexity and beauty.
+
+### Contemporary Interpretations
+
+Modern practitioners blend traditional knowledge with new tools and technologies, creating fresh perspectives on timeless themes.
+
+## Conclusion
+
+The ongoing dialogue between past and present ensures these art forms remain vibrant and relevant.

--- a/volumetric/content/posts/glow-effects.md
+++ b/volumetric/content/posts/glow-effects.md
@@ -1,0 +1,26 @@
++++
+title = "Glow and Bloom Effects"
+date = "2026-03-21"
+description = "Mastering glow and bloom effects for dramatic visual compositions."
+tags = ["effects", "visual"]
+template = "post"
++++
+
+Mastering glow and bloom effects for dramatic visual compositions.
+
+## The Creative Process
+
+Glow and Bloom Effects represents an exciting frontier in creative expression. By combining established principles with innovative approaches, new possibilities emerge.
+
+## Design Principles
+
+Several core principles guide this work:
+
+1. **Balance** between complexity and clarity
+2. **Harmony** of color and form
+3. **Rhythm** in visual composition
+4. **Unity** across all design elements
+
+## Looking Forward
+
+As tools and techniques continue to evolve, the potential for creative expression grows. The future promises even more exciting developments in this space.

--- a/volumetric/content/posts/light-and-shadow.md
+++ b/volumetric/content/posts/light-and-shadow.md
@@ -1,0 +1,27 @@
++++
+title = "Light and Shadow"
+date = "2026-02-14"
+description = "Understanding volumetric lighting techniques and their visual impact."
+tags = ["lighting", "3d"]
+template = "post"
++++
+
+Understanding volumetric lighting techniques and their visual impact.
+
+## Introduction
+
+This post explores the fundamental concepts behind Light and Shadow. Understanding these principles helps us appreciate the depth and richness of this artistic tradition.
+
+## Key Concepts
+
+The study of this subject reveals several important aspects:
+
+- **Historical context** shapes our understanding of artistic evolution
+- **Technical mastery** requires years of dedicated practice
+- **Cultural significance** extends beyond mere aesthetics
+
+## Modern Applications
+
+Today, these concepts find new life in digital design and contemporary art. Designers draw on these traditions to create work that resonates with audiences across cultures.
+
+The intersection of tradition and technology opens exciting possibilities for creative expression.

--- a/volumetric/static/css/style.css
+++ b/volumetric/static/css/style.css
@@ -1,0 +1,280 @@
+:root {
+  --void: #0a0a0f;
+  --surface: #1a1a2e;
+  --glow-blue: #4fc3f7;
+  --glow-purple: #b388ff;
+  --cyan: #00e5ff;
+  --soft-white: #e8eaf6;
+  --text-primary: #c8cad6;
+  --text-secondary: #9a9cb0;
+  --text-muted: #6a6c80;
+  --border: rgba(79, 195, 247, 0.15);
+  --shadow-glow: rgba(79, 195, 247, 0.2);
+  --font-display: 'Space Grotesk', 'Segoe UI', sans-serif;
+  --font-body: 'IBM Plex Sans', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.7;
+  margin: 0;
+  color: var(--text-primary);
+  background: var(--void);
+}
+
+a { color: var(--glow-blue); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--cyan); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  color: var(--soft-white);
+}
+
+h1 { font-size: 2.2rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.25rem; }
+p { margin: 1em 0; }
+
+code {
+  background: rgba(79, 195, 247, 0.1);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  color: var(--cyan);
+}
+
+pre {
+  background: var(--surface);
+  color: var(--soft-white);
+  padding: 1.25rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  box-shadow: 0 0 20px rgba(79, 195, 247, 0.05);
+}
+
+pre code { background: none; padding: 0; color: inherit; }
+
+blockquote {
+  border-left: 3px solid var(--glow-purple);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(179, 136, 255, 0.06);
+  border-radius: 0 8px 8px 0;
+  color: var(--text-secondary);
+}
+
+img { max-width: 100%; height: auto; border-radius: 8px; }
+
+hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--glow-blue), var(--glow-purple), transparent);
+  margin: 2.5rem 0;
+}
+
+.site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.site-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--glow-blue);
+  text-shadow: 0 0 10px rgba(79, 195, 247, 0.3);
+}
+
+.site-brand:hover { color: var(--cyan); text-shadow: 0 0 15px rgba(0, 229, 255, 0.4); }
+
+.site-nav { display: flex; gap: 1.5rem; }
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 2px;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0; height: 2px;
+  background: var(--glow-blue);
+  transition: width 0.3s;
+  box-shadow: 0 0 8px var(--shadow-glow);
+}
+
+.site-nav a:hover { color: var(--glow-blue); }
+.site-nav a:hover::after { width: 100%; }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--glow-blue);
+  color: var(--glow-blue);
+  font-size: 1.1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.hero {
+  position: relative;
+  padding: 4rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 0 40px rgba(79, 195, 247, 0.08), inset 0 0 60px rgba(79, 195, 247, 0.03);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(79, 195, 247, 0.15) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 100%, rgba(179, 136, 255, 0.1) 0%, transparent 50%);
+}
+
+.hero-content { position: relative; z-index: 1; }
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--soft-white);
+  margin: 0 0 0.75rem;
+  text-shadow: 0 0 30px rgba(79, 195, 247, 0.3);
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin: 0 auto 2rem;
+  max-width: 500px;
+}
+
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: var(--glow-blue);
+  color: var(--void);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 0 20px var(--shadow-glow);
+}
+
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 0 35px var(--shadow-glow); color: var(--void); }
+
+.btn-outline {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  background: transparent;
+  color: var(--glow-blue);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 1px solid rgba(79, 195, 247, 0.4);
+  border-radius: 8px;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.btn-outline:hover { background: rgba(79, 195, 247, 0.08); border-color: var(--glow-blue); box-shadow: 0 0 15px var(--shadow-glow); color: var(--glow-blue); }
+
+.section-heading { font-family: var(--font-display); font-size: 1.5rem; text-align: center; margin-bottom: 2rem; color: var(--soft-white); }
+.section-title { font-family: var(--font-display); font-size: 2rem; margin-bottom: 1.5rem; color: var(--glow-blue); text-shadow: 0 0 15px rgba(79, 195, 247, 0.2); }
+
+.posts-grid, .posts-list { display: flex; flex-direction: column; gap: 1.25rem; margin-bottom: 3rem; }
+
+.post-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-card:hover { transform: translateY(-3px); box-shadow: 0 0 30px var(--shadow-glow); }
+
+.post-date { font-size: 0.8rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.post-card .post-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0.4rem 0; }
+.post-card .post-title a { color: var(--soft-white); }
+.post-card .post-title a:hover { color: var(--glow-blue); }
+.post-excerpt { color: var(--text-secondary); font-size: 0.95rem; margin: 0.5rem 0; line-height: 1.6; }
+
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.tag-pill { display: inline-block; padding: 0.2rem 0.7rem; background: rgba(79, 195, 247, 0.1); color: var(--glow-blue); font-size: 0.75rem; font-weight: 600; border-radius: 50px; border: 1px solid rgba(79, 195, 247, 0.2); }
+
+.post-content { max-width: 100%; }
+.post-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
+.post-header .post-title { font-size: 2.2rem; margin: 0 0 0.75rem; color: var(--soft-white); text-shadow: 0 0 20px rgba(79, 195, 247, 0.2); }
+.post-meta { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+.meta-dot { color: var(--glow-blue); }
+
+.content-body { font-size: 1.05rem; line-height: 1.8; }
+.content-body h2 { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.content-body h3 { color: var(--glow-blue); }
+.content-body ul, .content-body ol { padding-left: 1.5rem; }
+.content-body li { margin-bottom: 0.4rem; }
+
+.post-nav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); }
+.post-nav a { font-family: var(--font-display); font-weight: 500; font-size: 0.9rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 8px; transition: border-color 0.2s, box-shadow 0.2s; }
+.post-nav a:hover { border-color: var(--glow-blue); box-shadow: 0 0 12px var(--shadow-glow); }
+
+.page-content { min-height: 60vh; }
+.page-title { font-size: 2rem; margin-bottom: 1.5rem; color: var(--glow-blue); }
+
+.taxonomy-list a { color: var(--glow-blue); font-weight: 500; }
+.taxonomy-list ul { list-style: none; padding: 0; }
+.taxonomy-list li { margin-bottom: 0.6rem; padding: 0.6rem 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; transition: box-shadow 0.2s; }
+.taxonomy-list li:hover { box-shadow: 0 0 15px var(--shadow-glow); }
+
+.error-page { text-align: center; padding: 5rem 1rem; }
+.error-icon { font-size: 3rem; margin-bottom: 1rem; color: var(--glow-blue); text-shadow: 0 0 20px var(--shadow-glow); }
+.error-page h1 { font-size: 5rem; color: var(--glow-blue); margin: 0; text-shadow: 0 0 30px var(--shadow-glow); }
+.error-page p { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+
+.alert { padding: 1rem 1.25rem; border-radius: 8px; margin: 1.5rem 0; border-left: 3px solid var(--glow-blue); background: rgba(79, 195, 247, 0.06); }
+.alert-warning { border-left-color: #fdd835; background: rgba(253, 216, 53, 0.06); }
+.alert-error { border-left-color: #ef5350; background: rgba(239, 83, 80, 0.06); }
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0; border-top: 1px solid var(--border); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+.site-footer p { margin: 0.25rem 0; }
+.site-footer a { color: var(--glow-blue); }
+.site-footer a:hover { color: var(--cyan); }
+
+@media (max-width: 600px) {
+  .site-header { flex-wrap: wrap; }
+  .site-nav { display: none; width: 100%; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 0.75rem; }
+  .site-nav.open { display: flex; }
+  .menu-toggle { display: block; }
+  .hero { padding: 3rem 1rem; }
+  .hero-title { font-size: 2rem; }
+  .site-wrapper { padding: 0 1rem; }
+  .post-header .post-title { font-size: 1.6rem; }
+}

--- a/volumetric/templates/404.html
+++ b/volumetric/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <div class="error-page">
+        <div class="error-icon">[V]</div>
+        <h1>404</h1>
+        <p>The page you are looking for does not exist.</p>
+        <a href="{{ base_url }}/" class="btn-primary">Back to Home</a>
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/footer.html
+++ b/volumetric/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2026 <a href="{{ base_url }}/">{{ site.title }}</a> &#183; <a href="{{ base_url }}/rss.xml" target="_blank">RSS</a></p>
+        <p>Powered by <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">Hwaro</a></p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/volumetric/templates/header.html
+++ b/volumetric/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) }}">
+  <title>{% if page.title %}{{ page.title }} -- {% endif %}{{ site.title }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,700;1,400&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-brand">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <button class="menu-toggle" onclick="document.querySelector('.site-nav').classList.toggle('open')" aria-label="Menu">|||</button>
+    </header>

--- a/volumetric/templates/home.html
+++ b/volumetric/templates/home.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <section class="hero">
+        <div class="hero-bg"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">{{ site.title }}</h1>
+          <p class="hero-tagline">{{ site.description }}</p>
+          <div class="hero-actions">
+            <a href="{{ base_url }}/posts/" class="btn-primary">Read the Blog</a>
+            <a href="{{ base_url }}/about/" class="btn-outline">About</a>
+          </div>
+        </div>
+      </section>
+      <section class="latest-posts">
+        <h2 class="section-heading">Latest Posts</h2>
+        <div class="posts-grid">
+          {% for post in site.pages %}
+            {% if post.section == "posts" %}
+              {% if post.date %}
+                <article class="post-card">
+                  <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+                  <h3 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h3>
+                  {% if post.description %}
+                    <p class="post-excerpt">{{ post.description }}</p>
+                  {% endif %}
+                  {% if post.tags %}
+                    <div class="post-tags">
+                      {% for tag in post.tags %}
+                        <span class="tag-pill">{{ tag }}</span>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                </article>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+      </section>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/page.html
+++ b/volumetric/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="page-content">
+        <h1 class="page-title">{{ page.title }}</h1>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/post.html
+++ b/volumetric/templates/post.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <article class="post-content">
+        <header class="post-header">
+          <h1 class="post-title">{{ page.title }}</h1>
+          <div class="post-meta">
+            {% if page.date %}
+              <time datetime="{{ page.date }}">{{ page.date | date("%B %d, %Y") }}</time>
+            {% endif %}
+            {% if page.reading_time %}
+              <span class="meta-dot">·</span>
+              <span>{{ page.reading_time }} min read</span>
+            {% endif %}
+          </div>
+          {% if page.tags %}
+            <div class="post-tags">
+              {% for tag in page.tags %}
+                <span class="tag-pill">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </header>
+        <div class="content-body">
+          {{ content | safe }}
+        </div>
+        <nav class="post-nav">
+          {% if page.lower %}
+            <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">&larr; {{ page.lower.title }}</a>
+          {% endif %}
+          {% if page.higher %}
+            <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">{{ page.higher.title }} &rarr;</a>
+          {% endif %}
+        </nav>
+      </article>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/section.html
+++ b/volumetric/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="posts-list">
+        {% for post in section.pages %}
+          {% if post.date %}
+            <article class="post-card">
+              <time class="post-date" datetime="{{ post.date }}">{{ post.date | date("%B %d, %Y") }}</time>
+              <h2 class="post-title"><a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a></h2>
+              {% if post.description %}
+                <p class="post-excerpt">{{ post.description }}</p>
+              {% endif %}
+              {% if post.tags %}
+                <div class="post-tags">
+                  {% for tag in post.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/shortcodes/alert.html
+++ b/volumetric/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("info") | upper }}:</strong> {{ message }}
+</div>

--- a/volumetric/templates/taxonomy.html
+++ b/volumetric/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}

--- a/volumetric/templates/taxonomy_term.html
+++ b/volumetric/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+    <main class="site-main">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="content-body taxonomy-list">
+        {{ content | safe }}
+      </div>
+    </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Add 10 new example sites: ukiyo-e, mughal, byzantine, chinoiserie, jugendstil, madhubani, talavera, persian-carpet, volumetric, particle-storm
- Each includes complete config, templates (header, footer, home, page, post, section, 404, taxonomy, shortcodes), content (about, 3 posts), and unique CSS theme
- Updated tags.json with entries for all 10 new examples

## New Examples
| Example | Theme | Style |
|---------|-------|-------|
| ukiyo-e | Japanese woodblock prints | Light, indigo/vermillion |
| mughal | Mughal art & architecture | Light, emerald/gold |
| byzantine | Byzantine mosaics | Light, purple/gold |
| chinoiserie | Chinese porcelain | Light, blue/white |
| jugendstil | German Art Nouveau | Light, sage/gold |
| madhubani | Indian folk art | Light, vibrant primaries |
| talavera | Mexican pottery | Light, cobalt/yellow |
| persian-carpet | Persian rugs | Light, red/navy/gold |
| volumetric | 3D volumetric lighting | Dark, blue glow |
| particle-storm | Particle effects | Dark, neon/magenta |

Closes #847, #848, #849, #850, #851, #852, #853, #854, #855, #856