### PR TITLE
feat: add new lumina example site

### DIFF
--- a/lumina/config.toml
+++ b/lumina/config.toml
@@ -1,0 +1,199 @@
+title = "Lumina"
+description = "Elegant Dark Theme"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/lumina/content/about.md
+++ b/lumina/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/lumina/content/index.md
+++ b/lumina/content/index.md
@@ -1,0 +1,5 @@
++++
+title = "Lumina"
+template = "section"
++++
+Welcome to Lumina, a space dedicated to clarity, focus, and elegant design. The layout uses subtle luminescent effects to guide the eye.

--- a/lumina/content/posts/_index.md
+++ b/lumina/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Writing"
+template = "section"
++++
+Thoughts and observations.

--- a/lumina/content/posts/first-post.md
+++ b/lumina/content/posts/first-post.md
@@ -1,0 +1,7 @@
++++
+title = "The beauty of simplicity"
+date = "2024-05-01"
++++
+In a world full of noise, finding focus is essential. Lumina strips away the unnecessary, leaving only what matters.
+<!-- more -->
+This is the rest of the post.

--- a/lumina/templates/404.html
+++ b/lumina/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div style="text-align: center; padding: 4rem 0;">
+  <h1 style="font-size: 4rem; text-shadow: 0 0 20px rgba(255,255,255,0.2);">404</h1>
+  <p>The page you are looking for has drifted into the void.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.5rem 1rem; border: 1px solid rgba(255,255,255,0.2); border-radius: 4px;">Return Home</a>
+</div>
+{% endblock %}

--- a/lumina/templates/base.html
+++ b/lumina/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background-color: #0f0f11;
+      color: #eaeaea;
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      padding: 0;
+      line-height: 1.6;
+    }
+    a { color: #8cb4ff; text-decoration: none; transition: text-shadow 0.3s; }
+    a:hover { text-shadow: 0 0 8px rgba(140, 180, 255, 0.6); }
+    .container { max-width: 800px; margin: 0 auto; padding: 2rem; }
+    .header { display: flex; justify-content: space-between; align-items: center; padding-bottom: 2rem; border-bottom: 1px solid rgba(255,255,255,0.1); margin-bottom: 2rem; }
+    .logo { font-size: 1.5rem; font-weight: 600; color: #fff; letter-spacing: 1px; }
+    .nav a { margin-left: 1.5rem; }
+    .card { background: #1a1a1d; border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 10px rgba(255,255,255,0.03); transition: box-shadow 0.3s; }
+    .card:hover { box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 15px rgba(255,255,255,0.08); }
+    .footer { text-align: center; margin-top: 4rem; padding-top: 2rem; border-top: 1px solid rgba(255,255,255,0.1); font-size: 0.85rem; color: #888; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    {% include "header.html" %}
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+    {% include "footer.html" %}
+  </div>
+</body>
+</html>

--- a/lumina/templates/footer.html
+++ b/lumina/templates/footer.html
@@ -1,0 +1,3 @@
+<footer class="footer">
+  <p>&copy; {{ current_year }} {{ site.title }}. Designed with elegance.</p>
+</footer>

--- a/lumina/templates/header.html
+++ b/lumina/templates/header.html
@@ -1,0 +1,7 @@
+<header class="header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav class="nav">
+    <a href="{{ base_url }}/">Home</a>
+    <a href="{{ base_url }}/posts/">Writing</a>
+  </nav>
+</header>

--- a/lumina/templates/page.html
+++ b/lumina/templates/page.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="card">
+  <h1>{{ page.title }}</h1>
+  {% if page.date %}<p style="color: #888; font-size: 0.9rem;">{{ page.date | date("%B %d, %Y") }}</p>{% endif %}
+  <div>{{ content | safe }}</div>
+</article>
+{% endblock %}

--- a/lumina/templates/section.html
+++ b/lumina/templates/section.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<div>
+  {{ content | safe }}
+</div>
+<div class="post-list">
+  {% for post in section.pages %}
+  <div class="card">
+    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+    {% if post.summary %}<p>{{ post.summary | strip_html }}</p>{% endif %}
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/lumina/templates/shortcodes/alert.html
+++ b/lumina/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/lumina/templates/taxonomy.html
+++ b/lumina/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ taxonomy_name }}</h1>
+<ul>
+  {% for term in taxonomy_terms %}
+  <li>{{ term }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/lumina/templates/taxonomy_term.html
+++ b/lumina/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ taxonomy_term }}</h1>
+{% for post in taxonomy_pages %}
+<div class="card"><h2><a href="{{ post.url }}">{{ post.title }}</a></h2></div>
+{% endfor %}
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -299,6 +299,11 @@
     "docs",
     "spec"
   ],
+  "blueprint-pro": [
+    "landing",
+    "dark",
+    "devtool"
+  ],
   "bonfire": [
     "dark",
     "blog",
@@ -1622,6 +1627,11 @@
     "light",
     "portfolio",
     "fashion"
+  ],
+  "lumina": [
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "luminescent-mesh": [
     "dark",
@@ -3326,10 +3336,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "blueprint-pro": [
-    "landing",
-    "dark",
-    "devtool"
   ]
 }


### PR DESCRIPTION
Creates a new elegantly designed example site named `lumina` focused on a minimalist dark aesthetic. The site uses the `Inter` font, dark background (`#0f0f11`), and subtle luminescent `box-shadow` effects (`rgba(255,255,255,0.1)`) instead of gradients or emojis. 

The example is correctly registered in the root `tags.json` and follows the Hwaro configuration standards. All template files (page, section, 404, taxonomy, taxonomy_term) extend a common `base.html` layout that incorporates `header.html` and `footer.html` partials. Simple content has been added to demonstrate its use as a portfolio or clean writing blog.

---
*PR created automatically by Jules for task [17881403234005377252](https://jules.google.com/task/17881403234005377252) started by @chei-l*