### PR TITLE
fix: resolve 404 links in gothic theme

### DIFF
--- a/gothic/config.toml
+++ b/gothic/config.toml
@@ -26,8 +26,161 @@ enabled = true
 [feeds]
 enabled = true
 type = "rss"
+filename = "rss.xml"
 limit = 10
 sections = ["chronicles"]
 
 [markdown]
 safe = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/gothic/content/tags/_index.md
+++ b/gothic/content/tags/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Tags"
+description = "All tags"
+template = "taxonomy"
++++

--- a/gothic/templates/footer.html
+++ b/gothic/templates/footer.html
@@ -33,7 +33,7 @@
         <nav class="flex gap-6">
           <a href="{{ base_url }}/chronicles/" style="font-family: 'Cinzel', serif; font-size: 0.75rem; color: #6b7280; text-decoration: none; text-transform: uppercase; letter-spacing: 0.15em;" onmouseover="this.style.color='#d4a017'" onmouseout="this.style.color='#6b7280'">Chronicles</a>
           <a href="{{ base_url }}/tags/" style="font-family: 'Cinzel', serif; font-size: 0.75rem; color: #6b7280; text-decoration: none; text-transform: uppercase; letter-spacing: 0.15em;" onmouseover="this.style.color='#d4a017'" onmouseout="this.style.color='#6b7280'">Reliquary</a>
-          <a href="{{ base_url }}/feed.xml" style="font-family: 'Cinzel', serif; font-size: 0.75rem; color: #6b7280; text-decoration: none; text-transform: uppercase; letter-spacing: 0.15em;" onmouseover="this.style.color='#d4a017'" onmouseout="this.style.color='#6b7280'">RSS</a>
+          <a href="{{ base_url }}/rss.xml" style="font-family: 'Cinzel', serif; font-size: 0.75rem; color: #6b7280; text-decoration: none; text-transform: uppercase; letter-spacing: 0.15em;" onmouseover="this.style.color='#d4a017'" onmouseout="this.style.color='#6b7280'">RSS</a>
         </nav>
         <p style="font-family: 'Cinzel', serif; font-size: 0.7rem; color: #4b5563; text-transform: uppercase; letter-spacing: 0.1em; margin: 0;">
           {{ site.description }}

--- a/gothic/templates/page.html
+++ b/gothic/templates/page.html
@@ -21,7 +21,7 @@
         {{ page.date | date(format="%B %d, Anno Domini %Y") }}
       </time>
       {% endif %}
-      {% if page.taxonomies.tags %}
+      {% if page.taxonomies and page.taxonomies.tags %}
       <div class="flex flex-wrap gap-2 justify-center mt-4">
         {% if page.taxonomies is defined and page.taxonomies.tags is defined %}{% for tag in page.taxonomies.tags %}
         <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-pill">{{ tag }}</a>

--- a/gothic/templates/section.html
+++ b/gothic/templates/section.html
@@ -57,7 +57,7 @@
             {% if post.description %}
             <p style="font-family: 'IM Fell English', serif; color: #6b7280; margin: 0 0 0.75rem 0; font-size: 0.95rem; font-style: italic; padding-left: 1.25rem;">{{ post.description }}</p>
             {% endif %}
-            {% if post.taxonomies.tags %}
+            {% if post.taxonomies and post.taxonomies.tags %}
             <div class="flex flex-wrap gap-2" style="padding-left: 1.25rem;">
               {% if post.taxonomies is defined and post.taxonomies.tags is defined %}{% for tag in post.taxonomies.tags %}
               <span style="font-family: 'Cinzel', serif; font-size: 0.65rem; color: #4b5563; border: 1px solid #374151; padding: 0.15rem 0.5rem; text-transform: uppercase; letter-spacing: 0.1em;">{{ tag }}</span>


### PR DESCRIPTION
This PR resolves broken 404 links in the `gothic` example site. 

* **Taxonomy fix:** Added `content/tags/_index.md` so the `/tags/` route successfully renders.
* **RSS fix:** Updated `config.toml` to explicitly output `rss.xml` and modified `templates/footer.html` to link to it instead of the missing `feed.xml`.
* **Template warnings:** Fixed build-time warnings related to `taxonomies` rendering in `page.html` and `section.html` when a page does not have tags configured.

---
*PR created automatically by Jules for task [14799889968689197320](https://jules.google.com/task/14799889968689197320) started by @chei-l*