### PR TITLE
Add Luminary Portfolio Example Site

### DIFF
--- a/luminary/config.toml
+++ b/luminary/config.toml
@@ -1,0 +1,203 @@
+title = "Luminary"
+base_url = "http://127.0.0.1:3000"
+language = "en"
+description = "An elegant portfolio."
+
+[markdown]
+emoji = false
+
+[highlight]
+enabled = true
+theme = "atom-one-light"
+use_cdn = true
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+# [feeds]
+# enabled = true
+# type = "rss"
+# limit = 10
+# full_content = true
+# sections = []
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/luminary/content/about.md
+++ b/luminary/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/luminary/content/index.md
+++ b/luminary/content/index.md
@@ -1,0 +1,8 @@
++++
+title = "Luminary Portfolio"
+template = "section"
++++
+
+Welcome to Luminary, an elegant and sophisticated portfolio theme focusing on typography and subtle luminescence.
+
+Below you can find some of my featured projects.

--- a/luminary/content/project-alpha.md
+++ b/luminary/content/project-alpha.md
@@ -1,0 +1,25 @@
++++
+title = "Project Alpha"
+date = 2024-03-15
+description = "A sophisticated web application interface."
+template = "page"
++++
+
+## Introduction
+
+Project Alpha represents a leap forward in user interface design. By utilizing a minimalist approach, we stripped away the non-essential to reveal the core experience.
+
+> Design is not just what it looks like and feels like. Design is how it works.
+
+### Key Features
+* Clean layout
+* Subtle interactive elements
+* Responsive typography
+
+```javascript
+function initializeProject() {
+  console.log("Project Alpha is ready.");
+}
+```
+
+The approach combines functional necessity with aesthetic elegance, resulting in a timeless product.

--- a/luminary/templates/404.html
+++ b/luminary/templates/404.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>404 Not Found</h1>
+  <p>The page you are looking for does not exist or has been moved.</p>
+  <p><a href="{{ base_url }}/">Return to Home</a></p>
+{% endblock %}

--- a/luminary/templates/base.html
+++ b/luminary/templates/base.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --primary: rgba(140, 160, 200, 1);
+      --primary-glow: rgba(140, 160, 200, 0.4);
+      --text: #333333;
+      --text-muted: #666666;
+      --border: #eaeaea;
+      --bg: #fafafa;
+      --bg-card: #ffffff;
+      --bg-subtle: #f0f0f0;
+
+      --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      --font-heading: "Playfair Display", Georgia, serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-body);
+      line-height: 1.7;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 3rem 0;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 4rem;
+    }
+
+    .site-logo {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+
+    .site-logo:hover {
+      color: var(--primary);
+      text-shadow: 0 0 15px var(--primary-glow);
+    }
+
+    .site-header nav {
+      display: flex;
+      gap: 2rem;
+    }
+
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      transition: color 0.3s ease;
+    }
+
+    .site-header nav a:hover {
+      color: var(--text);
+    }
+
+    .site-main {
+      flex: 1;
+    }
+
+    .site-footer {
+      margin-top: 5rem;
+      padding: 3rem 0;
+      border-top: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-heading);
+      line-height: 1.3;
+      margin-top: 2em;
+      margin-bottom: 1em;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    h1 {
+      font-size: 2.5rem;
+      margin-top: 0;
+      letter-spacing: -0.02em;
+    }
+
+    h2 { font-size: 1.75rem; }
+    h3 { font-size: 1.35rem; }
+
+    p { margin: 1.5em 0; }
+
+    a {
+      color: var(--text);
+      text-decoration: none;
+      border-bottom: 1px solid var(--border);
+      transition: border-color 0.3s ease, color 0.3s ease;
+    }
+
+    a:hover {
+      color: var(--primary);
+      border-bottom-color: var(--primary);
+    }
+
+    blockquote {
+      margin: 2em 0;
+      padding: 1em 2em;
+      border-left: 3px solid var(--primary);
+      background: var(--bg-card);
+      font-style: italic;
+      color: var(--text-muted);
+      box-shadow: 0 4px 20px rgba(0,0,0,0.03);
+    }
+
+    code {
+      background: var(--bg-subtle);
+      padding: 0.2rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.85em;
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      color: #e83e8c;
+    }
+
+    pre {
+      background: var(--bg-card);
+      padding: 1.5rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      box-shadow: 0 4px 20px rgba(0,0,0,0.02);
+    }
+
+    pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+
+    /* Components */
+    .section-list {
+      list-style: none;
+      padding: 0;
+      margin: 2rem 0;
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    }
+
+    .section-list li {
+      background: var(--bg-card);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      overflow: hidden;
+    }
+
+    .section-list li:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 15px 30px rgba(0,0,0,0.05), 0 0 20px var(--primary-glow);
+    }
+
+    .section-list li a {
+      display: block;
+      padding: 2rem;
+      font-family: var(--font-heading);
+      font-size: 1.25rem;
+      font-weight: 600;
+      border-bottom: none;
+    }
+
+    .taxonomy-desc {
+      color: var(--text-muted);
+      margin-bottom: 2rem;
+      font-size: 1.1rem;
+    }
+
+    nav.pagination {
+      margin: 4rem 0 2rem;
+    }
+
+    nav.pagination .pagination-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+    }
+
+    nav.pagination a, nav.pagination span {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      transition: all 0.3s ease;
+    }
+
+    nav.pagination a:hover {
+      color: var(--text);
+      border-color: var(--text);
+      box-shadow: 0 0 10px var(--primary-glow);
+    }
+
+    .pagination-current span {
+      border-color: var(--text);
+      background: var(--text);
+      color: var(--bg);
+    }
+
+    .pagination-disabled span {
+      opacity: 0.5;
+      background: var(--bg-subtle);
+    }
+
+    /* Post specific */
+    .post-meta {
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      margin-top: -1rem;
+      margin-bottom: 2rem;
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .post-date {
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .site-header {
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 2rem 0;
+      }
+
+      .site-wrapper {
+        padding: 0 1.5rem;
+      }
+
+      h1 { font-size: 2rem; }
+
+      .section-list {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} {{ site.title }}. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/luminary/templates/page.html
+++ b/luminary/templates/page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  {% if page.date %}
+    <div class="post-meta">
+      <time class="post-date">{{ page.date | date("%Y-%m-%d") }}</time>
+    </div>
+  {% endif %}
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/luminary/templates/section.html
+++ b/luminary/templates/section.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  {% if content %}
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+  <ul class="section-list">
+    {{ section.list }}
+  </ul>
+  {{ pagination }}
+{% endblock %}

--- a/luminary/templates/shortcodes/alert.html
+++ b/luminary/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/luminary/templates/taxonomy.html
+++ b/luminary/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>{{ taxonomy_name | capitalize }}</h1>
+  <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+  <ul class="section-list">
+    {% for term in taxonomy_terms %}
+      <li>
+        <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term | urlencode }}/">{{ term }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/luminary/templates/taxonomy_term.html
+++ b/luminary/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>Posts tagged with "{{ term }}"</h1>
+  <p class="taxonomy-desc">Showing all posts under this category.</p>
+  <ul class="section-list">
+    {% for page in taxonomy_pages %}
+      <li>
+        <a href="{{ base_url }}{{ page.url }}">{{ page.title | e }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1633,6 +1633,11 @@
     "portfolio",
     "minimal"
   ],
+  "luminary": [
+    "light",
+    "elegant",
+    "portfolio"
+  ],
   "luminescent-mesh": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR adds a new Hwaro example site named `luminary`. It features an elegant, minimalist portfolio design using system fonts with a classic serif heading (`Playfair Display`), avoiding emojis and gradients as requested. It uses template inheritance by modifying the generated scaffold to extend a centralized `base.html`. The repository registry (`tags.json`) has also been updated to include the new example.

---
*PR created automatically by Jules for task [7294861308380488171](https://jules.google.com/task/7294861308380488171) started by @chei-l*