### PR TITLE
fix: create missing pages in y2k example

### DIFF
--- a/y2k/content/about.md
+++ b/y2k/content/about.md
@@ -1,0 +1,5 @@
++++
+title = "About"
++++
+
+System information and mission.

--- a/y2k/content/archive.md
+++ b/y2k/content/archive.md
@@ -1,0 +1,5 @@
++++
+title = "Archive"
++++
+
+System logs and archive.

--- a/y2k/content/links.md
+++ b/y2k/content/links.md
@@ -1,0 +1,5 @@
++++
+title = "Links"
++++
+
+External connections and links.


### PR DESCRIPTION
Fix broken links in the y2k example by creating missing pages (`/about`, `/archive`, `/links`).

---
*PR created automatically by Jules for task [6087698500094731447](https://jules.google.com/task/6087698500094731447) started by @chei-l*