### PR TITLE
feat: add midnight-launch example site

### DIFF
--- a/midnight-launch/config.toml
+++ b/midnight-launch/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Midnight Launch"
+description = "Welcome to my new Hwaro site."
+base_url = "http://127.0.0.1:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/midnight-launch/content/about.md
+++ b/midnight-launch/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/midnight-launch/content/index.md
+++ b/midnight-launch/content/index.md
@@ -1,0 +1,31 @@
++++
+title = "Midnight Launch"
+description = "A refined and trendy landing page."
++++
+
+<div class="hero">
+  <h1>Midnight Innovation</h1>
+  <p>Experience the next generation of product design, bathed in the refined luminescence of the midnight hour.</p>
+  <a href="#features" class="btn">Explore Features</a>
+</div>
+
+<div id="features" class="feature-grid">
+  <div class="feature-card">
+    <h3>Stellar Performance</h3>
+    <p>Engineered for speed, delivering uninterrupted flow through our dark-themed universe.</p>
+  </div>
+  <div class="feature-card">
+    <h3>Radiant Design</h3>
+    <p>Subtle glowing highlights guide your attention precisely where it matters.</p>
+  </div>
+  <div class="feature-card">
+    <h3>Infinite Scroll</h3>
+    <p>Discover endless possibilities as new elements gracefully fade into view.</p>
+  </div>
+</div>
+
+<div class="reveal" style="text-align: center; padding: 4rem 0; margin-top: 4rem; border-top: 1px solid var(--border);">
+  <h2>Ready to launch?</h2>
+  <p>Join us in the darkness and illuminate your next big idea.</p>
+  <a href="/about/" class="btn" style="margin-top: 1.5rem;">Learn More</a>
+</div>

--- a/midnight-launch/templates/404.html
+++ b/midnight-launch/templates/404.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="reveal" style="text-align: center; padding: 4rem 0;">
+  <h1>404</h1>
+  <p>Page not found</p>
+</div>
+{% endblock %}

--- a/midnight-launch/templates/base.html
+++ b/midnight-launch/templates/base.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --bg: #050505;
+      --text: #e0e0e0;
+      --text-muted: #888888;
+      --primary: #6b4cff;
+      --border: #333333;
+      --card-bg: #111111;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      overflow-x: hidden;
+    }
+
+    /* Starfield */
+    #starfield {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      z-index: -1;
+      pointer-events: none;
+    }
+    .star {
+      position: absolute;
+      background: #ffffff;
+      border-radius: 50%;
+      animation: twinkle linear infinite;
+    }
+    @keyframes twinkle {
+      0% { opacity: 0.1; transform: scale(0.8); }
+      50% { opacity: 0.8; transform: scale(1.2); }
+      100% { opacity: 0.1; transform: scale(0.8); }
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 900px; margin: 0 auto; padding: 0 1.5rem; display: flex; flex-direction: column; min-height: 100vh; }
+    .site-header { display: flex; align-items: center; justify-content: space-between; padding: 1.5rem 0; border-bottom: 1px solid var(--border); margin-bottom: 2rem; position: relative; z-index: 10;}
+    .site-logo { font-weight: 700; font-size: 1.25rem; color: #ffffff; text-decoration: none; letter-spacing: 1px; transition: text-shadow 0.3s ease, color 0.3s ease; }
+    .site-logo:hover { color: var(--primary); text-shadow: 0 0 15px rgba(107, 76, 255, 0.4); }
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.95rem; font-weight: 500; transition: color 0.3s ease; }
+    .site-header nav a:hover { color: var(--primary); }
+    .site-main { flex: 1; position: relative; z-index: 1; }
+    .site-footer { margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.85rem; text-align: center; }
+
+    /* Typography */
+    h1, h2, h3 { line-height: 1.2; margin-top: 1.5em; margin-bottom: 0.5em; font-weight: 700; color: #ffffff; }
+    h1 { font-size: 3rem; margin-top: 0; letter-spacing: -1px; }
+    h2 { font-size: 2rem; }
+    h3 { font-size: 1.25rem; }
+    p { margin: 1.2em 0; font-size: 1.1rem; color: var(--text-muted); }
+    a { color: var(--primary); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { background: #1a1a1a; padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, monospace; }
+    pre { background: #111111; padding: 1.25rem; border-radius: 8px; overflow-x: auto; border: 1px solid var(--border); }
+    pre code { background: none; padding: 0; }
+
+    /* Components - Feature Cards */
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2rem;
+      margin: 3rem 0;
+    }
+    .feature-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2.5rem 2rem;
+      transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+      opacity: 0;
+      transform: translateY(30px);
+      text-align: center;
+    }
+    .feature-card.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .feature-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 0 25px rgba(107, 76, 255, 0.2);
+      border-color: rgba(107, 76, 255, 0.5);
+    }
+    .feature-card h3 { margin-top: 0; margin-bottom: 1rem; color: #ffffff; }
+    .feature-card p { font-size: 0.95rem; margin-bottom: 0; color: var(--text-muted); }
+
+    /* Hero Section */
+    .hero {
+      text-align: center;
+      padding: 6rem 0 4rem;
+      opacity: 0;
+      transform: translateY(30px);
+      animation: fadeUp 1s forwards ease-out;
+    }
+    .hero h1 {
+      font-size: 4rem;
+      margin-bottom: 1.5rem;
+      text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
+    }
+    .hero p {
+      font-size: 1.25rem;
+      max-width: 600px;
+      margin: 0 auto 2.5rem;
+      color: var(--text-muted);
+    }
+    .btn {
+      display: inline-block;
+      background: transparent;
+      color: var(--primary);
+      border: 1px solid var(--primary);
+      padding: 0.85rem 2.5rem;
+      border-radius: 30px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: all 0.3s ease;
+      box-shadow: 0 0 15px rgba(107, 76, 255, 0.1);
+    }
+    .btn:hover {
+      background: var(--primary);
+      color: #ffffff;
+      box-shadow: 0 0 25px rgba(107, 76, 255, 0.4);
+      text-decoration: none;
+    }
+
+    /* Scroll Reveal */
+    .reveal {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: all 0.8s ease-out;
+    }
+    .reveal.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    @keyframes fadeUp {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    /* Taxonomies list */
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul.section-list li { margin-bottom: 0.5rem; padding: 0.8rem 1rem; background: var(--card-bg); border-radius: 8px; border: 1px solid var(--border); transition: border-color 0.3s;}
+    ul.section-list li:hover { border-color: var(--primary); box-shadow: 0 0 15px rgba(107, 76, 255, 0.1); }
+    ul.section-list li a { font-weight: 600; color: #ffffff; }
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; align-items: center; }
+      .hero h1 { font-size: 2.5rem; }
+      .hero p { font-size: 1.1rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div id="starfield"></div>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} {{ site.title }}. Built with Hwaro.</p>
+    </footer>
+  </div>
+
+  <script>
+    // Starfield animation
+    const starfield = document.getElementById('starfield');
+    const numStars = 100;
+    for (let i = 0; i < numStars; i++) {
+      const star = document.createElement('div');
+      star.className = 'star';
+
+      const size = Math.random() * 2 + 1;
+      star.style.width = size + 'px';
+      star.style.height = size + 'px';
+
+      star.style.left = Math.random() * 100 + 'vw';
+      star.style.top = Math.random() * 100 + 'vh';
+
+      star.style.animationDuration = Math.random() * 3 + 2 + 's';
+      star.style.animationDelay = Math.random() * 3 + 's';
+
+      starfield.appendChild(star);
+    }
+
+    // Scroll reveal
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.1
+    };
+
+    const observer = new IntersectionObserver((entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, observerOptions);
+
+    // Observe specific elements dynamically loaded via markdown
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.feature-card, .reveal, h2, h3, p').forEach(el => {
+        if (!el.closest('.hero')) {
+           el.classList.add('reveal');
+           observer.observe(el);
+        }
+      });
+      // also specifically observe elements with .feature-card to avoid double add
+      document.querySelectorAll('.feature-card').forEach(el => {
+         observer.observe(el);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/midnight-launch/templates/page.html
+++ b/midnight-launch/templates/page.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="page-content reveal">
+  {{ content | safe }}
+</article>
+{% endblock %}

--- a/midnight-launch/templates/section.html
+++ b/midnight-launch/templates/section.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="reveal">
+  <h1>{{ section.title }}</h1>
+  {% if section.content %}
+    {{ section.content | safe }}
+  {% endif %}
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/midnight-launch/templates/shortcodes/alert.html
+++ b/midnight-launch/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/midnight-launch/templates/taxonomy.html
+++ b/midnight-launch/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="reveal">
+  <h1>{{ taxonomy_name | capitalize }}</h1>
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/midnight-launch/templates/taxonomy_term.html
+++ b/midnight-launch/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="reveal">
+  <h1>{{ taxonomy_name | capitalize }}: {{ taxonomy_term }}</h1>
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1660,16 +1660,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",
@@ -1858,6 +1858,12 @@
     "dark",
     "blog",
     "reading"
+  ],
+  "midnight-launch": [
+    "landing",
+    "dark",
+    "animation",
+    "product"
   ],
   "migration": [
     "light",


### PR DESCRIPTION
Fixes #900 by introducing the `midnight-launch` example template. The design relies on CSS box-shadow for glowing effects instead of gradients, and avoids emojis entirely to ensure a refined and elegant look. Included an animated starfield background and intersection-observer scroll reveals. Tags have been sorted and updated in `tags.json`.

---
*PR created automatically by Jules for task [5927101786542616836](https://jules.google.com/task/5927101786542616836) started by @chei-l*