### PR TITLE
feat: add horizon-ai example landing page

### DIFF
--- a/horizon-ai/config.toml
+++ b/horizon-ai/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/horizon-ai/content/about.md
+++ b/horizon-ai/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/horizon-ai/content/index.md
+++ b/horizon-ai/content/index.md
@@ -1,0 +1,376 @@
++++
+title = "Home"
+template = "page"
++++
+
+<style>
+/* Landing Page Specific Styles */
+.hero-section {
+  padding: 8rem 0 6rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--accent-blue);
+  background-color: rgba(0, 210, 255, 0.05);
+  border: 1px solid rgba(0, 210, 255, 0.2);
+  margin-bottom: 2rem;
+  box-shadow: 0 0 15px var(--accent-glow-blue);
+}
+
+.hero-title {
+  font-size: 4.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin-bottom: 1.5rem;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero-subtitle {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto 3rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+/* Neural Network Visualization Background */
+.neural-bg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.node {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  background-color: var(--border-color);
+  border-radius: 50%;
+  box-shadow: 0 0 8px rgba(255,255,255,0.1);
+}
+
+.node.active {
+  background-color: var(--accent-blue);
+  box-shadow: 0 0 12px var(--accent-blue);
+}
+
+.connection {
+  position: absolute;
+  background-color: var(--border-color);
+  height: 1px;
+  transform-origin: 0 50%;
+  opacity: 0.3;
+}
+
+/* Feature Grid */
+.features-section {
+  padding: 6rem 0;
+  background-color: var(--bg-surface);
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.section-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.feature-card {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 2.5rem 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.feature-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.feature-icon-wrapper {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.feature-icon {
+  width: 20px;
+  height: 20px;
+  background-color: var(--text-main);
+  mask-size: cover;
+  -webkit-mask-size: cover;
+}
+
+.feature-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.feature-desc {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+/* Code Demo Section */
+.demo-section {
+  padding: 8rem 0;
+}
+
+.demo-container {
+  display: flex;
+  align-items: center;
+  gap: 4rem;
+}
+
+.demo-content {
+  flex: 1;
+}
+
+.demo-visual {
+  flex: 1;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+}
+
+.demo-header {
+  background-color: rgba(255,255,255,0.02);
+  border-bottom: 1px solid var(--border-color);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.demo-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--border-color);
+}
+
+.demo-body {
+  padding: 2rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.code-line {
+  display: flex;
+}
+
+.code-num {
+  color: rgba(255,255,255,0.2);
+  width: 2rem;
+  user-select: none;
+}
+
+.code-keyword { color: var(--accent-blue); text-shadow: 0 0 8px var(--accent-glow-blue); }
+.code-string { color: #a5d6ff; }
+.code-func { color: #d2a8ff; }
+
+@media (max-width: 900px) {
+  .demo-container { flex-direction: column; }
+  .hero-title { font-size: 3rem; }
+}
+</style>
+
+<section class="hero-section">
+<div class="neural-bg">
+<div class="node active" style="top: 20%; left: 30%;"></div>
+<div class="node" style="top: 25%; left: 60%;"></div>
+<div class="node active" style="top: 50%; left: 20%;"></div>
+<div class="node" style="top: 60%; left: 75%;"></div>
+<div class="node active" style="top: 80%; left: 40%;"></div>
+<div class="node" style="top: 70%; left: 85%;"></div>
+<div class="connection" style="top: 20%; left: 30%; width: 300px; transform: rotate(15deg);"></div>
+<div class="connection" style="top: 20%; left: 30%; width: 350px; transform: rotate(65deg);"></div>
+<div class="connection" style="top: 50%; left: 20%; width: 400px; transform: rotate(20deg);"></div>
+<div class="connection" style="top: 25%; left: 60%; width: 250px; transform: rotate(70deg);"></div>
+<div class="connection" style="top: 60%; left: 75%; width: 300px; transform: rotate(140deg);"></div>
+</div>
+<div class="container">
+<div class="hero-badge">v2.0 Model Release</div>
+<h1 class="hero-title">Intelligence Architecture for the Modern Web</h1>
+<p class="hero-subtitle">Deploy sophisticated cognitive models to your applications with single-line integrations. Built for scale, engineered for precision.</p>
+<div class="hero-actions">
+<a href="#" class="btn-primary" style="padding: 0.8rem 2rem; font-size: 1rem;">Start Building</a>
+<a href="#" class="btn-outline" style="padding: 0.8rem 2rem; font-size: 1rem;">Read Docs</a>
+</div>
+</div>
+</section>
+
+<section class="features-section" id="features">
+<div class="container">
+<div class="section-header">
+<h2 class="section-title">Cognitive Capabilities</h2>
+<p style="color: var(--text-muted); max-width: 600px; margin: 0 auto;">Our neural architecture provides unprecedented contextual understanding with latency under 50ms.</p>
+</div>
+<div class="feature-grid">
+<div class="feature-card">
+<div class="feature-icon-wrapper">
+<div style="width: 16px; height: 16px; border: 2px solid var(--accent-blue); border-radius: 2px; box-shadow: 0 0 10px var(--accent-glow-blue);"></div>
+</div>
+<h3 class="feature-title">Contextual Awareness</h3>
+<p class="feature-desc">Models that understand multi-turn interactions, maintaining state across extended sessions without degrading response quality.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon-wrapper">
+<div style="width: 16px; height: 16px; border-radius: 50%; border: 2px solid var(--text-main); border-top-color: var(--accent-purple); box-shadow: 0 0 10px var(--accent-glow-purple); transform: rotate(45deg);"></div>
+</div>
+<h3 class="feature-title">Sub-50ms Latency</h3>
+<p class="feature-desc">Distributed edge inference ensures responses are generated and delivered globally with virtually imperceptible delay.</p>
+</div>
+<div class="feature-card">
+<div class="feature-icon-wrapper">
+<div style="display: flex; gap: 4px;">
+<div style="width: 4px; height: 16px; background-color: var(--text-main); opacity: 0.5;"></div>
+<div style="width: 4px; height: 16px; background-color: var(--accent-blue); box-shadow: 0 0 8px var(--accent-blue);"></div>
+<div style="width: 4px; height: 16px; background-color: var(--text-main); opacity: 0.5;"></div>
+</div>
+</div>
+<h3 class="feature-title">Data Sovereignty</h3>
+<p class="feature-desc">Strict compliance protocols ensuring zero-retention processing. Your data never trains our base models.</p>
+</div>
+</div>
+</div>
+</section>
+
+<section class="demo-section" id="architecture">
+<div class="container demo-container">
+<div class="demo-content">
+<h2 class="section-title" style="text-align: left; margin-bottom: 1.5rem;">Integration by Design</h2>
+<p style="color: var(--text-muted); margin-bottom: 2rem; font-size: 1.1rem;">
+Initialize the client, connect to the edge network, and stream responses directly to your UI components. The complexity of model orchestration is entirely abstracted.
+</p>
+<ul style="list-style: none; display: flex; flex-direction: column; gap: 1rem;">
+<li style="display: flex; align-items: center; gap: 1rem;">
+<div style="width: 8px; height: 8px; background-color: var(--accent-blue); border-radius: 50%; box-shadow: 0 0 8px var(--accent-blue);"></div>
+<span style="font-weight: 500;">Type-safe SDKs for major frameworks</span>
+</li>
+<li style="display: flex; align-items: center; gap: 1rem;">
+<div style="width: 8px; height: 8px; background-color: var(--border-color); border-radius: 50%;"></div>
+<span style="color: var(--text-muted);">Automatic fallback and retry logic</span>
+</li>
+<li style="display: flex; align-items: center; gap: 1rem;">
+<div style="width: 8px; height: 8px; background-color: var(--border-color); border-radius: 50%;"></div>
+<span style="color: var(--text-muted);">Built-in streaming parsers</span>
+</li>
+</ul>
+</div>
+<div class="demo-visual">
+<div class="demo-header">
+<div class="demo-dot"></div>
+<div class="demo-dot"></div>
+<div class="demo-dot"></div>
+</div>
+<div class="demo-body">
+<div class="code-line">
+<span class="code-num">1</span>
+<span><span class="code-keyword">import</span> { HorizonClient } <span class="code-keyword">from</span> <span class="code-string">'@horizon/sdk'</span>;</span>
+</div>
+<div class="code-line"><span class="code-num">2</span></div>
+<div class="code-line">
+<span class="code-num">3</span>
+<span><span class="code-keyword">const</span> client = <span class="code-keyword">new</span> <span class="code-func">HorizonClient</span>({</span>
+</div>
+<div class="code-line">
+<span class="code-num">4</span>
+<span>  apiKey: process.env.HORIZON_KEY,</span>
+</div>
+<div class="code-line">
+<span class="code-num">5</span>
+<span>  edge: <span class="code-keyword">true</span></span>
+</div>
+<div class="code-line">
+<span class="code-num">6</span>
+<span>});</span>
+</div>
+<div class="code-line"><span class="code-num">7</span></div>
+<div class="code-line">
+<span class="code-num">8</span>
+<span><span class="code-keyword">async function</span> <span class="code-func">processQuery</span>(input) {</span>
+</div>
+<div class="code-line">
+<span class="code-num">9</span>
+<span>  <span class="code-keyword">const</span> stream = <span class="code-keyword">await</span> client.models.<span class="code-func">generate</span>({</span>
+</div>
+<div class="code-line">
+<span class="code-num">10</span>
+<span>    model: <span class="code-string">'horizon-v2-instruct'</span>,</span>
+</div>
+<div class="code-line">
+<span class="code-num">11</span>
+<span>    prompt: input,</span>
+</div>
+<div class="code-line">
+<span class="code-num">12</span>
+<span>    stream: <span class="code-keyword">true</span></span>
+</div>
+<div class="code-line">
+<span class="code-num">13</span>
+<span>  });</span>
+</div>
+<div class="code-line">
+<span class="code-num">14</span>
+<span>  <span class="code-keyword">return</span> stream;</span>
+</div>
+<div class="code-line">
+<span class="code-num">15</span>
+<span>}</span>
+</div>
+</div>
+</div>
+</div>
+</section>

--- a/horizon-ai/templates/404.html
+++ b/horizon-ai/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/horizon-ai/templates/footer.html
+++ b/horizon-ai/templates/footer.html
@@ -1,0 +1,22 @@
+    <footer class="site-footer" style="margin-top: auto; padding: 4rem 0 2rem; border-top: 1px solid var(--border-color); background-color: var(--bg-surface);">
+      <div class="container" style="display: flex; flex-direction: column; align-items: center; text-align: center;">
+        <div class="logo-mark" style="margin-bottom: 1.5rem; width: 24px; height: 24px;"></div>
+        <p style="color: var(--text-muted); font-size: 0.9rem; margin-bottom: 2rem; max-width: 400px;">
+          Empowering the next generation of applications with advanced neural processing.
+        </p>
+        <div style="display: flex; gap: 2rem; margin-bottom: 3rem;">
+          <a href="#" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem; font-weight: 500;">Twitter</a>
+          <a href="#" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem; font-weight: 500;">GitHub</a>
+          <a href="#" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem; font-weight: 500;">Discord</a>
+        </div>
+        <div style="width: 100%; border-top: 1px solid rgba(255, 255, 255, 0.05); padding-top: 2rem; display: flex; justify-content: space-between; align-items: center; color: rgba(255, 255, 255, 0.3); font-size: 0.8rem;">
+          <span>&copy; {{ current_year }} Horizon AI. All rights reserved.</span>
+          <span>Powered by Hwaro</span>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/horizon-ai/templates/header.html
+++ b/horizon-ai/templates/header.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-dark: #050505;
+      --bg-surface: #0a0a0c;
+      --bg-card: #111114;
+      --border-color: #22222a;
+      --text-main: #f0f0f2;
+      --text-muted: #a0a0ab;
+      --accent-blue: #00d2ff;
+      --accent-purple: #9d00ff;
+      --accent-glow-blue: rgba(0, 210, 255, 0.15);
+      --accent-glow-purple: rgba(157, 0, 255, 0.15);
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: var(--font-sans);
+      background-color: var(--bg-dark);
+      color: var(--text-main);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      overflow-x: hidden;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    /* Header */
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background-color: rgba(5, 5, 5, 0.8);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border-color);
+      padding: 1rem 0;
+    }
+
+    .header-content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .logo-container {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+    }
+
+    .logo-mark {
+      width: 28px;
+      height: 28px;
+      border-radius: 6px;
+      background-color: transparent;
+      border: 2px solid var(--text-main);
+      box-shadow: 0 0 10px var(--accent-glow-blue), inset 0 0 10px var(--accent-glow-blue);
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .logo-mark::after {
+      content: '';
+      width: 10px;
+      height: 10px;
+      background-color: var(--accent-blue);
+      border-radius: 50%;
+      box-shadow: 0 0 8px var(--accent-blue);
+    }
+
+    .site-title {
+      font-weight: 700;
+      font-size: 1.25rem;
+      letter-spacing: -0.02em;
+      color: var(--text-main);
+    }
+
+    .main-nav {
+      display: flex;
+      gap: 2rem;
+    }
+
+    .nav-link {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+      transition: color 0.2s ease;
+    }
+
+    .nav-link:hover {
+      color: var(--text-main);
+      text-shadow: 0 0 8px rgba(240, 240, 242, 0.3);
+    }
+
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bg-dark);
+      background-color: var(--text-main);
+      border-radius: 4px;
+      text-decoration: none;
+      transition: all 0.2s ease;
+      border: 1px solid transparent;
+    }
+
+    .btn-primary:hover {
+      box-shadow: 0 0 15px rgba(255, 255, 255, 0.2);
+      transform: translateY(-1px);
+    }
+
+    .btn-outline {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.25rem;
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: var(--text-main);
+      background-color: transparent;
+      border: 1px solid var(--border-color);
+      border-radius: 4px;
+      text-decoration: none;
+      transition: all 0.2s ease;
+    }
+
+    .btn-outline:hover {
+      border-color: var(--text-muted);
+      background-color: rgba(255, 255, 255, 0.05);
+    }
+
+    /* Utility Classes */
+    .glow-blue { color: var(--accent-blue); text-shadow: 0 0 12px var(--accent-glow-blue); }
+    .glow-purple { color: var(--accent-purple); text-shadow: 0 0 12px var(--accent-glow-purple); }
+
+    @media (max-width: 768px) {
+      .main-nav, .header-actions .btn-outline {
+        display: none;
+      }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <div class="container header-content">
+        <a href="{{ base_url }}/" class="logo-container">
+          <div class="logo-mark"></div>
+          <span class="site-title">{{ site.title }}</span>
+        </a>
+        <nav class="main-nav">
+          <a href="#features" class="nav-link">Features</a>
+          <a href="#architecture" class="nav-link">Architecture</a>
+          <a href="#pricing" class="nav-link">Pricing</a>
+          <a href="#docs" class="nav-link">Documentation</a>
+        </nav>
+        <div class="header-actions">
+          <a href="#" class="btn-outline" style="margin-right: 0.75rem;">Log In</a>
+          <a href="#" class="btn-primary">Get Access</a>
+        </div>
+      </div>
+    </header>

--- a/horizon-ai/templates/page.html
+++ b/horizon-ai/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/horizon-ai/templates/section.html
+++ b/horizon-ai/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/horizon-ai/templates/shortcodes/alert.html
+++ b/horizon-ai/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/horizon-ai/templates/taxonomy.html
+++ b/horizon-ai/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/horizon-ai/templates/taxonomy_term.html
+++ b/horizon-ai/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1342,6 +1342,12 @@
     "holographic",
     "3d"
   ],
+  "horizon-ai": [
+    "landing",
+    "dark",
+    "ai",
+    "futuristic"
+  ],
   "hwaro.386": [
     "dark",
     "blog",
@@ -1660,16 +1666,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",


### PR DESCRIPTION
Closes #891

Adds a new Hwaro example site named `horizon-ai`.
The site implements a futuristic AI landing page featuring:
- A sophisticated dark theme with glowing elements using CSS box-shadows (strictly no gradients used).
- Complete absence of emojis, maintaining an elegant, professional tone.
- A custom CSS-only background visualization simulating a neural network architecture.
- Updates to `tags.json` adding the necessary meta-tags for this new example.

The code avoids extraneous build files and respects standard Hwaro scaffolding.

---
*PR created automatically by Jules for task [18182706084121553393](https://jules.google.com/task/18182706084121553393) started by @chei-l*