### PR TITLE
Add terracotta-studio example site

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -1660,16 +1660,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",
@@ -3011,6 +3011,12 @@
     "light",
     "blog",
     "lifestyle"
+  ],
+  "terracotta-studio": [
+    "landing",
+    "light",
+    "creative",
+    "artisan"
   ],
   "terracotta-tiles": [
     "dark",

--- a/terracotta-studio/config.toml
+++ b/terracotta-studio/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Terracotta Studio"
+description = "Warm earthy-toned creative studio landing with terracotta, clay, and natural texture aesthetics."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/terracotta-studio/content/about.md
+++ b/terracotta-studio/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "The Studio"
++++
+
+We believe in the power of organic design. Our approach is rooted in the physical world, bringing the warmth of terracotta, the texture of clay, and the elegance of natural materials into the digital space.
+
+Every project we undertake is an opportunity to craft something unique and enduring.
+
+### Our Philosophy
+
+- **Simplicity:** We strip away the unnecessary to reveal the essential.
+- **Warmth:** Digital spaces shouldn't feel cold. We use color and typography to create inviting environments.
+- **Craftsmanship:** Attention to detail is at the heart of everything we do.
+
+*Let's build something beautiful together.*

--- a/terracotta-studio/content/index.md
+++ b/terracotta-studio/content/index.md
@@ -1,0 +1,28 @@
++++
+title = "Home"
+template = "page"
++++
+
+<div class="hero">
+  <h1>Crafting Digital Elegance</h1>
+  <p>We are a boutique creative studio specializing in warm, organic, and artisanal web experiences.</p>
+  <a href="/about/" class="btn">Our Studio</a>
+</div>
+
+<div class="services-grid">
+  <div class="service-card">
+    <div class="service-icon">I.</div>
+    <h3>Brand Identity</h3>
+    <p>Creating timeless visual identities that resonate with your audience and reflect your core values.</p>
+  </div>
+  <div class="service-card">
+    <div class="service-icon">II.</div>
+    <h3>Web Design</h3>
+    <p>Designing immersive digital experiences with a focus on typography, spacing, and natural aesthetics.</p>
+  </div>
+  <div class="service-card">
+    <div class="service-icon">III.</div>
+    <h3>Art Direction</h3>
+    <p>Guiding the visual narrative of your project to ensure consistency and emotional impact.</p>
+  </div>
+</div>

--- a/terracotta-studio/content/services.md
+++ b/terracotta-studio/content/services.md
@@ -1,0 +1,17 @@
++++
+title = "Services"
++++
+
+Our expertise spans across multiple disciplines, allowing us to provide comprehensive creative solutions for our clients.
+
+### Strategy
+
+Before we design, we think. We work closely with you to understand your goals, your audience, and your unique position in the market.
+
+### Design
+
+From brand identity to web design, we create cohesive visual systems that tell your story beautifully and effectively.
+
+### Development
+
+We build fast, accessible, and robust digital experiences using modern tools and best practices, ensuring your site performs as well as it looks.

--- a/terracotta-studio/templates/404.html
+++ b/terracotta-studio/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/terracotta-studio/templates/footer.html
+++ b/terracotta-studio/templates/footer.html
@@ -1,0 +1,7 @@
+    </main>
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} Terracotta Studio. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/terracotta-studio/templates/header.html
+++ b/terracotta-studio/templates/header.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      /* Terracotta Studio Palette */
+      --primary: #c46a4f;      /* Terracotta */
+      --primary-hover: #a35640;
+      --secondary: #d68c74;    /* Lighter clay */
+      --bg: #f9f6f0;           /* Warm off-white */
+      --bg-alt: #f0e9e1;       /* Light stone */
+      --text: #3d3532;         /* Dark espresso brown */
+      --text-muted: #6b605c;
+      --border: #e3d8cd;
+
+      --font-serif: 'Playfair Display', serif;
+      --font-sans: 'Inter', sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-sans);
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      font-weight: 300;
+      /* Subtle noise texture */
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 1100px; margin: 0 auto; padding: 0 2rem; }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 2rem 0;
+      margin-bottom: 2rem;
+    }
+
+    .site-logo {
+      font-family: var(--font-serif);
+      font-weight: 600;
+      font-size: 1.5rem;
+      color: var(--primary);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+    }
+
+    .site-header nav { display: flex; gap: 2rem; }
+
+    .site-header nav a {
+      color: var(--text);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      transition: color 0.3s ease;
+    }
+
+    .site-header nav a:hover { color: var(--primary); }
+
+    .site-main { min-height: calc(100vh - 250px); }
+
+    .site-footer {
+      margin-top: 5rem;
+      padding: 3rem 0;
+      border-top: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5 {
+      font-family: var(--font-serif);
+      line-height: 1.2;
+      margin-top: 2em;
+      margin-bottom: 0.5em;
+      font-weight: 400;
+      color: var(--text);
+    }
+
+    h1 { font-size: 3.5rem; margin-top: 1rem; margin-bottom: 1.5rem; }
+    h2 { font-size: 2.2rem; }
+    h3 { font-size: 1.5rem; }
+
+    p { margin: 1.2em 0; font-size: 1.1rem; }
+
+    a { color: var(--primary); text-decoration: none; transition: color 0.2s; }
+    a:hover { color: var(--primary-hover); }
+
+    /* Hero Section Specifics */
+    .hero {
+      text-align: center;
+      padding: 4rem 0 6rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: var(--text-muted);
+      max-width: 600px;
+      margin: 0 auto 2.5rem;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 0.8rem 2rem;
+      background-color: var(--primary);
+      color: #fff;
+      text-decoration: none;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.9rem;
+      border-radius: 2px;
+      transition: background-color 0.3s ease, transform 0.2s ease;
+    }
+
+    .btn:hover {
+      background-color: var(--primary-hover);
+      color: #fff;
+      transform: translateY(-2px);
+    }
+
+    /* Services Grid */
+    .services-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 3rem;
+      margin: 4rem 0;
+    }
+
+    .service-card {
+      background: var(--bg-alt);
+      padding: 2.5rem;
+      border-radius: 4px;
+      text-align: center;
+      transition: transform 0.3s ease;
+      box-shadow: 0 4px 20px rgba(196, 106, 79, 0.05);
+    }
+
+    .service-card:hover {
+      transform: translateY(-5px);
+    }
+
+    .service-icon {
+      font-size: 2rem;
+      color: var(--primary);
+      margin-bottom: 1rem;
+      font-family: var(--font-serif);
+      font-style: italic;
+    }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem;
+      padding: 1.5rem;
+      background: var(--bg-alt);
+      border-radius: 4px;
+    }
+    ul.section-list li a { font-weight: 500; font-family: var(--font-serif); font-size: 1.2rem; }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .site-header { flex-direction: column; gap: 1rem; }
+      h1 { font-size: 2.5rem; }
+      .hero { padding: 2rem 0 3rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">Terracotta</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">Studio</a>
+        <a href="{{ base_url }}/services/">Services</a>
+      </nav>
+    </header>

--- a/terracotta-studio/templates/page.html
+++ b/terracotta-studio/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {% if page.url != "/" %}
+      <h1>{{ page.title }}</h1>
+    {% endif %}
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/terracotta-studio/templates/section.html
+++ b/terracotta-studio/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/terracotta-studio/templates/shortcodes/alert.html
+++ b/terracotta-studio/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/terracotta-studio/templates/taxonomy.html
+++ b/terracotta-studio/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/terracotta-studio/templates/taxonomy_term.html
+++ b/terracotta-studio/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Resolves #898 by adding `terracotta-studio`, an elegant and earthy-toned landing page example site.

- **Design:** Features a refined `terracotta` and `light-stone` aesthetic with solid colors and a subtle SVG noise filter, strictly avoiding all CSS gradients.
- **Content:** Clean and sophisticated markdown content without any emojis. 
- **Configuration:** Updated and alphabetically sorted the repository `tags.json` registry. Fully built and visually verified via Playwright.

---
*PR created automatically by Jules for task [11665740509702610596](https://jules.google.com/task/11665740509702610596) started by @chei-l*