### PR TITLE
Add new example site: helix-docs

### DIFF
--- a/helix-docs/AGENTS.md
+++ b/helix-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/helix-docs/config.toml
+++ b/helix-docs/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Helix Docs"
+description = "A refined and trendy documentation site with a DNA-inspired layout."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/helix-docs/content/getting-started/_index.md
+++ b/helix-docs/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/helix-docs/content/getting-started/configuration.md
+++ b/helix-docs/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/helix-docs/content/getting-started/installation.md
+++ b/helix-docs/content/getting-started/installation.md
@@ -1,0 +1,40 @@
++++
+title = "Isolation Protocols"
+description = "How to isolate and set up your research environment."
+weight = 1
++++
+
+Before beginning any synthesis, it is critical to isolate your research environment to prevent data contamination.
+
+## Environmental Setup
+
+We recommend using a sterile virtual environment for all Helix projects.
+
+### Prerequisites
+
+- **Node.js**: Minimum version 18.x (LTS)
+- **Hwaro CLI**: Latest stable release
+- **Scientific Precision**: A commitment to detail
+
+## Installation Steps
+
+1. **Create Directory**: Establish a new focal point for your research.
+   ```bash
+   mkdir helix-lab && cd helix-lab
+   ```
+
+2. **Initialize Sequence**: Run the Hwaro initialization command.
+   ```bash
+   hwaro init . --scaffold docs
+   ```
+
+3. **Verify Integrity**: Ensure all core modules are correctly mapped.
+   ```bash
+   hwaro tool doctor
+   ```
+
+{{ alert(type="warning", message="Failure to follow isolation protocols may result in unstable data structures.") }}
+
+## Next Steps
+
+Once your environment is isolated, proceed to [Rapid Prototyping]({{ base_url }}/getting-started/quick-start/) to begin building your first model.

--- a/helix-docs/content/getting-started/quick-start.md
+++ b/helix-docs/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/helix-docs/content/guide/_index.md
+++ b/helix-docs/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/helix-docs/content/guide/content-management.md
+++ b/helix-docs/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/helix-docs/content/guide/shortcodes.md
+++ b/helix-docs/content/guide/shortcodes.md
@@ -1,0 +1,39 @@
++++
+title = "Components"
++++
+
+Components (shortcodes) are reusable content snippets you can embed in your research sequence to enhance data synthesis.
+
+## Using Components
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", message="This is an info alert") }}
+```
+
+## Built-in Components
+
+### Alert
+
+Display an alert box for critical parameters or findings:
+
+```jinja
+{{ alert(type="warning", message="Be careful!") }}
+```
+
+Available types: `note`, `warning`, `tip`
+
+## Synthesis Examples
+
+### Warning Node
+
+{{ alert(type="warning", message="Data contamination detected in trial 4-B.") }}
+
+### Prototyping Tip
+
+{{ alert(type="tip", message="Always isolate your environment before synthesis.") }}
+
+## Advanced Components
+
+Shortcode templates are located in `templates/shortcodes/`. They have access to all passed arguments plus the `site` and `page` objects, allowing for highly dynamic and contextual UI elements.

--- a/helix-docs/content/guide/templates.md
+++ b/helix-docs/content/guide/templates.md
@@ -1,0 +1,37 @@
++++
+title = "Data Visualization"
+description = "Synthesizing visual models from raw helix data."
+weight = 2
++++
+
+Visualization is the core of the Helix experience. We transform raw technical data into intuitive, threaded models.
+
+## Template Architecture
+
+Helix uses the Crinja engine (a Jinja2 implementation) to render structural layouts.
+
+### Structural Nodes
+
+Every page is a node within the larger helix structure. You can customize these nodes using standard HTML and CSS.
+
+```jinja
+{# Example of a structural node template #}
+<div class="helix-node">
+  <h2>{{ page.title }}</h2>
+  {{ content }}
+</div>
+```
+
+### Threading Logic
+
+Navigation threads are automatically generated based on your section structure. By mapping files to directories, you create natural links between related sequences.
+
+## Advanced Synthesis
+
+For complex data models, use our built-in shortcodes to enhance clarity.
+
+- **Alerts**: Highlight critical data or warnings.
+- **DNA Patterns**: Inject subtle helix-themed decorations.
+- **Progressive Disclosure**: Reveal content based on user interaction.
+
+Proceed to the [Terminal Hub]({{ base_url }}/reference/cli/) for advanced command-line control over your visualization engine.

--- a/helix-docs/content/index.md
+++ b/helix-docs/content/index.md
@@ -1,0 +1,29 @@
++++
+title = "Helix Documentation"
+description = "A refined and trendy documentation site with a DNA-inspired layout."
++++
+
+Welcome to the **Helix Research Hub**. This platform is designed for scientific precision, featuring a spiral-themed architecture that connects topic threads through progressive disclosure and high-fidelity visualization.
+
+## Scientific Foundation
+
+Helix provides a robust framework for documenting complex biological systems and technical architectures. Our design philosophy prioritizes clarity, performance, and aesthetic refinement.
+
+{{ alert(type="tip", message="Explore the 'Sequence' section to begin your structural analysis.") }}
+
+### Key Principles
+
+- **Precision Layout**: Every element is positioned with mathematical accuracy to ensure optimal readability.
+- **Threaded Navigation**: Topics are linked like DNA strands, allowing for intuitive exploration of related concepts.
+- **Dynamic Synthesis**: Content is revealed progressively, reducing cognitive load and highlighting the most relevant data.
+
+## Getting Started
+
+To initialize your research environment, follow our isolation protocols and rapid prototyping guides.
+
+```bash
+# Initialize a new helix sequence
+helix init my-research --scaffold science
+```
+
+Next, analyze the [Structural Components]({{ base_url }}/guide/) to understand how data is synthesized within our environment.

--- a/helix-docs/content/reference/_index.md
+++ b/helix-docs/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/helix-docs/content/reference/cli.md
+++ b/helix-docs/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/helix-docs/content/reference/config.md
+++ b/helix-docs/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/helix-docs/static/css/style.css
+++ b/helix-docs/static/css/style.css
@@ -1,0 +1,480 @@
+:root {
+  --primary: #0ea5e9; /* Sky blue */
+  --primary-glow: rgba(14, 165, 233, 0.15);
+  --accent: #22d3ee; /* Cyan */
+  --text: #0f172a; /* Slate 900 */
+  --text-secondary: #475569; /* Slate 600 */
+  --text-muted: #94a3b8; /* Slate 400 */
+  --border: #e2e8f0; /* Slate 200 */
+  --border-focus: #bae6fd; /* Sky 200 */
+  --bg: #ffffff;
+  --bg-secondary: #f8fafc; /* Slate 50 */
+  --bg-dots: #f1f5f9;
+  --header-h: 64px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 12px;
+  --radius-sm: 8px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  background-image: radial-gradient(var(--bg-dots) 1px, transparent 1px);
+  background-size: 32px 32px;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 10px;
+  border: 2px solid var(--bg);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 1000;
+}
+
+.docs-header .logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--text);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.docs-header .logo::before {
+  content: "";
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 7L2 4.5M2 4.5l2.5-2.5M2 4.5H10'/%3E%3Cpath d='M19.5 17L22 19.5M22 19.5l-2.5 2.5M22 19.5H14'/%3E%3Cpath d='M16 3c1.7 0 3 1.3 3 3s-1.3 3-3 3-3-1.3-3-3 1.3-3 3-3z'/%3E%3Cpath d='M8 21c1.7 0 3-1.3 3-3s-1.3-3-3-3-3 1.3-3 3 1.3-3 3-3z'/%3E%3Cpath d='M12 9v6'/%3E%3C/svg%3E") no-repeat center;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4.5 7L2 4.5M2 4.5l2.5-2.5M2 4.5H10'/%3E%3Cpath d='M19.5 17L22 19.5M22 19.5l-2.5 2.5M22 19.5H14'/%3E%3Cpath d='M16 3c1.7 0 3 1.3 3 3s-1.3 3-3 3-3-1.3-3-3 1.3-3 3-3z'/%3E%3Cpath d='M8 21c1.7 0 3-1.3 3-3s-1.3-3-3-3-3 1.3-3 3 1.3-3 3-3z'/%3E%3Cpath d='M12 9v6'/%3E%3C/svg%3E") no-repeat center;
+}
+
+.docs-header .logo span {
+  color: var(--primary);
+  opacity: 0.8;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.docs-header nav {
+  display: flex;
+  margin-left: 3rem;
+  gap: 1.5rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.docs-header nav a:hover {
+  color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+/* Search Trigger */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 200px;
+}
+
+.search-trigger:hover {
+  border-color: var(--primary);
+  background: var(--bg);
+  box-shadow: 0 4px 12px var(--primary-glow);
+}
+
+.search-trigger kbd {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  padding: 2.5rem 1.5rem;
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+}
+
+.sidebar-section {
+  margin-bottom: 2.5rem;
+  position: relative;
+}
+
+/* Helix spine effect */
+.sidebar-section::before {
+  content: "";
+  position: absolute;
+  left: 0.5rem;
+  top: 2rem;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(to bottom, var(--primary), transparent);
+  opacity: 0.3;
+}
+
+.sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  letter-spacing: 0.1em;
+  padding-left: 1.5rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+/* Topic thread nodes */
+.sidebar-links li::before {
+  content: "";
+  position: absolute;
+  left: 0.35rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--border);
+  transition: all 0.2s;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.5rem 0;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: all 0.2s;
+}
+
+.sidebar-links a:hover {
+  color: var(--primary);
+  transform: translateX(4px);
+}
+
+.sidebar-links li:hover::before {
+  background: var(--primary);
+  box-shadow: 0 0 8px var(--primary);
+}
+
+.sidebar-links a.active {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.sidebar-links li:has(a.active)::before {
+  background: var(--primary);
+  width: 8px;
+  height: 8px;
+  left: 0.3rem;
+  box-shadow: 0 0 10px var(--primary);
+}
+
+/* Main content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 4rem 6rem;
+  max-width: var(--content-max-w);
+}
+
+.docs-main h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin-bottom: 2rem;
+  letter-spacing: -0.04em;
+  color: var(--text);
+  line-height: 1.1;
+  background: linear-gradient(to right, var(--text), var(--primary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.docs-main h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-top: 4rem;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.02em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+}
+
+.docs-main h3 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.docs-main p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+}
+
+/* Progressive Disclosure Effect */
+.docs-main > * {
+  opacity: 0;
+  transform: translateY(10px);
+  animation: reveal 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+@keyframes reveal {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.docs-main > *:nth-child(1) { animation-delay: 0.1s; }
+.docs-main > *:nth-child(2) { animation-delay: 0.2s; }
+.docs-main > *:nth-child(3) { animation-delay: 0.3s; }
+.docs-main > *:nth-child(4) { animation-delay: 0.4s; }
+.docs-main > *:nth-child(n+5) { animation-delay: 0.5s; }
+
+/* Code Blocks */
+pre {
+  background: var(--bg-secondary) !important;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin: 2rem 0;
+  position: relative;
+  overflow: hidden;
+}
+
+pre::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: linear-gradient(to bottom, var(--primary), var(--accent));
+}
+
+code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  background: var(--bg-secondary);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: var(--primary);
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+/* Info Boxes */
+.info-box {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  display: flex;
+  gap: 1rem;
+}
+
+.info-box::before {
+  font-size: 1.25rem;
+}
+
+.info-box.note {
+  background: #f0f9ff;
+  border-color: #e0f2fe;
+  color: #0369a1;
+}
+
+.info-box.warning {
+  background: #fffbeb;
+  border-color: #fef3c7;
+  color: #b45309;
+}
+
+.info-box.tip {
+  background: #f0fdf4;
+  border-color: #dcfce7;
+  color: #15803d;
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 6rem;
+  padding: 2rem 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.footer-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.footer-nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.footer-nav a:hover {
+  color: var(--primary);
+}
+
+/* Search Overlay */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(8px);
+  z-index: 2000;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 640px;
+  max-width: 90vw;
+  background: var(--bg);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.search-input-wrap {
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1.1rem;
+  font-family: inherit;
+  color: var(--text);
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .docs-main {
+    padding: 3rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 2rem 1.5rem;
+  }
+  .docs-header nav {
+    display: none;
+  }
+}

--- a/helix-docs/static/js/search.js
+++ b/helix-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/helix-docs/templates/404.html
+++ b/helix-docs/templates/404.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>404 Not Found</h1>
+    <p>The sequence you are looking for has been lost or does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Research Hub</a></p>
+{% include "footer.html" %}

--- a/helix-docs/templates/footer.html
+++ b/helix-docs/templates/footer.html
@@ -1,0 +1,15 @@
+    <div class="docs-footer">
+      <p>&copy; {{ current_year }} Helix Science. Refined Documentation.</p>
+      <div class="footer-nav">
+        <a href="#">Privacy</a>
+        <a href="#">Terms</a>
+        <a href="https://github.com/hahwul/hwaro">GitHub</a>
+      </div>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/helix-docs/templates/header.html
+++ b/helix-docs/templates/header.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono&display=swap" rel="stylesheet">
+</head>
+<body data-section="{{ page.section }}">
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }} <span>Research</span></a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Sequence</a>
+    <a href="{{ base_url }}/guide/">Structure</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search Topic...</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Analyze helix data..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Helix Sequence</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Isolation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Rapid Prototyping</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Parameters</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Architecture</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Structural Analysis</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Data Synthesis</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Visualization</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Components</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Archive</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Catalog</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">Terminal Hub</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Core Spec</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">

--- a/helix-docs/templates/page.html
+++ b/helix-docs/templates/page.html
@@ -1,0 +1,4 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+{% include "footer.html" %}

--- a/helix-docs/templates/section.html
+++ b/helix-docs/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+
+    <h2>Module Sequence</h2>
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+{% include "footer.html" %}

--- a/helix-docs/templates/shortcodes/alert.html
+++ b/helix-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box {{ type }}">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/helix-docs/templates/taxonomy.html
+++ b/helix-docs/templates/taxonomy.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+{% include "footer.html" %}

--- a/helix-docs/templates/taxonomy_term.html
+++ b/helix-docs/templates/taxonomy_term.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Nodes tagged with this term:</p>
+    {{ content }}
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1313,6 +1313,11 @@
     "biotech",
     "3d"
   ],
+  "helix-docs": [
+    "docs",
+    "light",
+    "science"
+  ],
   "herald": [
     "light",
     "magazine",


### PR DESCRIPTION
Added a sophisticated and trendy documentation example site named `helix-docs`. The design features a DNA-inspired layout with a vertical spine and topic nodes, scientific terminology, progressive disclosure animations, and a refined light-themed aesthetic.

Fixes #908

---
*PR created automatically by Jules for task [12774847913622627602](https://jules.google.com/task/12774847913622627602) started by @hahwul*