### PR TITLE
Add graphite-docs example site

### DIFF
--- a/graphite-docs/AGENTS.md
+++ b/graphite-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/graphite-docs/config.toml
+++ b/graphite-docs/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Graphite Docs"
+description = "Sleek graphite-toned technical documentation with a hand-drawn aesthetic."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github-dark"
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/graphite-docs/content/getting-started/_index.md
+++ b/graphite-docs/content/getting-started/_index.md
@@ -1,0 +1,25 @@
++++
+title = "Drafting Board"
++++
+
+Welcome to the **Drafting Board**. This section will guide you through the initial setup of your Graphite documentation.
+
+## Preparation
+
+Before you begin, ensure you have the following tools:
+1. **Hwaro CLI**: Our primary drafting instrument.
+2. **Markdown Editor**: Your pencil and paper.
+
+## Sketching Your Site
+
+Setting up a new project is as simple as a single stroke:
+
+```bash
+hwaro init my-new-docs --scaffold docs
+```
+
+## Core Principles
+
+- **Clarity**: Every line must serve a purpose.
+- **Consistency**: Maintain a uniform sketch style across all sections.
+- **Precision**: Ensure your technical details are as sharp as a newly sharpened lead.

--- a/graphite-docs/content/getting-started/configuration.md
+++ b/graphite-docs/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/graphite-docs/content/getting-started/installation.md
+++ b/graphite-docs/content/getting-started/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
++++
+
+Learn how to install Hwaro on your system.
+
+## Prerequisites
+
+- [Crystal](https://crystal-lang.org/) 1.0 or later
+- Git (optional, for cloning)
+
+## Install from Source
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards install
+shards build --release
+```
+
+## Verify Installation
+
+```bash
+./bin/hwaro --version
+```
+
+You should see the version number if Hwaro is installed correctly.
+
+## Next Steps
+
+Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.

--- a/graphite-docs/content/getting-started/quick-start.md
+++ b/graphite-docs/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/graphite-docs/content/guide/_index.md
+++ b/graphite-docs/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/graphite-docs/content/guide/content-management.md
+++ b/graphite-docs/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/graphite-docs/content/guide/shortcodes.md
+++ b/graphite-docs/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/graphite-docs/content/guide/templates.md
+++ b/graphite-docs/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/graphite-docs/content/index.md
+++ b/graphite-docs/content/index.md
@@ -1,0 +1,33 @@
++++
+title = "Graphite Docs"
++++
+
+Welcome to the **Graphite Docs** prototype. This site demonstrates a refined and trendy documentation design inspired by technical drawings and graphite sketches.
+
+> "A well-drawn blueprint is the foundation of every great project."
+
+## Design Philosophy
+
+The Graphite theme focuses on high-contrast technical aesthetics:
+- **Graphite Palette**: Deep lead-gray backgrounds with crisp paper-white text.
+- **Hand-Drafted Details**: Subtle pencil-sketch effects on borders and dividers.
+- **Precision Grid**: A subtle technical drawing grid that grounds the layout.
+
+## Get Started
+
+Explore the drafting process through our sections:
+
+- **[Getting Started](/getting-started/)** - Set up your drawing board.
+- **[Guide](/guide/)** - Mastering the graphite strokes.
+- **[Reference](/reference/)** - Technical specifications.
+
+## Technical Preview
+
+```crystal
+# Example of Crystal code highlighting
+def render_blueprint(project : Project)
+  puts "Rendering #{project.name} in Graphite style..."
+end
+```
+
+Enjoy the blend of technical precision and artistic flair.

--- a/graphite-docs/content/reference/_index.md
+++ b/graphite-docs/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/graphite-docs/content/reference/cli.md
+++ b/graphite-docs/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/graphite-docs/content/reference/config.md
+++ b/graphite-docs/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/graphite-docs/static/css/style.css
+++ b/graphite-docs/static/css/style.css
@@ -1,0 +1,268 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,700;1,700&family=JetBrains+Mono&display=swap');
+
+:root {
+  --primary: #888;
+  --primary-hover: #aaa;
+  --text: #e0e0e0;
+  --text-secondary: #b0b0b0;
+  --text-muted: #777;
+  --border: #444;
+  --border-light: #333;
+  --bg: #1a1a1a;
+  --bg-secondary: #242424;
+  --bg-code: #121212;
+  --header-h: 60px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 4px;
+  --radius-sm: 2px;
+  --grid-color: rgba(255, 255, 255, 0.03);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  background-image:
+    linear-gradient(var(--grid-color) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+  background-size: 20px 20px;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* SVG Filter Application */
+.sketch-effect {
+  filter: url('#rough-edges');
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(26, 26, 26, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 2px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 100;
+  filter: url('#rough-edges');
+}
+
+.docs-header .logo {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.docs-header nav {
+  display: flex;
+  gap: 1.5rem;
+  margin-left: 2rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.docs-header nav a:hover {
+  color: var(--text);
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: var(--bg);
+  border-right: 2px solid var(--border);
+  padding: 2rem 1rem;
+  overflow-y: auto;
+  filter: url('#rough-edges');
+}
+
+.sidebar-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  font-style: italic;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+.sidebar-links {
+  list-style: none;
+  padding: 0;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.4rem 0.75rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  border-radius: var(--radius-sm);
+}
+
+.sidebar-links a:hover {
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+
+.sidebar-links a.active {
+  background: var(--primary);
+  color: var(--bg);
+  font-weight: 600;
+  filter: url('#rough-edges');
+}
+
+/* Main Content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 4rem 5rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w));
+}
+
+.docs-main h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 0.5rem;
+  filter: url('#rough-edges');
+}
+
+.docs-main h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  margin: 3rem 0 1rem;
+  filter: url('#rough-edges');
+}
+
+.docs-main h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  margin: 2rem 0 1rem;
+}
+
+.docs-main p {
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+}
+
+/* Sketchy Borders for Blocks */
+pre, blockquote, .info-box {
+  border: 2px solid var(--border) !important;
+  filter: url('#rough-edges');
+  background: var(--bg-secondary) !important;
+  border-radius: 0 !important;
+}
+
+pre {
+  padding: 1.5rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+blockquote {
+  padding: 1.5rem;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+.info-box {
+  padding: 1rem 1.5rem;
+  margin: 2rem 0;
+  border-left-width: 8px !important;
+}
+
+.info-box.note {
+  border-color: #888 !important;
+}
+
+.info-box.warning {
+  border-color: #b8860b !important;
+}
+
+.info-box.tip {
+  border-color: #556b2f !important;
+}
+
+/* Custom Dividers */
+hr {
+  border: none;
+  height: 2px;
+  background: var(--border);
+  margin: 3rem 0;
+  filter: url('#rough-edges');
+}
+
+/* Search */
+.search-trigger {
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  filter: url('#rough-edges');
+  padding: 0.5rem 1rem;
+  color: var(--text-secondary);
+}
+
+.search-modal {
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  filter: url('#rough-edges');
+  border-radius: 0;
+}
+
+.search-input-wrap {
+  border-bottom: 2px solid var(--border);
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  filter: url('#rough-edges');
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 2rem 1.5rem;
+  }
+}

--- a/graphite-docs/static/js/search.js
+++ b/graphite-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/graphite-docs/templates/404.html
+++ b/graphite-docs/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <h1>404: Page Not Found</h1>
+    <p>The drafting sheet you are looking for seems to have been misplaced or erased.</p>
+    <p><a href="{{ base_url }}/">Return to the Drafting Board</a></p>
+{% include "footer.html" %}

--- a/graphite-docs/templates/footer.html
+++ b/graphite-docs/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} Graphite Docs &mdash; Drafting the future of technical writing. Powered by Hwaro.</p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/graphite-docs/templates/header.html
+++ b/graphite-docs/templates/header.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <!-- SVG Filter for pencil-sketch effect -->
+  <svg style="position: absolute; width: 0; height: 0;" aria-hidden="true" focusable="false">
+    <filter id="rough-edges">
+      <feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="3" result="noise" />
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" />
+    </filter>
+  </svg>

--- a/graphite-docs/templates/nav.html
+++ b/graphite-docs/templates/nav.html
@@ -1,0 +1,25 @@
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>

--- a/graphite-docs/templates/page.html
+++ b/graphite-docs/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+{% include "footer.html" %}

--- a/graphite-docs/templates/section.html
+++ b/graphite-docs/templates/section.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+
+    <h2>In This Section</h2>
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+{% include "footer.html" %}

--- a/graphite-docs/templates/shortcodes/alert.html
+++ b/graphite-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box {{ type | default(value="note") }}">
+  {{ body | safe }}
+</div>

--- a/graphite-docs/templates/sidebar.html
+++ b/graphite-docs/templates/sidebar.html
@@ -1,0 +1,28 @@
+<aside class="docs-sidebar">
+  <div class="sidebar-section">
+    <div class="sidebar-title">Getting Started</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/getting-started/" {% if current_path == "getting-started/" %}class="active"{% endif %}>Overview</a></li>
+      <li><a href="{{ base_url }}/getting-started/installation/" {% if current_path == "getting-started/installation/" %}class="active"{% endif %}>Installation</a></li>
+      <li><a href="{{ base_url }}/getting-started/quick-start/" {% if current_path == "getting-started/quick-start/" %}class="active"{% endif %}>Quick Start</a></li>
+      <li><a href="{{ base_url }}/getting-started/configuration/" {% if current_path == "getting-started/configuration/" %}class="active"{% endif %}>Configuration</a></li>
+    </ul>
+  </div>
+  <div class="sidebar-section">
+    <div class="sidebar-title">Guide</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/guide/" {% if current_path == "guide/" %}class="active"{% endif %}>Overview</a></li>
+      <li><a href="{{ base_url }}/guide/content-management/" {% if current_path == "guide/content-management/" %}class="active"{% endif %}>Content Management</a></li>
+      <li><a href="{{ base_url }}/guide/templates/" {% if current_path == "guide/templates/" %}class="active"{% endif %}>Templates</a></li>
+      <li><a href="{{ base_url }}/guide/shortcodes/" {% if current_path == "guide/shortcodes/" %}class="active"{% endif %}>Shortcodes</a></li>
+    </ul>
+  </div>
+  <div class="sidebar-section">
+    <div class="sidebar-title">Reference</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/reference/" {% if current_path == "reference/" %}class="active"{% endif %}>Overview</a></li>
+      <li><a href="{{ base_url }}/reference/cli/" {% if current_path == "reference/cli/" %}class="active"{% endif %}>CLI Commands</a></li>
+      <li><a href="{{ base_url }}/reference/config/" {% if current_path == "reference/config/" %}class="active"{% endif %}>Configuration</a></li>
+    </ul>
+  </div>
+</aside>

--- a/graphite-docs/templates/taxonomy.html
+++ b/graphite-docs/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <h1>{{ taxonomy.name | capitalize }}</h1>
+    <ul class="section-list">
+      {% for term in terms %}
+      <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+      {% endfor %}
+    </ul>
+{% include "footer.html" %}

--- a/graphite-docs/templates/taxonomy_term.html
+++ b/graphite-docs/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <h1>{{ taxonomy.name | capitalize }}: {{ term.name }}</h1>
+    <ul class="section-list">
+      {% for page in pages %}
+      <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+      {% endfor %}
+    </ul>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1238,6 +1238,11 @@
     "street-art",
     "urban"
   ],
+  "graphite-docs": [
+    "docs",
+    "dark",
+    "technical"
+  ],
   "greenhouse": [
     "light",
     "blog",


### PR DESCRIPTION
Added a new Hwaro example site 'graphite-docs' with a refined technical drawing aesthetic, featuring custom CSS, SVG filters for a sketch effect, and modular templates.

Fixes #915

---
*PR created automatically by Jules for task [5366671826309089815](https://jules.google.com/task/5366671826309089815) started by @hahwul*