### PR TITLE
Add new example codecraft

### DIFF
--- a/codecraft/config.toml
+++ b/codecraft/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Codecraft"
+description = "Project documentation powered by Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/codecraft/content/getting-started/_index.md
+++ b/codecraft/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/codecraft/content/getting-started/configuration.md
+++ b/codecraft/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/codecraft/content/getting-started/installation.md
+++ b/codecraft/content/getting-started/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
++++
+
+Learn how to install Hwaro on your system.
+
+## Prerequisites
+
+- [Crystal](https://crystal-lang.org/) 1.0 or later
+- Git (optional, for cloning)
+
+## Install from Source
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards install
+shards build --release
+```
+
+## Verify Installation
+
+```bash
+./bin/hwaro --version
+```
+
+You should see the version number if Hwaro is installed correctly.
+
+## Next Steps
+
+Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.

--- a/codecraft/content/getting-started/quick-start.md
+++ b/codecraft/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/codecraft/content/guide/_index.md
+++ b/codecraft/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/codecraft/content/guide/content-management.md
+++ b/codecraft/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/codecraft/content/guide/shortcodes.md
+++ b/codecraft/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/codecraft/content/guide/templates.md
+++ b/codecraft/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/codecraft/content/index.md
+++ b/codecraft/content/index.md
@@ -1,0 +1,98 @@
++++
+title = "Codecraft"
++++
+
+This documentation site is designed to look sophisticated, trendy, and entirely focused on the developer experience. It features clean typography, a deep dark theme, and custom components for showcasing technical content.
+
+## Features
+
+- **Refined Typography** - Crisp, readable fonts for prose and code.
+- **Deep Dark Theme** - Easy on the eyes, elegant, and minimal.
+- **No Gradients** - Solid colors and subtle borders ensure a timeless look.
+
+## Inline Code Playgrounds
+
+Simulate live code execution or interactive examples. The dual-pane layout separates the code from the visual output or interactive state.
+
+<div class="code-playground">
+  <div class="code-playground-header">
+    <span>React Component</span>
+    <span>Live Preview</span>
+  </div>
+  <div class="code-playground-body">
+<pre><code class="language-jsx">function Greeting({ name }) {
+  return (
+    &lt;div className="greeting"&gt;
+      Hello, {name}!
+    &lt;/div&gt;
+  );
+}</code></pre>
+    <div class="code-playground-preview" style="display:flex; align-items:center; justify-content:center; color:#58a6ff; font-weight:bold;">
+      Hello, Developer!
+    </div>
+  </div>
+</div>
+
+## API Endpoint Cards
+
+Present your RESTful or GraphQL endpoints cleanly with distinct methods and parameters.
+
+<div class="api-card">
+  <div class="api-card-header">
+    <span class="api-method get">GET</span>
+    <span class="api-endpoint">/api/v1/users/{id}</span>
+  </div>
+  <div class="api-card-body">
+    <p>Retrieve the details of a specific user by their unique identifier.</p>
+    <br>
+    <h5>Parameters</h5>
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td><code>id</code></td>
+        <td>String</td>
+        <td>The UUID of the user to retrieve.</td>
+      </tr>
+      <tr>
+        <td><code>include_profile</code></td>
+        <td>Boolean</td>
+        <td>Whether to include extended profile data.</td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="api-card">
+  <div class="api-card-header">
+    <span class="api-method post">POST</span>
+    <span class="api-endpoint">/api/v1/users</span>
+  </div>
+  <div class="api-card-body">
+    <p>Create a new user in the system.</p>
+  </div>
+</div>
+
+## Terminal Styled Blocks
+
+Show CLI commands and server output in realistic terminal windows.
+
+<div class="terminal-window">
+  <div class="terminal-header">
+    <div class="terminal-controls">
+      <span class="close"></span>
+      <span class="minimize"></span>
+      <span class="maximize"></span>
+    </div>
+    <div class="terminal-title">bash - server-deploy</div>
+  </div>
+<pre><code class="language-bash">$ hwaro build --minify
+Building site in /codecraft...
+✓ Processed 14 markdown files
+✓ Generated 21 html files
+✓ Processed static assets
+Done in 142ms. Output to public/</code></pre>
+</div>

--- a/codecraft/content/reference/_index.md
+++ b/codecraft/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/codecraft/content/reference/cli.md
+++ b/codecraft/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/codecraft/content/reference/config.md
+++ b/codecraft/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/codecraft/static/css/style.css
+++ b/codecraft/static/css/style.css
@@ -1,0 +1,573 @@
+:root {
+  --primary: #58a6ff;
+  --primary-hover: #79c0ff;
+  --text: #c9d1d9;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --border: #30363d;
+  --border-light: #21262d;
+  --bg: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-code: #161b22;
+  --header-h: 60px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 8px;
+  --radius-sm: 6px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(13, 17, 23, 0.85);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  padding: 0 1.5rem;
+  z-index: 100;
+}
+
+.docs-header .logo {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--text);
+  text-decoration: none;
+  margin-right: 2.5rem;
+  letter-spacing: -0.01em;
+}
+
+.docs-header .logo span {
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-left: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.docs-header nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 400;
+  padding: 0.25rem 0;
+  transition: color 0.15s;
+}
+
+.docs-header nav a:hover {
+  color: var(--text);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-right a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: color 0.15s;
+}
+
+.header-right a:hover {
+  color: var(--text);
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: var(--bg);
+  border-right: 1px solid var(--border-light);
+  padding: 1.5rem 1rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.docs-sidebar::-webkit-scrollbar {
+  width: 4px;
+}
+
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.sidebar-section {
+  margin-bottom: 1.75rem;
+}
+
+.sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.05em;
+  padding-left: 0.75rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  margin-bottom: 2px;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.4rem 0.75rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  transition: all 0.15s;
+  line-height: 1.4;
+}
+
+.sidebar-links a:hover {
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+
+.sidebar-links a.active {
+  background: rgba(88, 166, 255, 0.1);
+  color: var(--primary);
+  font-weight: 500;
+}
+
+/* Main content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 3rem 4rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w) + 8rem);
+}
+
+.docs-main h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin: 0 0 1rem 0;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.docs-main h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 3rem 0 1rem 0;
+  letter-spacing: -0.015em;
+  color: var(--text);
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 0.5rem;
+}
+
+.docs-main h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 2rem 0 0.75rem 0;
+  color: var(--text);
+}
+
+.docs-main h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem 0;
+  color: var(--text);
+}
+
+.docs-main p {
+  margin-bottom: 1.25rem;
+  line-height: 1.7;
+}
+
+.docs-main ul,
+.docs-main ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.5rem;
+}
+
+.docs-main li {
+  margin-bottom: 0.5rem;
+  line-height: 1.6;
+}
+
+/* Links */
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Code */
+code {
+  background: var(--bg-code);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: "JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  color: var(--text);
+  border: 1px solid var(--border-light);
+}
+
+pre {
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  margin: 1.25rem 0;
+  line-height: 1.5;
+  background: var(--bg-secondary) !important;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85rem;
+  border: none;
+}
+
+/* Terminal styled block */
+.terminal-window {
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.terminal-controls {
+  display: flex;
+  gap: 6px;
+}
+
+.terminal-controls span {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.terminal-controls .close { background-color: #ff5f56; }
+.terminal-controls .minimize { background-color: #ffbd2e; }
+.terminal-controls .maximize { background-color: #27c93f; }
+
+.terminal-title {
+  margin-left: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: "JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+}
+
+.terminal-window pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+/* API Endpoint Cards */
+.api-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+
+.api-card-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg);
+}
+
+.api-method {
+  font-weight: 700;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  margin-right: 0.75rem;
+  text-transform: uppercase;
+}
+
+.api-method.get { color: #58a6ff; background: rgba(88, 166, 255, 0.1); }
+.api-method.post { color: #3fb950; background: rgba(63, 185, 80, 0.1); }
+.api-method.put { color: #d29922; background: rgba(210, 153, 34, 0.1); }
+.api-method.delete { color: #f85149; background: rgba(248, 81, 73, 0.1); }
+
+.api-endpoint {
+  font-family: "JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.api-card-body {
+  padding: 1rem;
+}
+
+.api-card-body h5 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.api-card-body p {
+  font-size: 0.9rem;
+  margin-bottom: 0;
+}
+
+/* Inline code playground */
+.code-playground {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  margin: 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.code-playground-header {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  display: flex;
+  justify-content: space-between;
+}
+
+.code-playground-body {
+  display: flex;
+}
+
+.code-playground-body pre {
+  margin: 0;
+  border: none;
+  border-radius: 0 0 0 var(--radius);
+  flex: 1;
+  border-right: 1px solid var(--border-light);
+}
+
+.code-playground-preview {
+  flex: 1;
+  padding: 1.25rem;
+  background: var(--bg);
+  border-radius: 0 0 var(--radius) 0;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+}
+
+td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: top;
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 3px solid var(--primary);
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  background: rgba(88, 166, 255, 0.05);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--text-secondary);
+}
+
+blockquote p {
+  margin-bottom: 0;
+}
+
+/* Section list */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
+  transition: border-color 0.15s;
+}
+
+ul.section-list li:hover {
+  border-color: var(--border);
+}
+
+ul.section-list li a {
+  font-weight: 500;
+  color: var(--primary);
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+/* Search */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.search-trigger:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.search-trigger kbd {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 17, 23, 0.8);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 200;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 600px;
+  max-width: 90vw;
+  max-height: 70vh;
+  background: var(--bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 70px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg-secondary);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1.05rem;
+  font-family: inherit;
+  color: var(--text);
+  background: transparent;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 2rem 1.5rem;
+  }
+}

--- a/codecraft/static/js/search.js
+++ b/codecraft/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/codecraft/templates/404.html
+++ b/codecraft/templates/404.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+{% include "footer.html" %}

--- a/codecraft/templates/footer.html
+++ b/codecraft/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>Powered by Hwaro</p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/codecraft/templates/header.html
+++ b/codecraft/templates/header.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }} <span>Documentation</span></a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">

--- a/codecraft/templates/page.html
+++ b/codecraft/templates/page.html
@@ -1,0 +1,4 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+{% include "footer.html" %}

--- a/codecraft/templates/section.html
+++ b/codecraft/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+
+    <h2>In This Section</h2>
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+{% include "footer.html" %}

--- a/codecraft/templates/shortcodes/alert.html
+++ b/codecraft/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/codecraft/templates/taxonomy.html
+++ b/codecraft/templates/taxonomy.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+{% include "footer.html" %}

--- a/codecraft/templates/taxonomy_term.html
+++ b/codecraft/templates/taxonomy_term.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -638,6 +638,12 @@
     "docs",
     "styleguide"
   ],
+  "codecraft": [
+    "api",
+    "dark",
+    "developer",
+    "docs"
+  ],
   "codex": [
     "light",
     "blog",
@@ -1660,16 +1666,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",


### PR DESCRIPTION
Closes #903. This PR introduces the new sophisticated and trendy docs example site: `codecraft`. It features a dark theme layout with custom CSS for "API endpoint cards", "terminal-styled blocks", and "inline code playgrounds". Gradients and emojis were explicitly excluded, focusing on solid colors, crisp borders, and a professional typographic design. 

The site configuration and templates have been validated via `hwaro doctor` and `hwaro build`. Missing structural elements (sidebar and headers) in secondary templates (404, taxonomy) generated by the `docs` scaffold have also been fixed to maintain site layout integrity.

---
*PR created automatically by Jules for task [6589097917012000586](https://jules.google.com/task/6589097917012000586) started by @chei-l*