### PR TITLE
Add command-center documentation example site

### DIFF
--- a/command-center/AGENTS.md
+++ b/command-center/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/command-center/config.toml
+++ b/command-center/config.toml
@@ -1,0 +1,41 @@
+title = "Command Center"
+description = "Sophisticated and trendy CLI documentation example site"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "tokyo-night-dark"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+
+[markdown]
+safe = false
+emoji = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[[taxonomies]]
+name = "authors"
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10

--- a/command-center/content/getting-started/_index.md
+++ b/command-center/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/command-center/content/getting-started/configuration.md
+++ b/command-center/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/command-center/content/getting-started/installation.md
+++ b/command-center/content/getting-started/installation.md
@@ -1,0 +1,66 @@
++++
+title = "Installation Guide"
+description = "Step-by-step instructions to get the Command Center CLI running on your machine."
++++
+
+Deploying the Command Center CLI is straightforward across all major platforms. Follow the instructions below for your specific environment.
+
+## macOS & Linux
+
+The recommended way to install on Unix-like systems is via our automated shell script:
+
+```bash
+curl -sSL https://command-center.io/install | sh
+```
+
+Alternatively, you can use **Homebrew**:
+
+```bash
+brew tap command-center/tap
+brew install command-center-cli
+```
+
+## Windows
+
+For Windows users, we provide a **PowerShell** installation script:
+
+```powershell
+powershell -Command "iwr -useb https://command-center.io/install.ps1 | iex"
+```
+
+You can also use **Scoop**:
+
+```bash
+scoop bucket add command-center https://github.com/command-center/scoop
+scoop install cc
+```
+
+## Docker
+
+If you prefer to run the CLI in a containerized environment, use our official image:
+
+```bash
+docker pull commandcenter/cli:latest
+docker run -it commandcenter/cli cc --version
+```
+
+## Verification
+
+After installation, verify that the CLI is accessible by checking the version:
+
+```bash
+cc --version
+```
+
+<div class="info-box note">
+  <strong>Note:</strong> You may need to restart your terminal session for the changes to take effect.
+</div>
+
+## Post-Installation
+
+Once installed, we recommend running the [Quick Start](/getting-started/quick-start.html) command to configure your environment:
+
+```bash
+cc auth login
+cc setup
+```

--- a/command-center/content/getting-started/quick-start.md
+++ b/command-center/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/command-center/content/guide/_index.md
+++ b/command-center/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/command-center/content/guide/content-management.md
+++ b/command-center/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/command-center/content/guide/shortcodes.md
+++ b/command-center/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/command-center/content/guide/templates.md
+++ b/command-center/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/command-center/content/index.md
+++ b/command-center/content/index.md
@@ -1,0 +1,32 @@
++++
+title = "The Ultimate CLI Command Center"
+description = "Sophisticated, modern, and visually polished documentation for next-generation developer tools."
++++
+
+Welcome to the **Command Center**. This is a refined documentation template designed for developers who value aesthetic precision and functional clarity.
+
+<div class="info-box note">
+  <strong>Pro Tip:</strong> Use the search bar (⌘K) to quickly find command references and configuration flags.
+</div>
+
+## Key Capabilities
+
+- **Command Orchestration** - Manage complex CLI workflows with ease.
+- **Real-time Telemetry** - Monitor tool performance and output in high fidelity.
+- **Extensible Architecture** - Build custom plugins using our robust SDK.
+
+## Getting Started in Seconds
+
+To begin using the Command Center CLI, simply run the installation script:
+
+```bash
+curl -sSL https://command-center.io/install | sh
+```
+
+For more detailed instructions, head over to the [Installation Guide](/getting-started/installation/).
+
+## System Architecture
+
+> The Command Center is built on a foundation of performance and reliability, ensuring that your developer experience is seamless and lightning-fast.
+
+Our distributed architecture allows for horizontal scaling across multiple environments, from local development to global production clusters.

--- a/command-center/content/reference/_index.md
+++ b/command-center/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/command-center/content/reference/cli.md
+++ b/command-center/content/reference/cli.md
@@ -1,0 +1,97 @@
++++
+title = "CLI Command Reference"
+description = "Comprehensive guide to all Command Center CLI tools and utilities."
++++
+
+The Command Center CLI (`cc`) is your primary interface for interacting with the platform. Below is a detailed reference of available commands and their options.
+
+## Global Options
+
+The following flags can be used with any command:
+
+<div class="table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--verbose</code></td>
+        <td>Enable detailed logging output for debugging.</td>
+        <td><code>false</code></td>
+      </tr>
+      <tr>
+        <td><code>--config</code></td>
+        <td>Path to a custom configuration file.</td>
+        <td><code>./cc.toml</code></td>
+      </tr>
+      <tr>
+        <td><code>--format</code></td>
+        <td>Output format: <code>text</code>, <code>json</code>, or <code>yaml</code>.</td>
+        <td><code>text</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## `cc init`
+
+Initialize a new project environment.
+
+```bash
+cc init [project-name] [flags]
+```
+
+### Options
+
+<div class="table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--template</code></td>
+        <td>Specify a starter template (e.g., <code>api</code>, <code>web</code>, <code>worker</code>).</td>
+      </tr>
+      <tr>
+        <td><code>--private</code></td>
+        <td>Initialize as a private repository.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## `cc deploy`
+
+Deploy your project to the Command Center cloud.
+
+```bash
+cc deploy [environment]
+```
+
+### Examples
+
+Deploy to the production environment:
+```bash
+cc deploy production --verbose
+```
+
+## `cc status`
+
+Check the real-time status of your services.
+
+```bash
+cc status --watch
+```
+
+<div class="info-box warning">
+  <strong>Warning:</strong> Continuous watching of status may consume significant bandwidth in large-scale deployments.
+</div>

--- a/command-center/content/reference/config.md
+++ b/command-center/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/command-center/static/css/style.css
+++ b/command-center/static/css/style.css
@@ -1,0 +1,471 @@
+:root {
+  --primary: #38bdf8;
+  --primary-glow: rgba(56, 189, 248, 0.15);
+  --secondary: #818cf8;
+  --text: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --border: #334155;
+  --border-light: #1e293b;
+  --bg: #0f172a;
+  --bg-secondary: #1e293b;
+  --bg-code: #111827;
+  --header-h: 64px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', ui-monospace, monospace;
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 100;
+}
+
+.docs-header .logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--text);
+  text-decoration: none;
+  margin-right: 3rem;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.docs-header .logo::before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  border-radius: 6px;
+  box-shadow: 0 0 15px var(--primary-glow);
+}
+
+.docs-header .logo span {
+  color: var(--primary);
+  font-weight: 500;
+  font-size: 0.85rem;
+  background: rgba(56, 189, 248, 0.1);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 0.5rem;
+}
+
+.docs-header nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.docs-header nav a:hover {
+  color: var(--primary);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: var(--bg);
+  border-right: 1px solid var(--border-light);
+  padding: 2rem 1rem;
+  overflow-y: auto;
+}
+
+.sidebar-section {
+  margin-bottom: 2rem;
+}
+
+.sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+  padding-left: 1rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  margin-bottom: 4px;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  transition: all 0.2s;
+  line-height: 1.5;
+}
+
+.sidebar-links a:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+.sidebar-links a.active {
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* Main content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 3rem 4rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w) + 8rem);
+}
+
+.docs-main h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  background: linear-gradient(to bottom right, #fff, #94a3b8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.docs-main h2 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 3.5rem 0 1.25rem 0;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 0.5rem;
+}
+
+.docs-main h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 2.5rem 0 1rem 0;
+  color: var(--text);
+}
+
+.docs-main p {
+  margin-bottom: 1.25rem;
+  line-height: 1.8;
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.docs-main ul,
+.docs-main ol {
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.docs-main li {
+  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
+}
+
+/* Links */
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: var(--secondary);
+}
+
+/* Code */
+code {
+  background: var(--bg-code);
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.9em;
+  font-family: var(--font-mono);
+  color: var(--primary);
+  border: 1px solid rgba(56, 189, 248, 0.1);
+}
+
+pre {
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  background: var(--bg-code) !important;
+  border: 1px solid var(--border);
+  margin: 1.5rem 0 2rem 0;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85rem;
+  color: inherit;
+  border: none;
+}
+
+/* Tables */
+.table-wrapper {
+  overflow-x: auto;
+  margin: 1.5rem 0 2rem 0;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+th {
+  text-align: left;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+td {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: top;
+  color: var(--text-secondary);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 4px solid var(--primary);
+  padding: 1rem 1.5rem;
+  margin: 2rem 0;
+  background: rgba(56, 189, 248, 0.05);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+blockquote p {
+  margin-bottom: 0;
+  color: var(--text);
+  font-style: italic;
+}
+
+/* Info boxes */
+.info-box {
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius);
+  margin: 1.5rem 0;
+  display: flex;
+  gap: 1rem;
+  border: 1px solid transparent;
+}
+
+.info-box.note {
+  background: rgba(56, 189, 248, 0.1);
+  border-color: rgba(56, 189, 248, 0.2);
+  color: #bae6fd;
+}
+
+.info-box.warning {
+  background: rgba(245, 158, 11, 0.1);
+  border-color: rgba(245, 158, 11, 0.2);
+  color: #fde68a;
+}
+
+/* Search trigger button */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: 240px;
+}
+
+.search-trigger:hover {
+  border-color: var(--primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.search-trigger kbd {
+  margin-left: auto;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+/* Search overlay */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 200;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 640px;
+  max-width: 90vw;
+  max-height: 60vh;
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 1px var(--border), 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1.1rem;
+  font-family: inherit;
+  color: var(--text);
+  background: transparent;
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 5rem;
+  padding: 2.5rem 0;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 2rem 1.5rem;
+  }
+  .search-trigger {
+    width: auto;
+  }
+  .search-trigger span, .search-trigger kbd {
+    display: none;
+  }
+}

--- a/command-center/static/js/search.js
+++ b/command-center/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/command-center/templates/404.html
+++ b/command-center/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">Command <span>Center</span></a>
+</header>
+
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Introduction</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">Welcome</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <article class="prose">
+      <h1>404 Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+      <p><a href="{{ base_url }}/">Return to Home</a></p>
+    </article>
+{% include "footer.html" %}

--- a/command-center/templates/footer.html
+++ b/command-center/templates/footer.html
@@ -1,0 +1,26 @@
+    <footer class="docs-footer">
+      <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }}. Built with Hwaro.</p>
+      <div class="footer-links">
+        <a href="https://github.com/hahwul/hwaro">GitHub</a>
+      </div>
+    </footer>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+<script>
+  // Add active class to current sidebar link
+  document.addEventListener('DOMContentLoaded', () => {
+    const currentPath = window.location.pathname;
+    const sidebarLinks = document.querySelectorAll('.sidebar-links a');
+    sidebarLinks.forEach(link => {
+      const href = link.getAttribute('href');
+      if (currentPath === href || currentPath === href + 'index.html') {
+        link.classList.add('active');
+      }
+    });
+  });
+</script>
+</body>
+</html>

--- a/command-center/templates/header.html
+++ b/command-center/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | escape }}">
+  <title>{{ page.title | escape }} - {{ site.title | escape }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">

--- a/command-center/templates/nav.html
+++ b/command-center/templates/nav.html
@@ -1,0 +1,30 @@
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">Command <span>Center</span></a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search (⌘K)">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Quick search...</span>
+      <kbd>⌘K</kbd>
+    </button>
+  </div>
+</header>
+
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+    <div class="search-hint">
+      <span><kbd>↑↓</kbd> to navigate</span>
+      <span><kbd>↵</kbd> to select</span>
+    </div>
+  </div>
+</div>

--- a/command-center/templates/page.html
+++ b/command-center/templates/page.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <article class="prose">
+      <h1>{{ page.title | escape }}</h1>
+      {{ content | safe }}
+    </article>
+{% include "footer.html" %}

--- a/command-center/templates/section.html
+++ b/command-center/templates/section.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+{% include "nav.html" %}
+
+<div class="docs-container">
+  {% include "sidebar.html" %}
+  <main class="docs-main">
+    <article class="prose">
+      <h1>{{ page.title | escape }}</h1>
+      {{ content | safe }}
+
+      <div class="section-nav">
+        <h2>In This Section</h2>
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+      </div>
+    </article>
+{% include "footer.html" %}

--- a/command-center/templates/shortcodes/alert.html
+++ b/command-center/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box note">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/command-center/templates/sidebar.html
+++ b/command-center/templates/sidebar.html
@@ -1,0 +1,24 @@
+<aside class="docs-sidebar">
+  <div class="sidebar-section">
+    <div class="sidebar-title">Introduction</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/">Welcome</a></li>
+    </ul>
+  </div>
+  <div class="sidebar-section">
+    <div class="sidebar-title">Getting Started</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+      <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+      <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+    </ul>
+  </div>
+  <div class="sidebar-section">
+    <div class="sidebar-title">Reference</div>
+    <ul class="sidebar-links">
+      <li><a href="{{ base_url }}/reference/">Overview</a></li>
+      <li><a href="{{ base_url }}/reference/cli/">CLI Reference</a></li>
+      <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+    </ul>
+  </div>
+</aside>

--- a/command-center/templates/taxonomy_list.html
+++ b/command-center/templates/taxonomy_list.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">Command <span>Center</span></a>
+</header>
+
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Introduction</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">Welcome</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <article class="prose">
+      <h1>{{ page.title | escape }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content | safe }}
+    </article>
+{% include "footer.html" %}

--- a/command-center/templates/taxonomy_single.html
+++ b/command-center/templates/taxonomy_single.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">Command <span>Center</span></a>
+</header>
+
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Introduction</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">Welcome</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <article class="prose">
+      <h1>{{ page.title | escape }}</h1>
+      <p class="taxonomy-desc">Content tagged with this term:</p>
+      {{ content | safe }}
+    </article>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -654,6 +654,12 @@
     "blog",
     "comic"
   ],
+  "command-center": [
+    "docs",
+    "dark",
+    "cli",
+    "developer"
+  ],
   "compass": [
     "light",
     "landing",
@@ -1660,16 +1666,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",


### PR DESCRIPTION
Added a new sophisticated and trendy documentation example site called `command-center`. 

Key features:
- Dark-themed aesthetic with a palette of deep space blues and vibrant accents.
- Modern typography using Inter for prose and JetBrains Mono for code blocks.
- Polished CLI reference tables and info boxes.
- Modular template structure with extracted navigation and sidebar components.
- Responsive design and keyboard-accessible search overlay.

Fixes #913

---
*PR created automatically by Jules for task [8975882921795018907](https://jules.google.com/task/8975882921795018907) started by @hahwul*