### PR TITLE
Add atlas-docs example site

### DIFF
--- a/atlas-docs/AGENTS.md
+++ b/atlas-docs/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md - AI Agent Instructions for Atlas Docs
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a documentation website built with [Hwaro](https://github.com/hahwul/hwaro), featuring an "Atlas" explorer theme.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   ├── expeditions/     # Expedition protocols
+│   ├── cartography/     # Mapping standards
+│   └── equipment/       # Field gear specs
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── header.html      # Header & Navigation
+│   ├── footer.html      # Footer
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Always preview** with `hwaro serve` before committing.
+4. **Use `{{ base_url }}` prefix** for URLs in templates.
+5. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+- **Theme Palette:** Parchment (#fdfcf0), Ink (#1a1a1a), Exploration Blue (#2c4a63), Terracotta (#b35a44).
+- **Cartographic Elements:** Use coordinates, dashed lines, and grid patterns in styling.
+- **Tone:** Sophisticated, authoritative, and discovery-oriented.

--- a/atlas-docs/config.toml
+++ b/atlas-docs/config.toml
@@ -1,0 +1,20 @@
+title = "Atlas Docs"
+description = "Exploration and Discovery Documentation"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[markdown]
+safe = false
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+
+[taxonomies]
+tags = "tags"

--- a/atlas-docs/content/cartography/_index.md
+++ b/atlas-docs/content/cartography/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Cartography"
+description = "Standards for mapping and topographical documentation."
++++
+
+Technical standards and methods for generating accurate maps of newly discovered regions.

--- a/atlas-docs/content/cartography/content-management.md
+++ b/atlas-docs/content/cartography/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/atlas-docs/content/cartography/shortcodes.md
+++ b/atlas-docs/content/cartography/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/atlas-docs/content/cartography/templates.md
+++ b/atlas-docs/content/cartography/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/atlas-docs/content/equipment/_index.md
+++ b/atlas-docs/content/equipment/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Equipment"
+description = "Specifications for field gear and survey instruments."
++++
+
+Detailed guides and specifications for the tools of the trade.

--- a/atlas-docs/content/equipment/cli.md
+++ b/atlas-docs/content/equipment/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/atlas-docs/content/equipment/config.md
+++ b/atlas-docs/content/equipment/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/atlas-docs/content/expeditions/_index.md
+++ b/atlas-docs/content/expeditions/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Expeditions"
+description = "Field operations and discovery protocols."
++++
+
+This section covers the essential protocols for planning and executing discovery expeditions.

--- a/atlas-docs/content/expeditions/configuration.md
+++ b/atlas-docs/content/expeditions/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/atlas-docs/content/expeditions/installation.md
+++ b/atlas-docs/content/expeditions/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
++++
+
+Learn how to install Hwaro on your system.
+
+## Prerequisites
+
+- [Crystal](https://crystal-lang.org/) 1.0 or later
+- Git (optional, for cloning)
+
+## Install from Source
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards install
+shards build --release
+```
+
+## Verify Installation
+
+```bash
+./bin/hwaro --version
+```
+
+You should see the version number if Hwaro is installed correctly.
+
+## Next Steps
+
+Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.

--- a/atlas-docs/content/expeditions/quick-start.md
+++ b/atlas-docs/content/expeditions/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/atlas-docs/content/index.md
+++ b/atlas-docs/content/index.md
@@ -1,0 +1,24 @@
++++
+title = "The Explorer's Compendium"
+description = "A comprehensive guide to mapping the unknown and documenting the world's most remote regions."
++++
+
+Welcome to the **Atlas Docs**, the central repository for cartographers, explorers, and discovery teams. This compendium serves as the authoritative source for expedition protocols, cartographic standards, and field equipment specifications.
+
+## The Core Pillars
+
+Our documentation is organized into three primary clusters to assist in your discovery efforts:
+
+- **[Expeditions](@/expeditions/_index.md)**: Procedures for planning and executing field operations in diverse terrains.
+- **[Cartography](@/cartography/_index.md)**: Technical standards for map generation, coordinate systems, and topographical rendering.
+- **[Equipment](@/equipment/_index.md)**: Specifications and maintenance guides for essential field gear and survey tools.
+
+## Discovery Philosophy
+
+We believe that every discovery starts with meticulous documentation. Our goal is to provide a framework that allows explorers to focus on the unknown, knowing that their findings will be recorded with precision and clarity.
+
+> "The map is not the territory, but it is the only way we can share the journey." — *Lead Cartographer*
+
+## Getting Started
+
+If you are a newly commissioned explorer, please begin with the **[Expedition Briefing](@/expeditions/quick-start.md)** to familiarize yourself with our basic protocols.

--- a/atlas-docs/static/css/style.css
+++ b/atlas-docs/static/css/style.css
@@ -1,0 +1,532 @@
+/* ==========================================================================
+   Atlas Docs — Exploration & Discovery Documentation Theme
+   Palette: Parchment (#fdfcf0), Ink (#1a1a1a), Exploration Blue (#2c4a63), Terracotta (#b35a44)
+   ========================================================================== */
+
+:root {
+  --parchment: #fdfcf0;
+  --parchment-dark: #f5f4e6;
+  --ink: #1a1a1a;
+  --ink-light: #4a4a4a;
+  --exploration-blue: #2c4a63;
+  --exploration-blue-light: #4a6a83;
+  --terracotta: #b35a44;
+  --border: #dcdbc8;
+  --border-light: #ecebe0;
+  --accent: var(--terracotta);
+
+  --font-heading: "Cormorant Garamond", Georgia, serif;
+  --font-body: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+/* ---------- Reset & Base ---------- */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--parchment);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--exploration-blue);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: var(--terracotta);
+}
+
+/* ---------- Layout ---------- */
+
+.site-header {
+  border-bottom: 2px solid var(--ink);
+  background-color: var(--parchment);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--ink);
+}
+
+.site-title-text {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ink-light);
+}
+
+.nav-links a:hover {
+  color: var(--exploration-blue);
+}
+
+.search-container input {
+  background-color: var(--parchment-dark);
+  border: 1px solid var(--border);
+  padding: 0.4rem 1rem;
+  border-radius: 4px;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  width: 250px;
+}
+
+.site-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  max-width: 1400px;
+  margin: 0 auto;
+  min-height: calc(100vh - 70px);
+}
+
+.site-sidebar {
+  border-right: 1px solid var(--border);
+  padding: 2rem 1.5rem;
+  background-color: var(--parchment-dark);
+}
+
+.sidebar-section {
+  margin-bottom: 2rem;
+}
+
+.sidebar-heading {
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--terracotta);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px dashed var(--border);
+}
+
+.sidebar-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-links li {
+  margin-bottom: 0.4rem;
+}
+
+.sidebar-links a {
+  font-size: 0.9rem;
+  color: var(--ink-light);
+  display: block;
+  padding: 0.2rem 0;
+}
+
+.sidebar-links li.active a {
+  color: var(--exploration-blue);
+  font-weight: 600;
+}
+
+.site-main {
+  padding: 3rem 4rem;
+  max-width: 900px;
+}
+
+/* ---------- Content Styling ---------- */
+
+.page-header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.header-metadata {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.metadata-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.metadata-item .label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--terracotta);
+  letter-spacing: 0.1em;
+}
+
+.metadata-item .value {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--exploration-blue);
+}
+
+.page-title {
+  font-family: var(--font-heading);
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.page-description {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  font-style: italic;
+  color: var(--ink-light);
+  margin: 0;
+}
+
+.breadcrumbs {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 2rem;
+  color: var(--border);
+}
+
+.breadcrumbs a {
+  color: var(--ink-light);
+}
+
+.breadcrumbs .separator {
+  margin: 0 0.5rem;
+}
+
+.prose h2 {
+  font-family: var(--font-heading);
+  font-size: 1.75rem;
+  margin: 2.5rem 0 1rem;
+  color: var(--exploration-blue);
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 0.5rem;
+}
+
+.prose h3 {
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  margin: 2rem 0 0.75rem;
+  color: var(--ink);
+}
+
+.prose p {
+  margin-bottom: 1.5rem;
+}
+
+.prose ul, .prose ol {
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.prose li {
+  margin-bottom: 0.5rem;
+}
+
+.prose blockquote {
+  margin: 2rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 3px solid var(--terracotta);
+  background-color: var(--parchment-dark);
+  font-style: italic;
+}
+
+/* ---------- Discovery Cluster (Sections) ---------- */
+
+.cluster-heading {
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 2rem;
+  text-align: center;
+  position: relative;
+}
+
+.cluster-heading::before, .cluster-heading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 30%;
+  height: 1px;
+  background-color: var(--border);
+}
+
+.cluster-heading::before { left: 0; }
+.cluster-heading::after { right: 0; }
+
+.cluster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.discovery-item {
+  background-color: var(--parchment-dark);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  position: relative;
+}
+
+.discovery-item::before {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  border: 1px dashed var(--border-light);
+  pointer-events: none;
+}
+
+.item-metadata {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--terracotta);
+  margin-bottom: 1rem;
+}
+
+.item-title {
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  margin: 0 0 0.75rem;
+}
+
+.item-excerpt {
+  font-size: 0.9rem;
+  color: var(--ink-light);
+  margin-bottom: 1.5rem;
+}
+
+.item-footer .read-more {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+/* ---------- Footer ---------- */
+
+.site-footer {
+  margin-top: 5rem;
+  border-top: 1px solid var(--ink);
+  padding: 2rem 1.5rem;
+  background-color: var(--parchment);
+}
+
+.footer-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--ink-light);
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 1024px) {
+  .site-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .site-sidebar {
+    display: none;
+  }
+
+  .site-main {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-inner {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .site-nav {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .search-container input {
+    width: 100%;
+  }
+}
+
+/* ---------- Search Overlay ---------- */
+
+.search-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(26, 26, 26, 0.8);
+  z-index: 1000;
+  padding: 10vh 1.5rem;
+}
+
+.search-overlay.active {
+  display: flex;
+  justify-content: center;
+}
+
+.search-modal {
+  background-color: var(--parchment);
+  width: 100%;
+  max-width: 600px;
+  height: min-content;
+  max-height: 80vh;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-input-wrap {
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  background: none;
+  border: none;
+  font-family: var(--font-body);
+  font-size: 1.1rem;
+  outline: none;
+  color: var(--ink);
+}
+
+.search-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 1rem;
+  border-radius: 6px;
+  border-bottom: 1px solid var(--border-light);
+  transition: background-color 0.2s;
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.search-result-item:hover, .search-result-item.active {
+  background-color: var(--parchment-dark);
+}
+
+.search-result-title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--exploration-blue);
+  margin-bottom: 0.25rem;
+}
+
+.search-result-snippet {
+  font-size: 0.85rem;
+  color: var(--ink-light);
+}
+
+.search-result-snippet mark {
+  background-color: rgba(179, 90, 68, 0.2);
+  color: var(--terracotta);
+  font-weight: 600;
+}
+
+.search-hint {
+  padding: 0.75rem 1.25rem;
+  background-color: var(--parchment-dark);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--ink-light);
+  display: flex;
+  gap: 1.5rem;
+}
+
+.search-hint kbd {
+  background-color: var(--parchment);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  margin-right: 0.2rem;
+}
+
+.search-trigger {
+  background-color: var(--parchment-dark);
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--ink-light);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.search-trigger kbd {
+  font-size: 0.7rem;
+  opacity: 0.6;
+}

--- a/atlas-docs/static/js/search.js
+++ b/atlas-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/atlas-docs/templates/404.html
+++ b/atlas-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/atlas-docs/templates/footer.html
+++ b/atlas-docs/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>Powered by Hwaro</p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/atlas-docs/templates/header.html
+++ b/atlas-docs/templates/header.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | escape }}">
+  <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}</title>
+  {{ og_all_tags | safe }}
+  {{ canonical_tag | safe }}
+  {{ highlight_tags | safe }}
+  {{ auto_includes_css | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body data-section="{{ page.section }}">
+  <header class="site-header">
+    <div class="header-inner">
+      <div class="header-brand">
+        <a href="{{ base_url }}/" class="site-logo">
+          <svg class="compass-icon" viewBox="0 0 40 40" width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="20" cy="20" r="18" stroke="currentColor" stroke-width="1.5"/>
+            <circle cx="20" cy="20" r="2" fill="currentColor"/>
+            <line x1="20" y1="4" x2="20" y2="12" stroke="currentColor" stroke-width="1.5"/>
+            <line x1="20" y1="28" x2="20" y2="36" stroke="currentColor" stroke-width="1"/>
+            <line x1="4" y1="20" x2="12" y2="20" stroke="currentColor" stroke-width="1"/>
+            <line x1="28" y1="20" x2="36" y2="20" stroke="currentColor" stroke-width="1"/>
+            <polygon points="20,6 17,16 20,14 23,16" fill="currentColor"/>
+            <text x="20" y="3" text-anchor="middle" font-size="5" fill="currentColor" font-family="sans-serif" font-weight="600">N</text>
+          </svg>
+          <span class="site-title-text">Atlas Docs</span>
+        </a>
+      </div>
+      <nav class="site-nav">
+        <div class="nav-links">
+          <a href="{{ base_url }}/expeditions/">Expeditions</a>
+          <a href="{{ base_url }}/cartography/">Cartography</a>
+          <a href="{{ base_url }}/equipment/">Equipment</a>
+        </div>
+        {% if site.search and site.search.enabled %}
+        <div class="header-right">
+          <button class="search-trigger" onclick="openSearch()" title="Search (Ctrl+K)">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <span>Search</span>
+            <kbd>&#8984;K</kbd>
+          </button>
+        </div>
+        {% endif %}
+      </nav>
+    </div>
+  </header>
+
+  {% if site.search and site.search.enabled %}
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="site-layout">
+    <aside class="site-sidebar">
+      <nav class="sidebar-nav">
+        {% for s in site.sections %}
+        <div class="sidebar-section">
+          <h3 class="sidebar-heading"><a href="{{ s.url }}">{{ s.title }}</a></h3>
+          <ul class="sidebar-links">
+            {% for p in s.pages %}
+            <li class="{% if current_path == p.path %}active{% endif %}">
+              <a href="{{ p.url }}">{{ p.title }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endfor %}
+      </nav>
+    </aside>
+    <main class="site-main">

--- a/atlas-docs/templates/page.html
+++ b/atlas-docs/templates/page.html
@@ -1,0 +1,53 @@
+{% include "header.html" %}
+<article class="page-content">
+  <nav class="breadcrumbs">
+    <a href="{{ base_url }}/">Atlas</a>
+    {% for ancestor in page.ancestors %}
+    <span class="separator">/</span>
+    <a href="{{ ancestor.url }}">{{ ancestor.title }}</a>
+    {% endfor %}
+    <span class="separator">/</span>
+    <span class="current">{{ page.title }}</span>
+  </nav>
+
+  <header class="page-header">
+    <div class="header-metadata">
+      <div class="metadata-item">
+        <span class="label">COORDINATES</span>
+        <span class="value">{% if page.extra.lat %}{{ page.extra.lat }}{% else %}48.8584° N{% endif %}, {% if page.extra.lng %}{{ page.extra.lng }}{% else %}2.2945° E{% endif %}</span>
+      </div>
+      <div class="metadata-item">
+        <span class="label">LAST UPDATED</span>
+        <span class="value">{{ page.date | default(value="2024-05-20") }}</span>
+      </div>
+    </div>
+    <h1 class="page-title">{{ page.title | escape }}</h1>
+    {% if page.description %}
+    <p class="page-description">{{ page.description | escape }}</p>
+    {% endif %}
+  </header>
+
+  <div class="discovery-log prose">
+    {{ content | safe }}
+  </div>
+
+  <footer class="page-footer">
+    {% if page.lower or page.higher %}
+    <nav class="page-nav">
+      {% if page.lower %}
+      <a href="{{ page.lower.url }}" class="nav-prev">
+        <span class="nav-label">PREVIOUS EXPEDITION</span>
+        <span class="nav-title">{{ page.lower.title }}</span>
+      </a>
+      {% endif %}
+      {% if page.higher %}
+      <a href="{{ page.higher.url }}" class="nav-next">
+        <span class="nav-label">NEXT EXPEDITION</span>
+        <span class="nav-title">{{ page.higher.title }}</span>
+      </a>
+      {% endif %}
+    </nav>
+    {% endif %}
+  </footer>
+</article>
+{% include "footer.html" %}

--- a/atlas-docs/templates/section.html
+++ b/atlas-docs/templates/section.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+<div class="section-content">
+  <header class="section-header">
+    <h1 class="section-title">{{ section.title | escape }}</h1>
+    {% if section.content %}
+    <div class="prose">
+      {{ section.content | safe }}
+    </div>
+    {% endif %}
+  </header>
+
+  <div class="discovery-cluster">
+    <h2 class="cluster-heading">Discovery Log</h2>
+    <div class="cluster-grid">
+      {% for page in section.pages %}
+      <div class="discovery-item">
+        <div class="item-metadata">
+          <span class="item-coordinates">{% if page.extra.lat %}{{ page.extra.lat }}{% else %}LAT {{ loop.index0 * 2 + 10 }}° N{% endif %}</span>
+          <span class="item-id">#{{ loop.index }}</span>
+        </div>
+        <h3 class="item-title">
+          <a href="{{ page.url }}">{{ page.title | escape }}</a>
+        </h3>
+        {% if page.description %}
+        <p class="item-excerpt">{{ page.description | truncate(length=120) | escape }}</p>
+        {% endif %}
+        <div class="item-footer">
+          <a href="{{ page.url }}" class="read-more">Read Log &rarr;</a>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  {% if pagination %}
+  {{ pagination | safe }}
+  {% endif %}
+</div>
+{% include "footer.html" %}

--- a/atlas-docs/templates/shortcodes/alert.html
+++ b/atlas-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/atlas-docs/templates/taxonomy.html
+++ b/atlas-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/atlas-docs/templates/taxonomy_term.html
+++ b/atlas-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3368,5 +3368,10 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
   ]
 }


### PR DESCRIPTION
Add a new sophisticated and trendy docs example site: atlas-docs

Design Concept: Refined & Trendy Docs Design
Map/exploration themed docs with discovery navigation, topic clusters, and visual content hierarchy

- Sophisticated, modern, and visually polished
- Trendy design patterns with attention to detail
- Excellent typography (Cormorant Garamond, IBM Plex Sans)
- Cohesive color palette: Parchment, Ink, Exploration Blue, Terracotta

Implemented templates, content, static assets, and updated tags.json.

Fixes #914

---
*PR created automatically by Jules for task [5368310335719370044](https://jules.google.com/task/5368310335719370044) started by @hahwul*