### PR TITLE
Add new example site: inkdrop-docs

### DIFF
--- a/inkdrop-docs/AGENTS.md
+++ b/inkdrop-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/inkdrop-docs/config.toml
+++ b/inkdrop-docs/config.toml
@@ -1,0 +1,357 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Inkdrop Docs"
+description = "Refined & Trendy Documentation with Ink-Drop Aesthetics"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github-dark"    # Dark theme for syntax highlighting
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+[extra]
+font_family = "'JetBrains Mono', 'Fira Code', monospace"
+accent_color = "#3a86ff"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/inkdrop-docs/content/docs/_index.md
+++ b/inkdrop-docs/content/docs/_index.md
@@ -1,0 +1,13 @@
+---
+title: Documentation
+description: Welcome to the Inkdrop documentation.
+---
+
+Welcome to **Inkdrop Docs**, a sophisticated and trendy documentation theme for Hwaro.
+
+This theme features:
+- **Refined Monospace Typography**: Elegant and technical.
+- **Ink-Drop Hover Effects**: Visual feedback with a liquid feel.
+- **Smooth Page Transitions**: For a visually polished experience.
+
+Check out the [Introduction](introduction/) to learn more.

--- a/inkdrop-docs/content/docs/introduction.md
+++ b/inkdrop-docs/content/docs/introduction.md
@@ -1,0 +1,18 @@
+---
+title: Introduction
+description: An introduction to Inkdrop Docs.
+---
+
+Inkdrop Docs is designed for developers who appreciate fine typography and subtle, high-quality animations.
+
+## Design Philosophy
+
+The core of Inkdrop is *refinement*. We use high-contrast dark backgrounds paired with soft white text and vibrant ink-blue accents.
+
+### Typography
+
+We use **JetBrains Mono** for its excellent readability and technical character. Every element on the page is spaced with intention.
+
+### Animation
+
+Animations in Inkdrop are deliberate and smooth. The "ink-drop" effect on links and buttons simulates liquid spreading from the point of interaction.

--- a/inkdrop-docs/content/docs/setup.md
+++ b/inkdrop-docs/content/docs/setup.md
@@ -1,0 +1,30 @@
+---
+title: Setup
+description: How to set up your project with Inkdrop.
+---
+
+# Setup Guide
+
+Follow these steps to get your documentation site up and running with the Inkdrop aesthetic.
+
+## 1. Installation
+
+Initialize your project with the `inkdrop-docs` scaffold:
+
+```bash
+hwaro init my-docs --scaffold inkdrop-docs
+```
+
+## 2. Configuration
+
+Edit your `config.toml` to customize your site:
+
+```toml
+title = "My Docs"
+[extra]
+accent_color = "#3a86ff"
+```
+
+## 3. Writing Content
+
+Add your markdown files to the `content/docs` directory. Hwaro will automatically generate the documentation structure.

--- a/inkdrop-docs/content/index.md
+++ b/inkdrop-docs/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Documentation"
++++
+
+This documentation site is powered by [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator.
+
+## Quick Links
+
+- **[Getting Started](/getting-started/)** - Installation, setup, and basic usage
+- **[Guide](/guide/)** - In-depth guides on content, templates, and more
+- **[Reference](/reference/)** - CLI commands and configuration options
+
+## Features
+
+- **Write in Markdown** - Simple, readable content authoring
+- **Jinja2 Templates** - Customizable templates via Crinja engine
+- **Fast Builds** - Powered by Crystal for blazing fast build times
+- **Built-in Search** - Client-side search with keyboard shortcuts
+- **Responsive Layout** - Documentation layout that works on all devices
+- **Syntax Highlighting** - Code blocks with automatic syntax highlighting

--- a/inkdrop-docs/static/css/style.css
+++ b/inkdrop-docs/static/css/style.css
@@ -1,0 +1,678 @@
+:root {
+  --primary: #3a86ff;
+  --primary-hover: #2a6fdf;
+  --text: #e0e0e0;
+  --text-secondary: #b0b0b5;
+  --text-muted: #66666e;
+  --border: #2a2a2d;
+  --border-light: #1a1a1c;
+  --bg: #0a0a0b;
+  --bg-secondary: #121214;
+  --bg-code: #161618;
+  --header-h: 64px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 4px;
+  --radius-sm: 2px;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(10, 10, 11, 0.9);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 100;
+}
+
+.docs-header .logo {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--text);
+  text-decoration: none;
+  margin-right: 2rem;
+  letter-spacing: -0.01em;
+}
+
+.docs-header .logo span {
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-left: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.docs-header nav {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.85rem;
+  font-weight: 400;
+  padding: 0.25rem 0;
+  transition: color 0.15s;
+}
+
+.docs-header nav a:hover {
+  color: var(--text);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-right a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: color 0.15s;
+}
+
+.header-right a:hover {
+  color: var(--text);
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: var(--bg);
+  border-right: 1px solid var(--border-light);
+  padding: 1.25rem 0.75rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.docs-sidebar::-webkit-scrollbar {
+  width: 4px;
+}
+
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.sidebar-section {
+  margin-bottom: 1.5rem;
+}
+
+.sidebar-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+  letter-spacing: 0.04em;
+  padding-left: 0.75rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  margin-bottom: 1px;
+}
+
+.sidebar-links a {
+  display: block;
+  position: relative;
+  padding: 0.5rem 1rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  overflow: hidden;
+  transition: color 0.3s ease;
+  line-height: 1.4;
+  background: transparent;
+  z-index: 1;
+}
+
+.sidebar-links a::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: radial-gradient(circle, var(--primary) 0%, transparent 70%);
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: width 0.6s ease-out, height 0.6s ease-out, opacity 0.4s ease;
+  z-index: -1;
+  border-radius: 50%;
+}
+
+.sidebar-links a:hover::before {
+  width: 300%;
+  height: 300%;
+  opacity: 0.15;
+}
+
+.sidebar-links a:hover {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.sidebar-links a.active {
+  color: var(--primary);
+  font-weight: 600;
+  border-left: 2px solid var(--primary);
+  border-radius: 0;
+}
+
+/* Main content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 4rem 6rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w) + 12rem);
+}
+
+.content-fade-in {
+  animation: fadeIn 0.8s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.prose {
+  color: var(--text-secondary);
+}
+
+.prose h1, .prose h2, .prose h3, .prose h4 {
+  color: var(--text);
+}
+
+.docs-main h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.docs-main h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 2.5rem 0 0.75rem 0;
+  letter-spacing: -0.015em;
+  color: var(--text);
+}
+
+.docs-main h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 2rem 0 0.5rem 0;
+  color: var(--text);
+}
+
+.docs-main h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem 0;
+  color: var(--text);
+}
+
+.docs-main p {
+  margin-bottom: 1rem;
+  line-height: 1.7;
+}
+
+.docs-main ul,
+.docs-main ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.docs-main li {
+  margin-bottom: 0.35rem;
+  line-height: 1.6;
+}
+
+/* Links */
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Code */
+code {
+  background: var(--bg-code);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  color: var(--text);
+}
+
+pre {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  border: 1px solid var(--border-light);
+  margin: 1rem 0 1.5rem 0;
+  line-height: 1.5;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.82rem;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+th {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--border);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: top;
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 3px solid var(--primary);
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  background: var(--bg-secondary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--text-secondary);
+}
+
+blockquote p {
+  margin-bottom: 0;
+}
+
+/* Ink Drop Effect for Buttons and Links */
+.ink-drop-btn {
+  position: relative;
+  display: inline-block;
+  padding: 0.6rem 1.2rem;
+  background: var(--bg-secondary);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  overflow: hidden;
+  z-index: 1;
+  transition: color 0.4s ease, border-color 0.4s ease;
+}
+
+.ink-drop-btn::after {
+  content: '';
+  position: absolute;
+  top: var(--y, 50%);
+  left: var(--x, 50%);
+  width: 0;
+  height: 0;
+  background: var(--primary);
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: width 0.6s cubic-bezier(0.1, 0, 0.3, 1), height 0.6s cubic-bezier(0.1, 0, 0.3, 1), opacity 0.4s ease;
+  z-index: -1;
+  border-radius: 50%;
+}
+
+.ink-drop-btn:hover::after {
+  width: 350%;
+  height: 350%;
+  opacity: 1;
+}
+
+.ink-drop-btn:hover {
+  color: #fff;
+  border-color: var(--primary);
+  text-decoration: none;
+}
+
+/* Info boxes */
+.info-box {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  margin: 1.5rem 0;
+  border-left: 2px solid;
+  font-size: 0.9rem;
+  background: var(--bg-secondary);
+}
+
+.info-box.note {
+  background: rgba(41, 151, 255, 0.1);
+  border-color: var(--primary);
+}
+
+.info-box.warning {
+  background: rgba(255, 159, 10, 0.1);
+  border-color: #ff9f0a;
+}
+
+.info-box.tip {
+  background: rgba(48, 209, 88, 0.1);
+  border-color: #30d158;
+}
+
+/* Section list */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
+  transition: border-color 0.15s;
+}
+
+ul.section-list li:hover {
+  border-color: var(--border);
+}
+
+ul.section-list li a {
+  font-weight: 500;
+  color: var(--primary);
+}
+
+/* Navigation pagination */
+nav.pagination {
+  margin: 1.5rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+nav.pagination a:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--primary);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  color: var(--primary);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+/* Search trigger button */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.search-trigger:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.search-trigger kbd {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+/* Search overlay */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 200;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 560px;
+  max-width: 90vw;
+  max-height: 70vh;
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+  box-shadow: 0 16px 70px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.search-input-wrap svg {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.search-input-wrap input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--text);
+  background: transparent;
+}
+
+.search-input-wrap input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-input-wrap kbd {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-family: inherit;
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.search-results {
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.search-result-item:hover,
+.search-result-item.active {
+  background: var(--bg);
+  text-decoration: none;
+}
+
+.search-result-item .search-result-title {
+  font-weight: 500;
+  font-size: 0.9rem;
+  margin-bottom: 0.15rem;
+}
+
+.search-result-item .search-result-snippet {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-result-item .search-result-snippet mark {
+  background: rgba(41, 151, 255, 0.2);
+  color: var(--primary);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-no-results {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.search-hint {
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.search-hint kbd {
+  font-size: 0.65rem;
+  padding: 0 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 1.5rem 1rem;
+  }
+}

--- a/inkdrop-docs/static/js/search.js
+++ b/inkdrop-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/inkdrop-docs/templates/404.html
+++ b/inkdrop-docs/templates/404.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo ink-drop-btn" style="border:none;background:transparent;">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/docs/" class="ink-drop-btn" style="border:none;background:transparent;">Docs</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Documentation</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/docs/">Overview</a></li>
+        <li><a href="{{ base_url }}/docs/introduction/">Introduction</a></li>
+        <li><a href="{{ base_url }}/docs/setup/">Setup</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-fade-in">
+      <h1>404 Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+      <p><a href="{{ base_url }}/" class="ink-drop-btn">Return to Home</a></p>
+    </div>
+{% include "footer.html" %}

--- a/inkdrop-docs/templates/footer.html
+++ b/inkdrop-docs/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>Powered by Hwaro</p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/inkdrop-docs/templates/header.html
+++ b/inkdrop-docs/templates/header.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">

--- a/inkdrop-docs/templates/page.html
+++ b/inkdrop-docs/templates/page.html
@@ -1,0 +1,43 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo ink-drop-btn" style="border:none;background:transparent;">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/docs/" class="ink-drop-btn" style="border:none;background:transparent;">Docs</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Documentation</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/docs/" {% if page.path == "/docs/" %}class="active"{% endif %}>Overview</a></li>
+        <li><a href="{{ base_url }}/docs/introduction/" {% if page.path == "/docs/introduction/" %}class="active"{% endif %}>Introduction</a></li>
+        <li><a href="{{ base_url }}/docs/setup/" {% if page.path == "/docs/setup/" %}class="active"{% endif %}>Setup</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-fade-in">
+      <h1>{{ page.title | e }}</h1>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+{% include "footer.html" %}

--- a/inkdrop-docs/templates/shortcodes/alert.html
+++ b/inkdrop-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box {{ type | default(value="note") }}">
+  <strong>{{ type | default(value="note") | upper }}:</strong> {{ body }}
+</div>

--- a/inkdrop-docs/templates/taxonomy.html
+++ b/inkdrop-docs/templates/taxonomy.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo ink-drop-btn" style="border:none;background:transparent;">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/docs/" class="ink-drop-btn" style="border:none;background:transparent;">Docs</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Documentation</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/docs/">Overview</a></li>
+        <li><a href="{{ base_url }}/docs/introduction/">Introduction</a></li>
+        <li><a href="{{ base_url }}/docs/setup/">Setup</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-fade-in">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+{% include "footer.html" %}

--- a/inkdrop-docs/templates/taxonomy_term.html
+++ b/inkdrop-docs/templates/taxonomy_term.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo ink-drop-btn" style="border:none;background:transparent;">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/docs/" class="ink-drop-btn" style="border:none;background:transparent;">Docs</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Documentation</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/docs/">Overview</a></li>
+        <li><a href="{{ base_url }}/docs/introduction/">Introduction</a></li>
+        <li><a href="{{ base_url }}/docs/setup/">Setup</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-fade-in">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Posts tagged with this term:</p>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1399,6 +1399,12 @@
     "seoul",
     "minimal"
   ],
+  "inkdrop-docs": [
+    "docs",
+    "dark",
+    "elegant",
+    "animation"
+  ],
   "inkwell": [
     "light",
     "blog",
@@ -1660,16 +1666,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",


### PR DESCRIPTION
I have added a new sophisticated and trendy documentation example site called `inkdrop-docs`. 

Key changes include:
- **Design Concept**: A refined dark theme with "ink-drop" hover animations and a strong focus on monospace typography (JetBrains Mono).
- **CSS Implementation**: Custom styles in `static/css/style.css` using `radial-gradient` and transitions to create the signature ink-drop effect on links and buttons.
- **Template Refinement**: Updated `page.html`, `404.html`, and taxonomy templates to ensure a cohesive and structurally sound layout.
- **Shortcodes**: Refined the `alert` shortcode to align with the theme's dark aesthetic.
- **Content**: Added sample documentation pages (`Introduction`, `Setup`) to demonstrate the theme's features.
- **Project Index**: Updated the root `tags.json` so the new site appears in the gallery with the tags: docs, dark, elegant, animation.
- **Verification**: Confirmed the build and visual design through automated screenshots and local server testing.

Fixes #905

---
*PR created automatically by Jules for task [9144247495179212416](https://jules.google.com/task/9144247495179212416) started by @hahwul*