### PR TITLE
Add dark-manual example site

### DIFF
--- a/dark-manual/AGENTS.md
+++ b/dark-manual/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/dark-manual/config.toml
+++ b/dark-manual/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Dark Manual"
+description = "A refined and trendy technical manual with industrial styling."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github-dark"    # Dark theme for syntax highlighting
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/dark-manual/content/getting-started/_index.md
+++ b/dark-manual/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/dark-manual/content/getting-started/configuration.md
+++ b/dark-manual/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/dark-manual/content/getting-started/installation.md
+++ b/dark-manual/content/getting-started/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
++++
+
+Learn how to install Hwaro on your system.
+
+## Prerequisites
+
+- [Crystal](https://crystal-lang.org/) 1.0 or later
+- Git (optional, for cloning)
+
+## Install from Source
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards install
+shards build --release
+```
+
+## Verify Installation
+
+```bash
+./bin/hwaro --version
+```
+
+You should see the version number if Hwaro is installed correctly.
+
+## Next Steps
+
+Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.

--- a/dark-manual/content/getting-started/quick-start.md
+++ b/dark-manual/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/dark-manual/content/guide/_index.md
+++ b/dark-manual/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/dark-manual/content/guide/content-management.md
+++ b/dark-manual/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/dark-manual/content/guide/shortcodes.md
+++ b/dark-manual/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/dark-manual/content/guide/templates.md
+++ b/dark-manual/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/dark-manual/content/index.md
+++ b/dark-manual/content/index.md
@@ -1,0 +1,36 @@
++++
+title = "System Overview"
+date = "2025-01-24"
+template = "page"
++++
+
+Welcome to the **Dark Manual** technical documentation system. This manual provides comprehensive specifications and operational procedures for industrial-grade deployments.
+
+## Core Architecture
+
+The system is designed with a modular architecture, prioritizing high-performance data processing and secure communication protocols.
+
+### Hardware Interface
+
+Operational units interface directly with the hardware abstraction layer (HAL) to ensure low-latency execution.
+
+| Component | Specification | Operational Status |
+|-----------|---------------|--------------------|
+| Core-Processor | 4.2GHz Hexa-core | ONLINE |
+| Memory-Bus | 64GB DDR5 | ACTIVE |
+| Thermal-Sync | Cryo-Grid 4.0 | OPTIMAL |
+| Network-Bridge | 10Gbps Fiber | CONNECTED |
+
+## Operational Procedures
+
+Follow these steps to initialize the core system and verify environmental stability.
+
+1.  **Verify Power Source**: Ensure primary and redundant power cells are at >85% capacity.
+2.  **Initialize HAL**: Execute `dm_syst --init` from the control terminal.
+3.  **Sync Data-Nodes**: Wait for the synchronization pulse to propagate through all active nodes.
+
+{{ alert(type="note", message="Always perform a manual thermal check before scaling operations beyond 150% load.") }}
+
+## Reference Data
+
+For detailed command-line interface parameters, please refer to the [CLI Operations]({{ base_url }}/reference/cli/) section.

--- a/dark-manual/content/reference/_index.md
+++ b/dark-manual/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/dark-manual/content/reference/cli.md
+++ b/dark-manual/content/reference/cli.md
@@ -1,0 +1,41 @@
++++
+title = "CLI Operations"
+date = "2025-01-24"
+template = "page"
++++
+
+The `dm_syst` command-line utility is the primary interface for system management and diagnostic reporting.
+
+## Command Structure
+
+All commands follow the standard industrial syntax:
+`dm_syst [MODULE] [ACTION] --flags`
+
+### Module Reference
+
+| Module | Purpose | Access Level |
+|--------|---------|--------------|
+| `core` | Primary system control | ADMIN |
+| `data` | Buffer and storage management | OPERATOR |
+| `link` | Network and external protocols | OPERATOR |
+| `sync` | Inter-node synchronization | SYSTEM |
+
+## Common Operations
+
+### System Status
+
+Check the current operational state of all core modules.
+
+```bash
+dm_syst core status --verbose
+```
+
+### Buffer Flush
+
+Clear volatile data buffers to reclaim memory blocks.
+
+```bash
+dm_syst data flush --force
+```
+
+{{ alert(type="warning", message="Data flush operations cannot be undone. Ensure all critical logs are archived before execution.") }}

--- a/dark-manual/content/reference/config.md
+++ b/dark-manual/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/dark-manual/static/css/style.css
+++ b/dark-manual/static/css/style.css
@@ -1,0 +1,324 @@
+:root {
+  --bg-primary: #121212;
+  --bg-secondary: #1a1a1a;
+  --bg-tertiary: #242424;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --text-muted: #666666;
+  --accent: #ff6b00; /* Industrial Orange */
+  --accent-muted: #cc5600;
+  --border: #333333;
+  --border-strong: #444444;
+  --code-bg: #0d0d0d;
+  --header-h: 60px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "IBM Plex Mono", monospace;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 40px 40px;
+  background-position: center center;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-primary);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  color: var(--text-primary);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+h1 { font-size: 2.5rem; margin-bottom: 2rem; border-left: 4px solid var(--accent); padding-left: 1rem; }
+
+/* Section Numbering */
+body { counter-reset: section; }
+.docs-main h2 { counter-reset: subsection; margin-top: 3rem; margin-bottom: 1.5rem; display: flex; align-items: baseline; }
+.docs-main h2::before {
+  counter-increment: section;
+  content: counter(section) ".0";
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--accent);
+  margin-right: 1rem;
+  font-weight: 400;
+}
+
+.docs-main h3 { counter-reset: subsubsection; margin-top: 2rem; margin-bottom: 1rem; display: flex; align-items: baseline; }
+.docs-main h3::before {
+  counter-increment: subsection;
+  content: counter(section) "." counter(subsection);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-right: 1rem;
+  font-weight: 400;
+}
+
+p { margin-bottom: 1.25rem; }
+
+/* Layout */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(18, 18, 18, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 2px solid var(--accent);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 1000;
+}
+
+.logo {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.logo span { color: var(--accent); }
+
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+}
+
+.docs-sidebar {
+  width: var(--sidebar-w);
+  border-right: 1px solid var(--border);
+  background: var(--bg-secondary);
+  height: calc(100vh - var(--header-h));
+  position: sticky;
+  top: var(--header-h);
+  padding: 2rem 1rem;
+  overflow-y: auto;
+}
+
+.sidebar-section { margin-bottom: 2rem; }
+.sidebar-title {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+.sidebar-links { list-style: none; }
+.sidebar-links a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+  border-left: 2px solid transparent;
+}
+.sidebar-links a:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-left-color: var(--accent-muted);
+}
+.sidebar-links a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--bg-tertiary);
+}
+
+.docs-main {
+  flex: 1;
+  padding: 4rem;
+  max-width: var(--content-max-w);
+  margin: 0 auto;
+}
+
+/* Reference Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-strong);
+}
+
+th {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  text-align: left;
+  padding: 1rem;
+  border-bottom: 2px solid var(--border-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+tr:hover td {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Code */
+code {
+  font-family: var(--font-mono);
+  background: var(--code-bg);
+  color: var(--accent);
+  padding: 0.2rem 0.4rem;
+  font-size: 0.9em;
+}
+
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border-strong);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+pre code {
+  color: var(--text-primary);
+  padding: 0;
+}
+
+/* Alerts */
+.info-box {
+  padding: 1.5rem;
+  margin: 2rem 0;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-secondary);
+  position: relative;
+}
+
+.info-box::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+}
+
+.info-box.note { border-color: #2997ff; }
+.info-box.note::before { background: #2997ff; }
+.info-box.warning { border-color: #ff9f0a; }
+.info-box.warning::before { background: #ff9f0a; }
+.info-box.tip { border-color: #30d158; }
+.info-box.tip::before { background: #30d158; }
+
+/* Search */
+.search-trigger {
+  margin-left: auto;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 2000;
+  justify-content: center;
+  padding-top: 10vh;
+}
+.search-overlay.active { display: flex; }
+
+.search-modal {
+  width: 600px;
+  max-width: 90vw;
+  background: var(--bg-secondary);
+  border: 1px solid var(--accent);
+  display: flex;
+  flex-direction: column;
+}
+
+.search-input-wrap {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-strong);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-input-wrap input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 1.2rem;
+  outline: none;
+}
+
+.search-results {
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.search-result-item {
+  display: block;
+  padding: 1rem;
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+}
+.search-result-item:hover { background: var(--bg-tertiary); }
+.search-result-title { color: var(--accent); font-weight: 700; margin-bottom: 0.25rem; }
+.search-result-snippet { color: var(--text-secondary); font-size: 0.85rem; }
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .docs-sidebar { display: none; }
+  .docs-main { padding: 2rem; }
+}

--- a/dark-manual/static/js/search.js
+++ b/dark-manual/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/dark-manual/templates/404.html
+++ b/dark-manual/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">CORE_MODULES</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">0.0 OVERVIEW</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">1.1 INSTALLATION</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">1.2 QUICK_START</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>404: MODULE_NOT_FOUND</h1>
+    <p>The requested system resource could not be located in the current memory map.</p>
+    <p><a href="{{ base_url }}/">Return to System Overview</a></p>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/dark-manual/templates/footer.html
+++ b/dark-manual/templates/footer.html
@@ -1,0 +1,9 @@
+  <footer class="docs-footer">
+    <div class="footer-content">
+      <p>&copy; {{ current_year }} DARK_MANUAL // INDUSTRIAL_DOCS_SYSTEM</p>
+    </div>
+  </footer>
+  <script src="{{ base_url }}/js/search.js"></script>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/dark-manual/templates/header.html
+++ b/dark-manual/templates/header.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} | {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">DM<span>_SYST</span></a>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>SEARCH_SYS</span>
+    </button>
+  </div>
+</header>
+
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="ENTER_QUERY..." autocomplete="off">
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>

--- a/dark-manual/templates/page.html
+++ b/dark-manual/templates/page.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">CORE_MODULES</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/" {% if page.url == base_url ~ "/" %}class="active"{% endif %}>0.0 OVERVIEW</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/" {% if page.url == base_url ~ "/getting-started/installation/" %}class="active"{% endif %}>1.1 INSTALLATION</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/" {% if page.url == base_url ~ "/getting-started/quick-start/" %}class="active"{% endif %}>1.2 QUICK_START</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">REF_DATA</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/cli/" {% if page.url == base_url ~ "/reference/cli/" %}class="active"{% endif %}>2.1 CLI_OPERATIONS</a></li>
+        <li><a href="{{ base_url }}/reference/config/" {% if page.url == base_url ~ "/reference/config/" %}class="active"{% endif %}>2.2 CONFIG_MAP</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+  </main>
+</div>
+{% include "footer.html" %}

--- a/dark-manual/templates/section.html
+++ b/dark-manual/templates/section.html
@@ -1,0 +1,33 @@
+{% include "header.html" %}
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">CORE_MODULES</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/" {% if page.url == base_url ~ "/" %}class="active"{% endif %}>0.0 OVERVIEW</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/" {% if page.url == base_url ~ "/getting-started/installation/" %}class="active"{% endif %}>1.1 INSTALLATION</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/" {% if page.url == base_url ~ "/getting-started/quick-start/" %}class="active"{% endif %}>1.2 QUICK_START</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">REF_DATA</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/cli/" {% if page.url == base_url ~ "/reference/cli/" %}class="active"{% endif %}>2.1 CLI_OPERATIONS</a></li>
+        <li><a href="{{ base_url }}/reference/config/" {% if page.url == base_url ~ "/reference/config/" %}class="active"{% endif %}>2.2 CONFIG_MAP</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ section.title | e }}</h1>
+    {{ content | safe }}
+
+    <ul class="section-list">
+      {% for p in section.pages %}
+      <li>
+        <a href="{{ p.url }}">{{ p.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/dark-manual/templates/shortcodes/alert.html
+++ b/dark-manual/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box {{ type }}">
+  <strong>{{ type | upper }}:</strong> {{ message }}
+</div>

--- a/dark-manual/templates/taxonomy_list.html
+++ b/dark-manual/templates/taxonomy_list.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">CORE_MODULES</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">0.0 OVERVIEW</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">1.1 INSTALLATION</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">1.2 QUICK_START</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ taxonomy_name | upper }}_INDEX</h1>
+
+    <ul class="section-list">
+      {% for term in taxonomy_terms %}
+      <li>
+        <a href="{{ term.url }}">{{ term.name }} ({{ term.count }})</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/dark-manual/templates/taxonomy_single.html
+++ b/dark-manual/templates/taxonomy_single.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">CORE_MODULES</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/">0.0 OVERVIEW</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">1.1 INSTALLATION</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">1.2 QUICK_START</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <h1>{{ taxonomy_name | upper }}: {{ taxonomy_term | e }}</h1>
+
+    <ul class="section-list">
+      {% for page in taxonomy_pages %}
+      <li>
+        <a href="{{ page.url }}">{{ page.title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+</div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -772,6 +772,12 @@
     "luxury",
     "glamorous"
   ],
+  "dark-manual": [
+    "docs",
+    "dark",
+    "technical",
+    "manual"
+  ],
   "darkfolio": [
     "dark",
     "portfolio",


### PR DESCRIPTION
This PR adds a new sophisticated and trendy docs example site called `dark-manual`.

Design Concept:
- Refined & Trendy Docs Design
- Dark-themed technical manual with industrial styling
- Automated section numbering (1.0, 1.1, etc.)
- Industrial palette: Graphite, Slate, and Industrial Orange accents
- Grid background and monospace technical details

Technical Implementation:
- Uses Hwaro `docs-dark` scaffold as a base
- Custom CSS for industrial aesthetic and section counters
- Refined templates for consistent technical manual layout
- High-quality sample content showcasing technical specifications and CLI operations
- Updated `tags.json` for site-wide indexing

Fixes #911

---
*PR created automatically by Jules for task [18113969523420010629](https://jules.google.com/task/18113969523420010629) started by @hahwul*