### PR TITLE
Add pastel-docs example site

### DIFF
--- a/pastel-docs/AGENTS.md
+++ b/pastel-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/pastel-docs/config.toml
+++ b/pastel-docs/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Pastel Docs"
+description = "A soft, friendly documentation theme with pastel gradients."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/pastel-docs/content/getting-started/_index.md
+++ b/pastel-docs/content/getting-started/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Getting Started"
++++
+
+We're so excited to help you begin your journey with Pastel Docs! This section is designed to walk you through everything you need to know to get set up and start creating beautiful, friendly documentation.
+
+Feel free to follow along at your own pace!

--- a/pastel-docs/content/getting-started/configuration.md
+++ b/pastel-docs/content/getting-started/configuration.md
@@ -1,0 +1,34 @@
++++
+title = "Configuration"
++++
+
+Let's make this project feel exactly like you! Configuring Pastel Docs is designed to be a gentle and intuitive process.
+
+## The `config.toml` file
+
+Your project's heart lives in the `config.toml` file. This is where you can give your project a title, a description, and more!
+
+```toml
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Friendly Project"
+description = "A beautiful, approachable documentation site."
+base_url = "http://localhost:3000"
+```
+
+## Customizing the Look
+
+You can make Pastel Docs truly your own by adjusting the CSS variables in `static/css/style.css`.
+
+- **Primary Color:** `--primary`
+- **Pastel Colors:** `--pastel-blue`, `--pastel-pink`, and more!
+
+<div class="info-box note">
+  **A friendly tip:** Don't be afraid to experiment! We've made it easy to try out new colors and see what feels best for you.
+</div>
+
+## Adding a Logo
+
+You can easily add your own logo to the header by updating the `header.html` template. Let's make it look fantastic together!

--- a/pastel-docs/content/getting-started/installation.md
+++ b/pastel-docs/content/getting-started/installation.md
@@ -1,0 +1,36 @@
++++
+title = "Installation"
++++
+
+Getting Pastel Docs up and running is as easy as pie! Just a few simple steps and you'll be on your way.
+
+## Step 1: Install Hwaro
+
+First things first, let's make sure you have Hwaro installed on your machine. We've worked hard to make this process feel friendly and straightforward.
+
+```bash
+# If you're on a Mac with Homebrew, just run:
+brew install hwaro
+```
+
+## Step 2: Create a new project
+
+Now, let's create a beautiful new space for your documentation:
+
+```bash
+hwaro init my-pastel-docs --scaffold docs
+```
+
+<div class="info-box tip">
+  **A friendly reminder:** Don't forget to navigate into your new project folder with `cd my-pastel-docs` before you start building!
+</div>
+
+## Step 3: Run the server
+
+Ready to see your work in action? Let's start the development server together:
+
+```bash
+hwaro serve
+```
+
+Now, just open your favorite browser and head over to `http://localhost:3000`. You're all set!

--- a/pastel-docs/content/getting-started/quick-start.md
+++ b/pastel-docs/content/getting-started/quick-start.md
@@ -1,0 +1,36 @@
++++
+title = "Quick Start"
++++
+
+Ready to get things moving together? This guide is designed to be a quick and friendly way to get your first page up and running.
+
+## Create your first page
+
+Let's make a new page called `hello-world.md` in the `content` folder:
+
+```bash
+# Using the Hwaro CLI to create a new page:
+hwaro new content/hello-world.md
+```
+
+## Add some friendly content
+
+Open up your new page and add a warm welcome:
+
+```markdown
++++
+title = "Hello World!"
++++
+
+This is my very first page in Pastel Docs! We're so excited to see what you create.
+```
+
+## Preview your work
+
+Now, just run `hwaro serve` and you'll see your new page appear in the navigation!
+
+<div class="info-box note">
+  **A friendly tip:** You can see your changes instantly as you save them! It's like magic, but better.
+</div>
+
+Happy writing!

--- a/pastel-docs/content/guide/_index.md
+++ b/pastel-docs/content/guide/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Guide"
++++
+
+Welcome to our guide! Here, we'll walk you through the many ways you can create beautiful and friendly documentation together.
+
+We hope you find this section helpful and inspiring!

--- a/pastel-docs/content/guide/content-management.md
+++ b/pastel-docs/content/guide/content-management.md
@@ -1,0 +1,45 @@
++++
+title = "Content Management"
++++
+
+Organizing your work should feel like a breeze! In Pastel Docs, managing your content is as friendly as it gets.
+
+## Using Sections
+
+You can group your pages into sections by creating folders in the `content` directory. Each folder should have an `_index.md` file to describe what's inside.
+
+```markdown
+content/
+  getting-started/
+    _index.md
+    installation.md
+    quick-start.md
+  guide/
+    _index.md
+    content-management.md
+```
+
+## Creating new pages
+
+Using the CLI is a quick and friendly way to make a new page:
+
+```bash
+hwaro new content/guide/new-page.md
+```
+
+<div class="info-box tip">
+  **A friendly tip:** You can even use the CLI to create new sections with `hwaro new content/new-section/_index.md`!
+</div>
+
+## Adding metadata
+
+Each page starts with a friendly block of metadata called frontmatter:
+
+```markdown
++++
+title = "My New Page"
+description = A gentle description of what's inside.
++++
+```
+
+Happy writing!

--- a/pastel-docs/content/guide/shortcodes.md
+++ b/pastel-docs/content/guide/shortcodes.md
@@ -1,0 +1,34 @@
++++
+title = "Shortcodes"
++++
+
+Let's make your content even more engaging together! Shortcodes in Pastel Docs are designed to be friendly and easy to use.
+
+## Using the `alert` shortcode
+
+Need to grab someone's attention with a gentle message? Just use the `alert` shortcode:
+
+```markdown
+{{ alert(type="note", content="A friendly tip: You're doing a great job!") }}
+```
+
+## Creating new shortcodes
+
+Want to add your own friendly components? You can easily create new shortcodes in the `templates/shortcodes/` folder!
+
+- **`alert.html`:** A gentle message for your readers.
+- **`button.html`:** A friendly call to action!
+
+<div class="info-box note">
+  **A friendly tip:** You can see your shortcode changes instantly as you save them! It's like magic, but better.
+</div>
+
+## Using Shortcodes in your content
+
+Just like this:
+
+```markdown
+{{ alert(type="tip", content="A friendly tip: You can use shortcodes in any page!") }}
+```
+
+Happy writing!

--- a/pastel-docs/content/guide/templates.md
+++ b/pastel-docs/content/guide/templates.md
@@ -1,0 +1,36 @@
++++
+title = "Templates"
++++
+
+Let's make your project look exactly how you want it to! Templates in Pastel Docs are designed to be friendly and flexible.
+
+## The `templates/` folder
+
+Your project's look is defined by the templates in the `templates/` folder. We've made them easy to understand and customize:
+
+- **`header.html`:** The friendly top bar with your logo and navigation.
+- **`footer.html`:** The gentle bottom section for your project's information.
+- **`page.html`:** The main layout for your individual pages.
+- **`section.html`:** The layout for your section overview pages.
+
+## Customizing the `header.html`
+
+Want to change the logo or the navigation links? Just open up `templates/header.html` and make your changes together!
+
+```html
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">My Friendly Logo</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <!-- Add your own links here! -->
+  </nav>
+</header>
+```
+
+<div class="info-box note">
+  **A friendly tip:** You can see your template changes instantly as you save them! It's like magic, but better.
+</div>
+
+## Using Crinja
+
+Templates in Pastel Docs use a friendly language called Crinja. It's designed to be simple and easy to learn. Let's make something fantastic together!

--- a/pastel-docs/content/index.md
+++ b/pastel-docs/content/index.md
@@ -1,0 +1,25 @@
++++
+title = "Welcome to Pastel Docs"
++++
+
+Welcome! We're so happy to have you here. **Pastel Docs** is designed to be a soft, friendly, and approachable space for all your documentation needs.
+
+Whether you're building a new project or organizing your thoughts, we hope this theme makes the process feel light and enjoyable.
+
+## Quick Start
+
+If you're ready to jump in, here are a few friendly places to start:
+
+- [**Installation Guide**](/getting-started/installation/) — A gentle guide to getting set up.
+- [**Quick Start**](/getting-started/quick-start/) — Let's get things moving together!
+- [**Core Concepts**](/guide/) — Exploring how everything works in harmony.
+
+<div class="info-box note">
+  **A friendly tip:** You can use the search bar at the top (or press `Cmd+K`) to find exactly what you're looking for in a flash!
+</div>
+
+## Why Pastel?
+
+We believe that documentation doesn't have to be cold or clinical. By using soft colors, rounded corners, and plenty of breathing room, we want to create a documentation experience that feels like a warm cup of tea on a rainy afternoon.
+
+Happy writing!

--- a/pastel-docs/content/reference/_index.md
+++ b/pastel-docs/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/pastel-docs/content/reference/cli.md
+++ b/pastel-docs/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/pastel-docs/content/reference/config.md
+++ b/pastel-docs/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/pastel-docs/static/css/style.css
+++ b/pastel-docs/static/css/style.css
@@ -1,0 +1,405 @@
+:root {
+  --primary: #90caf9; /* Pastel Blue Accent */
+  --primary-hover: #64b5f6;
+  --text: #37474f;
+  --text-secondary: #546e7a;
+  --text-muted: #90a4ae;
+  --border: #eceff1;
+  --border-light: #f5f7f8;
+  --bg: #ffffff;
+  --bg-secondary: #fafafa;
+  --bg-code: #fdfdfd;
+
+  /* Pastel Palette */
+  --pastel-blue: #e3f2fd;
+  --pastel-pink: #fce4ec;
+  --pastel-green: #e8f5e9;
+  --pastel-yellow: #fffde7;
+  --pastel-purple: #f3e5f5;
+  --pastel-orange: #fff3e0;
+
+  --header-h: 64px;
+  --sidebar-w: 280px;
+  --content-max-w: 800px;
+  --radius: 20px;
+  --radius-lg: 30px;
+  --radius-sm: 12px;
+
+  --shadow-soft: 0 4px 20px rgba(0, 0, 0, 0.04);
+  --shadow-medium: 0 8px 30px rgba(0, 0, 0, 0.06);
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Header */
+.docs-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-h);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  z-index: 100;
+}
+
+.docs-header .logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--text);
+  text-decoration: none;
+  margin-right: 2.5rem;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.docs-header .logo::before {
+  content: "";
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--pastel-blue), var(--pastel-pink));
+  border-radius: 8px;
+}
+
+.docs-header nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.docs-header nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  transition: all 0.2s ease;
+}
+
+.docs-header nav a:hover {
+  background: var(--pastel-blue);
+  color: var(--text);
+}
+
+.header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+/* Layout */
+.docs-container {
+  display: flex;
+  padding-top: var(--header-h);
+  min-height: 100vh;
+  background: linear-gradient(180deg, #ffffff 0%, var(--pastel-blue) 100%);
+  background-attachment: fixed;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: fixed;
+  top: var(--header-h);
+  left: 0;
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  background: transparent;
+  padding: 2rem 1rem;
+  overflow-y: auto;
+}
+
+.sidebar-section {
+  margin-bottom: 2rem;
+}
+
+.sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.08em;
+  padding-left: 1rem;
+}
+
+.sidebar-links {
+  list-style: none;
+}
+
+.sidebar-links li {
+  margin-bottom: 4px;
+}
+
+.sidebar-links a {
+  display: block;
+  padding: 0.6rem 1rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.sidebar-links a:hover {
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--text);
+  transform: translateX(4px);
+}
+
+.sidebar-links a.active {
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: var(--shadow-soft);
+  font-weight: 600;
+}
+
+/* Main content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 3rem 4rem;
+  max-width: calc(var(--content-max-w) + var(--sidebar-w) + 8rem);
+}
+
+.content-wrapper {
+  background: var(--bg);
+  padding: 3.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-medium);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+.docs-main h1 {
+  font-size: 2.75rem;
+  font-weight: 800;
+  margin: 0 0 1.5rem 0;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  color: var(--text);
+}
+
+.docs-main h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 3rem 0 1.25rem 0;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.docs-main h3 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 2.5rem 0 1rem 0;
+  color: var(--text);
+}
+
+.docs-main p {
+  margin-bottom: 1.25rem;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+/* Links */
+a {
+  color: #5c6bc0; /* Indigo-ish pastel accent */
+  text-decoration: none;
+  font-weight: 500;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Code */
+code {
+  background: var(--pastel-blue);
+  padding: 0.2rem 0.5rem;
+  border-radius: 8px;
+  font-size: 0.9em;
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+  color: #1976d2;
+}
+
+pre {
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  background: #f8f9fa;
+  border: 1px solid var(--border-light);
+  margin: 1.5rem 0 2rem 0;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.02);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.9rem;
+  color: inherit;
+}
+
+/* Info boxes */
+.info-box {
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius);
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+}
+
+.info-box.note {
+  background: var(--pastel-blue);
+  border-color: rgba(144, 202, 249, 0.3);
+  color: #1565c0;
+}
+
+.info-box.warning {
+  background: var(--pastel-orange);
+  border-color: rgba(255, 183, 77, 0.3);
+  color: #e65100;
+}
+
+.info-box.tip {
+  background: var(--pastel-green);
+  border-color: rgba(129, 199, 132, 0.3);
+  color: #2e7d32;
+}
+
+/* Section list */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0;
+  padding: 1.5rem;
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-light);
+  transition: all 0.3s ease;
+}
+
+ul.section-list li:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--shadow-medium);
+  border-color: var(--primary);
+}
+
+ul.section-list li a {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+/* Search trigger button */
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 200px;
+}
+
+.search-trigger:hover {
+  border-color: var(--primary);
+  background: var(--pastel-blue);
+  color: var(--text);
+}
+
+.search-trigger kbd {
+  margin-left: auto;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+/* Search Modal */
+.search-modal {
+  border-radius: var(--radius-lg) !important;
+  background: var(--bg) !important;
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.15) !important;
+}
+
+.search-input-wrap {
+  padding: 1.25rem 1.5rem !important;
+}
+
+.search-input-wrap input {
+  font-weight: 500;
+}
+
+/* Footer */
+.docs-footer {
+  margin-top: 5rem;
+  padding: 2.5rem 0;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .docs-main {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 1.5rem 1rem;
+  }
+  .content-wrapper {
+    padding: 2rem 1.5rem;
+  }
+  .docs-main h1 {
+    font-size: 2rem;
+  }
+}

--- a/pastel-docs/static/js/search.js
+++ b/pastel-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/pastel-docs/templates/404.html
+++ b/pastel-docs/templates/404.html
@@ -1,0 +1,65 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-wrapper">
+      <h1>{{ page.title | default(value="404 Not Found") | e }}</h1>
+      {{ content | safe }}
+      {% if not content %}
+      <p>The page you are looking for does not exist.</p>
+      <p><a href="{{ base_url }}/">Return to Home</a></p>
+      {% endif %}
+    </div>
+{% include "footer.html" %}

--- a/pastel-docs/templates/footer.html
+++ b/pastel-docs/templates/footer.html
@@ -1,0 +1,10 @@
+    <div class="docs-footer">
+      <p>Powered by Hwaro</p>
+    </div>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/pastel-docs/templates/header.html
+++ b/pastel-docs/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">

--- a/pastel-docs/templates/page.html
+++ b/pastel-docs/templates/page.html
@@ -1,0 +1,61 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-wrapper">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+    </div>
+{% include "footer.html" %}

--- a/pastel-docs/templates/section.html
+++ b/pastel-docs/templates/section.html
@@ -1,0 +1,67 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-wrapper">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+
+      <h2>In This Section</h2>
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </div>
+{% include "footer.html" %}

--- a/pastel-docs/templates/shortcodes/alert.html
+++ b/pastel-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="info-box {{ type | default(value='note') }}">
+  <strong>{{ type | default(value='note') | upper }}:</strong> {{ content }}
+</div>

--- a/pastel-docs/templates/taxonomy.html
+++ b/pastel-docs/templates/taxonomy.html
@@ -1,0 +1,62 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-wrapper">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content | safe }}
+    </div>
+{% include "footer.html" %}

--- a/pastel-docs/templates/taxonomy_term.html
+++ b/pastel-docs/templates/taxonomy_term.html
@@ -1,0 +1,64 @@
+{% include "header.html" %}
+<header class="docs-header">
+  <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+  <nav>
+    <a href="{{ base_url }}/getting-started/">Getting Started</a>
+    <a href="{{ base_url }}/guide/">Guide</a>
+    <a href="{{ base_url }}/reference/">Reference</a>
+  </nav>
+  <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" title="Search">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <span>Search</span>
+      <kbd>&#8984;K</kbd>
+    </button>
+  </div>
+</header>
+<div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+  <div class="search-modal">
+    <div class="search-input-wrap">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off">
+      <kbd onclick="closeSearch()">ESC</kbd>
+    </div>
+    <div class="search-results" id="searchResults"></div>
+  </div>
+</div>
+<div class="docs-container">
+  <aside class="docs-sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-title">Getting Started</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/getting-started/">Overview</a></li>
+        <li><a href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+        <li><a href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+        <li><a href="{{ base_url }}/getting-started/configuration/">Configuration</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Guide</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/guide/">Overview</a></li>
+        <li><a href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+        <li><a href="{{ base_url }}/guide/templates/">Templates</a></li>
+        <li><a href="{{ base_url }}/guide/shortcodes/">Shortcodes</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Reference</div>
+      <ul class="sidebar-links">
+        <li><a href="{{ base_url }}/reference/">Overview</a></li>
+        <li><a href="{{ base_url }}/reference/cli/">CLI Commands</a></li>
+        <li><a href="{{ base_url }}/reference/config/">Configuration</a></li>
+      </ul>
+    </div>
+  </aside>
+  <main class="docs-main">
+    <div class="content-wrapper">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+      <ul class="taxonomy-list">
+        {{ taxonomy.list }}
+      </ul>
+    </div>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3506,5 +3506,10 @@
     "docs",
     "light",
     "navigation"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
   ]
 }


### PR DESCRIPTION
I have added a new sophisticated and trendy documentation example site called `pastel-docs`. 

Key features:
- **Design:** Soft pastel palette (Blue, Pink, Green, Yellow, Purple) with gentle gradients.
- **Visuals:** Refined rounded look with 20px border-radius on content cards, search bars, and code blocks.
- **Typography:** Modern and approachable 'Inter' font.
- **Tone:** Friendly and warm content throughout the site.
- **Technical:** Consistent template structure for all page types, standardized TOML frontmatter, and an updated root `tags.json`.

I addressed initial review feedback by ensuring valid HTML nesting in 404 and taxonomy templates and fixing the `alert` shortcode to correctly display content using the theme's palette.

Fixes #912

---
*PR created automatically by Jules for task [1540526338441237826](https://jules.google.com/task/1540526338441237826) started by @hahwul*