### PR TITLE
Add evergreen-docs example site

### DIFF
--- a/evergreen-docs/config.toml
+++ b/evergreen-docs/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Evergreen Docs"
+description = "Refined documentation for modern enterprises with a timeless aesthetic."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/evergreen-docs/content/getting-started/_index.md
+++ b/evergreen-docs/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/evergreen-docs/content/getting-started/configuration.md
+++ b/evergreen-docs/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/evergreen-docs/content/getting-started/installation.md
+++ b/evergreen-docs/content/getting-started/installation.md
@@ -1,0 +1,31 @@
++++
+title = "Installation"
++++
+
+Learn how to install Hwaro on your system.
+
+## Prerequisites
+
+- [Crystal](https://crystal-lang.org/) 1.0 or later
+- Git (optional, for cloning)
+
+## Install from Source
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards install
+shards build --release
+```
+
+## Verify Installation
+
+```bash
+./bin/hwaro --version
+```
+
+You should see the version number if Hwaro is installed correctly.
+
+## Next Steps
+
+Once installed, proceed to the [Quick Start](/getting-started/quick-start.html) guide.

--- a/evergreen-docs/content/getting-started/quick-start.md
+++ b/evergreen-docs/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/evergreen-docs/content/guide/_index.md
+++ b/evergreen-docs/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/evergreen-docs/content/guide/content-management.md
+++ b/evergreen-docs/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/evergreen-docs/content/guide/shortcodes.md
+++ b/evergreen-docs/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/evergreen-docs/content/guide/templates.md
+++ b/evergreen-docs/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/evergreen-docs/content/index.md
+++ b/evergreen-docs/content/index.md
@@ -1,0 +1,29 @@
++++
+title = "Evergreen Documentation"
+description = "Sophisticated and timeless documentation for modern enterprises."
++++
+
+# Welcome to Evergreen Docs
+
+Evergreen provides a **refined and professional** documentation experience designed for high-end enterprises and sophisticated software projects. Our goal is to offer a timeless aesthetic that prioritizes clarity, readability, and a sense of established authority.
+
+## Why Evergreen?
+
+Documentation is more than just instructions; it's a reflection of your brand's commitment to quality and longevity.
+
+- **Classic Typography**: Using a harmonious blend of modern sans-serif and timeless serif fonts.
+- **Emerald Accents**: A sophisticated color palette that feels natural, professional, and trustworthy.
+- **Enterprise-Ready**: Designed to handle complex documentation hierarchies with a clean, organized layout.
+- **Performance First**: Built with Hwaro and Tailwind CSS for lightning-fast loading speeds and excellent SEO.
+
+## Quick Links
+
+Get started with Evergreen in minutes:
+
+1. [**Getting Started**](/getting-started/) — Learn the basics and set up your environment.
+2. [**Installation Guide**](/getting-started/installation/) — Step-by-step instructions for all platforms.
+3. [**Template Customization**](/guide/templates/) — Make Evergreen your own with our flexible templating system.
+
+---
+
+> "Documentation is the hallmark of a mature project. Evergreen ensures that your hallmark is as elegant as your code."

--- a/evergreen-docs/content/reference/_index.md
+++ b/evergreen-docs/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/evergreen-docs/content/reference/cli.md
+++ b/evergreen-docs/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/evergreen-docs/content/reference/config.md
+++ b/evergreen-docs/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/evergreen-docs/static/js/search.js
+++ b/evergreen-docs/static/js/search.js
@@ -1,0 +1,166 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    // Determine search.json URL relative to the current path or base_url
+    var searchUrl = window.location.origin + '/search.json';
+
+    // Attempt to find base_url from links if we are in a subdirectory
+    var navLinks = document.querySelectorAll('nav a');
+    if (navLinks.length > 0) {
+      var href = navLinks[0].getAttribute('href');
+      if (href && href.startsWith('http')) {
+        var url = new URL(href);
+        searchUrl = url.origin + '/search.json';
+      }
+    }
+
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function (err) {
+        console.error('Failed to load search index:', err);
+        searchData = []; cb([]);
+      });
+  }
+
+  window.openSearch = function () {
+    if (!overlay) return;
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    if (!overlay) return;
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay && overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    if (idx === -1) return content.substring(0, 140) + '...';
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 8);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="p-8 text-center text-slate-500">No results found for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item block p-4 rounded-lg border border-transparent transition-all mb-1" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title font-semibold text-slate-900 mb-1">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet text-sm text-slate-500 line-clamp-2">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="mt-4 p-3 border-t border-slate-100 flex gap-4 text-[10px] text-slate-400 uppercase tracking-widest font-semibold">'
+      + '<span><kbd class="bg-slate-50 border border-slate-200 px-1 rounded mr-1">↑↓</kbd> Navigate</span>'
+      + '<span><kbd class="bg-slate-50 border border-slate-200 px-1 rounded mr-1">Enter</kbd> Open</span>'
+      + '</div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/evergreen-docs/templates/404.html
+++ b/evergreen-docs/templates/404.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="text-center py-24">
+    <h1 class="text-9xl font-serif font-bold text-slate-200">404</h1>
+    <h2 class="text-3xl font-serif font-bold mt-4">Page Not Found</h2>
+    <p class="text-slate-600 mt-4 max-w-md mx-auto">The documentation page you're looking for might have been moved, renamed, or is temporarily unavailable.</p>
+    <div class="mt-10">
+      <a href="{{ base_url }}/" class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-emerald-700 hover:bg-emerald-800 transition-colors">
+        Go back home
+      </a>
+    </div>
+  </div>
+{% endblock %}

--- a/evergreen-docs/templates/base.html
+++ b/evergreen-docs/templates/base.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            emerald: {
+              50: '#ecfdf5',
+              100: '#d1fae5',
+              600: '#059669',
+              700: '#047857',
+              800: '#065f46',
+              900: '#064e3b',
+            },
+            slate: {
+              50: '#f8fafc',
+              900: '#0f172a',
+            }
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            serif: ['ui-serif', 'Georgia', 'Cambria', '"Times New Roman"', 'Times', 'serif'],
+          },
+        },
+      },
+    }
+  </script>
+
+  <style type="text/tailwindcss">
+    @layer base {
+      body {
+        @apply bg-slate-50 text-slate-900 font-sans antialiased;
+      }
+      h1, h2, h3, h4, h5, h6 {
+        @apply font-serif text-slate-900;
+      }
+    }
+
+    .prose {
+      @apply max-w-none text-slate-700 leading-relaxed;
+    }
+    .prose h1 { @apply text-4xl font-bold mb-8 mt-4; }
+    .prose h2 { @apply text-2xl font-semibold mb-4 mt-12 border-b border-slate-200 pb-2; }
+    .prose h3 { @apply text-xl font-semibold mb-3 mt-8; }
+    .prose p { @apply mb-6; }
+    .prose a { @apply text-emerald-700 hover:text-emerald-600 underline decoration-emerald-200 decoration-2 underline-offset-4 transition-all; }
+    .prose strong { @apply text-slate-900 font-semibold; }
+    .prose code {
+      @apply bg-slate-100 px-1.5 py-0.5 rounded text-sm font-mono text-emerald-800 border border-slate-200;
+    }
+    .prose pre {
+      @apply bg-slate-900 p-6 rounded-xl overflow-x-auto my-8 shadow-sm;
+    }
+    .prose pre code { @apply bg-transparent p-0 border-0 text-slate-300; }
+    .prose blockquote {
+      @apply my-8 pl-6 border-l-4 border-emerald-600 italic text-slate-600 bg-emerald-50/50 py-4 pr-4 rounded-r-lg;
+    }
+    .prose ul { @apply list-disc pl-6 mb-6 marker:text-emerald-600; }
+    .prose ol { @apply list-decimal pl-6 mb-6 marker:text-emerald-600; }
+    .prose li { @apply mb-2; }
+    .prose img { @apply rounded-xl border border-slate-200 shadow-sm my-8; }
+
+    /* Custom Scrollbar */
+    ::-webkit-scrollbar {
+      width: 10px;
+    }
+    ::-webkit-scrollbar-track {
+      @apply bg-slate-100;
+    }
+    ::-webkit-scrollbar-thumb {
+      @apply bg-slate-300 rounded-full border-2 border-solid border-slate-100 hover:bg-slate-400;
+    }
+
+    /* Search Styles */
+    #searchOverlay.active {
+      @apply opacity-100 pointer-events-auto;
+    }
+    .search-result-item.active {
+      @apply bg-emerald-50 border-emerald-200;
+    }
+    .search-result-item.active .search-result-title {
+      @apply text-emerald-900;
+    }
+    mark {
+      @apply bg-emerald-100 text-emerald-900 font-medium px-0.5 rounded;
+    }
+  </style>
+
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body class="flex flex-col min-h-screen">
+  <!-- Sticky Header -->
+  <header class="sticky top-0 z-40 w-full backdrop-blur flex-none transition-colors duration-500 lg:z-50 lg:border-b lg:border-slate-900/10 bg-white/95">
+    <div class="max-w-8xl mx-auto">
+      <div class="py-4 border-b border-slate-900/10 lg:px-8 lg:border-0 mx-4 lg:mx-0">
+        <div class="relative flex items-center">
+          <a class="mr-3 flex-none w-[2.0625rem] overflow-hidden md:w-auto" href="{{ base_url }}/">
+            <span class="sr-only">Evergreen Docs home page</span>
+            <div class="flex items-center gap-2">
+              <div class="w-8 h-8 bg-emerald-700 rounded-lg flex items-center justify-center text-white font-serif font-bold text-xl">E</div>
+              <span class="text-slate-900 font-serif font-bold text-xl tracking-tight">Evergreen <span class="text-emerald-700 font-normal italic">Docs</span></span>
+            </div>
+          </a>
+          <nav class="hidden md:flex items-center ml-auto text-sm font-medium text-slate-700">
+            <a href="{{ base_url }}/getting-started/" class="hover:text-emerald-700 px-4 py-2">Getting Started</a>
+            <a href="{{ base_url }}/guide/" class="hover:text-emerald-700 px-4 py-2">Guide</a>
+            <a href="{{ base_url }}/reference/" class="hover:text-emerald-700 px-4 py-2 border-r border-slate-200 mr-4">Reference</a>
+            <div class="flex items-center gap-4 pl-4">
+              <button onclick="openSearch()" class="text-slate-400 hover:text-slate-500 flex items-center gap-2 px-3 py-1.5 border border-slate-200 rounded-md bg-slate-50 text-xs">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                <span>Search</span>
+                <kbd class="font-sans font-semibold">⌘K</kbd>
+              </button>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- Search Overlay -->
+  <div id="searchOverlay" class="fixed inset-0 z-50 bg-slate-900/50 backdrop-blur-sm opacity-0 pointer-events-none transition-opacity duration-200 flex items-start justify-center pt-24" onclick="if(event.target===this)closeSearch()">
+    <div class="bg-white w-full max-w-2xl rounded-xl shadow-2xl overflow-hidden mx-4 flex flex-col max-h-[70vh]">
+      <div class="p-4 border-b border-slate-200 flex items-center gap-3">
+        <svg width="20" height="20" class="text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search documentation..." autocomplete="off" class="flex-1 text-lg outline-none text-slate-900 placeholder-slate-400">
+        <kbd class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-500 cursor-pointer" onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div id="searchResults" class="overflow-y-auto p-2">
+        <!-- Results injected here -->
+      </div>
+    </div>
+  </div>
+
+  <div class="flex-auto w-full max-w-8xl mx-auto lg:flex">
+    <!-- Sidebar -->
+    <aside class="hidden lg:block fixed z-20 inset-0 top-[3.8125rem] left-[max(0px,calc(50%-45rem))] right-auto w-[19rem] pb-10 px-8 overflow-y-auto border-r border-slate-100">
+      <nav class="lg:text-sm lg:leading-6 relative pt-10">
+        <div class="space-y-10">
+          <div>
+            <h5 class="mb-4 lg:mb-3 font-semibold text-slate-900">Getting Started</h5>
+            <ul class="space-y-2 border-l border-slate-100">
+              <li><a class="block border-l pl-4 -ml-px border-transparent hover:border-slate-400 text-slate-700 hover:text-slate-900 py-1" href="{{ base_url }}/getting-started/">Overview</a></li>
+              <li><a class="block border-l pl-4 -ml-px border-transparent hover:border-slate-400 text-slate-700 hover:text-slate-900 py-1" href="{{ base_url }}/getting-started/installation/">Installation</a></li>
+              <li><a class="block border-l pl-4 -ml-px border-transparent hover:border-slate-400 text-slate-700 hover:text-slate-900 py-1" href="{{ base_url }}/getting-started/quick-start/">Quick Start</a></li>
+            </ul>
+          </div>
+          <div>
+            <h5 class="mb-4 lg:mb-3 font-semibold text-slate-900">Core Concepts</h5>
+            <ul class="space-y-2 border-l border-slate-100">
+              <li><a class="block border-l pl-4 -ml-px border-transparent hover:border-slate-400 text-slate-700 hover:text-slate-900 py-1" href="{{ base_url }}/guide/content-management/">Content Management</a></li>
+              <li><a class="block border-l pl-4 -ml-px border-transparent hover:border-slate-400 text-slate-700 hover:text-slate-900 py-1" href="{{ base_url }}/guide/templates/">Templates</a></li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="lg:pl-[19rem] flex-auto">
+      <div class="max-w-3xl mx-auto pt-10 pb-24 px-6 lg:px-8">
+        <article class="prose">
+          {% block content %}{% endblock %}
+        </article>
+
+        <footer class="mt-24 pt-10 border-t border-slate-200">
+          <div class="flex justify-between items-center text-sm text-slate-500">
+            <p>&copy; {{ current_year }} Evergreen Docs. Built with Hwaro.</p>
+            <div class="flex gap-6">
+              <a href="#" class="hover:text-slate-900">Status</a>
+              <a href="#" class="hover:text-slate-900">Privacy</a>
+              <a href="#" class="hover:text-slate-900">Terms</a>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </main>
+  </div>
+
+  {{ highlight_js }}
+  <script src="{{ base_url }}/js/search.js"></script>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/evergreen-docs/templates/page.html
+++ b/evergreen-docs/templates/page.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  {{ content | safe }}
+{% endblock %}

--- a/evergreen-docs/templates/section.html
+++ b/evergreen-docs/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  {{ content | safe }}
+
+  <div class="mt-12">
+    <h2 class="text-xl font-bold mb-6">Articles in this section</h2>
+    <div class="grid gap-4">
+      {{ section.list | safe }}
+    </div>
+  </div>
+{% endblock %}

--- a/evergreen-docs/templates/shortcodes/alert.html
+++ b/evergreen-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/evergreen-docs/templates/taxonomy.html
+++ b/evergreen-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  <div class="mt-8">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/evergreen-docs/templates/taxonomy_term.html
+++ b/evergreen-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>{{ page.title | e }}</h1>
+  <div class="mt-8">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1033,6 +1033,12 @@
     "light",
     "blog"
   ],
+  "evergreen-docs": [
+    "docs",
+    "light",
+    "enterprise",
+    "classic"
+  ],
   "faberge": [
     "light",
     "blog",


### PR DESCRIPTION
Added a new sophisticated documentation example site 'evergreen-docs' with a refined enterprise-grade design, emerald green accents, and professional typography. Features a robust Tailwind-based layout with template inheritance, a functional search implementation, and comprehensive sample content.

Fixes #916

---
*PR created automatically by Jules for task [12139575298298804339](https://jules.google.com/task/12139575298298804339) started by @chei-l*