### PR TITLE
Add obsidian-docs example site

### DIFF
--- a/obsidian-docs/AGENTS.md
+++ b/obsidian-docs/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/obsidian-docs/config.toml
+++ b/obsidian-docs/config.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Obsidian Docs"
+description = "A sophisticated, ultra-dark documentation theme inspired by Obsidian. Features purple accents, knowledge graph concepts, and wiki-style cross-linking."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+# =============================================================================
+# Markdown Configuration
+# =============================================================================
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/obsidian-docs/content/getting-started/_index.md
+++ b/obsidian-docs/content/getting-started/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Getting Started"
++++
+
+Welcome to the Getting Started guide. This section will help you set up your first Hwaro documentation site.
+
+## What You'll Learn
+
+1. How to install Hwaro
+2. Creating your first documentation site
+3. Basic configuration options
+4. Building and previewing your site

--- a/obsidian-docs/content/getting-started/configuration.md
+++ b/obsidian-docs/content/getting-started/configuration.md
@@ -1,0 +1,36 @@
++++
+title = "Configuration"
++++
+
+Hwaro is configured through a `config.toml` file in your project root.
+
+## Basic Configuration
+
+```toml
+title = "My Documentation"
+description = "Project documentation"
+base_url = "https://docs.example.com"
+```
+
+## Search Configuration
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+```
+
+## SEO Configuration
+
+```toml
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+```
+
+## Full Reference
+
+See the [Configuration Reference](/reference/config.html) for all available options.

--- a/obsidian-docs/content/getting-started/installation.md
+++ b/obsidian-docs/content/getting-started/installation.md
@@ -1,0 +1,33 @@
++++
+title = "Installation"
+description = "How to install and set up your Obsidian-style docs."
+tags = ["setup", "install"]
++++
+
+Setting up your **Obsidian Docs** is straightforward.
+
+## Prerequisites
+
+Before you begin, ensure you have <a href="https://github.com/hahwul/hwaro" class="wiki-link">Hwaro</a> installed on your system.
+
+## Quick Install
+
+1.  Initialize a new project:
+    ```bash
+    hwaro init my-docs --scaffold docs
+    ```
+2.  Apply the Obsidian theme (copy the styles and templates).
+3.  Run the development server:
+    ```bash
+    hwaro serve
+    ```
+
+## Vault Structure
+
+We recommend organizing your notes into logical folders:
+
+- `/daily`: For journal entries.
+- `/projects`: For active work.
+- `/archive`: For completed knowledge.
+
+{{ alert(type="note", content="Links like [[Installation]] are automatically styled as wiki links in this theme.") }}

--- a/obsidian-docs/content/getting-started/quick-start.md
+++ b/obsidian-docs/content/getting-started/quick-start.md
@@ -1,0 +1,46 @@
++++
+title = "Quick Start"
++++
+
+Get up and running with Hwaro in minutes.
+
+## Create a New Project
+
+```bash
+hwaro init my-docs --scaffold docs
+cd my-docs
+```
+
+## Project Structure
+
+```
+my-docs/
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── index.md
+│   ├── getting-started/
+│   └── guide/
+├── templates/           # Jinja2 templates
+└── static/              # Static assets
+```
+
+## Build Your Site
+
+```bash
+hwaro build
+```
+
+The generated site will be in the `public/` directory.
+
+## Preview Locally
+
+```bash
+hwaro serve
+```
+
+Visit `http://localhost:3000` to see your site.
+
+## Next Steps
+
+- Read about [Configuration](/getting-started/configuration.html)
+- Learn about [Content Management](/guide/content-management.html)

--- a/obsidian-docs/content/guide/_index.md
+++ b/obsidian-docs/content/guide/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Guide"
++++
+
+This section contains in-depth guides for using Hwaro effectively.
+
+## Topics
+
+Learn about the core concepts and features of Hwaro:
+
+- **Content Management** - Organize and write your documentation
+- **Templates** - Customize the look and feel of your site
+- **Shortcodes** - Add reusable components to your content

--- a/obsidian-docs/content/guide/content-management.md
+++ b/obsidian-docs/content/guide/content-management.md
@@ -1,0 +1,54 @@
++++
+title = "Content Management"
++++
+
+Learn how to organize and write content in Hwaro.
+
+## Content Directory
+
+All content files live in the `content/` directory:
+
+```
+content/
+├── index.md              # Homepage
+├── getting-started/      # Section
+│   ├── _index.md         # Section index
+│   ├── installation.md   # Page
+│   └── quick-start.md    # Page
+└── guide/
+    └── ...
+```
+
+## Front Matter
+
+Each content file starts with front matter in TOML format:
+
+```markdown
++++
+title = "Page Title"
+date = "2024-01-01"
+description = "Page description for SEO"
++++
+
+# Your Content Here
+```
+
+## Sections
+
+Sections are directories containing related content. Each section should have an `_index.md` file.
+
+## Links
+
+Link to other pages using relative paths:
+
+```markdown
+[Installation](/getting-started/installation.html)
+```
+
+## Images
+
+Place images in `static/` and reference them:
+
+```markdown
+![Diagram](/images/diagram.png)
+```

--- a/obsidian-docs/content/guide/shortcodes.md
+++ b/obsidian-docs/content/guide/shortcodes.md
@@ -1,0 +1,58 @@
++++
+title = "Shortcodes"
++++
+
+Shortcodes are reusable content snippets you can embed in your Markdown.
+
+## Using Shortcodes
+
+In your Markdown content:
+
+```jinja
+{{ alert(type="info", body="This is an info alert") }}
+```
+
+## Built-in Shortcodes
+
+### Alert
+
+Display an alert box:
+
+```jinja
+{{ alert(type="warning", body="Be careful!") }}
+```
+
+Types: `info`, `warning`, `tip`, `note`
+
+## Creating Custom Shortcodes
+
+1. Create a template in `templates/shortcodes/`:
+
+```jinja
+{# templates/shortcodes/highlight.html #}
+<mark class="highlight">{{ text }}</mark>
+```
+
+2. Use it in your content:
+
+```jinja
+{{ highlight(text="Important text here") }}
+```
+
+## Advanced Example
+
+```jinja
+{# templates/shortcodes/alert.html #}
+{% if type and body %}
+<div class="alert alert-{{ type }}">
+  {{ body | safe }}
+</div>
+{% endif %}
+```
+
+## Best Practices
+
+- Keep shortcodes simple and focused
+- Document your custom shortcodes
+- Use semantic HTML in shortcode templates
+- Use the `safe` filter for HTML content

--- a/obsidian-docs/content/guide/templates.md
+++ b/obsidian-docs/content/guide/templates.md
@@ -1,0 +1,51 @@
++++
+title = "Templates"
++++
+
+Hwaro uses Jinja2-compatible templates (via Crinja) for rendering pages.
+
+## Template Directory
+
+Templates are stored in `templates/`:
+
+```
+templates/
+├── base.html       # Base template with common structure
+├── page.html       # Regular pages
+├── section.html    # Section indexes
+├── partials/       # Partial templates
+│   └── nav.html
+└── shortcodes/     # Shortcode templates
+```
+
+## Available Variables
+
+In templates, you have access to:
+
+| Flat Variable | Object Access | Description |
+|---------------|---------------|-------------|
+| `page_title` | `page.title` | Current page title |
+| `site_title` | `site.title` | Site title from config |
+| `content` | — | Rendered page content |
+| `base_url` | `site.base_url` | Site base URL |
+
+## Template Inheritance
+
+Extend base templates:
+
+```jinja
+{% extends "base.html" %}
+{% block content %}{{ content }}{% endblock %}
+```
+
+## Including Partials
+
+Include other templates:
+
+```jinja
+{% include "partials/nav.html" %}
+```
+
+## Customization
+
+Modify templates to change the site layout, add navigation, or include custom scripts.

--- a/obsidian-docs/content/index.md
+++ b/obsidian-docs/content/index.md
@@ -1,0 +1,27 @@
++++
+title = "Digital Garden Overview"
+description = "Welcome to the Obsidian-inspired digital garden."
++++
+
+Welcome to the **Obsidian Docs** example. This site demonstrates a sophisticated, ultra-dark documentation theme designed for knowledge bases, wikis, and digital gardens.
+
+## Design Concept
+
+This theme is built with an **OLED-optimized** palette, utilizing true blacks and deep grays to create a focused, distraction-free environment.
+
+### Core Features
+
+- **Wiki-style linking**: Use double brackets or standard markdown for cross-linking.
+- **Glassmorphism**: Subtle glass effects on cards and sidebars.
+- **Typography**: Refined pairing of [Inter](https://rsms.me/inter/) and [JetBrains Mono](https://www.jetbrains.com/lp/mono/).
+- **Knowledge Graph**: A structured sidebar that acts as your knowledge map.
+
+## Navigation
+
+Explore the different sections of this documentation:
+
+- <a href="/getting-started/" class="wiki-link">Getting Started</a>: Learn how to initialize your vault.
+- <a href="/guide/" class="wiki-link">User Guide</a>: Master the art of note-taking.
+- <a href="/reference/" class="wiki-link">API Reference</a>: Deep dive into the technical details.
+
+{{ alert(type="tip", content="Try pressing ⌘K to search through your knowledge base!") }}

--- a/obsidian-docs/content/reference/_index.md
+++ b/obsidian-docs/content/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
++++
+
+Technical reference documentation for Hwaro.
+
+## Contents
+
+- **CLI Commands** - All available command-line commands
+- **Configuration** - Complete configuration options reference

--- a/obsidian-docs/content/reference/cli.md
+++ b/obsidian-docs/content/reference/cli.md
@@ -1,0 +1,73 @@
++++
+title = "CLI Commands"
++++
+
+Reference for all Hwaro command-line commands.
+
+## hwaro init
+
+Initialize a new Hwaro project.
+
+```bash
+hwaro init [path] [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--scaffold TYPE` | Scaffold type: simple, blog, blog-dark, docs, docs-dark, book, book-dark (default: simple) |
+| `--force` | Overwrite existing files |
+| `--skip-sample-content` | Don't create sample content |
+
+**Examples:**
+
+```bash
+hwaro init my-site
+hwaro init my-blog --scaffold blog
+hwaro init my-blog --scaffold blog-dark
+hwaro init my-docs --scaffold docs --force
+hwaro init my-docs --scaffold docs-dark
+hwaro init my-book --scaffold book
+hwaro init my-book --scaffold book-dark
+```
+
+## hwaro build
+
+Build the static site.
+
+```bash
+hwaro build [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--config FILE` | Use a custom config file |
+| `--output DIR` | Output directory (default: public) |
+
+## hwaro serve
+
+Start a development server.
+
+```bash
+hwaro serve [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Server port (default: 3000) |
+| `--host HOST` | Server host (default: localhost) |
+
+## hwaro new
+
+Create a new content file.
+
+```bash
+hwaro new [path]
+```
+
+Creates a new Markdown file with front matter template.

--- a/obsidian-docs/content/reference/config.md
+++ b/obsidian-docs/content/reference/config.md
@@ -1,0 +1,67 @@
++++
+title = "Configuration Reference"
++++
+
+Complete reference for `config.toml` options.
+
+## Site Settings
+
+```toml
+title = "Site Title"
+description = "Site description"
+base_url = "https://example.com"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `base_url` | string | Production URL |
+
+## Search
+
+```toml
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | false | Enable search index |
+| `format` | string | "fuse_json" | Index format |
+| `fields` | array | ["title"] | Fields to index |
+
+## Sitemap
+
+```toml
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+```
+
+## RSS/Atom Feeds
+
+```toml
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+```
+
+## Taxonomies
+
+```toml
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 10
+```

--- a/obsidian-docs/server.log
+++ b/obsidian-docs/server.log
@@ -1,0 +1,10 @@
+Performing initial build...
+Building site...
+  Found 12 pages.
+  Generated robots.txt
+  Generated llms.txt
+  Generated search index with 12 pages.
+Build complete! Generated 12 pages in 16.51ms.
+Serving site at http://127.0.0.1:3000
+Press Ctrl+C to stop.
+Watching for changes in content/, templates/, static/ and config.toml...

--- a/obsidian-docs/static/css/style.css
+++ b/obsidian-docs/static/css/style.css
@@ -1,0 +1,337 @@
+/* ==========================================================================
+   Obsidian Docs -- Refined & Trendy Knowledge Base
+   Ultra-dark OLED optimized with purple accents
+   ========================================================================== */
+
+:root {
+  --bg: #050505;
+  --bg-sidebar: #0a0a0a;
+  --bg-card: rgba(255, 255, 255, 0.03);
+  --bg-card-hover: rgba(255, 255, 255, 0.05);
+  --bg-code: #0d0d0d;
+  --border: #1f2937;
+  --border-glass: rgba(255, 255, 255, 0.08);
+  --text: #e5e7eb;
+  --text-secondary: #9ca3af;
+  --text-muted: #6b7280;
+  --accent: #a855f7;
+  --accent-dim: rgba(168, 85, 247, 0.15);
+  --accent-glow: rgba(168, 85, 247, 0.3);
+  --header-h: 60px;
+  --sidebar-w: 280px;
+  --content-max-w: 900px;
+  --radius: 8px;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  background-image:
+    radial-gradient(circle at 2px 2px, var(--border) 1px, transparent 0);
+  background-size: 40px 40px;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* ==========================================================================
+   Layout
+   ========================================================================== */
+
+.docs-container {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  width: var(--sidebar-w);
+  height: 100vh;
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  padding: 2rem 1.5rem;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--text);
+  text-decoration: none;
+  margin-bottom: 2.5rem;
+}
+
+.sidebar-logo .dot {
+  width: 10px;
+  height: 100%;
+  aspect-ratio: 1/1;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 10px var(--accent-glow);
+}
+
+.sidebar-nav-section {
+  margin-bottom: 2rem;
+}
+
+.sidebar-nav-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+
+.sidebar-nav-list {
+  list-style: none;
+}
+
+.sidebar-nav-item a {
+  display: block;
+  padding: 0.4rem 0;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.sidebar-nav-item a:hover {
+  color: var(--accent);
+  transform: translateX(4px);
+}
+
+.sidebar-nav-item.active a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* Main Content */
+.docs-main {
+  flex: 1;
+  margin-left: var(--sidebar-w);
+  padding: 4rem 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.docs-content {
+  width: 100%;
+  max-width: var(--content-max-w);
+}
+
+/* ==========================================================================
+   Typography & Prose
+   ========================================================================== */
+
+.prose h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 1.5rem;
+  color: #fff;
+}
+
+.prose h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  color: #fff;
+}
+
+.prose h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose p {
+  margin-bottom: 1.25rem;
+  color: var(--text-secondary);
+}
+
+.prose a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s;
+}
+
+.prose a:hover {
+  border-bottom-color: var(--accent);
+}
+
+.prose ul, .prose ol {
+  margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.prose li {
+  margin-bottom: 0.5rem;
+}
+
+/* ==========================================================================
+   Components
+   ========================================================================== */
+
+.glass-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.glass-card:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--accent-dim);
+}
+
+/* Alert / Callout */
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  display: flex;
+  gap: 1rem;
+  border: 1px solid var(--border-glass);
+}
+
+.alert-info { background: rgba(59, 130, 246, 0.1); border-color: rgba(59, 130, 246, 0.2); color: #93c5fd; }
+.alert-warning { background: rgba(245, 158, 11, 0.1); border-color: rgba(245, 158, 11, 0.2); color: #fcd34d; }
+.alert-tip { background: rgba(16, 185, 129, 0.1); border-color: rgba(16, 185, 129, 0.2); color: #6ee7b7; }
+.alert-note { background: var(--bg-card); border-color: var(--border-glass); color: var(--text-secondary); }
+
+/* Code Blocks */
+code {
+  font-family: var(--font-mono);
+  background: var(--bg-sidebar);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: var(--accent);
+}
+
+pre {
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 0.88rem;
+}
+
+/* ==========================================================================
+   Search Trigger (In sidebar)
+   ========================================================================== */
+
+.search-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  margin-bottom: 2rem;
+  transition: border-color 0.2s;
+}
+
+.search-trigger:hover {
+  border-color: var(--accent);
+}
+
+.search-trigger kbd {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+}
+
+/* ==========================================================================
+   Wiki Links Concept
+   ========================================================================== */
+
+.wiki-link {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: none;
+  position: relative;
+}
+
+.wiki-link::before {
+  content: '[[';
+  color: var(--text-muted);
+  margin-right: 2px;
+  opacity: 0.5;
+}
+
+.wiki-link::after {
+  content: ']]';
+  color: var(--text-muted);
+  margin-left: 2px;
+  opacity: 0.5;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 1024px) {
+  .docs-sidebar {
+    width: 240px;
+  }
+  .docs-main {
+    margin-left: 240px;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+  }
+  .docs-main {
+    margin-left: 0;
+    padding: 2rem 1.5rem;
+  }
+}

--- a/obsidian-docs/static/js/search.js
+++ b/obsidian-docs/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/obsidian-docs/templates/404.html
+++ b/obsidian-docs/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/obsidian-docs/templates/footer.html
+++ b/obsidian-docs/templates/footer.html
@@ -1,0 +1,23 @@
+      </div><!-- .docs-content -->
+    </main><!-- .docs-main -->
+  </div><!-- .docs-container -->
+
+  {% if site.search and site.search.enabled %}
+  <div id="searchOverlay" class="search-overlay">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        <input type="text" id="searchInput" placeholder="Search notes and files..." autocomplete="off">
+        <kbd onclick="closeSearch()">ESC</kbd>
+      </div>
+      <div id="searchResults" class="search-results"></div>
+      <div class="search-hint">
+        <span><kbd>↑↓</kbd> to navigate</span>
+        <span><kbd>↵</kbd> to select</span>
+      </div>
+    </div>
+  </div>
+  <script src="{{ base_url }}/js/search.js"></script>
+  {% endif %}
+</body>
+</html>

--- a/obsidian-docs/templates/header.html
+++ b/obsidian-docs/templates/header.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{{ page.title | e }} - {{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="docs-container">
+    <aside class="docs-sidebar">
+      <a href="{{ base_url }}/" class="sidebar-logo">
+        <span class="dot"></span>
+        <span>{{ site.title }}</span>
+      </a>
+
+      {% if site.search and site.search.enabled %}
+      <button class="search-trigger" onclick="openSearch()">
+        <span>Search notes...</span>
+        <kbd>⌘K</kbd>
+      </button>
+      {% endif %}
+
+      <nav class="sidebar-nav">
+        {% set section_started = "" %}
+        <div class="sidebar-nav-section">
+          <div class="sidebar-nav-title">Knowledge</div>
+          <ul class="sidebar-nav-list">
+            <li class="sidebar-nav-item {% if current_path == '/' %}active{% endif %}">
+              <a href="{{ base_url }}/">Overview</a>
+            </li>
+          </ul>
+        </div>
+
+        {% for s in site.sections %}
+        <div class="sidebar-nav-section">
+          <div class="sidebar-nav-title">{{ s.title }}</div>
+          <ul class="sidebar-nav-list">
+            {% for p in s.pages %}
+            <li class="sidebar-nav-item {% if current_path == p.path %}active{% endif %}">
+              <a href="{{ base_url }}{{ p.path }}">{{ p.title }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endfor %}
+      </nav>
+    </aside>
+
+    <main class="docs-main">
+      <div class="docs-content prose">

--- a/obsidian-docs/templates/page.html
+++ b/obsidian-docs/templates/page.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+
+<article>
+  <header>
+    <h1>{{ page.title }}</h1>
+  </header>
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.taxonomies and page.taxonomies.tags %}
+  <footer class="page-footer">
+    <div class="tags">
+      {% for tag in page.taxonomies.tags %}
+      <a href="{{ get_taxonomy_url(kind="tags", name=tag) }}" class="tag">#{{ tag }}</a>
+      {% endfor %}
+    </div>
+  </footer>
+  {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/obsidian-docs/templates/section.html
+++ b/obsidian-docs/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+<div class="section-container">
+  <header>
+    <h1>{{ section.title }}</h1>
+    {% if section.content %}
+    <div class="section-description">
+      {{ section.content | safe }}
+    </div>
+    {% endif %}
+  </header>
+
+  <div class="section-pages">
+    <ul class="section-list">
+      {% for page in section.pages %}
+      <li class="glass-card">
+        <a href="{{ base_url }}{{ page.path }}">
+          <h3>{{ page.title }}</h3>
+          {% if page.description %}
+          <p>{{ page.description }}</p>
+          {% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+
+{% include "footer.html" %}

--- a/obsidian-docs/templates/shortcodes/alert.html
+++ b/obsidian-docs/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type }}">
+  {{ content | safe }}
+</div>

--- a/obsidian-docs/templates/taxonomy.html
+++ b/obsidian-docs/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/obsidian-docs/templates/taxonomy_term.html
+++ b/obsidian-docs/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1660,16 +1660,16 @@
     "luminescent",
     "mesh"
   ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
   "lunar-breeze": [
     "dark",
     "blog",
     "elegant",
     "minimal"
-  ],
-  "lunar-base": [
-    "elegant",
-    "portfolio",
-    "dark"
   ],
   "luxe-noir": [
     "dark",
@@ -2127,6 +2127,12 @@
     "wiki",
     "glass",
     "oled"
+  ],
+  "obsidian-docs": [
+    "docs",
+    "dark",
+    "wiki",
+    "knowledge"
   ],
   "obsidian-mirror": [
     "dark",


### PR DESCRIPTION
I have added a new example site called `obsidian-docs`. This site is designed with a sophisticated and trendy 'Obsidian-dark' aesthetic, featuring purple accents, a background grid pattern, and glassmorphism. It uses a documentation-focused structure with a sidebar navigation that mimics a knowledge base or digital garden. I have also implemented wiki-style cross-linking styles and updated the global `tags.json` to include this new example. During the process, I fixed several template bugs related to undefined variables and path concatenation to ensure a smoother build process.

Fixes #919

---
*PR created automatically by Jules for task [15106511648148112445](https://jules.google.com/task/15106511648148112445) started by @hahwul*