### PR TITLE
feat: add double-header example site (closes #1676)

### DIFF
--- a/double-header/config.toml
+++ b/double-header/config.toml
@@ -1,0 +1,44 @@
+title = "Double Header"
+description = "Two-event day, split-screen hero -- dual identities, one venue, zero downtime"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "events"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["sessions"]
+
+[markdown]
+safe = false

--- a/double-header/content/index.md
+++ b/double-header/content/index.md
@@ -1,0 +1,159 @@
++++
+title = "Home"
+description = "Two-event day, split-screen hero -- dual identities, one venue, zero downtime"
++++
+
+<div class="hero-split">
+  <div class="hero-side hero-side-a">
+    <div class="hero-event-label">Morning Session</div>
+    <h1 class="font-a">Design<br>Symposium</h1>
+    <div class="hero-time">09:00</div>
+    <p class="hero-desc">A curated morning of design thinking, typography deep-dives, and visual storytelling from leading practitioners.</p>
+  </div>
+
+  <div class="connector">
+    <!-- SVG vertical split divider -->
+    <svg width="64" height="200" viewBox="0 0 64 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="32" y1="0" x2="32" y2="68" stroke="#1e1e3a" stroke-width="2"/>
+      <rect x="8" y="68" width="48" height="64" fill="#0a0a12" stroke="#f472b6" stroke-width="3"/>
+      <text x="32" y="107" text-anchor="middle" fill="#f472b6" font-family="Montserrat, sans-serif" font-weight="900" font-size="16">VS</text>
+      <line x1="32" y1="132" x2="32" y2="200" stroke="#1e1e3a" stroke-width="2"/>
+    </svg>
+  </div>
+
+  <div class="hero-side hero-side-b">
+    <div class="hero-event-label">Afternoon Session</div>
+    <h1 class="font-b">CODE<br>FORGE</h1>
+    <div class="hero-time">14:00</div>
+    <p class="hero-desc">An afternoon of live coding, systems architecture, and engineering craft. Build, break, rebuild.</p>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Dual Clock</div>
+  <h2>Event Timing</h2>
+
+  <div class="clock-row">
+    <div class="clock-block clock-a">
+      <div class="clock-label">Event A Begins</div>
+      <!-- SVG clock display A -->
+      <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 12px auto; display: block;">
+        <circle cx="60" cy="60" r="55" stroke="#c084fc" stroke-width="2" fill="none"/>
+        <circle cx="60" cy="60" r="3" fill="#c084fc"/>
+        <line x1="60" y1="60" x2="60" y2="25" stroke="#c084fc" stroke-width="3" stroke-linecap="round"/>
+        <line x1="60" y1="60" x2="85" y2="60" stroke="#c084fc" stroke-width="2" stroke-linecap="round"/>
+        <text x="60" y="8" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">12</text>
+        <text x="112" y="64" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">3</text>
+        <text x="60" y="118" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">6</text>
+        <text x="8" y="64" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">9</text>
+      </svg>
+      <div class="clock-time">09:00</div>
+      <div class="clock-period">Morning // Design Symposium</div>
+    </div>
+    <div class="clock-block clock-b">
+      <div class="clock-label">Event B Begins</div>
+      <!-- SVG clock display B -->
+      <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 12px auto; display: block;">
+        <circle cx="60" cy="60" r="55" stroke="#38bdf8" stroke-width="2" fill="none"/>
+        <circle cx="60" cy="60" r="3" fill="#38bdf8"/>
+        <line x1="60" y1="60" x2="60" y2="30" stroke="#38bdf8" stroke-width="3" stroke-linecap="round"/>
+        <line x1="60" y1="60" x2="35" y2="60" stroke="#38bdf8" stroke-width="2" stroke-linecap="round"/>
+        <text x="60" y="8" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">12</text>
+        <text x="112" y="64" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">3</text>
+        <text x="60" y="118" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">6</text>
+        <text x="8" y="64" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="8">9</text>
+      </svg>
+      <div class="clock-time">14:00</div>
+      <div class="clock-period">Afternoon // Code Forge</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Combined Schedule</div>
+  <h2>Parallel Program</h2>
+
+  <div class="split-card">
+    <div class="split-card-side">
+      <div class="split-card-time">09:00 - 09:45</div>
+      <div class="split-card-title">The Grid Manifesto</div>
+      <div class="split-card-speaker">Ava Chen -- Design Lead, Lattice</div>
+    </div>
+    <div class="split-card-connector">PLUS</div>
+    <div class="split-card-side">
+      <div class="split-card-time">14:00 - 14:45</div>
+      <div class="split-card-title">Zero-Alloc Systems</div>
+      <div class="split-card-speaker">Kai Ortiz -- Staff Eng, Oxide</div>
+    </div>
+  </div>
+
+  <div class="split-card">
+    <div class="split-card-side">
+      <div class="split-card-time">10:00 - 10:45</div>
+      <div class="split-card-title">Type as Interface</div>
+      <div class="split-card-speaker">Lena Park -- Typography Director</div>
+    </div>
+    <div class="split-card-connector">VS</div>
+    <div class="split-card-side">
+      <div class="split-card-time">15:00 - 15:45</div>
+      <div class="split-card-title">Compiler Internals</div>
+      <div class="split-card-speaker">Rho Vasquez -- Compiler Team, Zig</div>
+    </div>
+  </div>
+
+  <div class="split-card">
+    <div class="split-card-side">
+      <div class="split-card-time">11:00 - 12:00</div>
+      <div class="split-card-title">Color Systems Workshop</div>
+      <div class="split-card-speaker">Mika Tanaka -- Color Scientist</div>
+    </div>
+    <div class="split-card-connector">PLUS</div>
+    <div class="split-card-side">
+      <div class="split-card-time">16:00 - 17:00</div>
+      <div class="split-card-title">Live Debugging Arena</div>
+      <div class="split-card-speaker">Priya Nair -- SRE Lead, Fleet</div>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 12px; margin-top: 24px; align-items: center; flex-wrap: wrap;">
+    <span class="event-badge event-badge-a">DESIGN SYMPOSIUM</span>
+    <span class="event-badge event-badge-vs">VS</span>
+    <span class="event-badge event-badge-b">CODE FORGE</span>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Split Divider</div>
+  <h2>Two Worlds, One Stage</h2>
+
+  <!-- SVG vertical split divider pattern -->
+  <svg width="100%" height="160" viewBox="0 0 600 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Left side - Design / Playfair -->
+    <rect x="0" y="0" width="290" height="160" fill="#10101c" stroke="#c084fc" stroke-width="1"/>
+    <text x="145" y="45" text-anchor="middle" fill="#c084fc" font-family="Playfair Display, serif" font-weight="900" font-size="14" letter-spacing="4" font-style="italic">DESIGN</text>
+    <text x="145" y="70" text-anchor="middle" fill="#c084fc" font-family="Playfair Display, serif" font-weight="900" font-size="36" font-style="italic">AM</text>
+    <text x="145" y="100" text-anchor="middle" fill="#5a5a7a" font-family="Inter, sans-serif" font-weight="500" font-size="11">09:00 - 12:30</text>
+    <text x="145" y="130" text-anchor="middle" fill="#5a5a7a" font-family="Inter, sans-serif" font-weight="500" font-size="11">4 Sessions // 1 Workshop</text>
+    <line x1="60" y1="145" x2="230" y2="145" stroke="#c084fc" stroke-width="1" stroke-dasharray="4,4"/>
+
+    <!-- Divider -->
+    <line x1="300" y1="0" x2="300" y2="60" stroke="#1e1e3a" stroke-width="2"/>
+    <rect x="280" y="60" width="40" height="40" fill="#0a0a12" stroke="#f472b6" stroke-width="2"/>
+    <text x="300" y="85" text-anchor="middle" fill="#f472b6" font-family="Montserrat, sans-serif" font-weight="900" font-size="11">PLUS</text>
+    <line x1="300" y1="100" x2="300" y2="160" stroke="#1e1e3a" stroke-width="2"/>
+
+    <!-- Right side - Code / Montserrat -->
+    <rect x="310" y="0" width="290" height="160" fill="#0a0a12" stroke="#38bdf8" stroke-width="1"/>
+    <text x="455" y="45" text-anchor="middle" fill="#38bdf8" font-family="Montserrat, sans-serif" font-weight="900" font-size="14" letter-spacing="4">CODE</text>
+    <text x="455" y="70" text-anchor="middle" fill="#38bdf8" font-family="Montserrat, sans-serif" font-weight="900" font-size="36">PM</text>
+    <text x="455" y="100" text-anchor="middle" fill="#5a5a7a" font-family="Inter, sans-serif" font-weight="500" font-size="11">14:00 - 17:30</text>
+    <text x="455" y="130" text-anchor="middle" fill="#5a5a7a" font-family="Inter, sans-serif" font-weight="500" font-size="11">4 Sessions // 1 Live Debug</text>
+    <line x1="370" y1="145" x2="540" y2="145" stroke="#38bdf8" stroke-width="1" stroke-dasharray="4,4"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Montserrat', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">2026.10.18 // MERIDIAN HALL, TORONTO</p>
+</div>
+
+</div>

--- a/double-header/content/register.md
+++ b/double-header/content/register.md
@@ -1,0 +1,28 @@
++++
+title = "Register"
+description = "Register for one or both events"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Choose Your Track</h2>
+
+  <div class="clock-row">
+    <div class="clock-block clock-a">
+      <div class="clock-label">Event A Only</div>
+      <div class="clock-time" style="font-size: 2rem;">AM</div>
+      <div class="clock-period">Design Symposium // 09:00-12:30</div>
+    </div>
+    <div class="clock-block clock-b">
+      <div class="clock-label">Event B Only</div>
+      <div class="clock-time" style="font-size: 2rem;">PM</div>
+      <div class="clock-period">Code Forge // 14:00-17:30</div>
+    </div>
+  </div>
+
+  <div style="text-align: center; margin-top: 32px;">
+    <span class="event-badge event-badge-vs" style="font-size: 0.85rem; padding: 8px 24px;">DOUBLE HEADER PASS -- BOTH EVENTS</span>
+  </div>
+
+  <p style="color: var(--text-secondary); margin-top: 24px; text-align: center; font-size: 0.9rem;">2026.10.18 // Meridian Hall, Toronto</p>
+</div>

--- a/double-header/content/schedule.md
+++ b/double-header/content/schedule.md
@@ -1,0 +1,44 @@
++++
+title = "Schedule"
+description = "Combined schedule overlay for both events"
++++
+
+<div class="section-block">
+  <div class="section-label">Full Day</div>
+  <h2>Combined Schedule</h2>
+
+  <svg width="100%" height="340" viewBox="0 0 600 340" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Timeline spine -->
+    <line x1="300" y1="20" x2="300" y2="320" stroke="#1e1e3a" stroke-width="2"/>
+
+    <!-- Morning block - Event A -->
+    <rect x="30" y="20" width="240" height="140" fill="#10101c" stroke="#c084fc" stroke-width="1.5"/>
+    <text x="150" y="45" text-anchor="middle" fill="#c084fc" font-family="Playfair Display, serif" font-weight="900" font-size="14" font-style="italic">DESIGN SYMPOSIUM</text>
+    <text x="150" y="70" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="10" letter-spacing="2">09:00 - 12:30</text>
+    <line x1="80" y1="85" x2="220" y2="85" stroke="#c084fc" stroke-width="0.5"/>
+    <text x="150" y="105" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">The Grid Manifesto</text>
+    <text x="150" y="122" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">Type as Interface</text>
+    <text x="150" y="139" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">Color Systems Workshop</text>
+
+    <!-- Connector -->
+    <rect x="275" y="155" width="50" height="30" fill="#0a0a12" stroke="#f472b6" stroke-width="2"/>
+    <text x="300" y="175" text-anchor="middle" fill="#f472b6" font-family="Montserrat, sans-serif" font-weight="900" font-size="11">PLUS</text>
+
+    <!-- Afternoon block - Event B -->
+    <rect x="330" y="180" width="240" height="140" fill="#0a0a12" stroke="#38bdf8" stroke-width="1.5"/>
+    <text x="450" y="205" text-anchor="middle" fill="#38bdf8" font-family="Montserrat, sans-serif" font-weight="900" font-size="14" letter-spacing="2">CODE FORGE</text>
+    <text x="450" y="230" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="700" font-size="10" letter-spacing="2">14:00 - 17:30</text>
+    <line x1="380" y1="245" x2="520" y2="245" stroke="#38bdf8" stroke-width="0.5"/>
+    <text x="450" y="265" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">Zero-Alloc Systems</text>
+    <text x="450" y="282" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">Compiler Internals</text>
+    <text x="450" y="299" text-anchor="middle" fill="#9898b8" font-family="Inter, sans-serif" font-weight="500" font-size="10">Live Debugging Arena</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Montserrat', sans-serif; font-weight: 700; font-size: 0.75rem; color: var(--text-muted); letter-spacing: 0.15em; text-transform: uppercase;">Lunch Break: 12:30 - 14:00 // Transition Window</p>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Venue</div>
+  <h2>Location</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8;">Meridian Hall, Toronto. Both events share a single stage with a 90-minute transition at midday. Attendees may register for one event or both.</p>
+</div>

--- a/double-header/content/sessions/_index.md
+++ b/double-header/content/sessions/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Sessions"
+description = "All sessions across both events"
+sort_by = "weight"
+template = "section"
++++
+
+Every session. Two events. One packed day.

--- a/double-header/content/sessions/the-grid-manifesto.md
+++ b/double-header/content/sessions/the-grid-manifesto.md
@@ -1,0 +1,33 @@
++++
+title = "The Grid Manifesto"
+date = "2026-10-18"
+description = "Morning keynote -- why the grid is the skeleton of all visual systems"
+weight = 1
+tags = ["design", "keynote", "morning"]
+[extra]
+event = "Design Symposium"
+speaker = "Ava Chen"
+time = "09:00 - 09:45"
++++
+
+## The Grid Manifesto
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#10101c" stroke="#c084fc" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#c084fc" font-family="Montserrat, sans-serif" font-weight="700" font-size="9" letter-spacing="3">DESIGN SYMPOSIUM</text>
+  <text x="140" y="52" text-anchor="middle" fill="#e8e8f4" font-family="Playfair Display, serif" font-weight="900" font-size="22" font-style="italic">The Grid Manifesto</text>
+  <text x="140" y="72" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="600" font-size="9">09:00 - 09:45 // AVA CHEN</text>
+</svg>
+
+<span class="event-badge event-badge-a">MORNING</span>
+
+### Session Summary
+
+Ava Chen opens the Design Symposium with a sharp argument for grid-first thinking. Every layout decision traces back to an invisible skeleton.
+
+| Detail | Info |
+|--------|------|
+| Event | Design Symposium |
+| Time | 09:00 - 09:45 |
+| Speaker | Ava Chen, Design Lead at Lattice |
+| Format | Keynote (45 min) |

--- a/double-header/content/sessions/type-as-interface.md
+++ b/double-header/content/sessions/type-as-interface.md
@@ -1,0 +1,33 @@
++++
+title = "Type as Interface"
+date = "2026-10-18"
+description = "How letterforms become the primary UI element in modern product design"
+weight = 3
+tags = ["design", "typography", "morning"]
+[extra]
+event = "Design Symposium"
+speaker = "Lena Park"
+time = "10:00 - 10:45"
++++
+
+## Type as Interface
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#10101c" stroke="#c084fc" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#c084fc" font-family="Montserrat, sans-serif" font-weight="700" font-size="9" letter-spacing="3">DESIGN SYMPOSIUM</text>
+  <text x="140" y="52" text-anchor="middle" fill="#e8e8f4" font-family="Playfair Display, serif" font-weight="900" font-size="22" font-style="italic">Type as Interface</text>
+  <text x="140" y="72" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="600" font-size="9">10:00 - 10:45 // LENA PARK</text>
+</svg>
+
+<span class="event-badge event-badge-a">MORNING</span>
+
+### Session Summary
+
+Lena Park argues that typography is not decoration. It is the primary interaction surface. Every font choice is a UX decision.
+
+| Detail | Info |
+|--------|------|
+| Event | Design Symposium |
+| Time | 10:00 - 10:45 |
+| Speaker | Lena Park, Typography Director |
+| Format | Talk (45 min) |

--- a/double-header/content/sessions/zero-alloc-systems.md
+++ b/double-header/content/sessions/zero-alloc-systems.md
@@ -1,0 +1,33 @@
++++
+title = "Zero-Alloc Systems"
+date = "2026-10-18"
+description = "Afternoon keynote -- building high-performance systems with zero heap allocations"
+weight = 2
+tags = ["engineering", "keynote", "afternoon"]
+[extra]
+event = "Code Forge"
+speaker = "Kai Ortiz"
+time = "14:00 - 14:45"
++++
+
+## Zero-Alloc Systems
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a12" stroke="#38bdf8" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#38bdf8" font-family="Montserrat, sans-serif" font-weight="700" font-size="9" letter-spacing="3">CODE FORGE</text>
+  <text x="140" y="52" text-anchor="middle" fill="#e8e8f4" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">ZERO-ALLOC SYSTEMS</text>
+  <text x="140" y="72" text-anchor="middle" fill="#5a5a7a" font-family="Montserrat, sans-serif" font-weight="600" font-size="9">14:00 - 14:45 // KAI ORTIZ</text>
+</svg>
+
+<span class="event-badge event-badge-b">AFTERNOON</span>
+
+### Session Summary
+
+Kai Ortiz shows how to build systems that never touch the heap. Stack-only allocation patterns for latency-critical paths.
+
+| Detail | Info |
+|--------|------|
+| Event | Code Forge |
+| Time | 14:00 - 14:45 |
+| Speaker | Kai Ortiz, Staff Eng at Oxide |
+| Format | Keynote (45 min) |

--- a/double-header/static/css/style.css
+++ b/double-header/static/css/style.css
@@ -1,0 +1,596 @@
+/* Double Header - Two-Event Day, Split-Screen Hero */
+/* Fonts: Playfair Display Black (Event A morning), Montserrat Black (Event B afternoon) */
+
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=Montserrat:wght@600;700;800;900&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --bg-primary: #0a0a12;
+  --bg-secondary: #10101c;
+  --bg-panel: #16162a;
+  --text-primary: #e8e8f4;
+  --text-secondary: #9898b8;
+  --text-muted: #5a5a7a;
+  --accent-a: #c084fc;
+  --accent-a-dim: rgba(192, 132, 252, 0.12);
+  --accent-b: #38bdf8;
+  --accent-b-dim: rgba(56, 189, 248, 0.12);
+  --accent-vs: #f472b6;
+  --border-color: #1e1e3a;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+h1 { font-size: 2.8rem; font-family: 'Montserrat', sans-serif; font-weight: 900; text-transform: uppercase; }
+h2 { font-size: 1.8rem; font-family: 'Montserrat', sans-serif; font-weight: 800; text-transform: uppercase; }
+h3 { font-size: 1.2rem; font-family: 'Montserrat', sans-serif; font-weight: 700; }
+
+.font-a { font-family: 'Playfair Display', serif; font-weight: 900; }
+.font-b { font-family: 'Montserrat', sans-serif; font-weight: 900; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 2px solid var(--accent-a);
+  border-image: linear-gradient(90deg, var(--accent-a), var(--accent-b)) 1;
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.site-logo .logo-a {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--accent-a);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-divider {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.site-logo .logo-b {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--accent-b);
+  letter-spacing: 0.06em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-a);
+  border-bottom-color: var(--accent-a);
+}
+
+.nav-cta {
+  background-color: var(--accent-b) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero - Split Screen */
+.hero-split {
+  display: flex;
+  min-height: 480px;
+  position: relative;
+}
+
+.hero-side {
+  flex: 1;
+  padding: 60px 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.hero-side-a {
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  text-align: right;
+}
+
+.hero-side-b {
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.hero-event-label {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.hero-side-a .hero-event-label { color: var(--accent-a); }
+.hero-side-b .hero-event-label { color: var(--accent-b); }
+
+.hero-side-a h1 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-size: 3.5rem;
+  color: var(--text-primary);
+  font-style: italic;
+  text-transform: none;
+}
+
+.hero-side-b h1 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 3.5rem;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.hero-time {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 2rem;
+  margin-top: 16px;
+}
+
+.hero-side-a .hero-time { color: var(--accent-a); }
+.hero-side-b .hero-time { color: var(--accent-b); }
+
+.hero-desc {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 12px;
+  max-width: 340px;
+}
+
+.hero-side-a .hero-desc { margin-left: auto; }
+
+/* VS / PLUS Connector */
+.connector {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+}
+
+.connector-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border: 3px solid var(--accent-vs);
+  background: var(--bg-primary);
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.1rem;
+  color: var(--accent-vs);
+  letter-spacing: 0.08em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-a);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Split Cards */
+.split-card {
+  display: flex;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 12px;
+}
+
+.split-card-side {
+  flex: 1;
+  padding: 20px 24px;
+}
+
+.split-card-side:first-child {
+  border-right: 2px solid var(--border-color);
+}
+
+.split-card-time {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  margin-bottom: 6px;
+}
+
+.split-card-side:first-child .split-card-time { color: var(--accent-a); }
+.split-card-side:last-child .split-card-time { color: var(--accent-b); }
+
+.split-card-title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-transform: uppercase;
+}
+
+.split-card-speaker {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.split-card-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  min-width: 48px;
+  background: var(--bg-primary);
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.7rem;
+  color: var(--accent-vs);
+  letter-spacing: 0.08em;
+  border-left: 2px solid var(--border-color);
+  border-right: 2px solid var(--border-color);
+}
+
+/* Clock Display */
+.clock-row {
+  display: flex;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.clock-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.clock-label {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.clock-a .clock-label { color: var(--accent-a); }
+.clock-b .clock-label { color: var(--accent-b); }
+
+.clock-time {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 2.8rem;
+  letter-spacing: 0.04em;
+}
+
+.clock-a .clock-time { color: var(--accent-a); }
+.clock-b .clock-time { color: var(--accent-b); }
+
+.clock-period {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+/* Event Badge */
+.event-badge {
+  display: inline-block;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 4px 14px;
+  border: 3px solid;
+}
+
+.event-badge-a { color: var(--accent-a); border-color: var(--accent-a); }
+.event-badge-b { color: var(--accent-b); border-color: var(--accent-b); }
+.event-badge-vs { color: var(--accent-vs); border-color: var(--accent-vs); transform: rotate(-2deg); }
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-a);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-a);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-a);
+  color: var(--accent-a);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 2px solid var(--accent-b);
+  border-image: linear-gradient(90deg, var(--accent-a), var(--accent-b)) 1;
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-a);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-vs);
+  line-height: 1;
+  letter-spacing: 0.1em;
+}
+
+.error-msg {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-split { flex-direction: column; min-height: auto; }
+  .hero-side { text-align: center; padding: 40px 24px; }
+  .hero-side-a { border-right: none; border-bottom: 1px solid var(--border-color); }
+  .hero-side-b { border-left: none; }
+  .hero-side-a .hero-desc { margin-left: auto; margin-right: auto; }
+  .hero-side-a h1, .hero-side-b h1 { font-size: 2.5rem; }
+  .connector { position: static; transform: none; display: flex; justify-content: center; margin: -32px auto; }
+  h1 { font-size: 2rem; }
+  .split-card { flex-direction: column; }
+  .split-card-side:first-child { border-right: none; border-bottom: 2px solid var(--border-color); }
+  .split-card-connector { width: 100%; min-width: 100%; height: 36px; border-left: none; border-right: none; border-top: 2px solid var(--border-color); border-bottom: 2px solid var(--border-color); }
+  .clock-row { flex-direction: column; gap: 12px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/double-header/templates/404.html
+++ b/double-header/templates/404.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="120" height="80" viewBox="0 0 120 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="5" y="5" width="50" height="70" stroke="#c084fc" stroke-width="2" fill="none"/>
+        <rect x="65" y="5" width="50" height="70" stroke="#38bdf8" stroke-width="2" fill="none"/>
+        <text x="30" y="48" text-anchor="middle" fill="#c084fc" font-family="Playfair Display, serif" font-weight="900" font-size="20">4</text>
+        <text x="90" y="48" text-anchor="middle" fill="#38bdf8" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">4</text>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Session Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-a); font-family: 'Montserrat', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Split View</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/double-header/templates/footer.html
+++ b/double-header/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">DOUBLE HEADER // TWO EVENTS, ONE DAY</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Split View</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/double-header/templates/header.html
+++ b/double-header/templates/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-a">EVENT A</span>
+        <span class="logo-divider">//</span>
+        <span class="logo-b">EVENT B</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Split View</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/double-header/templates/page.html
+++ b/double-header/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/double-header/templates/post.html
+++ b/double-header/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("session") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/double-header/templates/section.html
+++ b/double-header/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/double-header/templates/taxonomy.html
+++ b/double-header/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All event categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/double-header/templates/taxonomy_term.html
+++ b/double-header/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Category</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All sessions in this category:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3619,5 +3619,12 @@
     "competition",
     "dominant",
     "perfect"
+  ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
   ]
 }


### PR DESCRIPTION
Closes #1676

## Summary
- Two-event day split-screen hero with SVG vertical split divider
- Dual clock displays, VS/PLUS connectors, combined schedule overlay
- Typography: Playfair Display Black (Event A morning), Montserrat Black (Event B afternoon)
- Tags: event, dark, double, dual, packed