### PR TITLE
feat: add aftershock example site (closes #1673)

### DIFF
--- a/aftershock/config.toml
+++ b/aftershock/config.toml
@@ -1,0 +1,44 @@
+title = "Aftershock"
+description = "Post-event retrospective -- seismic impact, diminishing waves, lasting reverberations"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "impact"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["recordings"]
+
+[markdown]
+safe = false

--- a/aftershock/content/archive.md
+++ b/aftershock/content/archive.md
@@ -1,0 +1,25 @@
++++
+title = "Archive"
+description = "Full event archive and historical records"
++++
+
+<div class="section-block">
+  <div class="section-label">Archive</div>
+  <h2>Event Archive</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; font-family: 'Lora', serif;">All 36 sessions from Aftershock 2026 are archived and available for replay. Session recordings include timestamps, speaker notes, and audience Q&A transcripts.</p>
+
+  <div class="metric-row" style="margin-top: 24px;">
+    <div class="metric-block">
+      <div class="metric-number">36</div>
+      <div class="metric-label">Archived Sessions</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">48h</div>
+      <div class="metric-label">Total Runtime</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">2026</div>
+      <div class="metric-label">Event Year</div>
+    </div>
+  </div>
+</div>

--- a/aftershock/content/impact.md
+++ b/aftershock/content/impact.md
@@ -1,0 +1,55 @@
++++
+title = "Impact"
+description = "Impact metrics and retrospective data"
++++
+
+<div class="section-block">
+  <div class="section-label">Retrospective</div>
+  <h2>Event Impact Report</h2>
+
+  <div class="metric-row">
+    <div class="metric-block">
+      <div class="metric-number">4,218</div>
+      <div class="metric-label">Total Attendees</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">36</div>
+      <div class="metric-label">Sessions Delivered</div>
+    </div>
+  </div>
+
+  <div class="metric-row" style="margin-top: 12px;">
+    <div class="metric-block">
+      <div class="metric-number">18,420</div>
+      <div class="metric-label">Total Replay Views</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">92%</div>
+      <div class="metric-label">Avg Satisfaction</div>
+    </div>
+  </div>
+
+  <!-- SVG impact gauge -->
+  <svg width="100%" height="100" viewBox="0 0 600 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block; max-width: 600px;">
+    <!-- Gauge bars -->
+    <rect x="20" y="10" width="80" height="70" fill="#7c8a6e" opacity="0.8"/>
+    <text x="60" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">KEYNOTES</text>
+
+    <rect x="120" y="20" width="80" height="60" fill="#7c8a6e" opacity="0.6"/>
+    <text x="160" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">TALKS</text>
+
+    <rect x="220" y="25" width="80" height="55" fill="#7c8a6e" opacity="0.5"/>
+    <text x="260" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">WORKSHOPS</text>
+
+    <rect x="320" y="35" width="80" height="45" fill="#7c8a6e" opacity="0.4"/>
+    <text x="360" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">PANELS</text>
+
+    <rect x="420" y="40" width="80" height="40" fill="#7c8a6e" opacity="0.3"/>
+    <text x="460" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">LIGHTNING</text>
+
+    <rect x="520" y="50" width="60" height="30" fill="#7c8a6e" opacity="0.2"/>
+    <text x="550" y="88" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">BOF</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Lora', serif; font-style: italic; font-size: 0.9rem; color: var(--text-muted);">Session format impact by replay engagement, Oct-Dec 2026</p>
+</div>

--- a/aftershock/content/index.md
+++ b/aftershock/content/index.md
@@ -1,0 +1,143 @@
++++
+title = "Home"
+description = "Post-event retrospective -- seismic impact, diminishing waves, lasting reverberations"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Post-Event Retrospective</div>
+    <h1>AFTERSHOCK</h1>
+    <p class="hero-subtitle">The event is over. The reverberations are not. Revisit the sessions that shook the ground.</p>
+    <p class="hero-date">RECORDED OCT 2026 // NOW STREAMING</p>
+
+    <!-- SVG seismic waveform -->
+    <svg width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Primary wave - strong -->
+      <path d="M0,40 Q20,5 40,40 Q60,75 80,40 Q100,5 120,40 Q140,75 160,40 Q180,15 200,40 Q220,65 240,40 Q260,20 280,40 Q300,55 320,40 Q340,28 360,40 Q380,48 400,40" stroke="#7c8a6e" stroke-width="3" fill="none"/>
+      <!-- Secondary wave - diminishing -->
+      <path d="M0,40 Q20,15 40,40 Q60,65 80,40 Q100,18 120,40 Q140,58 160,40 Q180,22 200,40 Q220,54 240,40 Q260,28 280,40 Q300,48 320,40 Q340,34 360,40 Q380,44 400,40" stroke="#7c8a6e" stroke-width="1.5" fill="none" opacity="0.5"/>
+      <!-- Tertiary wave - fading -->
+      <path d="M0,40 Q20,25 40,40 Q60,55 80,40 Q100,28 120,40 Q140,52 160,40 Q180,30 200,40 Q220,48 240,40 Q260,34 280,40 Q300,44 320,40 Q340,37 360,40 Q380,42 400,40" stroke="#7c8a6e" stroke-width="1" fill="none" opacity="0.25"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Impact Metrics</div>
+  <h2>By the Numbers</h2>
+
+  <div class="metric-row">
+    <div class="metric-block">
+      <div class="metric-number">4,218</div>
+      <div class="metric-label">Attendees</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">36</div>
+      <div class="metric-label">Sessions</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">92%</div>
+      <div class="metric-label">Satisfaction</div>
+    </div>
+    <div class="metric-block">
+      <div class="metric-number">18K</div>
+      <div class="metric-label">Replay Views</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Ripple Impact</div>
+  <h2>Diminishing Waves</h2>
+
+  <!-- SVG ripple impact diagram -->
+  <svg width="340" height="200" viewBox="0 0 340 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Concentric ripple rings - diminishing -->
+    <circle cx="170" cy="100" r="90" stroke="#7c8a6e" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="170" cy="100" r="70" stroke="#7c8a6e" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <circle cx="170" cy="100" r="50" stroke="#7c8a6e" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="170" cy="100" r="30" stroke="#7c8a6e" stroke-width="2.5" fill="none" opacity="0.6"/>
+    <circle cx="170" cy="100" r="10" fill="#7c8a6e" opacity="0.8"/>
+    <!-- Impact labels at ring edges -->
+    <text x="170" y="8" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="2">INDUSTRY SHIFT</text>
+    <text x="170" y="28" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="2">COMMUNITY GROWTH</text>
+    <text x="170" y="48" text-anchor="middle" fill="#98a890" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="2">KNOWLEDGE TRANSFER</text>
+    <text x="170" y="145" text-anchor="middle" fill="#98a890" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="2">DIRECT CONNECTIONS</text>
+    <text x="170" y="100" text-anchor="middle" fill="#e4e8e0" font-family="Anton, sans-serif" font-size="12">EVENT</text>
+    <text x="170" y="195" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="2">LONG-TERM IMPACT</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Recordings</div>
+  <h2>Session Replays</h2>
+
+  <div class="recording-card">
+    <div class="recording-icon">
+      <!-- Replay icon SVG -->
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="18" cy="18" r="16" stroke="#7c8a6e" stroke-width="2" fill="none"/>
+        <polygon points="14,10 28,18 14,26" fill="#7c8a6e"/>
+      </svg>
+    </div>
+    <div class="recording-info">
+      <div class="recording-title">OPENING KEYNOTE: THE SEISMIC SHIFT</div>
+      <div class="recording-meta">Dr. Elena Voss -- Recorded Oct 12, 2026</div>
+    </div>
+    <div class="recording-timestamp">01:12:34</div>
+  </div>
+
+  <div class="recording-card">
+    <div class="recording-icon">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="18" cy="18" r="16" stroke="#7c8a6e" stroke-width="2" fill="none"/>
+        <polygon points="14,10 28,18 14,26" fill="#7c8a6e"/>
+      </svg>
+    </div>
+    <div class="recording-info">
+      <div class="recording-title">FAULT LINES IN DISTRIBUTED SYSTEMS</div>
+      <div class="recording-meta">Kenji Mori -- Recorded Oct 12, 2026</div>
+    </div>
+    <div class="recording-timestamp">00:48:22</div>
+  </div>
+
+  <div class="recording-card">
+    <div class="recording-icon">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="18" cy="18" r="16" stroke="#7c8a6e" stroke-width="2" fill="none"/>
+        <polygon points="14,10 28,18 14,26" fill="#7c8a6e"/>
+      </svg>
+    </div>
+    <div class="recording-info">
+      <div class="recording-title">MEASURING WHAT MATTERS</div>
+      <div class="recording-meta">Priya Anand -- Recorded Oct 13, 2026</div>
+    </div>
+    <div class="recording-timestamp">00:42:15</div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Impact Gauge</div>
+  <h2>Seismograph Reading</h2>
+
+  <!-- SVG seismograph / impact gauge -->
+  <svg width="100%" height="120" viewBox="0 0 600 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Baseline -->
+    <line x1="0" y1="60" x2="600" y2="60" stroke="#1e2a1e" stroke-width="1"/>
+    <!-- Seismograph trace - decreasing intensity over time -->
+    <polyline points="0,60 20,60 25,20 30,95 35,15 40,90 45,25 50,85 55,30 60,80 70,35 80,75 90,38 100,70 120,42 140,65 160,44 180,60 200,48 220,58 240,50 260,56 280,52 300,55 320,53 340,55 360,54 400,56 450,55 500,56 550,57 600,58" stroke="#7c8a6e" stroke-width="2" fill="none"/>
+    <!-- Time labels -->
+    <text x="30" y="110" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">DAY 1</text>
+    <text x="150" y="110" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">WEEK 1</text>
+    <text x="300" y="110" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">MONTH 1</text>
+    <text x="500" y="110" text-anchor="middle" fill="#586850" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">MONTH 3</text>
+    <!-- Peak label -->
+    <text x="35" y="12" text-anchor="middle" fill="#b8944a" font-family="Anton, sans-serif" font-size="10">PEAK</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Lora', serif; font-weight: 500; font-style: italic; font-size: 0.9rem; color: var(--text-muted);">Impact diminishes over time, but the aftershocks never fully stop.</p>
+</div>
+
+</div>

--- a/aftershock/content/recordings/_index.md
+++ b/aftershock/content/recordings/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Recordings"
+description = "Session recordings with timestamps and impact metrics"
+sort_by = "weight"
+template = "section"
++++
+
+Every session recorded. Every moment preserved. Watch at your own pace.

--- a/aftershock/content/recordings/fault-lines.md
+++ b/aftershock/content/recordings/fault-lines.md
@@ -1,0 +1,31 @@
++++
+title = "Fault Lines in Distributed Systems"
+date = "2026-10-12"
+description = "Where distributed systems break -- and how to trace the cracks before they spread"
+weight = 2
+tags = ["engineering", "recording", "distributed"]
+[extra]
+speaker = "Kenji Mori"
+duration = "00:48:22"
+views = 5130
++++
+
+## Fault Lines in Distributed Systems
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101410" stroke="#7c8a6e" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#7c8a6e" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="3">RECORDING</text>
+  <text x="140" y="48" text-anchor="middle" fill="#e4e8e0" font-family="Anton, sans-serif" font-size="16">FAULT LINES</text>
+  <text x="140" y="68" text-anchor="middle" fill="#586850" font-family="Crimson Pro, serif" font-weight="600" font-size="10">00:48:22 // KENJI MORI // 5,130 VIEWS</text>
+</svg>
+
+### Session Summary
+
+Kenji mapped the fault lines in modern microservice architectures. When services fail, the cracks propagate. His talk showed how to instrument for early detection.
+
+| Metric | Value |
+|--------|-------|
+| Duration | 00:48:22 |
+| Live Attendance | 1,220 |
+| Replay Views | 5,130 |
+| Satisfaction | 94% |

--- a/aftershock/content/recordings/measuring-what-matters.md
+++ b/aftershock/content/recordings/measuring-what-matters.md
@@ -1,0 +1,31 @@
++++
+title = "Measuring What Matters"
+date = "2026-10-13"
+description = "Beyond vanity metrics -- instrumentation for real impact"
+weight = 3
+tags = ["metrics", "recording", "observability"]
+[extra]
+speaker = "Priya Anand"
+duration = "00:42:15"
+views = 3870
++++
+
+## Measuring What Matters
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101410" stroke="#7c8a6e" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#7c8a6e" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="3">RECORDING</text>
+  <text x="140" y="48" text-anchor="middle" fill="#e4e8e0" font-family="Anton, sans-serif" font-size="15">MEASURING WHAT MATTERS</text>
+  <text x="140" y="68" text-anchor="middle" fill="#586850" font-family="Crimson Pro, serif" font-weight="600" font-size="10">00:42:15 // PRIYA ANAND // 3,870 VIEWS</text>
+</svg>
+
+### Session Summary
+
+Priya dismantled the metrics most teams track and replaced them with indicators that actually predict outcomes. Stop measuring what is easy. Measure what matters.
+
+| Metric | Value |
+|--------|-------|
+| Duration | 00:42:15 |
+| Live Attendance | 980 |
+| Replay Views | 3,870 |
+| Satisfaction | 91% |

--- a/aftershock/content/recordings/opening-keynote.md
+++ b/aftershock/content/recordings/opening-keynote.md
@@ -1,0 +1,31 @@
++++
+title = "Opening Keynote: The Seismic Shift"
+date = "2026-10-12"
+description = "The talk that started the tremor -- recorded at Aftershock 2026"
+weight = 1
+tags = ["keynote", "recording", "high-impact"]
+[extra]
+speaker = "Dr. Elena Voss"
+duration = "01:12:34"
+views = 8420
++++
+
+## The Seismic Shift
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101410" stroke="#7c8a6e" stroke-width="2"/>
+  <text x="140" y="22" text-anchor="middle" fill="#7c8a6e" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="3">RECORDING</text>
+  <text x="140" y="48" text-anchor="middle" fill="#e4e8e0" font-family="Anton, sans-serif" font-size="18">THE SEISMIC SHIFT</text>
+  <text x="140" y="68" text-anchor="middle" fill="#586850" font-family="Crimson Pro, serif" font-weight="600" font-size="10">01:12:34 // DR. ELENA VOSS // 8,420 VIEWS</text>
+</svg>
+
+### Session Summary
+
+Dr. Voss opened Aftershock with a sweeping argument for why the industry's foundations are shifting. Frameworks come and go. The tectonic plates beneath them move on decade-long timescales.
+
+| Metric | Value |
+|--------|-------|
+| Duration | 01:12:34 |
+| Live Attendance | 1,840 |
+| Replay Views | 8,420 |
+| Satisfaction | 97% |

--- a/aftershock/static/css/style.css
+++ b/aftershock/static/css/style.css
@@ -1,0 +1,469 @@
+/* Aftershock - Post-Event Retrospective */
+/* Fonts: Anton / Bebas Neue display at decreasing scales, Lora / Crimson Pro body */
+
+@import url('https://fonts.googleapis.com/css2?family=Anton&family=Bebas+Neue&family=Lora:wght@400;500;600;700&family=Crimson+Pro:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0c0a;
+  --bg-secondary: #101410;
+  --bg-panel: #181c18;
+  --text-primary: #e4e8e0;
+  --text-secondary: #98a890;
+  --text-muted: #586850;
+  --accent-green: #7c8a6e;
+  --accent-teal: #5a8a7a;
+  --accent-amber: #b8944a;
+  --border-color: #1e2a1e;
+  --border-accent: #7c8a6e;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Crimson Pro', 'Lora', serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.7;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Anton', 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  text-transform: uppercase;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Bebas Neue', sans-serif; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 3px solid var(--accent-green);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Anton', sans-serif;
+  font-size: 1.4rem;
+  color: var(--text-primary);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 600;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Crimson Pro', serif;
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-green);
+  border-bottom-color: var(--accent-green);
+}
+
+.nav-cta {
+  background-color: var(--accent-green) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 3px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--accent-green);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Anton', sans-serif;
+  font-size: 5.5rem;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Lora', serif;
+  font-weight: 500;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 0 auto 24px;
+  font-style: italic;
+}
+
+.hero-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Impact Metric */
+.metric-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 28px;
+  flex-wrap: wrap;
+}
+
+.metric-block {
+  flex: 1;
+  min-width: 140px;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.metric-number {
+  font-family: 'Anton', sans-serif;
+  font-size: 3rem;
+  color: var(--accent-amber);
+  line-height: 1;
+}
+
+.metric-label {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Recording Card */
+.recording-card {
+  padding: 20px 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.recording-icon {
+  flex-shrink: 0;
+}
+
+.recording-info { flex: 1; }
+
+.recording-title {
+  font-family: 'Anton', sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.recording-meta {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.recording-timestamp {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--accent-green);
+  letter-spacing: 0.08em;
+  min-width: 80px;
+  text-align: right;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Crimson Pro', serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-green);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-green);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 0.08em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Crimson Pro', serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Anton', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-green);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+  font-family: 'Lora', serif;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Crimson Pro', serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 3px solid var(--accent-green);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Crimson Pro', serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-green);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Anton', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-green);
+  line-height: 1;
+  letter-spacing: 0.1em;
+}
+
+.error-msg {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .metric-row { flex-direction: column; }
+  .recording-card { flex-direction: column; align-items: flex-start; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/aftershock/templates/404.html
+++ b/aftershock/templates/404.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="120" height="60" viewBox="0 0 120 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M0,30 Q15,10 30,30 Q45,50 60,30 Q75,10 90,30 Q105,50 120,30" stroke="#7c8a6e" stroke-width="2" fill="none"/>
+        <path d="M0,30 Q15,18 30,30 Q45,42 60,30 Q75,18 90,30 Q105,42 120,30" stroke="#7c8a6e" stroke-width="1" fill="none" opacity="0.4"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Signal Lost</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-green); font-family: 'Crimson Pro', serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Epicenter</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aftershock/templates/footer.html
+++ b/aftershock/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">AFTERSHOCK // THE REVERBERATIONS CONTINUE</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Epicenter</a>
+        <a href="{{ base_url }}/recordings/">Recordings</a>
+        <a href="{{ base_url }}/impact/">Impact</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/aftershock/templates/header.html
+++ b/aftershock/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">AFTERSHOCK</span>
+        <span class="logo-sub">// RETRO</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Epicenter</a>
+        <a href="{{ base_url }}/recordings/">Recordings</a>
+        <a href="{{ base_url }}/impact/">Impact</a>
+        <a href="{{ base_url }}/archive/" class="nav-cta">Archive</a>
+      </nav>
+    </div>
+  </header>

--- a/aftershock/templates/page.html
+++ b/aftershock/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aftershock/templates/post.html
+++ b/aftershock/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("recording") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aftershock/templates/section.html
+++ b/aftershock/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aftershock/templates/taxonomy.html
+++ b/aftershock/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All impact categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aftershock/templates/taxonomy_term.html
+++ b/aftershock/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Impact</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All recordings in this category:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3640,5 +3640,12 @@
     "hackathon",
     "pressure",
     "deadline"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
   ]
 }


### PR DESCRIPTION
Closes #1673

## Summary
- Post-event retrospective site with SVG seismic waveforms at diminishing intensity
- Ripple impact diagrams, replay/recording icons, impact metric gauges
- Typography: Anton/Bebas Neue display at decreasing scales, Lora/Crimson Pro body
- Session recordings with timestamps, impact metrics in bold figures
- Tags: event, dark, post-event, retrospective, impact