### PR TITLE
feat: add overture example site (closes #1671)

### DIFF
--- a/overture/config.toml
+++ b/overture/config.toml
@@ -1,0 +1,41 @@
+title = "Overture"
+description = "Opening ceremony with orchestral grandeur -- the curtain rises"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["movements"]
+
+[markdown]
+safe = false

--- a/overture/content/attend.md
+++ b/overture/content/attend.md
@@ -1,0 +1,26 @@
++++
+title = "Attend"
+description = "Reserve your seat for the opening ceremony"
++++
+
+<div class="section-block">
+  <div class="section-label">Reservations</div>
+  <h2>Attend the Opening</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; font-family: 'Crimson Pro', serif;">The Overture opening ceremony is a single-evening event. Four movements, no intermission beyond the Intermezzo. Formal attire requested. Seating is assigned by tier.</p>
+
+  <!-- SVG dynamics marking -->
+  <svg width="200" height="60" viewBox="0 0 200 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <!-- Fortissimo marking -->
+    <text x="20" y="40" fill="#c9a84c" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="36" opacity="0.6">ff</text>
+    <!-- Crescendo hairpin -->
+    <line x1="70" y1="35" x2="180" y2="20" stroke="#c9a84c" stroke-width="1.5" opacity="0.4"/>
+    <line x1="70" y1="35" x2="180" y2="50" stroke="#c9a84c" stroke-width="1.5" opacity="0.4"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="tempo-badge" style="font-size: 0.9rem; padding: 6px 20px;">RESERVE SEAT</span>
+    <span style="font-family: 'Cormorant', serif; font-weight: 700; font-style: italic; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.1em;">DOORS OPEN 18:30</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Cormorant', serif; font-weight: 600; font-style: italic; font-size: 0.85rem; letter-spacing: 0.15em;">2027.03.15 // Grand Concert Hall, Vienna</p>
+</div>

--- a/overture/content/index.md
+++ b/overture/content/index.md
@@ -1,0 +1,151 @@
++++
+title = "Home"
+description = "Opening ceremony with orchestral grandeur -- the curtain rises"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Opening Ceremony</div>
+    <h1>Overture</h1>
+    <p class="hero-subtitle">The curtain rises. Four movements chart the arc of a single evening -- from orchestral grandeur to standing ovation. Every session is a score.</p>
+    <p class="hero-date">2027.03.15 // Grand Concert Hall, Vienna</p>
+
+    <!-- SVG musical staff lines -->
+    <svg width="360" height="100" viewBox="0 0 360 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Five staff lines -->
+      <line x1="20" y1="25" x2="340" y2="25" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+      <line x1="20" y1="35" x2="340" y2="35" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+      <line x1="20" y1="45" x2="340" y2="45" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+      <line x1="20" y1="55" x2="340" y2="55" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+      <line x1="20" y1="65" x2="340" y2="65" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+      <!-- Treble clef suggestion -->
+      <path d="M45,62 Q42,45 50,30 Q58,15 52,25 Q46,35 48,50 Q50,60 45,68" stroke="#c9a84c" stroke-width="2" fill="none" opacity="0.6"/>
+      <!-- Quarter notes -->
+      <ellipse cx="100" cy="55" rx="7" ry="5" fill="#c9a84c" opacity="0.5" transform="rotate(-15 100 55)"/>
+      <line x1="106" y1="52" x2="106" y2="25" stroke="#c9a84c" stroke-width="1.5" opacity="0.5"/>
+      <ellipse cx="145" cy="45" rx="7" ry="5" fill="#c9a84c" opacity="0.5" transform="rotate(-15 145 45)"/>
+      <line x1="151" y1="42" x2="151" y2="18" stroke="#c9a84c" stroke-width="1.5" opacity="0.5"/>
+      <!-- Half note -->
+      <ellipse cx="195" cy="35" rx="7" ry="5" fill="none" stroke="#c9a84c" stroke-width="1.5" opacity="0.5" transform="rotate(-15 195 35)"/>
+      <line x1="201" y1="32" x2="201" y2="10" stroke="#c9a84c" stroke-width="1.5" opacity="0.5"/>
+      <!-- Whole note -->
+      <ellipse cx="250" cy="45" rx="8" ry="5.5" fill="none" stroke="#c9a84c" stroke-width="1.5" opacity="0.5" transform="rotate(-15 250 45)"/>
+      <!-- Rest symbol -->
+      <path d="M295,30 L300,40 L290,50 L300,60" stroke="#c9a84c" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <!-- Double bar at end -->
+      <line x1="330" y1="25" x2="330" y2="65" stroke="#c9a84c" stroke-width="1" opacity="0.5"/>
+      <line x1="335" y1="25" x2="335" y2="65" stroke="#c9a84c" stroke-width="2.5" opacity="0.5"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Programme</div>
+  <h2>Movement Structure</h2>
+
+  <div class="movement-block">
+    <div class="movement-number">I</div>
+    <div class="movement-info">
+      <div class="movement-title">Overture -- The Grand Opening</div>
+      <div class="movement-meta">Keynote address and ceremonial welcome</div>
+    </div>
+    <div class="movement-badge-slot"><span class="tempo-badge">Allegro</span></div>
+  </div>
+
+  <div class="movement-block">
+    <div class="movement-number">II</div>
+    <div class="movement-info">
+      <div class="movement-title">Act I -- Foundations</div>
+      <div class="movement-meta">Core sessions establishing the evening's themes</div>
+    </div>
+    <div class="movement-badge-slot"><span class="tempo-badge">Andante</span></div>
+  </div>
+
+  <div class="movement-block">
+    <div class="movement-number">III</div>
+    <div class="movement-info">
+      <div class="movement-title">Intermezzo -- The Pause</div>
+      <div class="movement-meta">Interval networking and chamber conversations</div>
+    </div>
+    <div class="movement-badge-slot"><span class="tempo-badge-outline">Adagio</span></div>
+  </div>
+
+  <div class="movement-block">
+    <div class="movement-number">IV</div>
+    <div class="movement-info">
+      <div class="movement-title">Finale -- The Crescendo</div>
+      <div class="movement-meta">Closing keynote, awards, and standing ovation</div>
+    </div>
+    <div class="movement-badge-slot"><span class="tempo-badge">Presto</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Tempo Markings</div>
+  <h2>Session Pacing</h2>
+
+  <div class="programme-row">
+    <div class="programme-block">
+      <!-- SVG conductor baton gesture -->
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <line x1="15" y1="65" x2="60" y2="15" stroke="#c9a84c" stroke-width="2.5" stroke-linecap="round"/>
+        <circle cx="60" cy="15" r="4" fill="#c9a84c" opacity="0.3"/>
+        <path d="M58,18 Q70,25 65,35" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.4"/>
+        <path d="M58,18 Q45,10 50,5" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.4"/>
+      </svg>
+      <div class="programme-display">Allegro</div>
+      <div class="programme-label">Energetic Opening</div>
+    </div>
+    <div class="programme-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <line x1="20" y1="60" x2="55" y2="25" stroke="#a67c3d" stroke-width="2.5" stroke-linecap="round"/>
+        <circle cx="55" cy="25" r="4" fill="#a67c3d" opacity="0.3"/>
+        <path d="M53,28 Q62,38 58,45" stroke="#a67c3d" stroke-width="1" fill="none" opacity="0.4"/>
+      </svg>
+      <div class="programme-display" style="color: var(--accent-warm);">Andante</div>
+      <div class="programme-label">Walking Pace</div>
+    </div>
+    <div class="programme-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <line x1="25" y1="55" x2="50" y2="30" stroke="#c9a84c" stroke-width="2.5" stroke-linecap="round"/>
+        <circle cx="50" cy="30" r="4" fill="#c9a84c" opacity="0.3"/>
+        <path d="M48,33 Q55,40 52,48 Q49,55 55,58" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.4"/>
+      </svg>
+      <div class="programme-display">Presto</div>
+      <div class="programme-label">Rapid Finale</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Concert Hall</div>
+  <h2>The Venue</h2>
+
+  <!-- SVG concert hall architecture -->
+  <svg width="100%" height="140" viewBox="0 0 600 140" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Arch roof -->
+    <path d="M50,120 L50,50 Q300,0 550,50 L550,120" stroke="#c9a84c" stroke-width="2" fill="none" opacity="0.4"/>
+    <!-- Inner arch -->
+    <path d="M100,120 L100,60 Q300,20 500,60 L500,120" stroke="#c9a84c" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <!-- Columns -->
+    <line x1="120" y1="120" x2="120" y2="55" stroke="#c9a84c" stroke-width="2" opacity="0.3"/>
+    <line x1="200" y1="120" x2="200" y2="40" stroke="#c9a84c" stroke-width="2" opacity="0.3"/>
+    <line x1="300" y1="120" x2="300" y2="32" stroke="#c9a84c" stroke-width="2" opacity="0.3"/>
+    <line x1="400" y1="120" x2="400" y2="40" stroke="#c9a84c" stroke-width="2" opacity="0.3"/>
+    <line x1="480" y1="120" x2="480" y2="55" stroke="#c9a84c" stroke-width="2" opacity="0.3"/>
+    <!-- Stage platform -->
+    <rect x="200" y="105" width="200" height="15" fill="#c9a84c" opacity="0.06" stroke="#c9a84c" stroke-width="1" opacity="0.2"/>
+    <!-- Podium -->
+    <rect x="280" y="95" width="40" height="25" fill="#c9a84c" opacity="0.08" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+    <!-- Floor line -->
+    <line x1="50" y1="120" x2="550" y2="120" stroke="#c9a84c" stroke-width="1.5" opacity="0.4"/>
+    <!-- Labels -->
+    <text x="300" y="135" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="9" letter-spacing="3">GRAND CONCERT HALL</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Cormorant', serif; font-weight: 700; font-style: italic; font-size: 0.85rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">Four movements // One evening // Standing ovation</p>
+</div>
+
+</div>

--- a/overture/content/movements/_index.md
+++ b/overture/content/movements/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Movements"
+description = "All movements in the Overture programme"
+sort_by = "weight"
+template = "section"
++++
+
+The full programme. Four movements from Overture to Finale.

--- a/overture/content/movements/finale.md
+++ b/overture/content/movements/finale.md
@@ -1,0 +1,40 @@
++++
+title = "Finale -- The Crescendo"
+date = "2027-03-15"
+description = "Presto -- closing keynote, awards, and standing ovation"
+weight = 4
+tags = ["finale", "closing", "awards"]
+[extra]
+speaker = "Director Elena Vasquez"
+tempo = "Presto"
+duration = "40 min"
++++
+
+## Finale -- The Crescendo
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#161622" stroke="#c9a84c" stroke-width="2"/>
+  <rect x="0" y="0" width="50" height="80" fill="#c9a84c"/>
+  <text x="25" y="47" text-anchor="middle" fill="#0a0a0e" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="20">IV</text>
+  <text x="165" y="35" text-anchor="middle" fill="#eee8dc" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="13">FINALE -- THE CRESCENDO</text>
+  <text x="165" y="55" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="9">ELENA VASQUEZ // PRESTO</text>
+</svg>
+
+<span class="tempo-badge">Presto</span>
+
+### Movement Summary
+
+Presto. The final movement accelerates. Director Vasquez returns to the podium for the closing keynote -- a twenty-minute crescendo building to the evening's climax. Awards follow. The house lights rise. Standing ovation.
+
+<!-- SVG crescendo hairpin to fortissimo -->
+<svg width="300" height="50" viewBox="0 0 300 50" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <line x1="10" y1="25" x2="200" y2="8" stroke="#c9a84c" stroke-width="1.5" opacity="0.5"/>
+  <line x1="10" y1="25" x2="200" y2="42" stroke="#c9a84c" stroke-width="1.5" opacity="0.5"/>
+  <text x="225" y="32" fill="#c9a84c" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="28" opacity="0.6">fff</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Duration | 40 min |
+| Speaker | Director Elena Vasquez |
+| Tempo | Presto |

--- a/overture/content/movements/foundations.md
+++ b/overture/content/movements/foundations.md
@@ -1,0 +1,33 @@
++++
+title = "Act I -- Foundations"
+date = "2027-03-15"
+description = "Andante -- core sessions establishing the themes of the evening"
+weight = 2
+tags = ["act", "foundations", "core"]
+[extra]
+speaker = "Panel of four principals"
+tempo = "Andante"
+duration = "60 min"
++++
+
+## Act I -- Foundations
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#161622" stroke="#c9a84c" stroke-width="2"/>
+  <rect x="0" y="0" width="50" height="80" fill="#a67c3d"/>
+  <text x="25" y="47" text-anchor="middle" fill="#0a0a0e" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="20">II</text>
+  <text x="165" y="35" text-anchor="middle" fill="#eee8dc" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="13">ACT I -- FOUNDATIONS</text>
+  <text x="165" y="55" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="9">FOUR PRINCIPALS // ANDANTE</text>
+</svg>
+
+<span class="tempo-badge-outline">Andante</span>
+
+### Movement Summary
+
+Four principals take the stage in succession. Each lays one foundation stone: infrastructure, design, governance, community. The tempo slows to Andante -- walking pace -- giving the audience time to absorb each theme before the next begins.
+
+| Detail | Info |
+|--------|------|
+| Duration | 60 min |
+| Speakers | Panel of four principals |
+| Tempo | Andante |

--- a/overture/content/movements/grand-opening.md
+++ b/overture/content/movements/grand-opening.md
@@ -1,0 +1,33 @@
++++
+title = "Overture -- The Grand Opening"
+date = "2027-03-15"
+description = "Allegro -- keynote address and ceremonial welcome to open the evening"
+weight = 1
+tags = ["overture", "keynote", "opening"]
+[extra]
+speaker = "Director Elena Vasquez"
+tempo = "Allegro"
+duration = "45 min"
++++
+
+## Overture -- The Grand Opening
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#161622" stroke="#c9a84c" stroke-width="2"/>
+  <rect x="0" y="0" width="50" height="80" fill="#c9a84c"/>
+  <text x="25" y="47" text-anchor="middle" fill="#0a0a0e" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="20">I</text>
+  <text x="165" y="35" text-anchor="middle" fill="#eee8dc" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="13">THE GRAND OPENING</text>
+  <text x="165" y="55" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="9">ELENA VASQUEZ // ALLEGRO</text>
+</svg>
+
+<span class="tempo-badge">Allegro</span>
+
+### Movement Summary
+
+The curtain rises on Director Elena Vasquez's keynote. Forty-five minutes of orchestral vision: where the field has been, where it is going, and why this evening matters. The tempo is Allegro -- energetic, forward-moving, setting the pace for everything that follows.
+
+| Detail | Info |
+|--------|------|
+| Duration | 45 min |
+| Speaker | Director Elena Vasquez |
+| Tempo | Allegro |

--- a/overture/content/movements/intermezzo.md
+++ b/overture/content/movements/intermezzo.md
@@ -1,0 +1,37 @@
++++
+title = "Intermezzo -- The Pause"
+date = "2027-03-15"
+description = "Adagio -- interval networking and chamber conversations"
+weight = 3
+tags = ["intermezzo", "networking", "interval"]
+[extra]
+tempo = "Adagio"
+duration = "30 min"
++++
+
+## Intermezzo -- The Pause
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#161622" stroke="#c9a84c" stroke-width="2"/>
+  <rect x="0" y="0" width="50" height="80" fill="none" stroke="#c9a84c" stroke-width="2"/>
+  <text x="25" y="47" text-anchor="middle" fill="#c9a84c" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="20">III</text>
+  <text x="165" y="35" text-anchor="middle" fill="#eee8dc" font-family="Playfair Display, serif" font-weight="900" font-style="italic" font-size="13">INTERMEZZO</text>
+  <text x="165" y="55" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="700" font-style="italic" font-size="9">THE PAUSE // ADAGIO</text>
+</svg>
+
+<span class="tempo-badge-outline">Adagio</span>
+
+### Movement Summary
+
+The lights dim to half. Conversations bloom in the foyer. The Intermezzo is scored Adagio -- slow, reflective. Chamber groups form naturally. Refreshments circulate. The pause is not silence; it is the space between notes that gives the music meaning.
+
+<!-- SVG rest notation -->
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M25,10 L35,25 L22,40 L35,55" stroke="#c9a84c" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Duration | 30 min |
+| Format | Open networking |
+| Tempo | Adagio |

--- a/overture/content/venue.md
+++ b/overture/content/venue.md
@@ -1,0 +1,33 @@
++++
+title = "Venue"
+description = "Grand Concert Hall, Vienna -- the stage for Overture"
++++
+
+<div class="section-block">
+  <div class="section-label">Location</div>
+  <h2>Grand Concert Hall</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; font-family: 'Crimson Pro', serif;">The Grand Concert Hall in Vienna seats 1,200 across three tiers. Designed in 1891 with acoustics that carry a whisper from stage to gallery. Every seat hears the same performance.</p>
+
+  <!-- SVG concert hall cross-section -->
+  <svg width="100%" height="160" viewBox="0 0 500 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block; max-width: 500px;">
+    <!-- Outer shell -->
+    <path d="M30,140 L30,50 Q250,5 470,50 L470,140" stroke="#c9a84c" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <!-- Tier 1 seating arc -->
+    <path d="M80,130 Q250,110 420,130" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.25"/>
+    <!-- Tier 2 seating arc -->
+    <path d="M60,105 Q250,85 440,105" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Tier 3 gallery arc -->
+    <path d="M50,80 Q250,60 450,80" stroke="#c9a84c" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Stage -->
+    <rect x="190" y="125" width="120" height="15" fill="#c9a84c" opacity="0.08" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+    <!-- Floor -->
+    <line x1="30" y1="140" x2="470" y2="140" stroke="#c9a84c" stroke-width="1" opacity="0.3"/>
+    <!-- Tier labels -->
+    <text x="250" y="135" text-anchor="middle" fill="#6a6058" font-family="Cormorant, serif" font-weight="600" font-style="italic" font-size="7" letter-spacing="2">STAGE</text>
+    <text x="460" y="130" text-anchor="end" fill="#6a6058" font-family="Cormorant, serif" font-weight="600" font-style="italic" font-size="7" letter-spacing="1">STALLS</text>
+    <text x="460" y="105" text-anchor="end" fill="#6a6058" font-family="Cormorant, serif" font-weight="600" font-style="italic" font-size="7" letter-spacing="1">CIRCLE</text>
+    <text x="460" y="80" text-anchor="end" fill="#6a6058" font-family="Cormorant, serif" font-weight="600" font-style="italic" font-size="7" letter-spacing="1">GALLERY</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Cormorant', serif; font-weight: 700; font-style: italic; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.15em;">1,200 SEATS // THREE TIERS // BUILT 1891</p>
+</div>

--- a/overture/static/css/style.css
+++ b/overture/static/css/style.css
@@ -1,0 +1,522 @@
+/* Overture - Opening Ceremony with Orchestral Grandeur */
+/* Fonts: Playfair Display Italic / Cormorant Italic display, Crimson Pro / Lora body */
+
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,900;1,700;1,900&family=Cormorant:ital,wght@0,600;0,700;1,600;1,700&family=Crimson+Pro:wght@400;500;600&family=Lora:wght@400;500;600&display=swap');
+
+:root {
+  --bg-primary: #0a0a0e;
+  --bg-secondary: #10101a;
+  --bg-panel: #161622;
+  --text-primary: #eee8dc;
+  --text-secondary: #b0a898;
+  --text-muted: #6a6058;
+  --accent-gold: #c9a84c;
+  --accent-warm: #a67c3d;
+  --accent-ivory: #eee8dc;
+  --border-color: #2a2630;
+  --border-accent: #c9a84c;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Crimson Pro', 'Lora', serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.7;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  line-height: 1.15;
+  color: var(--text-primary);
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Cormorant', serif; font-weight: 700; font-style: italic; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 3px solid var(--accent-gold);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 1.5rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Cormorant', serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.1em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-gold);
+  border-bottom-color: var(--accent-gold);
+}
+
+.nav-cta {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 3px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 5.5rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.04em;
+}
+
+.hero-subtitle {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 500;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+  line-height: 1.6;
+}
+
+.hero-date {
+  font-family: 'Cormorant', serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.75rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Movement Block */
+.movement-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.movement-number {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 1.6rem;
+  color: var(--accent-gold);
+  min-width: 50px;
+  text-align: center;
+}
+
+.movement-info { flex: 1; }
+
+.movement-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.movement-meta {
+  font-family: 'Cormorant', serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.movement-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Tempo Badge */
+.tempo-badge {
+  display: inline-block;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  background: var(--accent-gold);
+  color: var(--bg-primary);
+}
+
+.tempo-badge-outline {
+  display: inline-block;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-gold);
+  color: var(--accent-gold);
+}
+
+/* Programme Row */
+.programme-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.programme-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.programme-display {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 2.2rem;
+  color: var(--accent-gold);
+  line-height: 1;
+}
+
+.programme-label {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Cormorant', serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+  font-style: italic;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-gold);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-gold);
+  font-weight: 600;
+  font-size: 0.85rem;
+  font-family: 'Cormorant', serif;
+  font-style: italic;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Crimson Pro', serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Cormorant', serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-gold);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Cormorant', serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-style: italic;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
+}
+
+/* Staff Divider */
+.staff-divider {
+  margin: 40px auto;
+  display: block;
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 3px solid var(--accent-gold);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.08em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Cormorant', serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-style: italic;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-gold);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-style: italic;
+  font-size: 8rem;
+  color: var(--accent-gold);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .movement-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .programme-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/overture/templates/404.html
+++ b/overture/templates/404.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Musical note -->
+        <ellipse cx="28" cy="58" rx="10" ry="7" fill="#c9a84c" opacity="0.3" transform="rotate(-20 28 58)"/>
+        <line x1="37" y1="54" x2="37" y2="18" stroke="#c9a84c" stroke-width="2.5"/>
+        <line x1="37" y1="18" x2="55" y2="22" stroke="#c9a84c" stroke-width="2"/>
+        <line x1="55" y1="22" x2="55" y2="38" stroke="#c9a84c" stroke-width="2.5"/>
+        <ellipse cx="46" cy="42" rx="10" ry="7" fill="#c9a84c" opacity="0.3" transform="rotate(-20 46 42)"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Movement Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-gold); font-family: 'Cormorant', serif; font-weight: 700; font-style: italic; font-size: 0.85rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Programme</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/overture/templates/footer.html
+++ b/overture/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">Overture // Opening Ceremony</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Programme</a>
+        <a href="{{ base_url }}/movements/">Movements</a>
+        <a href="{{ base_url }}/venue/">Venue</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/overture/templates/header.html
+++ b/overture/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">Overture</span>
+        <span class="logo-sub">opening ceremony</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Programme</a>
+        <a href="{{ base_url }}/movements/">Movements</a>
+        <a href="{{ base_url }}/venue/">Venue</a>
+        <a href="{{ base_url }}/attend/" class="nav-cta">Attend</a>
+      </nav>
+    </div>
+  </header>

--- a/overture/templates/page.html
+++ b/overture/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/overture/templates/post.html
+++ b/overture/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("movement") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/overture/templates/section.html
+++ b/overture/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/overture/templates/taxonomy.html
+++ b/overture/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px; font-family: 'Crimson Pro', serif;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/overture/templates/taxonomy_term.html
+++ b/overture/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px; font-family: 'Crimson Pro', serif;">All movements tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -10,11 +10,6 @@
     "blog",
     "cyberpunk"
   ],
-  "after-dark": [
-    "blog",
-    "dark",
-    "reading"
-  ],
   "acme-docs": [
     "light",
     "docs"
@@ -40,6 +35,18 @@
     "dark-mode",
     "elegant",
     "portfolio"
+  ],
+  "after-dark": [
+    "blog",
+    "dark",
+    "reading"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
   ],
   "airwave": [
     "dark",
@@ -161,11 +168,6 @@
     "docs",
     "git-workflow"
   ],
-  "archway-docs": [
-    "docs",
-    "light",
-    "architecture"
-  ],
   "archipelago": [
     "dark",
     "landing",
@@ -175,6 +177,11 @@
     "light",
     "docs",
     "archive"
+  ],
+  "archway-docs": [
+    "docs",
+    "light",
+    "architecture"
   ],
   "arctic-saas": [
     "landing",
@@ -218,6 +225,11 @@
     "light",
     "blog",
     "geography"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
   ],
   "aurelia": [
     "elegant",
@@ -319,6 +331,13 @@
     "dark",
     "fluorescent",
     "elegant"
+  ],
+  "blockade-run": [
+    "event",
+    "dark",
+    "breakthrough",
+    "barriers",
+    "overcome"
   ],
   "blueprint": [
     "dark",
@@ -426,11 +445,6 @@
     "mosaic",
     "imperial"
   ],
-  "carbon-fiber": [
-    "dark",
-    "blog",
-    "tech"
-  ],
   "cabaret": [
     "dark",
     "blog",
@@ -479,6 +493,11 @@
     "light",
     "portfolio",
     "agency"
+  ],
+  "carbon-fiber": [
+    "dark",
+    "blog",
+    "tech"
   ],
   "carnival": [
     "dark",
@@ -936,6 +955,13 @@
     "docs",
     "tutorial"
   ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
+  ],
   "driftwood": [
     "light",
     "blog",
@@ -1020,6 +1046,13 @@
     "blog",
     "art",
     "painting"
+  ],
+  "encore": [
+    "event",
+    "dark",
+    "repeat",
+    "popular",
+    "demanded"
   ],
   "enigma": [
     "dark",
@@ -1476,6 +1509,13 @@
     "dark",
     "startup"
   ],
+  "ignition-sequence": [
+    "event",
+    "dark",
+    "phased",
+    "launch",
+    "sequential"
+  ],
   "impasto": [
     "light",
     "blog",
@@ -1867,18 +1907,18 @@
     "geometric",
     "minimal"
   ],
-  "matcha": [
-    "blog",
-    "light",
-    "minimal",
-    "zen"
-  ],
   "masquerade": [
     "dark",
     "elegant",
     "glamorous",
     "luxury",
     "mystery"
+  ],
+  "matcha": [
+    "blog",
+    "light",
+    "minimal",
+    "zen"
   ],
   "matrix": [
     "light",
@@ -2016,12 +2056,6 @@
     "blog",
     "modern"
   ],
-  "monorepo-docs": [
-    "docs",
-    "dark",
-    "developer",
-    "monorepo"
-  ],
   "molten": [
     "dark",
     "blog",
@@ -2055,6 +2089,12 @@
     "monoprint",
     "bold",
     "creative"
+  ],
+  "monorepo-docs": [
+    "docs",
+    "dark",
+    "developer",
+    "monorepo"
   ],
   "moonrise": [
     "dark",
@@ -2317,12 +2357,6 @@
     "blog",
     "food"
   ],
-  "sage-guide": [
-    "docs",
-    "light",
-    "tutorial",
-    "guide"
-  ],
   "orchid": [
     "dark",
     "blog",
@@ -2339,6 +2373,13 @@
     "blog",
     "oscilloscope",
     "retro"
+  ],
+  "overture": [
+    "event",
+    "dark",
+    "opening",
+    "orchestral",
+    "grand"
   ],
   "oxidation": [
     "dark",
@@ -2418,6 +2459,11 @@
     "neon",
     "particles",
     "energy"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
   ],
   "patina": [
     "dark",
@@ -2579,10 +2625,24 @@
     "blog",
     "postcard"
   ],
+  "powder-burn": [
+    "event",
+    "dark",
+    "rapid-fire",
+    "flash",
+    "quick"
+  ],
   "prairie": [
     "light",
     "blog",
     "rural"
+  ],
+  "pressure-cooker": [
+    "event",
+    "dark",
+    "hackathon",
+    "pressure",
+    "deadline"
   ],
   "pricetable": [
     "light",
@@ -2778,6 +2838,13 @@
     "pastel",
     "elegant"
   ],
+  "roll-call": [
+    "event",
+    "light",
+    "assembly",
+    "formal",
+    "attendance"
+  ],
   "rooftop": [
     "dark",
     "blog",
@@ -2824,6 +2891,12 @@
     "light",
     "blog",
     "food"
+  ],
+  "sage-guide": [
+    "docs",
+    "light",
+    "tutorial",
+    "guide"
   ],
   "sakura-storm": [
     "dark",
@@ -2916,6 +2989,13 @@
     "blog",
     "sgraffito",
     "scratched"
+  ],
+  "shutout": [
+    "event",
+    "dark",
+    "competition",
+    "dominant",
+    "perfect"
   ],
   "silhouette": [
     "dark",
@@ -3019,6 +3099,13 @@
     "cathedral",
     "colorful",
     "gothic"
+  ],
+  "standing-ovation": [
+    "event",
+    "light",
+    "awards",
+    "acclaim",
+    "celebration"
   ],
   "statuspage": [
     "light",
@@ -3574,85 +3661,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "atlas-docs": [
-    "docs",
-    "light",
-    "navigation"
-  ],
-  "pastel-docs": [
-    "docs",
-    "light",
-    "friendly"
-  ],
-  "ignition-sequence": [
-    "event",
-    "dark",
-    "phased",
-    "launch",
-    "sequential"
-  ],
-  "roll-call": [
-    "event",
-    "light",
-    "assembly",
-    "formal",
-    "attendance"
-  ],
-  "blockade-run": [
-    "event",
-    "dark",
-    "breakthrough",
-    "barriers",
-    "overcome"
-  ],
-  "standing-ovation": [
-    "event",
-    "light",
-    "awards",
-    "acclaim",
-    "celebration"
-  ],
-  "shutout": [
-    "event",
-    "dark",
-    "competition",
-    "dominant",
-    "perfect"
-  ],
-  "double-header": [
-    "event",
-    "dark",
-    "double",
-    "dual",
-    "packed"
-  ],
-  "encore": [
-    "event",
-    "dark",
-    "repeat",
-    "popular",
-    "demanded"
-  ],
-  "pressure-cooker": [
-    "event",
-    "dark",
-    "hackathon",
-    "pressure",
-    "deadline"
-  ],
-  "aftershock": [
-    "event",
-    "dark",
-    "post-event",
-    "retrospective",
-    "impact"
-  ],
-  "powder-burn": [
-    "event",
-    "dark",
-    "rapid-fire",
-    "flash",
-    "quick"
   ]
 }


### PR DESCRIPTION
## Summary
- Add overture example site: opening ceremony with orchestral grandeur
- Playfair Display Italic / Cormorant Italic display, Crimson Pro / Lora body typography
- Inline SVG musical staff line patterns, conductor baton gestures, musical notation elements, concert hall architecture
- Movement structure: OVERTURE > ACT I > INTERMEZZO > FINALE with tempo markings (Allegro, Andante, Adagio, Presto)

Closes #1671