### PR TITLE
feat: add embargo-lift example site (closes #1670)

### DIFF
--- a/embargo-lift/config.toml
+++ b/embargo-lift/config.toml
@@ -1,0 +1,41 @@
+title = "Embargo Lift"
+description = "Embargoed content release event -- locked until the moment arrives"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["releases"]
+
+[markdown]
+safe = false

--- a/embargo-lift/content/access.md
+++ b/embargo-lift/content/access.md
@@ -1,0 +1,26 @@
++++
+title = "Access"
+description = "Request access to embargoed releases"
++++
+
+<div class="section-block">
+  <div class="section-label">Authorization</div>
+  <h2>Request Access</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Embargoed content is available to authorized press and partners under NDA. Access credentials are issued 24 hours before the embargo lifts. Violation of embargo terms results in permanent revocation.</p>
+
+  <!-- SVG key/lock -->
+  <svg width="120" height="60" viewBox="0 0 120 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="30" cy="30" r="18" fill="none" stroke="#c03030" stroke-width="2" opacity="0.4"/>
+    <circle cx="30" cy="30" r="8" fill="none" stroke="#c03030" stroke-width="1.5" opacity="0.3"/>
+    <line x1="48" y1="30" x2="100" y2="30" stroke="#c03030" stroke-width="2" opacity="0.4"/>
+    <line x1="85" y1="30" x2="85" y2="40" stroke="#c03030" stroke-width="2" opacity="0.4"/>
+    <line x1="95" y1="30" x2="95" y2="38" stroke="#c03030" stroke-width="2" opacity="0.4"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="embargo-status embargo-locked" style="font-size: 0.85rem; padding: 6px 18px;">REQUEST ACCESS</span>
+    <span style="font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.75rem; color: var(--text-muted); letter-spacing: 0.1em;">NDA REQUIRED</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Allerta Stencil', sans-serif; font-size: 0.8rem; letter-spacing: 0.15em;">EMBARGO LIFTS 2027.06.01 // 09:00 UTC</p>
+</div>

--- a/embargo-lift/content/index.md
+++ b/embargo-lift/content/index.md
@@ -1,0 +1,151 @@
++++
+title = "Home"
+description = "Embargoed content release event -- locked until the moment arrives"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Embargoed Content Release</div>
+    <h1>EMBARGO LIFT</h1>
+    <p class="hero-subtitle">Five announcements. One synchronized release. Every second counts down to the moment the seal breaks and the content goes live.</p>
+    <p class="hero-date">EMBARGOED UNTIL 2027.06.01 // 09:00 UTC</p>
+
+    <!-- SVG padlock locked/unlocked -->
+    <svg width="300" height="120" viewBox="0 0 300 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Locked padlock -->
+      <rect x="40" y="50" width="40" height="35" rx="3" fill="none" stroke="#c03030" stroke-width="2"/>
+      <path d="M48,50 L48,38 Q60,22 72,38 L72,50" stroke="#c03030" stroke-width="2" fill="none"/>
+      <circle cx="60" cy="66" r="4" fill="#c03030" opacity="0.4"/>
+      <line x1="60" y1="70" x2="60" y2="76" stroke="#c03030" stroke-width="2"/>
+      <text x="60" y="105" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">LOCKED</text>
+      <!-- Arrow -->
+      <line x1="110" y1="65" x2="180" y2="65" stroke="#d4920a" stroke-width="1.5" opacity="0.5"/>
+      <path d="M175,60 L185,65 L175,70" stroke="#d4920a" stroke-width="1.5" fill="none" opacity="0.5"/>
+      <text x="148" y="55" text-anchor="middle" fill="#d4920a" font-family="Allerta Stencil, sans-serif" font-size="8" letter-spacing="2" opacity="0.6">LIFT</text>
+      <!-- Unlocked padlock -->
+      <rect x="210" y="50" width="40" height="35" rx="3" fill="none" stroke="#2a9a3a" stroke-width="2"/>
+      <path d="M218,50 L218,38 Q230,22 242,38 L242,42" stroke="#2a9a3a" stroke-width="2" fill="none"/>
+      <circle cx="230" cy="66" r="4" fill="#2a9a3a" opacity="0.4"/>
+      <text x="230" y="105" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">UNLOCKED</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Embargo Status</div>
+  <h2>Release Queue</h2>
+
+  <div class="embargo-block">
+    <div class="embargo-status embargo-locked">LOCKED</div>
+    <div class="embargo-info">
+      <div class="embargo-title">Platform v3.0 Announcement</div>
+      <div class="embargo-meta">Major platform rewrite -- full feature breakdown</div>
+    </div>
+    <div class="embargo-time">2027.06.01 09:00 UTC</div>
+  </div>
+
+  <div class="embargo-block">
+    <div class="embargo-status embargo-locked">LOCKED</div>
+    <div class="embargo-info">
+      <div class="embargo-title">Strategic Partnership Details</div>
+      <div class="embargo-meta">Cross-industry collaboration agreement</div>
+    </div>
+    <div class="embargo-time">2027.06.01 09:00 UTC</div>
+  </div>
+
+  <div class="embargo-block">
+    <div class="embargo-status embargo-unlocked">LIVE</div>
+    <div class="embargo-info">
+      <div class="embargo-title">Developer Preview Access</div>
+      <div class="embargo-meta">Early access SDK and documentation release</div>
+    </div>
+    <div class="embargo-time">RELEASED</div>
+  </div>
+
+  <div class="embargo-block">
+    <div class="embargo-status embargo-locked">LOCKED</div>
+    <div class="embargo-info">
+      <div class="embargo-title">Pricing and Availability</div>
+      <div class="embargo-meta">Tier structure and global rollout schedule</div>
+    </div>
+    <div class="embargo-time">2027.06.01 12:00 UTC</div>
+  </div>
+
+  <div class="embargo-block">
+    <div class="embargo-status embargo-locked">LOCKED</div>
+    <div class="embargo-info">
+      <div class="embargo-title">Community Roadmap</div>
+      <div class="embargo-meta">Open-source contributions and governance model</div>
+    </div>
+    <div class="embargo-time">2027.06.02 09:00 UTC</div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Countdown</div>
+  <h2>Time to Lift</h2>
+
+  <div class="countdown-row">
+    <div class="countdown-block">
+      <!-- SVG countdown timer -->
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="42" r="32" stroke="#d4920a" stroke-width="2" fill="none"/>
+        <circle cx="40" cy="42" r="32" stroke="#c03030" stroke-width="2" fill="none" stroke-dasharray="50 151" stroke-dashoffset="-25"/>
+        <text x="40" y="47" text-anchor="middle" fill="#d4920a" font-family="Black Ops One, sans-serif" font-size="16">48</text>
+        <text x="40" y="10" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">HOURS</text>
+      </svg>
+      <div class="countdown-display">48</div>
+      <div class="countdown-label">Hours</div>
+    </div>
+    <div class="countdown-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="42" r="32" stroke="#d4920a" stroke-width="2" fill="none"/>
+        <text x="40" y="47" text-anchor="middle" fill="#d4920a" font-family="Black Ops One, sans-serif" font-size="16">00</text>
+        <text x="40" y="10" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">MIN</text>
+      </svg>
+      <div class="countdown-display">00</div>
+      <div class="countdown-label">Minutes</div>
+    </div>
+    <div class="countdown-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="42" r="32" stroke="#d4920a" stroke-width="2" fill="none"/>
+        <text x="40" y="47" text-anchor="middle" fill="#d4920a" font-family="Black Ops One, sans-serif" font-size="16">00</text>
+        <text x="40" y="10" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">SEC</text>
+      </svg>
+      <div class="countdown-display">00</div>
+      <div class="countdown-label">Seconds</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Seal</div>
+  <h2>Embargo Seal</h2>
+
+  <!-- SVG embargo seal stamp -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Outer ring -->
+    <circle cx="100" cy="100" r="85" stroke="#c03030" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="100" cy="100" r="78" stroke="#c03030" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Inner ring -->
+    <circle cx="100" cy="100" r="55" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <!-- Seal text arc (simulated) -->
+    <text x="100" y="55" text-anchor="middle" fill="#c03030" font-family="Allerta Stencil, sans-serif" font-size="10" letter-spacing="4" opacity="0.5">EMBARGOED</text>
+    <text x="100" y="110" text-anchor="middle" fill="#c03030" font-family="Black Ops One, sans-serif" font-size="22">SEALED</text>
+    <text x="100" y="135" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="3">2027.06.01</text>
+    <!-- Cross marks -->
+    <line x1="60" y1="72" x2="140" y2="72" stroke="#c03030" stroke-width="1" opacity="0.2"/>
+    <line x1="60" y1="145" x2="140" y2="145" stroke="#c03030" stroke-width="1" opacity="0.2"/>
+    <!-- Decorative notches on outer ring -->
+    <line x1="100" y1="15" x2="100" y2="22" stroke="#c03030" stroke-width="1.5" opacity="0.3"/>
+    <line x1="100" y1="178" x2="100" y2="185" stroke="#c03030" stroke-width="1.5" opacity="0.3"/>
+    <line x1="15" y1="100" x2="22" y2="100" stroke="#c03030" stroke-width="1.5" opacity="0.3"/>
+    <line x1="178" y1="100" x2="185" y2="100" stroke="#c03030" stroke-width="1.5" opacity="0.3"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">5 releases // 1 synchronized lift // zero leaks</p>
+</div>
+
+</div>

--- a/embargo-lift/content/protocol.md
+++ b/embargo-lift/content/protocol.md
@@ -1,0 +1,29 @@
++++
+title = "Protocol"
+description = "Embargo handling protocol and release procedures"
++++
+
+<div class="section-block">
+  <div class="section-label">Procedures</div>
+  <h2>Embargo Protocol</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">All embargoed content follows strict release procedures. Content is sealed with cryptographic timestamps. No preview, no early access, no exceptions. When the clock hits zero, every channel fires simultaneously.</p>
+
+  <!-- SVG broken chain pattern -->
+  <svg width="100%" height="80" viewBox="0 0 500 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block; max-width: 500px;">
+    <!-- Chain links -->
+    <ellipse cx="60" cy="40" rx="25" ry="15" fill="none" stroke="#c03030" stroke-width="2" opacity="0.3"/>
+    <ellipse cx="100" cy="40" rx="25" ry="15" fill="none" stroke="#c03030" stroke-width="2" opacity="0.3"/>
+    <ellipse cx="140" cy="40" rx="25" ry="15" fill="none" stroke="#c03030" stroke-width="2" opacity="0.3"/>
+    <!-- Break point -->
+    <line x1="175" y1="35" x2="185" y2="30" stroke="#d4920a" stroke-width="2" opacity="0.5"/>
+    <line x1="175" y1="45" x2="185" y2="50" stroke="#d4920a" stroke-width="2" opacity="0.5"/>
+    <text x="210" y="44" fill="#d4920a" font-family="Allerta Stencil, sans-serif" font-size="10" letter-spacing="2" opacity="0.6">BREAK</text>
+    <!-- Broken chain links -->
+    <ellipse cx="280" cy="40" rx="25" ry="15" fill="none" stroke="#2a9a3a" stroke-width="2" opacity="0.3"/>
+    <ellipse cx="320" cy="40" rx="25" ry="15" fill="none" stroke="#2a9a3a" stroke-width="2" opacity="0.3"/>
+    <ellipse cx="360" cy="40" rx="25" ry="15" fill="none" stroke="#2a9a3a" stroke-width="2" opacity="0.3"/>
+    <!-- Labels -->
+    <text x="100" y="70" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">SEALED</text>
+    <text x="320" y="70" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">RELEASED</text>
+  </svg>
+</div>

--- a/embargo-lift/content/releases/_index.md
+++ b/embargo-lift/content/releases/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Releases"
+description = "All embargoed and released content"
+sort_by = "weight"
+template = "section"
++++
+
+The full release queue. Locked items await their embargo lift time.

--- a/embargo-lift/content/releases/developer-preview.md
+++ b/embargo-lift/content/releases/developer-preview.md
@@ -1,0 +1,32 @@
++++
+title = "Developer Preview Access"
+date = "2027-05-15"
+description = "Released -- early access SDK and documentation"
+weight = 3
+tags = ["developer", "sdk", "released"]
+[extra]
+status = "unlocked"
++++
+
+## Developer Preview Access
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#14141e" stroke="#2a9a3a" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#2a9a3a"/>
+  <rect x="12" y="22" width="36" height="26" rx="2" fill="none" stroke="#08080c" stroke-width="2"/>
+  <path d="M20,22 L20,16 Q30,8 40,16 L40,14" stroke="#08080c" stroke-width="2" fill="none"/>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e4de" font-family="Allerta Stencil, sans-serif" font-size="12" letter-spacing="2">DEV PREVIEW</text>
+  <text x="170" y="55" text-anchor="middle" fill="#2a9a3a" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">RELEASED // 2027.05.15</text>
+</svg>
+
+<span class="embargo-status embargo-unlocked" style="display: inline-block;">LIVE</span>
+
+### Release Summary
+
+The developer preview SDK is now publicly available. Full API documentation, quickstart guides, and sample applications are accessible at the developer portal. Early adopters have been building since the preview opened.
+
+| Detail | Info |
+|--------|------|
+| Status | Released |
+| Released | 2027.05.15 |
+| Category | Developer Tools |

--- a/embargo-lift/content/releases/partnership.md
+++ b/embargo-lift/content/releases/partnership.md
@@ -1,0 +1,33 @@
++++
+title = "Strategic Partnership Details"
+date = "2027-06-01"
+description = "Embargoed until 2027.06.01 09:00 UTC -- cross-industry collaboration"
+weight = 2
+tags = ["partnership", "strategic", "embargoed"]
+[extra]
+status = "locked"
+embargo_time = "2027.06.01 09:00 UTC"
++++
+
+## Strategic Partnership Details
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#14141e" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#c03030"/>
+  <rect x="12" y="22" width="36" height="26" rx="2" fill="none" stroke="#08080c" stroke-width="2"/>
+  <path d="M20,22 L20,16 Q30,8 40,16 L40,22" stroke="#08080c" stroke-width="2" fill="none"/>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e4de" font-family="Allerta Stencil, sans-serif" font-size="12" letter-spacing="2">PARTNERSHIP</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">EMBARGOED // 2027.06.01</text>
+</svg>
+
+<span class="embargo-status embargo-locked" style="display: inline-block;">LOCKED</span>
+
+### Release Summary
+
+EMBARGOED UNTIL 2027.06.01 09:00 UTC. Details of the cross-industry collaboration agreement remain sealed. The partnership spans three verticals and represents the largest joint initiative in the organization's history.
+
+| Detail | Info |
+|--------|------|
+| Status | Embargoed |
+| Lift Time | 2027.06.01 09:00 UTC |
+| Category | Strategic |

--- a/embargo-lift/content/releases/platform-v3.md
+++ b/embargo-lift/content/releases/platform-v3.md
@@ -1,0 +1,33 @@
++++
+title = "Platform v3.0 Announcement"
+date = "2027-06-01"
+description = "Embargoed until 2027.06.01 09:00 UTC -- major platform rewrite"
+weight = 1
+tags = ["platform", "major-release", "embargoed"]
+[extra]
+status = "locked"
+embargo_time = "2027.06.01 09:00 UTC"
++++
+
+## Platform v3.0 Announcement
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#14141e" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#c03030"/>
+  <rect x="12" y="22" width="36" height="26" rx="2" fill="none" stroke="#08080c" stroke-width="2"/>
+  <path d="M20,22 L20,16 Q30,8 40,16 L40,22" stroke="#08080c" stroke-width="2" fill="none"/>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e4de" font-family="Allerta Stencil, sans-serif" font-size="12" letter-spacing="2">PLATFORM V3.0</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a5650" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">EMBARGOED // 2027.06.01</text>
+</svg>
+
+<span class="embargo-status embargo-locked" style="display: inline-block;">LOCKED</span>
+
+### Release Summary
+
+EMBARGOED UNTIL 2027.06.01 09:00 UTC. This content is under strict embargo. The full platform v3.0 announcement covers a complete architecture rewrite, new API surface, and migration path from v2.x.
+
+| Detail | Info |
+|--------|------|
+| Status | Embargoed |
+| Lift Time | 2027.06.01 09:00 UTC |
+| Category | Major Release |

--- a/embargo-lift/static/css/style.css
+++ b/embargo-lift/static/css/style.css
@@ -1,0 +1,479 @@
+/* Embargo Lift - Embargoed Content Release Event */
+/* Fonts: Allerta Stencil / Black Ops One display, IBM Plex Sans / Inter body */
+
+@import url('https://fonts.googleapis.com/css2?family=Allerta+Stencil&family=Black+Ops+One&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --bg-primary: #08080c;
+  --bg-secondary: #0e0e14;
+  --bg-panel: #14141e;
+  --text-primary: #e8e4de;
+  --text-secondary: #9a9690;
+  --text-muted: #5a5650;
+  --accent-red: #c03030;
+  --accent-amber: #d4920a;
+  --accent-green: #2a9a3a;
+  --accent-steel: #6878a0;
+  --border-color: #222230;
+  --border-accent: #c03030;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'IBM Plex Sans', 'Inter', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Black Ops One', sans-serif; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-red);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 1.4rem;
+  color: var(--accent-red);
+  letter-spacing: 0.08em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-red);
+  border-bottom-color: var(--accent-red);
+}
+
+.nav-cta {
+  background-color: var(--accent-red) !important;
+  color: var(--text-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 5rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.08em;
+}
+
+.hero-subtitle {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Embargo Block */
+.embargo-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.embargo-status {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.7rem;
+  min-width: 80px;
+  text-align: center;
+  padding: 4px 10px;
+  letter-spacing: 0.1em;
+}
+
+.embargo-locked {
+  border: 2px solid var(--accent-red);
+  color: var(--accent-red);
+}
+
+.embargo-unlocked {
+  border: 2px solid var(--accent-green);
+  color: var(--accent-green);
+}
+
+.embargo-info { flex: 1; }
+
+.embargo-title {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.embargo-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.embargo-time {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.75rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.08em;
+  flex-shrink: 0;
+}
+
+/* Countdown Row */
+.countdown-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.countdown-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.countdown-display {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 3rem;
+  color: var(--accent-amber);
+  line-height: 1;
+}
+
+.countdown-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-amber);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-red);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Allerta Stencil', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-red);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-red);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-red);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Black Ops One', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-red);
+  line-height: 1;
+  letter-spacing: 0.1em;
+}
+
+.error-msg {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 2.8rem; }
+  h1 { font-size: 2rem; }
+  .embargo-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .countdown-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/embargo-lift/templates/404.html
+++ b/embargo-lift/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Padlock -->
+        <rect x="22" y="36" width="36" height="30" rx="3" fill="none" stroke="#c03030" stroke-width="2.5"/>
+        <path d="M30,36 L30,24 Q40,10 50,24 L50,36" stroke="#c03030" stroke-width="2.5" fill="none"/>
+        <circle cx="40" cy="50" r="4" fill="#c03030" opacity="0.5"/>
+        <line x1="40" y1="54" x2="40" y2="60" stroke="#c03030" stroke-width="2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Content Embargoed</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-red); font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Status</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/embargo-lift/templates/footer.html
+++ b/embargo-lift/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">EMBARGO LIFT // CLASSIFIED RELEASE EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Status</a>
+        <a href="{{ base_url }}/releases/">Releases</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/embargo-lift/templates/header.html
+++ b/embargo-lift/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">EMBARGO LIFT</span>
+        <span class="logo-sub">classified</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Status</a>
+        <a href="{{ base_url }}/releases/">Releases</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+        <a href="{{ base_url }}/access/" class="nav-cta">Access</a>
+      </nav>
+    </div>
+  </header>

--- a/embargo-lift/templates/page.html
+++ b/embargo-lift/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/embargo-lift/templates/post.html
+++ b/embargo-lift/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("release") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/embargo-lift/templates/section.html
+++ b/embargo-lift/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/embargo-lift/templates/taxonomy.html
+++ b/embargo-lift/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/embargo-lift/templates/taxonomy_term.html
+++ b/embargo-lift/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All releases tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1019,6 +1019,13 @@
     "saas",
     "enterprise"
   ],
+  "embargo-lift": [
+    "event",
+    "dark",
+    "embargo",
+    "release",
+    "timed"
+  ],
   "ember": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Add embargo-lift example site: embargoed content release event
- Allerta Stencil / Black Ops One display, IBM Plex Sans / Inter body typography
- Inline SVG padlock illustrations (locked/unlocked states), embargo seal stamp marks, countdown timer displays, broken seal/chain patterns
- EMBARGOED UNTIL [date/time] headers, Lock > Unlock transition states

Closes #1670