### PR TITLE
feat: add last-call example site (closes #1669)

### DIFF
--- a/last-call/config.toml
+++ b/last-call/config.toml
@@ -1,0 +1,41 @@
+title = "Last Call"
+description = "Closing session event with last-call urgency -- the clock is running out"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["sessions"]
+
+[markdown]
+safe = false

--- a/last-call/content/closing.md
+++ b/last-call/content/closing.md
@@ -1,0 +1,32 @@
++++
+title = "Closing"
+description = "Final notes before the event ends"
++++
+
+<div class="section-block">
+  <div class="section-label">Final Notice</div>
+  <h2>Doors Close at 22:00</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">No extensions. No encores. When the clock strikes, the event is over. Collect your materials, exchange final contacts, and exit through the main hall. The lights will dim in stages.</p>
+
+  <!-- SVG dimming lights pattern -->
+  <svg width="300" height="60" viewBox="0 0 300 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <!-- Five lights dimming from left to right -->
+    <circle cx="30" cy="30" r="18" fill="#d42020" opacity="0.25"/>
+    <circle cx="30" cy="30" r="8" fill="#d42020" opacity="0.4"/>
+    <circle cx="90" cy="30" r="18" fill="#d42020" opacity="0.15"/>
+    <circle cx="90" cy="30" r="8" fill="#d42020" opacity="0.3"/>
+    <circle cx="150" cy="30" r="18" fill="#d42020" opacity="0.1"/>
+    <circle cx="150" cy="30" r="8" fill="#d42020" opacity="0.2"/>
+    <circle cx="210" cy="30" r="18" fill="#d42020" opacity="0.05"/>
+    <circle cx="210" cy="30" r="8" fill="#d42020" opacity="0.1"/>
+    <circle cx="270" cy="30" r="18" fill="#d42020" opacity="0.02"/>
+    <circle cx="270" cy="30" r="8" fill="#d42020" opacity="0.05"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="urgency-badge" style="font-size: 0.9rem; padding: 6px 20px;">LAST CALL</span>
+    <span style="font-family: 'Oswald', sans-serif; font-weight: 700; font-size: 0.75rem; color: var(--text-muted); letter-spacing: 0.1em;">22:00 SHARP</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Oswald', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">2027.04.18 // Signal Hall, Berlin</p>
+</div>

--- a/last-call/content/index.md
+++ b/last-call/content/index.md
@@ -1,0 +1,148 @@
++++
+title = "Home"
+description = "Closing session event with last-call urgency -- the clock is running out"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Closing Session Event</div>
+    <h1>LAST CALL</h1>
+    <p class="hero-subtitle">The lights are dimming. Three final sessions before the doors close for good. Every minute counts. This is your last chance.</p>
+    <p class="hero-date">2027.04.18 // CLOSING AT 22:00 // SIGNAL HALL, BERLIN</p>
+
+    <!-- SVG closing time clock -->
+    <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Clock face -->
+      <circle cx="100" cy="100" r="80" stroke="#d42020" stroke-width="2" fill="none" opacity="0.3"/>
+      <circle cx="100" cy="100" r="75" stroke="#d42020" stroke-width="1" fill="none" opacity="0.15"/>
+      <!-- Hour marks -->
+      <line x1="100" y1="25" x2="100" y2="35" stroke="#d42020" stroke-width="2" opacity="0.5"/>
+      <line x1="100" y1="165" x2="100" y2="175" stroke="#d42020" stroke-width="2" opacity="0.5"/>
+      <line x1="25" y1="100" x2="35" y2="100" stroke="#d42020" stroke-width="2" opacity="0.5"/>
+      <line x1="165" y1="100" x2="175" y2="100" stroke="#d42020" stroke-width="2" opacity="0.5"/>
+      <!-- Minute marks -->
+      <line x1="140" y1="32" x2="136" y2="38" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="168" y1="60" x2="162" y2="63" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="168" y1="140" x2="162" y2="137" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="140" y1="168" x2="136" y2="162" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="60" y1="168" x2="64" y2="162" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="32" y1="140" x2="38" y2="137" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="32" y1="60" x2="38" y2="63" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <line x1="60" y1="32" x2="64" y2="38" stroke="#d42020" stroke-width="1" opacity="0.3"/>
+      <!-- Clock hands pointing near midnight -->
+      <line x1="100" y1="100" x2="100" y2="38" stroke="#d42020" stroke-width="3" stroke-linecap="round"/>
+      <line x1="100" y1="100" x2="92" y2="42" stroke="#e8a020" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="100" cy="100" r="5" fill="#d42020"/>
+      <!-- Time text -->
+      <text x="100" y="145" text-anchor="middle" fill="#605048" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="3">22:00</text>
+      <text x="100" y="160" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="7" letter-spacing="2">CLOSING</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Countdown to Close</div>
+  <h2>Final Sessions</h2>
+
+  <div class="countdown-block-item">
+    <div class="countdown-number">FINAL HOUR</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Closing Keynote -- The Last Word</div>
+      <div class="countdown-meta">Final address before the doors shut</div>
+    </div>
+    <div class="countdown-badge"><span class="urgency-badge">LAST CALL</span></div>
+  </div>
+
+  <div class="countdown-block-item">
+    <div class="countdown-number" style="color: var(--accent-amber);">LAST 30 MIN</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Lightning Retrospective</div>
+      <div class="countdown-meta">Rapid-fire highlights from the full event</div>
+    </div>
+    <div class="countdown-badge"><span class="urgency-badge-outline">CLOSING</span></div>
+  </div>
+
+  <div class="countdown-block-item">
+    <div class="countdown-number" style="color: var(--accent-dim);">LAST CALL</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Final Networking Window</div>
+      <div class="countdown-meta">Last chance for hallway conversations</div>
+    </div>
+    <div class="countdown-badge"><span class="urgency-badge">FINAL</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Time Remaining</div>
+  <h2>Countdown</h2>
+
+  <div class="timer-row">
+    <div class="timer-block">
+      <!-- SVG dimming lights -->
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="35" r="20" fill="#d42020" opacity="0.08"/>
+        <circle cx="40" cy="35" r="12" fill="#d42020" opacity="0.12"/>
+        <circle cx="40" cy="35" r="5" fill="#d42020" opacity="0.3"/>
+        <line x1="40" y1="55" x2="40" y2="70" stroke="#d42020" stroke-width="1.5" opacity="0.3"/>
+        <line x1="32" y1="58" x2="48" y2="58" stroke="#d42020" stroke-width="1" opacity="0.2"/>
+      </svg>
+      <div class="timer-display">01</div>
+      <div class="timer-label">Hours</div>
+    </div>
+    <div class="timer-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="35" r="20" fill="#e8a020" opacity="0.06"/>
+        <circle cx="40" cy="35" r="12" fill="#e8a020" opacity="0.1"/>
+        <circle cx="40" cy="35" r="5" fill="#e8a020" opacity="0.25"/>
+        <line x1="40" y1="55" x2="40" y2="70" stroke="#e8a020" stroke-width="1.5" opacity="0.3"/>
+        <line x1="32" y1="58" x2="48" y2="58" stroke="#e8a020" stroke-width="1" opacity="0.2"/>
+      </svg>
+      <div class="timer-display" style="color: var(--accent-amber);">00</div>
+      <div class="timer-label">Minutes</div>
+    </div>
+    <div class="timer-block">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="40" cy="35" r="20" fill="#804030" opacity="0.05"/>
+        <circle cx="40" cy="35" r="12" fill="#804030" opacity="0.08"/>
+        <circle cx="40" cy="35" r="5" fill="#804030" opacity="0.15"/>
+        <line x1="40" y1="55" x2="40" y2="70" stroke="#804030" stroke-width="1.5" opacity="0.3"/>
+        <line x1="32" y1="58" x2="48" y2="58" stroke="#804030" stroke-width="1" opacity="0.2"/>
+      </svg>
+      <div class="timer-display" style="color: var(--accent-dim);">00</div>
+      <div class="timer-label">Seconds</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Curtain</div>
+  <h2>Closing Edge</h2>
+
+  <!-- SVG curtain-closing edge pattern -->
+  <svg width="100%" height="120" viewBox="0 0 600 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Left curtain -->
+    <path d="M0,0 Q30,40 10,120" stroke="#d42020" stroke-width="2" fill="none" opacity="0.4"/>
+    <path d="M20,0 Q50,40 30,120" stroke="#d42020" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <path d="M40,0 Q70,40 50,120" stroke="#d42020" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M60,0 Q90,40 70,120" stroke="#d42020" stroke-width="1" fill="none" opacity="0.15"/>
+    <path d="M80,0 Q110,40 90,120" stroke="#d42020" stroke-width="0.5" fill="none" opacity="0.1"/>
+    <!-- Right curtain -->
+    <path d="M600,0 Q570,40 590,120" stroke="#d42020" stroke-width="2" fill="none" opacity="0.4"/>
+    <path d="M580,0 Q550,40 570,120" stroke="#d42020" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <path d="M560,0 Q530,40 550,120" stroke="#d42020" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M540,0 Q510,40 530,120" stroke="#d42020" stroke-width="1" fill="none" opacity="0.15"/>
+    <path d="M520,0 Q490,40 510,120" stroke="#d42020" stroke-width="0.5" fill="none" opacity="0.1"/>
+    <!-- Final countdown numbers -->
+    <text x="200" y="65" text-anchor="middle" fill="#d42020" font-family="Bebas Neue, sans-serif" font-size="28" opacity="0.15">3</text>
+    <text x="300" y="65" text-anchor="middle" fill="#d42020" font-family="Bebas Neue, sans-serif" font-size="28" opacity="0.1">2</text>
+    <text x="400" y="65" text-anchor="middle" fill="#d42020" font-family="Bebas Neue, sans-serif" font-size="28" opacity="0.06">1</text>
+    <!-- Center label -->
+    <text x="300" y="100" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="8" letter-spacing="3">CURTAIN CLOSING</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Oswald', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">3 final sessions // 1 hour remaining // doors close at 22:00</p>
+</div>
+
+</div>

--- a/last-call/content/schedule.md
+++ b/last-call/content/schedule.md
@@ -1,0 +1,22 @@
++++
+title = "Schedule"
+description = "Final hour schedule -- every minute accounted for"
++++
+
+<div class="section-block">
+  <div class="section-label">Timeline</div>
+  <h2>Final Hour Schedule</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The last sixty minutes are tightly choreographed. No slack. No extensions. When 22:00 arrives, the lights go down and the doors lock.</p>
+
+  <!-- SVG final countdown number display -->
+  <svg width="100%" height="80" viewBox="0 0 500 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block; max-width: 500px;">
+    <text x="80" y="55" text-anchor="middle" fill="#d42020" font-family="Bebas Neue, sans-serif" font-size="48" opacity="0.3">60</text>
+    <text x="80" y="72" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="7" letter-spacing="2">MINUTES</text>
+    <text x="180" y="55" text-anchor="middle" fill="#e8a020" font-family="Bebas Neue, sans-serif" font-size="48" opacity="0.2">30</text>
+    <text x="180" y="72" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="7" letter-spacing="2">HALFWAY</text>
+    <text x="280" y="55" text-anchor="middle" fill="#804030" font-family="Bebas Neue, sans-serif" font-size="48" opacity="0.15">10</text>
+    <text x="280" y="72" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="7" letter-spacing="2">FINAL</text>
+    <text x="380" y="55" text-anchor="middle" fill="#d42020" font-family="Bebas Neue, sans-serif" font-size="48" opacity="0.1">00</text>
+    <text x="380" y="72" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="7" letter-spacing="2">CLOSED</text>
+  </svg>
+</div>

--- a/last-call/content/sessions/_index.md
+++ b/last-call/content/sessions/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Sessions"
+description = "All closing sessions in the final hour"
+sort_by = "weight"
+template = "section"
++++
+
+The final three sessions. Each one closer to the end.

--- a/last-call/content/sessions/closing-keynote.md
+++ b/last-call/content/sessions/closing-keynote.md
@@ -1,0 +1,34 @@
++++
+title = "Closing Keynote -- The Last Word"
+date = "2027-04-18"
+description = "Final Hour -- the closing address before the doors shut"
+weight = 1
+tags = ["keynote", "closing", "final"]
+[extra]
+speaker = "Director Kai Breuer"
+window = "FINAL HOUR"
+duration = "25 min"
++++
+
+## Closing Keynote -- The Last Word
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1414" stroke="#d42020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d42020"/>
+  <text x="35" y="36" text-anchor="middle" fill="#0a0808" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="1">FINAL</text>
+  <text x="35" y="52" text-anchor="middle" fill="#0a0808" font-family="Bebas Neue, sans-serif" font-size="10" letter-spacing="1">HOUR</text>
+  <text x="175" y="35" text-anchor="middle" fill="#f0e8e0" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="2">THE LAST WORD</text>
+  <text x="175" y="55" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="8" letter-spacing="2">KAI BREUER // 25 MIN</text>
+</svg>
+
+<span class="urgency-badge">LAST CALL</span>
+
+### Session Summary
+
+Director Kai Breuer takes the stage for twenty-five minutes. No slides. No demos. Just the final word on what was built this week and where the community goes from here. The clock is visible on every screen.
+
+| Detail | Info |
+|--------|------|
+| Duration | 25 min |
+| Speaker | Director Kai Breuer |
+| Window | FINAL HOUR |

--- a/last-call/content/sessions/final-networking.md
+++ b/last-call/content/sessions/final-networking.md
@@ -1,0 +1,33 @@
++++
+title = "Final Networking Window"
+date = "2027-04-18"
+description = "Last Call -- the final window for hallway conversations"
+weight = 3
+tags = ["networking", "final", "hallway"]
+[extra]
+window = "LAST CALL"
+duration = "15 min"
++++
+
+## Final Networking Window
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1414" stroke="#d42020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d42020"/>
+  <text x="35" y="36" text-anchor="middle" fill="#0a0808" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">LAST</text>
+  <text x="35" y="52" text-anchor="middle" fill="#0a0808" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">CALL</text>
+  <text x="175" y="35" text-anchor="middle" fill="#f0e8e0" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="2">FINAL NETWORKING</text>
+  <text x="175" y="55" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="8" letter-spacing="2">OPEN FORMAT // 15 MIN</text>
+</svg>
+
+<span class="urgency-badge">FINAL</span>
+
+### Session Summary
+
+The last fifteen minutes. Lights at fifty percent. No agenda. This is your final window to exchange contacts, close conversations, and say goodbye. At 22:00, the house lights drop to zero.
+
+| Detail | Info |
+|--------|------|
+| Duration | 15 min |
+| Format | Open networking |
+| Window | LAST CALL |

--- a/last-call/content/sessions/lightning-retro.md
+++ b/last-call/content/sessions/lightning-retro.md
@@ -1,0 +1,33 @@
++++
+title = "Lightning Retrospective"
+date = "2027-04-18"
+description = "Last 30 Min -- rapid-fire highlights from the full event"
+weight = 2
+tags = ["retrospective", "highlights", "rapid"]
+[extra]
+window = "LAST 30 MIN"
+duration = "20 min"
++++
+
+## Lightning Retrospective
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1414" stroke="#e8a020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="none" stroke="#e8a020" stroke-width="2"/>
+  <text x="35" y="36" text-anchor="middle" fill="#e8a020" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">LAST</text>
+  <text x="35" y="52" text-anchor="middle" fill="#e8a020" font-family="Bebas Neue, sans-serif" font-size="9" letter-spacing="1">30 MIN</text>
+  <text x="175" y="35" text-anchor="middle" fill="#f0e8e0" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="2">LIGHTNING RETRO</text>
+  <text x="175" y="55" text-anchor="middle" fill="#605048" font-family="Oswald, sans-serif" font-weight="700" font-size="8" letter-spacing="2">MULTI-SPEAKER // 20 MIN</text>
+</svg>
+
+<span class="urgency-badge-outline">CLOSING</span>
+
+### Session Summary
+
+Eight speakers, two minutes each. The best moments from four days compressed into twenty minutes. No context. No preamble. Just the highlights, delivered at speed.
+
+| Detail | Info |
+|--------|------|
+| Duration | 20 min |
+| Format | 8 speakers, 2 min each |
+| Window | LAST 30 MIN |

--- a/last-call/static/css/style.css
+++ b/last-call/static/css/style.css
@@ -1,0 +1,486 @@
+/* Last Call - Closing Session Event */
+/* Fonts: Bebas Neue / Oswald Black display, Inter / Roboto body */
+
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Oswald:wght@500;700;900&family=Inter:wght@400;500;600&family=Roboto:wght@400;500;700&display=swap');
+
+:root {
+  --bg-primary: #0a0808;
+  --bg-secondary: #120e0e;
+  --bg-panel: #1a1414;
+  --text-primary: #f0e8e0;
+  --text-secondary: #a89888;
+  --text-muted: #605048;
+  --accent-red: #d42020;
+  --accent-amber: #e8a020;
+  --accent-dim: #804030;
+  --border-color: #2a2020;
+  --border-accent: #d42020;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Roboto', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  line-height: 1.05;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+h1 { font-size: 3rem; }
+h2 { font-size: 2rem; }
+h3 { font-size: 1.3rem; font-family: 'Oswald', sans-serif; font-weight: 700; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-red);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.6rem;
+  color: var(--accent-red);
+  letter-spacing: 0.08em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-red);
+  border-bottom-color: var(--accent-red);
+}
+
+.nav-cta {
+  background-color: var(--accent-red) !important;
+  color: var(--text-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 6rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.08em;
+}
+
+.hero-subtitle {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 480px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Countdown Block */
+.countdown-block-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.countdown-number {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 2.2rem;
+  color: var(--accent-red);
+  min-width: 80px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.countdown-info { flex: 1; }
+
+.countdown-title {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.06em;
+}
+
+.countdown-meta {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.countdown-badge {
+  flex-shrink: 0;
+}
+
+/* Urgency Badge */
+.urgency-badge {
+  display: inline-block;
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  background: var(--accent-red);
+  color: var(--text-primary);
+}
+
+.urgency-badge-outline {
+  display: inline-block;
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* Timer Row */
+.timer-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.timer-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.timer-display {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 3.5rem;
+  color: var(--accent-red);
+  line-height: 1;
+}
+
+.timer-label {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Oswald', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-amber);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-red);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Oswald', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-red);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Oswald', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-red);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Oswald', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-red);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-red);
+  line-height: 1;
+  letter-spacing: 0.1em;
+}
+
+.error-msg {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3.5rem; }
+  h1 { font-size: 2rem; }
+  .countdown-block-item { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .timer-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/last-call/templates/404.html
+++ b/last-call/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Clock face -->
+        <circle cx="40" cy="40" r="32" stroke="#d42020" stroke-width="2" fill="none"/>
+        <line x1="40" y1="40" x2="40" y2="18" stroke="#d42020" stroke-width="2.5" stroke-linecap="round"/>
+        <line x1="40" y1="40" x2="55" y2="45" stroke="#d42020" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="40" cy="40" r="3" fill="#d42020" opacity="0.5"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Session Closed</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-red); font-family: 'Oswald', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Countdown</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/last-call/templates/footer.html
+++ b/last-call/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">LAST CALL // CLOSING SESSION EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Countdown</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/last-call/templates/header.html
+++ b/last-call/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">LAST CALL</span>
+        <span class="logo-sub">closing soon</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Countdown</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+        <a href="{{ base_url }}/closing/" class="nav-cta">Closing</a>
+      </nav>
+    </div>
+  </header>

--- a/last-call/templates/page.html
+++ b/last-call/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/last-call/templates/post.html
+++ b/last-call/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("session") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/last-call/templates/section.html
+++ b/last-call/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/last-call/templates/taxonomy.html
+++ b/last-call/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/last-call/templates/taxonomy_term.html
+++ b/last-call/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All sessions tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1700,6 +1700,13 @@
     "concert",
     "glamorous"
   ],
+  "last-call": [
+    "event",
+    "dark",
+    "closing",
+    "final",
+    "urgent"
+  ],
   "lattice": [
     "light",
     "docs",


### PR DESCRIPTION
## Summary
- Add last-call example site: closing session event with last-call urgency
- Bebas Neue / Oswald Black display, Inter / Roboto body typography
- Inline SVG closing time clock displays, dimming lights patterns, curtain-closing edge patterns, final countdown number displays
- Countdown to close: FINAL HOUR, LAST 30 MIN, LAST CALL format

Closes #1669