### PR TITLE
feat: add ground-zero example site (closes #1667)

### DIFF
--- a/ground-zero/config.toml
+++ b/ground-zero/config.toml
@@ -1,0 +1,41 @@
+title = "Ground Zero"
+description = "Impact origin event -- where transformation begins at the epicenter"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["zones"]
+
+[markdown]
+safe = false

--- a/ground-zero/content/attend.md
+++ b/ground-zero/content/attend.md
@@ -1,0 +1,28 @@
++++
+title = "Attend"
+description = "Register for the Ground Zero impact event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Enter the Epicenter</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Access is zone-based. Epicenter passes grant full access to all four zones. Zone passes restrict to the outer rings. Choose your distance from the point of impact.</p>
+
+  <!-- SVG crosshair target -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="50" cy="50" r="35" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="50" cy="50" r="20" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <line x1="50" y1="10" x2="50" y2="35" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+    <line x1="50" y1="65" x2="50" y2="90" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+    <line x1="10" y1="50" x2="35" y2="50" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+    <line x1="65" y1="50" x2="90" y2="50" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+    <circle cx="50" cy="50" r="5" fill="#22d3ee" opacity="0.4"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="impact-badge" style="font-size: 0.85rem; padding: 6px 20px;">EPICENTER PASS</span>
+    <span class="impact-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">ZONE PASS</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Anton', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.07.22 // EPICENTER COMPLEX, TOKYO</p>
+</div>

--- a/ground-zero/content/index.md
+++ b/ground-zero/content/index.md
@@ -1,0 +1,149 @@
++++
+title = "Home"
+description = "Impact origin event -- where transformation begins at the epicenter"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Impact Origin Event</div>
+    <h1>GROUND ZERO</h1>
+    <p class="hero-subtitle">Everything radiates from the epicenter. Four concentric zones mark the distance from the point of impact. The closer you are, the greater the transformation.</p>
+    <p class="hero-date">2027.07.22 // EPICENTER COMPLEX, TOKYO</p>
+
+    <!-- SVG concentric blast ring pattern -->
+    <svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Outer rings -->
+      <circle cx="120" cy="120" r="110" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.1"/>
+      <circle cx="120" cy="120" r="90" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.15"/>
+      <circle cx="120" cy="120" r="70" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.2"/>
+      <circle cx="120" cy="120" r="50" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.3"/>
+      <circle cx="120" cy="120" r="30" stroke="#22d3ee" stroke-width="2" fill="none" opacity="0.4"/>
+      <!-- Epicenter crosshair -->
+      <line x1="120" y1="5" x2="120" y2="45" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+      <line x1="120" y1="195" x2="120" y2="235" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+      <line x1="5" y1="120" x2="45" y2="120" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+      <line x1="195" y1="120" x2="235" y2="120" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+      <!-- Epicenter dot -->
+      <circle cx="120" cy="120" r="8" fill="#22d3ee" opacity="0.15"/>
+      <circle cx="120" cy="120" r="4" fill="#22d3ee" opacity="0.4"/>
+      <!-- Distance measurement marks -->
+      <text x="120" y="75" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ZONE 1</text>
+      <text x="120" y="55" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ZONE 2</text>
+      <text x="120" y="38" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ZONE 3</text>
+      <text x="120" y="18" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ZONE 4</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Impact Zones</div>
+  <h2>Concentric Layout</h2>
+
+  <div class="zone-block">
+    <div class="zone-distance">0-10m</div>
+    <div class="zone-info">
+      <div class="zone-title">Epicenter -- Core Impact</div>
+      <div class="zone-meta">Keynote stage, maximum intensity sessions</div>
+    </div>
+    <div class="zone-badge-slot"><span class="impact-badge">Epicenter</span></div>
+  </div>
+
+  <div class="zone-block">
+    <div class="zone-distance">10-50m</div>
+    <div class="zone-info">
+      <div class="zone-title">Zone 1 -- Shockwave</div>
+      <div class="zone-meta">Deep-dive workshops, hands-on transformation</div>
+    </div>
+    <div class="zone-badge-slot"><span class="impact-badge-outline">Zone 1</span></div>
+  </div>
+
+  <div class="zone-block">
+    <div class="zone-distance">50-150m</div>
+    <div class="zone-info">
+      <div class="zone-title">Zone 2 -- Propagation</div>
+      <div class="zone-meta">Panel discussions, collaborative sessions</div>
+    </div>
+    <div class="zone-badge-slot"><span class="impact-badge-outline">Zone 2</span></div>
+  </div>
+
+  <div class="zone-block">
+    <div class="zone-distance">150m+</div>
+    <div class="zone-info">
+      <div class="zone-title">Zone 3 -- Perimeter</div>
+      <div class="zone-meta">Networking lounges, exhibition hall, open space</div>
+    </div>
+    <div class="zone-badge-slot"><span class="impact-badge-outline">Zone 3</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Measurement</div>
+  <h2>Distance from Center</h2>
+
+  <div class="ring-row">
+    <div class="ring-block">
+      <!-- SVG epicenter crosshair -->
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="35" r="28" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.2"/>
+        <line x1="35" y1="5" x2="35" y2="22" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="35" y1="48" x2="35" y2="65" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="5" y1="35" x2="22" y2="35" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="48" y1="35" x2="65" y2="35" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <circle cx="35" cy="35" r="4" fill="#22d3ee" opacity="0.5"/>
+      </svg>
+      <div class="ring-display">0m</div>
+      <div class="ring-label">Epicenter</div>
+    </div>
+    <div class="ring-block">
+      <!-- SVG distance ring -->
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="35" r="28" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.15"/>
+        <circle cx="35" cy="35" r="18" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.2"/>
+        <circle cx="35" cy="35" r="3" fill="#22d3ee" opacity="0.3"/>
+      </svg>
+      <div class="ring-display" style="color: var(--accent-dim);">50m</div>
+      <div class="ring-label">Zone 1</div>
+    </div>
+    <div class="ring-block">
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="35" r="28" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.1"/>
+        <circle cx="35" cy="35" r="20" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.12"/>
+        <circle cx="35" cy="35" r="12" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.15"/>
+        <circle cx="35" cy="35" r="3" fill="#22d3ee" opacity="0.2"/>
+      </svg>
+      <div class="ring-display" style="color: var(--accent-dim);">150m</div>
+      <div class="ring-label">Zone 2</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Shockwave</div>
+  <h2>Propagation Pattern</h2>
+
+  <!-- SVG shockwave propagation diagram -->
+  <svg width="100%" height="120" viewBox="0 0 600 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Epicenter -->
+    <circle cx="60" cy="60" r="8" fill="#22d3ee" opacity="0.4"/>
+    <circle cx="60" cy="60" r="15" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <!-- Shockwave arcs radiating outward -->
+    <path d="M100,20 Q120,60 100,100" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <path d="M160,15 Q185,60 160,105" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <path d="M230,10 Q260,60 230,110" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.15"/>
+    <path d="M310,8 Q345,60 310,112" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.1"/>
+    <path d="M400,5 Q440,60 400,115" stroke="#22d3ee" stroke-width="0.5" fill="none" opacity="0.08"/>
+    <path d="M500,3 Q545,60 500,117" stroke="#22d3ee" stroke-width="0.5" fill="none" opacity="0.05"/>
+    <!-- Distance markers -->
+    <line x1="60" y1="85" x2="500" y2="85" stroke="#585450" stroke-width="0.5" opacity="0.3" stroke-dasharray="4"/>
+    <text x="60" y="98" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">0m</text>
+    <text x="160" y="98" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">50m</text>
+    <text x="310" y="98" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">150m</text>
+    <text x="500" y="98" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="7" letter-spacing="1">300m+</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Source Sans 3', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">4 concentric zones // 1 epicenter // total transformation</p>
+</div>
+
+</div>

--- a/ground-zero/content/origin.md
+++ b/ground-zero/content/origin.md
@@ -1,0 +1,30 @@
++++
+title = "Origin"
+description = "The origin story -- why Ground Zero exists"
++++
+
+<div class="section-block">
+  <div class="section-label">Genesis</div>
+  <h2>The Origin Point</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Every transformation has an epicenter. Ground Zero marks the exact point where ideas collide with enough force to reshape an entire field. This event is designed around that principle: maximum impact at the center, rippling outward through every zone.</p>
+
+  <!-- SVG concentric distance ring measurement -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <circle cx="100" cy="100" r="90" stroke="#22d3ee" stroke-width="0.5" fill="none" opacity="0.1"/>
+    <circle cx="100" cy="100" r="70" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="100" cy="100" r="50" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="100" cy="100" r="30" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <circle cx="100" cy="100" r="10" stroke="#22d3ee" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="100" cy="100" r="3" fill="#22d3ee" opacity="0.6"/>
+    <!-- Crosshair -->
+    <line x1="100" y1="5" x2="100" y2="40" stroke="#22d3ee" stroke-width="1" opacity="0.2"/>
+    <line x1="100" y1="160" x2="100" y2="195" stroke="#22d3ee" stroke-width="1" opacity="0.2"/>
+    <line x1="5" y1="100" x2="40" y2="100" stroke="#22d3ee" stroke-width="1" opacity="0.2"/>
+    <line x1="160" y1="100" x2="195" y2="100" stroke="#22d3ee" stroke-width="1" opacity="0.2"/>
+    <!-- Measurement ticks -->
+    <line x1="130" y1="98" x2="130" y2="102" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+    <line x1="150" y1="98" x2="150" y2="102" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+    <line x1="170" y1="98" x2="170" y2="102" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+    <line x1="190" y1="98" x2="190" y2="102" stroke="#22d3ee" stroke-width="1" opacity="0.3"/>
+  </svg>
+</div>

--- a/ground-zero/content/zones/_index.md
+++ b/ground-zero/content/zones/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Zones"
+description = "All impact zones radiating from the epicenter"
+sort_by = "weight"
+template = "section"
++++
+
+Four concentric zones. Closest to the center means closest to the impact.

--- a/ground-zero/content/zones/epicenter.md
+++ b/ground-zero/content/zones/epicenter.md
@@ -1,0 +1,34 @@
++++
+title = "Epicenter -- Core Impact"
+date = "2027-07-22"
+description = "0-10m from center -- keynote stage, maximum intensity sessions"
+weight = 1
+tags = ["epicenter", "keynote", "core"]
+[extra]
+distance = "0-10m"
+intensity = "Maximum"
+capacity = "200"
++++
+
+## Epicenter -- Core Impact
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#151518" stroke="#22d3ee" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#22d3ee"/>
+  <text x="30" y="35" text-anchor="middle" fill="#080808" font-family="Montserrat, sans-serif" font-weight="900" font-size="10">0-10m</text>
+  <text x="30" y="52" text-anchor="middle" fill="#080808" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8">CENTER</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e6e2" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">CORE IMPACT</text>
+  <text x="170" y="55" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8" letter-spacing="2">EPICENTER // MAXIMUM</text>
+</svg>
+
+<span class="impact-badge">Epicenter</span>
+
+### Zone Summary
+
+The innermost ring. Two hundred seats facing the keynote stage. This is where the impact originates. Every major announcement, every paradigm shift, every transformative moment happens here first. The shockwave starts at zero meters.
+
+| Detail | Info |
+|--------|------|
+| Distance | 0-10m from center |
+| Intensity | Maximum |
+| Capacity | 200 |

--- a/ground-zero/content/zones/perimeter.md
+++ b/ground-zero/content/zones/perimeter.md
@@ -1,0 +1,34 @@
++++
+title = "Zone 3 -- Perimeter"
+date = "2027-07-22"
+description = "150m+ from center -- networking lounges, exhibition, open space"
+weight = 4
+tags = ["perimeter", "networking", "exhibition"]
+[extra]
+distance = "150m+"
+intensity = "Open"
+capacity = "Unlimited"
++++
+
+## Zone 3 -- Perimeter
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#151518" stroke="#406068" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="none" stroke="#406068" stroke-width="2"/>
+  <text x="30" y="35" text-anchor="middle" fill="#406068" font-family="Montserrat, sans-serif" font-weight="900" font-size="10">150m+</text>
+  <text x="30" y="52" text-anchor="middle" fill="#406068" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8">ZONE 3</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e6e2" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">PERIMETER</text>
+  <text x="170" y="55" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8" letter-spacing="2">OPEN SPACE // UNLIMITED</text>
+</svg>
+
+<span class="impact-badge-outline">Zone 3</span>
+
+### Zone Summary
+
+The outer ring. No walls, no capacity limits. The perimeter is where the shockwave dissipates into sustained energy. Networking lounges, exhibition halls, and open collaboration spaces. The impact still reaches here -- attenuated but persistent.
+
+| Detail | Info |
+|--------|------|
+| Distance | 150m+ from center |
+| Intensity | Open |
+| Capacity | Unlimited |

--- a/ground-zero/content/zones/shockwave.md
+++ b/ground-zero/content/zones/shockwave.md
@@ -1,0 +1,34 @@
++++
+title = "Zone 1 -- Shockwave"
+date = "2027-07-22"
+description = "10-50m from center -- deep-dive workshops, hands-on transformation"
+weight = 2
+tags = ["shockwave", "workshops", "hands-on"]
+[extra]
+distance = "10-50m"
+intensity = "High"
+capacity = "500"
++++
+
+## Zone 1 -- Shockwave
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#151518" stroke="#22d3ee" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="none" stroke="#22d3ee" stroke-width="2"/>
+  <text x="30" y="35" text-anchor="middle" fill="#22d3ee" font-family="Montserrat, sans-serif" font-weight="900" font-size="10">10-50m</text>
+  <text x="30" y="52" text-anchor="middle" fill="#22d3ee" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8">ZONE 1</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8e6e2" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">SHOCKWAVE</text>
+  <text x="170" y="55" text-anchor="middle" fill="#585450" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="8" letter-spacing="2">WORKSHOPS // HIGH</text>
+</svg>
+
+<span class="impact-badge-outline">Zone 1</span>
+
+### Zone Summary
+
+The first ring outward. Five hundred participants in deep-dive workshops. The shockwave from the epicenter reaches here in minutes. Hands-on sessions translate keynote vision into actionable transformation. High intensity, maximum participation.
+
+| Detail | Info |
+|--------|------|
+| Distance | 10-50m from center |
+| Intensity | High |
+| Capacity | 500 |

--- a/ground-zero/static/css/style.css
+++ b/ground-zero/static/css/style.css
@@ -1,0 +1,498 @@
+/* Ground Zero - Impact Origin Event */
+/* Fonts: Montserrat Black / Anton display, Inter / Source Sans Pro body */
+
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800;900&family=Anton&family=Inter:wght@400;500;600&family=Source+Sans+3:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #080808;
+  --bg-secondary: #0e0e10;
+  --bg-panel: #151518;
+  --text-primary: #e8e6e2;
+  --text-secondary: #989490;
+  --text-muted: #585450;
+  --accent-cyan: #22d3ee;
+  --accent-white: #e8e6e2;
+  --accent-dim: #406068;
+  --border-color: #202024;
+  --border-accent: #22d3ee;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Source Sans 3', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  line-height: 1.1;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Anton', sans-serif; font-weight: 400; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-cyan);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.4rem;
+  color: var(--accent-cyan);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-cyan);
+  border-bottom-color: var(--accent-cyan);
+}
+
+.nav-cta {
+  background-color: var(--accent-cyan) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-cyan);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 5.5rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-cyan);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Zone Block */
+.zone-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.zone-distance {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.1rem;
+  color: var(--accent-cyan);
+  min-width: 70px;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.zone-info { flex: 1; }
+
+.zone-title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.zone-meta {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.zone-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Impact Badge */
+.impact-badge {
+  display: inline-block;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-cyan);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.impact-badge-outline {
+  display: inline-block;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-cyan);
+  color: var(--accent-cyan);
+  text-transform: uppercase;
+}
+
+/* Ring Row */
+.ring-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.ring-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.ring-display {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 2.5rem;
+  color: var(--accent-cyan);
+  line-height: 1;
+}
+
+.ring-label {
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-cyan);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-cyan);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Anton', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-cyan);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-cyan);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-cyan);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-cyan);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .zone-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .ring-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/ground-zero/templates/404.html
+++ b/ground-zero/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Crosshair -->
+        <circle cx="40" cy="40" r="25" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <circle cx="40" cy="40" r="15" stroke="#22d3ee" stroke-width="1" fill="none" opacity="0.2"/>
+        <line x1="40" y1="10" x2="40" y2="30" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="40" y1="50" x2="40" y2="70" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="10" y1="40" x2="30" y2="40" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <line x1="50" y1="40" x2="70" y2="40" stroke="#22d3ee" stroke-width="1.5" opacity="0.4"/>
+        <circle cx="40" cy="40" r="3" fill="#22d3ee" opacity="0.5"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Zone Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-cyan); font-family: 'Source Sans 3', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Epicenter</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ground-zero/templates/footer.html
+++ b/ground-zero/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">GROUND ZERO // IMPACT ORIGIN EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Impact</a>
+        <a href="{{ base_url }}/zones/">Zones</a>
+        <a href="{{ base_url }}/origin/">Origin</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/ground-zero/templates/header.html
+++ b/ground-zero/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">GROUND ZERO</span>
+        <span class="logo-sub">epicenter</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Impact</a>
+        <a href="{{ base_url }}/zones/">Zones</a>
+        <a href="{{ base_url }}/origin/">Origin</a>
+        <a href="{{ base_url }}/attend/" class="nav-cta">Attend</a>
+      </nav>
+    </div>
+  </header>

--- a/ground-zero/templates/page.html
+++ b/ground-zero/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ground-zero/templates/post.html
+++ b/ground-zero/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("zone") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ground-zero/templates/section.html
+++ b/ground-zero/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ground-zero/templates/taxonomy.html
+++ b/ground-zero/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ground-zero/templates/taxonomy_term.html
+++ b/ground-zero/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All zones tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1387,6 +1387,13 @@
     "minimal",
     "monochrome"
   ],
+  "ground-zero": [
+    "event",
+    "dark",
+    "origin",
+    "impact",
+    "transformative"
+  ],
   "guidebook": [
     "light",
     "docs",


### PR DESCRIPTION
## Summary
- Add ground-zero example site: impact origin event
- Montserrat Black / Anton display, Inter / Source Sans Pro body typography
- Inline SVG concentric blast ring patterns, epicenter crosshair markers, distance ring measurement marks, shockwave propagation diagrams
- Concentric ring layout with distance-from-center indicators (0-10m, 10-50m, 50-150m, 150m+)

Closes #1667