### PR TITLE
feat: add red-alert example site (closes #1663)

### DIFF
--- a/red-alert/config.toml
+++ b/red-alert/config.toml
@@ -1,0 +1,41 @@
+title = "Red Alert"
+description = "Emergency crisis summit -- threat assessment, response coordination, and crisis management"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["briefings"]
+
+[markdown]
+safe = false

--- a/red-alert/content/briefings/_index.md
+++ b/red-alert/content/briefings/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Briefings"
+description = "All crisis briefings organized by alert level"
+sort_by = "weight"
+template = "section"
++++
+
+Four alert levels. Each briefing escalates the response posture.

--- a/red-alert/content/briefings/green-monitoring.md
+++ b/red-alert/content/briefings/green-monitoring.md
@@ -1,0 +1,34 @@
++++
+title = "ALERT LEVEL GREEN -- Monitoring"
+date = "2027-08-20"
+description = "Baseline threat assessment and passive monitoring briefing"
+weight = 1
+tags = ["green", "monitoring", "baseline"]
+[extra]
+alert_level = "GREEN"
+threat = "Low"
+response = "Passive"
++++
+
+## ALERT LEVEL GREEN -- Monitoring
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a0a" stroke="#22c55e" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#22c55e"/>
+  <text x="35" y="35" text-anchor="middle" fill="#0a0a0a" font-family="Impact, sans-serif" font-size="11">ALERT</text>
+  <text x="35" y="52" text-anchor="middle" fill="#0a0a0a" font-family="Impact, sans-serif" font-size="11">GREEN</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0e0e0" font-family="Impact, sans-serif" font-size="13" letter-spacing="2">BASELINE MONITORING</text>
+  <text x="175" y="55" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">THREAT LOW // PASSIVE</text>
+</svg>
+
+<span class="level-badge level-green">Green</span>
+
+### Briefing Summary
+
+Standard operating posture. Passive monitoring of all threat channels. System health checks and baseline assessment. No active threats detected. Review of intelligence feeds and early warning indicators. Standing readiness confirmed.
+
+| Detail | Info |
+|--------|------|
+| Alert Level | GREEN |
+| Threat | Low |
+| Response | Passive |

--- a/red-alert/content/briefings/red-critical.md
+++ b/red-alert/content/briefings/red-critical.md
@@ -1,0 +1,34 @@
++++
+title = "ALERT LEVEL RED -- Critical"
+date = "2027-08-20"
+description = "Full incident response with active command coordination"
+weight = 3
+tags = ["red", "critical", "response"]
+[extra]
+alert_level = "RED"
+threat = "Critical"
+response = "Full"
++++
+
+## ALERT LEVEL RED -- Critical
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a0a" stroke="#dc2626" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="none" stroke="#dc2626" stroke-width="2"/>
+  <text x="35" y="35" text-anchor="middle" fill="#dc2626" font-family="Impact, sans-serif" font-size="11">ALERT</text>
+  <text x="35" y="52" text-anchor="middle" fill="#dc2626" font-family="Impact, sans-serif" font-size="11">RED</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0e0e0" font-family="Impact, sans-serif" font-size="13" letter-spacing="2">FULL RESPONSE</text>
+  <text x="175" y="55" text-anchor="middle" fill="#dc2626" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2" opacity="0.7">THIS IS NOT A DRILL</text>
+</svg>
+
+<span class="level-badge level-red">Red</span>
+
+### Briefing Summary
+
+Maximum alert. Full incident command activated. All-hands response across every agency. Real-time coordination in the command center. This is not a drill. Every channel open, every resource deployed, every decision counts. The summit converges on this moment.
+
+| Detail | Info |
+|--------|------|
+| Alert Level | RED |
+| Threat | Critical |
+| Response | Full |

--- a/red-alert/content/briefings/yellow-elevated.md
+++ b/red-alert/content/briefings/yellow-elevated.md
@@ -1,0 +1,34 @@
++++
+title = "ALERT LEVEL YELLOW -- Elevated"
+date = "2027-08-20"
+description = "Active surveillance and resource pre-positioning briefing"
+weight = 2
+tags = ["yellow", "elevated", "surveillance"]
+[extra]
+alert_level = "YELLOW"
+threat = "Elevated"
+response = "Active"
++++
+
+## ALERT LEVEL YELLOW -- Elevated
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a0a" stroke="#eab308" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="none" stroke="#eab308" stroke-width="2"/>
+  <text x="35" y="35" text-anchor="middle" fill="#eab308" font-family="Impact, sans-serif" font-size="11">ALERT</text>
+  <text x="35" y="52" text-anchor="middle" fill="#eab308" font-family="Impact, sans-serif" font-size="11">YELLOW</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0e0e0" font-family="Impact, sans-serif" font-size="13" letter-spacing="2">ACTIVE SURVEILLANCE</text>
+  <text x="175" y="55" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">THREAT ELEVATED // ACTIVE</text>
+</svg>
+
+<span class="level-badge level-yellow">Yellow</span>
+
+### Briefing Summary
+
+Elevated threat posture. Active surveillance across all channels. Resource pre-positioning begins. Team notifications sent. Increased monitoring frequency. Cross-agency check-ins initiated. Standing by for potential escalation.
+
+| Detail | Info |
+|--------|------|
+| Alert Level | YELLOW |
+| Threat | Elevated |
+| Response | Active |

--- a/red-alert/content/index.md
+++ b/red-alert/content/index.md
@@ -1,0 +1,158 @@
++++
+title = "Home"
+description = "Emergency crisis summit -- threat assessment, response coordination, and crisis management"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Emergency Crisis Summit</div>
+    <h1>RED ALERT</h1>
+    <p class="hero-subtitle">This is not a drill. A crisis summit dedicated to emergency response, threat escalation, and coordinated action across all alert levels.</p>
+    <p class="hero-date">2027.08.20 // COMMAND CENTER, WASHINGTON D.C.</p>
+
+    <!-- SVG rotating beacon light pattern -->
+    <svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Outer beacon sweep -->
+      <circle cx="110" cy="110" r="100" stroke="#dc2626" stroke-width="1" fill="none" opacity="0.08"/>
+      <circle cx="110" cy="110" r="80" stroke="#dc2626" stroke-width="1" fill="none" opacity="0.1"/>
+      <circle cx="110" cy="110" r="60" stroke="#dc2626" stroke-width="1.5" fill="none" opacity="0.15"/>
+      <circle cx="110" cy="110" r="40" stroke="#dc2626" stroke-width="1.5" fill="none" opacity="0.2"/>
+      <!-- Beacon rotation sweep lines -->
+      <line x1="110" y1="10" x2="110" y2="50" stroke="#dc2626" stroke-width="1.5" opacity="0.2"/>
+      <line x1="180" y1="40" x2="150" y2="70" stroke="#dc2626" stroke-width="1" opacity="0.12"/>
+      <line x1="210" y1="110" x2="170" y2="110" stroke="#dc2626" stroke-width="1" opacity="0.1"/>
+      <!-- Beacon core -->
+      <circle cx="110" cy="110" r="18" stroke="#dc2626" stroke-width="2" fill="none" opacity="0.3"/>
+      <circle cx="110" cy="110" r="8" fill="#dc2626" opacity="0.25"/>
+      <circle cx="110" cy="110" r="3" fill="#dc2626" opacity="0.5"/>
+      <!-- Alert level color bands -->
+      <rect x="25" y="185" width="30" height="8" fill="#22c55e" opacity="0.3"/>
+      <rect x="65" y="185" width="30" height="8" fill="#eab308" opacity="0.3"/>
+      <rect x="105" y="185" width="30" height="8" fill="#f97316" opacity="0.3"/>
+      <rect x="145" y="185" width="30" height="8" fill="#dc2626" opacity="0.4"/>
+      <text x="40" y="207" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">GREEN</text>
+      <text x="80" y="207" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">YELLOW</text>
+      <text x="120" y="207" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">ORANGE</text>
+      <text x="160" y="207" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="1">RED</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">THIS IS NOT A DRILL</div>
+  <h2>Alert Level Briefings</h2>
+
+  <div class="alert-block alert-green">
+    <div class="alert-level">GREEN</div>
+    <div class="alert-info">
+      <div class="alert-title">Monitoring -- Baseline Assessment</div>
+      <div class="alert-meta">Threat landscape review, passive monitoring, system checks</div>
+    </div>
+    <div class="alert-badge-slot"><span class="level-badge level-green">Low</span></div>
+  </div>
+
+  <div class="alert-block alert-yellow">
+    <div class="alert-level">YELLOW</div>
+    <div class="alert-info">
+      <div class="alert-title">Elevated -- Active Surveillance</div>
+      <div class="alert-meta">Increased monitoring, resource pre-positioning, team alerts</div>
+    </div>
+    <div class="alert-badge-slot"><span class="level-badge level-yellow">Elevated</span></div>
+  </div>
+
+  <div class="alert-block alert-orange">
+    <div class="alert-level">ORANGE</div>
+    <div class="alert-info">
+      <div class="alert-title">High -- Crisis Preparation</div>
+      <div class="alert-meta">Mobilization drills, cross-agency coordination, live briefings</div>
+    </div>
+    <div class="alert-badge-slot"><span class="level-badge level-orange">High</span></div>
+  </div>
+
+  <div class="alert-block alert-red">
+    <div class="alert-level">RED</div>
+    <div class="alert-info">
+      <div class="alert-title">Critical -- Full Response</div>
+      <div class="alert-meta">Active incident command, all-hands response, real-time coordination</div>
+    </div>
+    <div class="alert-badge-slot"><span class="level-badge level-red">Critical</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Severity Gauge</div>
+  <h2>Alert Level Indicators</h2>
+
+  <div class="gauge-row">
+    <div class="gauge-block">
+      <!-- SVG alert gauge GREEN -->
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="40" r="22" stroke="#505050" stroke-width="1" fill="none" opacity="0.15"/>
+        <path d="M18,52 A22,22 0 0,1 35,18" stroke="#22c55e" stroke-width="3" fill="none" opacity="0.4"/>
+        <circle cx="35" cy="40" r="3" fill="#22c55e" opacity="0.4"/>
+      </svg>
+      <div class="gauge-display" style="color: #22c55e;">GREEN</div>
+      <div class="gauge-label">Monitoring</div>
+    </div>
+    <div class="gauge-block">
+      <!-- SVG alert gauge YELLOW -->
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="40" r="22" stroke="#505050" stroke-width="1" fill="none" opacity="0.15"/>
+        <path d="M18,52 A22,22 0 0,1 52,52" stroke="#eab308" stroke-width="3" fill="none" opacity="0.4"/>
+        <circle cx="35" cy="40" r="3" fill="#eab308" opacity="0.4"/>
+      </svg>
+      <div class="gauge-display" style="color: #eab308;">YELLOW</div>
+      <div class="gauge-label">Elevated</div>
+    </div>
+    <div class="gauge-block">
+      <!-- SVG alert gauge RED -->
+      <svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="35" cy="40" r="22" stroke="#505050" stroke-width="1" fill="none" opacity="0.15"/>
+        <path d="M18,52 A22,22 0 1,1 52,52" stroke="#dc2626" stroke-width="3" fill="none" opacity="0.5"/>
+        <circle cx="35" cy="40" r="3" fill="#dc2626" opacity="0.5"/>
+      </svg>
+      <div class="gauge-display" style="color: #dc2626;">RED</div>
+      <div class="gauge-label">Critical</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Crisis Timeline</div>
+  <h2>Escalation Sequence</h2>
+
+  <!-- SVG crisis timeline diagram -->
+  <svg width="100%" height="120" viewBox="0 0 600 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Timeline base -->
+    <line x1="30" y1="60" x2="570" y2="60" stroke="#505050" stroke-width="1" opacity="0.2"/>
+    <!-- Emergency broadcast test pattern frame -->
+    <rect x="15" y="15" width="570" height="90" stroke="#dc2626" stroke-width="1" fill="none" opacity="0.1"/>
+    <rect x="20" y="20" width="560" height="80" stroke="#dc2626" stroke-width="0.5" fill="none" opacity="0.06"/>
+    <!-- GREEN node -->
+    <circle cx="80" cy="60" r="8" stroke="#22c55e" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="80" cy="60" r="3" fill="#22c55e" opacity="0.4"/>
+    <text x="80" y="90" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">GREEN</text>
+    <!-- YELLOW node -->
+    <circle cx="220" cy="60" r="8" stroke="#eab308" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="220" cy="60" r="3" fill="#eab308" opacity="0.4"/>
+    <text x="220" y="90" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">YELLOW</text>
+    <!-- ORANGE node -->
+    <circle cx="380" cy="60" r="8" stroke="#f97316" stroke-width="2" fill="none" opacity="0.4"/>
+    <circle cx="380" cy="60" r="3" fill="#f97316" opacity="0.4"/>
+    <text x="380" y="90" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ORANGE</text>
+    <!-- RED node -->
+    <circle cx="520" cy="60" r="10" stroke="#dc2626" stroke-width="2.5" fill="none" opacity="0.5"/>
+    <circle cx="520" cy="60" r="4" fill="#dc2626" opacity="0.5"/>
+    <text x="520" y="90" text-anchor="middle" fill="#dc2626" font-family="Impact, sans-serif" font-size="9" letter-spacing="2" opacity="0.6">RED</text>
+    <!-- Escalation arrows -->
+    <polygon points="140,57 150,60 140,63" fill="#505050" opacity="0.2"/>
+    <polygon points="290,57 300,60 290,63" fill="#505050" opacity="0.2"/>
+    <polygon points="445,57 455,60 445,63" fill="#505050" opacity="0.25"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">green > yellow > orange > red // this is not a drill</p>
+</div>
+
+</div>

--- a/red-alert/content/protocol.md
+++ b/red-alert/content/protocol.md
@@ -1,0 +1,27 @@
++++
+title = "Protocol"
+description = "Emergency response protocols and crisis escalation procedures"
++++
+
+<div class="section-block">
+  <div class="section-label">Response Framework</div>
+  <h2>Crisis Protocol</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Every crisis follows a predictable escalation pattern. Red Alert establishes clear protocols for each level -- from baseline monitoring at GREEN to full incident command at RED. The framework ensures coordinated response across all participating agencies.</p>
+
+  <!-- SVG emergency broadcast test pattern frame -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Outer frame -->
+    <rect x="10" y="10" width="180" height="180" stroke="#dc2626" stroke-width="2" fill="none" opacity="0.2"/>
+    <rect x="20" y="20" width="160" height="160" stroke="#dc2626" stroke-width="0.5" fill="none" opacity="0.1"/>
+    <!-- Color bars (broadcast test pattern) -->
+    <rect x="30" y="40" width="20" height="80" fill="#e8e8e8" opacity="0.15"/>
+    <rect x="55" y="40" width="20" height="80" fill="#eab308" opacity="0.15"/>
+    <rect x="80" y="40" width="20" height="80" fill="#22c55e" opacity="0.15"/>
+    <rect x="105" y="40" width="20" height="80" fill="#f97316" opacity="0.15"/>
+    <rect x="130" y="40" width="20" height="80" fill="#dc2626" opacity="0.2"/>
+    <rect x="155" y="40" width="20" height="80" fill="#e8e8e8" opacity="0.1"/>
+    <!-- Text overlay -->
+    <text x="100" y="145" text-anchor="middle" fill="#dc2626" font-family="Impact, sans-serif" font-size="11" letter-spacing="4" opacity="0.35">EMERGENCY BROADCAST</text>
+    <text x="100" y="165" text-anchor="middle" fill="#505050" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2" opacity="0.3">THIS IS NOT A DRILL</text>
+  </svg>
+</div>

--- a/red-alert/content/register.md
+++ b/red-alert/content/register.md
@@ -1,0 +1,28 @@
++++
+title = "Register"
+description = "Register for the Red Alert emergency crisis summit"
++++
+
+<div class="section-block">
+  <div class="section-label">Enrollment</div>
+  <h2>Join the Command</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Registration grants access to all alert-level briefings from GREEN through RED. Security clearance required for RED-level sessions. All participants receive crisis communications credentials.</p>
+
+  <!-- SVG beacon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="50" cy="50" r="30" stroke="#dc2626" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <circle cx="50" cy="50" r="18" stroke="#dc2626" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <circle cx="50" cy="50" r="6" fill="#dc2626" opacity="0.35"/>
+    <line x1="50" y1="15" x2="50" y2="25" stroke="#dc2626" stroke-width="1.5" opacity="0.2"/>
+    <line x1="50" y1="75" x2="50" y2="85" stroke="#dc2626" stroke-width="1.5" opacity="0.2"/>
+    <line x1="15" y1="50" x2="25" y2="50" stroke="#dc2626" stroke-width="1.5" opacity="0.2"/>
+    <line x1="75" y1="50" x2="85" y2="50" stroke="#dc2626" stroke-width="1.5" opacity="0.2"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="level-badge level-red" style="font-size: 0.85rem; padding: 6px 20px;">FULL CLEARANCE</span>
+    <span class="level-badge level-green" style="font-size: 0.85rem; padding: 6px 20px;">OBSERVER</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Bebas Neue', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.08.20 // COMMAND CENTER, WASHINGTON D.C.</p>
+</div>

--- a/red-alert/static/css/style.css
+++ b/red-alert/static/css/style.css
@@ -1,0 +1,493 @@
+/* Red Alert - Emergency Crisis Summit */
+/* Fonts: Impact / Bebas Neue display in alert-red, IBM Plex Sans Bold / Roboto Bold body */
+
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Sans:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap');
+
+:root {
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #0e0e0e;
+  --bg-panel: #141414;
+  --text-primary: #e0e0e0;
+  --text-secondary: #909090;
+  --text-muted: #505050;
+  --accent-red: #dc2626;
+  --accent-white: #e0e0e0;
+  --accent-dim: #6b2020;
+  --border-color: #1e1e1e;
+  --border-accent: #dc2626;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'IBM Plex Sans', 'Roboto', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Bebas Neue', sans-serif; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-red);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 1.5rem;
+  color: var(--accent-red);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-red);
+  border-bottom-color: var(--accent-red);
+}
+
+.nav-cta {
+  background-color: var(--accent-red) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 5.5rem;
+  color: var(--accent-red);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Alert Block */
+.alert-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.alert-level {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 0.95rem;
+  min-width: 70px;
+  text-align: center;
+  letter-spacing: 0.06em;
+}
+
+.alert-green .alert-level { color: #22c55e; }
+.alert-yellow .alert-level { color: #eab308; }
+.alert-orange .alert-level { color: #f97316; }
+.alert-red .alert-level { color: #dc2626; }
+
+.alert-info { flex: 1; }
+
+.alert-title {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.alert-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.alert-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Level Badge */
+.level-badge {
+  display: inline-block;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  text-transform: uppercase;
+}
+
+.level-green { background: #22c55e; color: #0a0a0a; }
+.level-yellow { background: #eab308; color: #0a0a0a; }
+.level-orange { background: #f97316; color: #0a0a0a; }
+.level-red { background: #dc2626; color: #0a0a0a; }
+
+/* Gauge Row */
+.gauge-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.gauge-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.gauge-display {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 1.8rem;
+  line-height: 1;
+  letter-spacing: 0.08em;
+}
+
+.gauge-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-red);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-red);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Bebas Neue', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-red);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-red);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-red);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: Impact, 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 8rem;
+  color: var(--accent-red);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .alert-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .gauge-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/red-alert/templates/404.html
+++ b/red-alert/templates/404.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Beacon light -->
+        <circle cx="40" cy="40" r="25" stroke="#dc2626" stroke-width="2" fill="none" opacity="0.3"/>
+        <circle cx="40" cy="40" r="15" stroke="#dc2626" stroke-width="1.5" fill="none" opacity="0.2"/>
+        <circle cx="40" cy="40" r="6" fill="#dc2626" opacity="0.4"/>
+        <!-- Rotation lines -->
+        <line x1="40" y1="10" x2="40" y2="18" stroke="#dc2626" stroke-width="1.5" opacity="0.25"/>
+        <line x1="40" y1="62" x2="40" y2="70" stroke="#dc2626" stroke-width="1.5" opacity="0.25"/>
+        <line x1="10" y1="40" x2="18" y2="40" stroke="#dc2626" stroke-width="1.5" opacity="0.25"/>
+        <line x1="62" y1="40" x2="70" y2="40" stroke="#dc2626" stroke-width="1.5" opacity="0.25"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Signal Lost</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-red); font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Command</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/red-alert/templates/footer.html
+++ b/red-alert/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">RED ALERT // EMERGENCY CRISIS SUMMIT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Command</a>
+        <a href="{{ base_url }}/briefings/">Briefings</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/red-alert/templates/header.html
+++ b/red-alert/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">RED ALERT</span>
+        <span class="logo-sub">crisis summit</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Command</a>
+        <a href="{{ base_url }}/briefings/">Briefings</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/red-alert/templates/page.html
+++ b/red-alert/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/red-alert/templates/post.html
+++ b/red-alert/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("briefing") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/red-alert/templates/section.html
+++ b/red-alert/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/red-alert/templates/taxonomy.html
+++ b/red-alert/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/red-alert/templates/taxonomy_term.html
+++ b/red-alert/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All briefings tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2796,6 +2796,13 @@
     "docs",
     "reactive"
   ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
+  ],
   "realty": [
     "light",
     "realestate",


### PR DESCRIPTION
Closes #1663

## Summary
- Add red-alert example site: emergency crisis summit with alert-level escalation theme
- SVG rotating beacon light patterns, alert level gauge displays with color-coded severity, emergency broadcast test pattern frames, crisis timeline diagrams
- Typography: Impact/Bebas Neue display in alert-red on black, IBM Plex Sans Bold/Roboto Bold body
- ALERT LEVEL indicators GREEN>YELLOW>ORANGE>RED, THIS IS NOT A DRILL header
- Tags: event, dark, emergency, crisis, urgent