### PR TITLE
feat: add firing-range example site (closes #1658)

### DIFF
--- a/firing-range/config.toml
+++ b/firing-range/config.toml
@@ -1,0 +1,41 @@
+title = "Firing Range"
+description = "Precision target skills event with competitive lane-based challenges"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["lanes"]
+
+[markdown]
+safe = false

--- a/firing-range/content/index.md
+++ b/firing-range/content/index.md
@@ -1,0 +1,154 @@
++++
+title = "Home"
+description = "Precision target skills event with competitive lane-based challenges"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Precision Target Skills Event</div>
+    <h1>FIRING RANGE</h1>
+    <p class="hero-subtitle">Four lanes. Escalating difficulty. Concentric scoring rings from X to 8. Prove your precision under pressure. Every shot counts.</p>
+    <p class="hero-date">2027.10.20 // IRON SIGHTS COMPLEX, DENVER</p>
+
+    <!-- SVG concentric ring target bullseye pattern -->
+    <svg width="220" height="220" viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Outer ring 8 -->
+      <circle cx="110" cy="110" r="95" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+      <text x="110" y="22" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" opacity="0.2">8</text>
+      <!-- Ring 9 -->
+      <circle cx="110" cy="110" r="72" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.18"/>
+      <text x="110" y="45" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" opacity="0.25">9</text>
+      <!-- Ring 10 -->
+      <circle cx="110" cy="110" r="48" stroke="#c0392b" stroke-width="2" fill="none" opacity="0.25"/>
+      <text x="110" y="70" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="9" opacity="0.3">10</text>
+      <!-- X ring center -->
+      <circle cx="110" cy="110" r="20" stroke="#c0392b" stroke-width="2" fill="none" opacity="0.35"/>
+      <circle cx="110" cy="110" r="6" fill="#c0392b" opacity="0.3"/>
+      <text x="110" y="114" text-anchor="middle" fill="#1a0a0a" font-family="Share Tech, sans-serif" font-weight="700" font-size="10">X</text>
+      <!-- Crosshair lines -->
+      <line x1="110" y1="5" x2="110" y2="40" stroke="#c0392b" stroke-width="0.5" opacity="0.15"/>
+      <line x1="110" y1="180" x2="110" y2="215" stroke="#c0392b" stroke-width="0.5" opacity="0.15"/>
+      <line x1="5" y1="110" x2="40" y2="110" stroke="#c0392b" stroke-width="0.5" opacity="0.15"/>
+      <line x1="180" y1="110" x2="215" y2="110" stroke="#c0392b" stroke-width="0.5" opacity="0.15"/>
+      <!-- Hit placement markers -->
+      <circle cx="115" cy="105" r="2" fill="#c0392b" opacity="0.5"/>
+      <circle cx="108" cy="112" r="2" fill="#c0392b" opacity="0.4"/>
+      <circle cx="112" cy="108" r="2" fill="#c0392b" opacity="0.45"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Lane Assignments</div>
+  <h2>Competition Lanes</h2>
+
+  <div class="lane-block">
+    <div class="lane-number">LANE 01</div>
+    <div class="lane-info">
+      <div class="lane-title">Qualification Round -- Steady Hands</div>
+      <div class="lane-meta">Standard distance. Prove you belong on the range.</div>
+    </div>
+    <div class="lane-badge-slot"><span class="range-badge">X/10</span></div>
+  </div>
+
+  <div class="lane-block">
+    <div class="lane-number">LANE 02</div>
+    <div class="lane-info">
+      <div class="lane-title">Timed Precision -- Under Pressure</div>
+      <div class="lane-meta">Clock is running. Accuracy under time constraint.</div>
+    </div>
+    <div class="lane-badge-slot"><span class="range-badge">10/9</span></div>
+  </div>
+
+  <div class="lane-block">
+    <div class="lane-number">LANE 03</div>
+    <div class="lane-info">
+      <div class="lane-title">Long Distance -- Extended Range</div>
+      <div class="lane-meta">Maximum distance. Patience and discipline tested.</div>
+    </div>
+    <div class="lane-badge-slot"><span class="range-badge-outline">9/8</span></div>
+  </div>
+
+  <div class="lane-block">
+    <div class="lane-number">LANE 04</div>
+    <div class="lane-info">
+      <div class="lane-title">Final Shootoff -- Champion Round</div>
+      <div class="lane-meta">Head to head elimination. One shot decides everything.</div>
+    </div>
+    <div class="lane-badge-slot"><span class="range-badge-outline">FINAL</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Scoring</div>
+  <h2>Scoring Zones</h2>
+
+  <div class="score-row">
+    <div class="score-block">
+      <svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="30" cy="30" r="18" stroke="#c0392b" stroke-width="2" fill="none" opacity="0.35"/>
+        <circle cx="30" cy="30" r="6" fill="#c0392b" opacity="0.4"/>
+        <text x="30" y="34" text-anchor="middle" fill="#1a0a0a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8">X</text>
+      </svg>
+      <div class="score-display">X</div>
+      <div class="score-label">Perfect Center</div>
+    </div>
+    <div class="score-block">
+      <svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="30" cy="30" r="22" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.25"/>
+        <circle cx="30" cy="30" r="12" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.15"/>
+        <circle cx="30" cy="30" r="3" fill="#c0392b" opacity="0.25"/>
+      </svg>
+      <div class="score-display" style="color: var(--accent-dim);">10</div>
+      <div class="score-label">Inner Ring</div>
+    </div>
+    <div class="score-block">
+      <svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 0 auto 12px; display: block;">
+        <circle cx="30" cy="30" r="25" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.18"/>
+        <circle cx="30" cy="30" r="16" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+        <circle cx="22" cy="26" r="2" fill="#c0392b" opacity="0.2"/>
+      </svg>
+      <div class="score-display" style="color: var(--text-muted);">8</div>
+      <div class="score-label">Outer Ring</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Range Layout</div>
+  <h2>Lane Dividers</h2>
+
+  <!-- SVG lane divider patterns for parallel tracks -->
+  <svg width="100%" height="100" viewBox="0 0 600 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Lane dividers -->
+    <line x1="0" y1="0" x2="0" y2="100" stroke="#c0392b" stroke-width="1" opacity="0.15"/>
+    <line x1="150" y1="0" x2="150" y2="100" stroke="#c0392b" stroke-width="1" opacity="0.15"/>
+    <line x1="300" y1="0" x2="300" y2="100" stroke="#c0392b" stroke-width="1" opacity="0.15"/>
+    <line x1="450" y1="0" x2="450" y2="100" stroke="#c0392b" stroke-width="1" opacity="0.15"/>
+    <line x1="600" y1="0" x2="600" y2="100" stroke="#c0392b" stroke-width="1" opacity="0.15"/>
+    <!-- Safety zone boundary -->
+    <line x1="0" y1="80" x2="600" y2="80" stroke="#c0392b" stroke-width="1" opacity="0.1" stroke-dasharray="8 4"/>
+    <!-- Lane numbers -->
+    <text x="75" y="20" text-anchor="middle" fill="#c0392b" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="14" opacity="0.25">01</text>
+    <text x="225" y="20" text-anchor="middle" fill="#c0392b" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="14" opacity="0.25">02</text>
+    <text x="375" y="20" text-anchor="middle" fill="#c0392b" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="14" opacity="0.25">03</text>
+    <text x="525" y="20" text-anchor="middle" fill="#c0392b" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="14" opacity="0.25">04</text>
+    <!-- Mini targets at end of each lane -->
+    <circle cx="75" cy="55" r="10" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+    <circle cx="75" cy="55" r="4" fill="#c0392b" opacity="0.1"/>
+    <circle cx="225" cy="55" r="10" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+    <circle cx="225" cy="55" r="4" fill="#c0392b" opacity="0.1"/>
+    <circle cx="375" cy="55" r="10" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+    <circle cx="375" cy="55" r="4" fill="#c0392b" opacity="0.1"/>
+    <circle cx="525" cy="55" r="10" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+    <circle cx="525" cy="55" r="4" fill="#c0392b" opacity="0.1"/>
+    <!-- Safety label -->
+    <text x="300" y="95" text-anchor="middle" fill="#551a1a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="7" letter-spacing="4">SAFETY BOUNDARY</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">4 lanes // x/10/9/8 scoring // precision wins</p>
+</div>
+
+</div>

--- a/firing-range/content/lanes/_index.md
+++ b/firing-range/content/lanes/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Lanes"
+description = "All competition lanes in the Firing Range event"
+sort_by = "weight"
+template = "section"
++++
+
+Four lanes. Escalating difficulty. Only precision advances.

--- a/firing-range/content/lanes/final-shootoff.md
+++ b/firing-range/content/lanes/final-shootoff.md
@@ -1,0 +1,34 @@
++++
+title = "Lane 04 -- Final Shootoff"
+date = "2027-10-20"
+description = "Head-to-head elimination round for the champion title"
+weight = 4
+tags = ["final", "elimination", "champion"]
+[extra]
+scoring = "X only"
+distance = "Variable"
+difficulty = "Expert"
++++
+
+## Lane 04 -- Final Shootoff
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a0a0a" stroke="#c0392b" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#c0392b"/>
+  <text x="35" y="35" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="8" letter-spacing="1">LANE</text>
+  <text x="35" y="58" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="22">04</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0c8c0" font-family="Share Tech, sans-serif" font-weight="700" font-size="13" letter-spacing="1">FINAL SHOOTOFF</text>
+  <text x="175" y="55" text-anchor="middle" fill="#551a1a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" letter-spacing="2">X RING ONLY // EXPERT</text>
+</svg>
+
+<span class="range-badge-outline">FINAL</span>
+
+### Lane Summary
+
+Two competitors. One lane. Variable distance that changes between shots. Only hits in the X ring count. Everything else is a miss. No time limit -- just accuracy under the weight of elimination. One shot decides who advances and who walks off the range. This is what every lane before was building toward.
+
+| Detail | Info |
+|--------|------|
+| Scoring Zone | X only |
+| Distance | Variable |
+| Difficulty | Expert |

--- a/firing-range/content/lanes/long-distance.md
+++ b/firing-range/content/lanes/long-distance.md
@@ -1,0 +1,34 @@
++++
+title = "Lane 03 -- Long Distance"
+date = "2027-10-20"
+description = "Maximum distance precision requiring patience and discipline"
+weight = 3
+tags = ["distance", "patience", "discipline"]
+[extra]
+scoring = "9/8"
+distance = "Extended"
+difficulty = "Advanced"
++++
+
+## Lane 03 -- Long Distance
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a0a0a" stroke="#c0392b" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#c0392b"/>
+  <text x="35" y="35" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="8" letter-spacing="1">LANE</text>
+  <text x="35" y="58" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="22">03</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0c8c0" font-family="Share Tech, sans-serif" font-weight="700" font-size="13" letter-spacing="1">LONG DISTANCE</text>
+  <text x="175" y="55" text-anchor="middle" fill="#551a1a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" letter-spacing="2">SCORING 9/8 // ADVANCED</text>
+</svg>
+
+<span class="range-badge-outline">9/8</span>
+
+### Lane Summary
+
+Extended range. The target shrinks to a point at this distance. Every micro-adjustment matters. Wind, breathing, heartbeat -- all become variables that separate precision from noise. The scoring zone widens to 9/8 because hitting anything at this range is an achievement. Patience is the skill being tested here.
+
+| Detail | Info |
+|--------|------|
+| Scoring Zone | 9/8 |
+| Distance | Extended |
+| Difficulty | Advanced |

--- a/firing-range/content/lanes/qualification.md
+++ b/firing-range/content/lanes/qualification.md
@@ -1,0 +1,34 @@
++++
+title = "Lane 01 -- Qualification Round"
+date = "2027-10-20"
+description = "Standard distance qualification to prove range readiness"
+weight = 1
+tags = ["qualification", "steady", "fundamentals"]
+[extra]
+scoring = "X/10"
+distance = "Standard"
+difficulty = "Entry"
++++
+
+## Lane 01 -- Qualification Round
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a0a0a" stroke="#c0392b" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#c0392b"/>
+  <text x="35" y="35" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="8" letter-spacing="1">LANE</text>
+  <text x="35" y="58" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="22">01</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0c8c0" font-family="Share Tech, sans-serif" font-weight="700" font-size="13" letter-spacing="1">QUALIFICATION</text>
+  <text x="175" y="55" text-anchor="middle" fill="#551a1a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" letter-spacing="2">SCORING X/10 // ENTRY</text>
+</svg>
+
+<span class="range-badge">X/10</span>
+
+### Lane Summary
+
+Standard distance. Standard conditions. Nothing fancy. This lane strips away excuses and tests pure fundamentals. Steady hands, controlled breathing, consistent groupings. Score in the X or 10 ring to qualify for the next lane. Anything below and you stay here until you earn your way forward.
+
+| Detail | Info |
+|--------|------|
+| Scoring Zone | X/10 |
+| Distance | Standard |
+| Difficulty | Entry |

--- a/firing-range/content/lanes/timed-precision.md
+++ b/firing-range/content/lanes/timed-precision.md
@@ -1,0 +1,47 @@
++++
+title = "Lane 02 -- Timed Precision"
+date = "2027-10-20"
+description = "Accuracy under time pressure with scoring overlay"
+weight = 2
+tags = ["timed", "pressure", "accuracy"]
+[extra]
+scoring = "10/9"
+distance = "Standard"
+difficulty = "Intermediate"
++++
+
+## Lane 02 -- Timed Precision
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a0a0a" stroke="#c0392b" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#c0392b"/>
+  <text x="35" y="35" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="8" letter-spacing="1">LANE</text>
+  <text x="35" y="58" text-anchor="middle" fill="#1a0a0a" font-family="Barlow Condensed, sans-serif" font-weight="900" font-size="22">02</text>
+  <text x="175" y="35" text-anchor="middle" fill="#e0c8c0" font-family="Share Tech, sans-serif" font-weight="700" font-size="13" letter-spacing="1">TIMED PRECISION</text>
+  <text x="175" y="55" text-anchor="middle" fill="#551a1a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8" letter-spacing="2">SCORING 10/9 // INTERMEDIATE</text>
+</svg>
+
+<span class="range-badge">10/9</span>
+
+### Lane Summary
+
+The clock starts. Your precision must hold under time pressure. Each shot must land in the 10 or 9 ring to count. Speed without accuracy is noise. Accuracy without speed is too late. This lane demands both. Scoring overlays display hit placement in real time.
+
+<!-- SVG scoring overlay with hit placement markers -->
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="80" cy="80" r="70" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.12"/>
+  <circle cx="80" cy="80" r="50" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.18"/>
+  <circle cx="80" cy="80" r="30" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.25"/>
+  <circle cx="80" cy="80" r="10" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <!-- Hit markers -->
+  <circle cx="85" cy="75" r="3" fill="#c0392b" opacity="0.5"/>
+  <circle cx="78" cy="82" r="3" fill="#c0392b" opacity="0.45"/>
+  <circle cx="83" cy="78" r="3" fill="#c0392b" opacity="0.4"/>
+  <circle cx="76" cy="72" r="3" fill="#c0392b" opacity="0.35"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Scoring Zone | 10/9 |
+| Distance | Standard |
+| Difficulty | Intermediate |

--- a/firing-range/content/register.md
+++ b/firing-range/content/register.md
@@ -1,0 +1,28 @@
++++
+title = "Register"
+description = "Register for the Firing Range precision skills event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Step Up to the Line</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register as a competitor to test your precision across all four lanes, or sign up as a range observer to watch the competition unfold from behind the safety boundary.</p>
+
+  <!-- SVG crosshair icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="50" cy="50" r="25" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <circle cx="50" cy="50" r="12" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="50" cy="50" r="3" fill="#c0392b" opacity="0.3"/>
+    <line x1="50" y1="15" x2="50" y2="35" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+    <line x1="50" y1="65" x2="50" y2="85" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+    <line x1="15" y1="50" x2="35" y2="50" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+    <line x1="65" y1="50" x2="85" y2="50" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="range-badge" style="font-size: 0.85rem; padding: 6px 20px;">COMPETITOR</span>
+    <span class="range-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">OBSERVER</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Share Tech', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.10.20 // IRON SIGHTS COMPLEX, DENVER</p>
+</div>

--- a/firing-range/content/rules.md
+++ b/firing-range/content/rules.md
@@ -1,0 +1,23 @@
++++
+title = "Rules"
+description = "Competition rules and scoring criteria for the Firing Range"
++++
+
+<div class="section-block">
+  <div class="section-label">Competition Rules</div>
+  <h2>Precision Wins</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Scoring is based on concentric ring placement. X ring is the dead center -- the perfect shot. The 10 ring surrounds it. Then 9, then 8. Anything outside the 8 ring does not score. Each lane has its own qualifying threshold. Meet it or stay where you are.</p>
+
+  <!-- SVG target with scoring overlay -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <circle cx="100" cy="100" r="90" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.1"/>
+    <circle cx="100" cy="100" r="70" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="100" cy="100" r="50" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <circle cx="100" cy="100" r="28" stroke="#c0392b" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="100" cy="100" r="10" fill="#c0392b" opacity="0.3"/>
+    <text x="100" y="104" text-anchor="middle" fill="#1a0a0a" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="8">X</text>
+    <text x="100" y="80" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="7" opacity="0.3">10</text>
+    <text x="100" y="58" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="7" opacity="0.25">9</text>
+    <text x="100" y="38" text-anchor="middle" fill="#c0392b" font-family="IBM Plex Mono, monospace" font-weight="700" font-size="7" opacity="0.2">8</text>
+  </svg>
+</div>

--- a/firing-range/static/css/style.css
+++ b/firing-range/static/css/style.css
@@ -1,0 +1,493 @@
+/* Firing Range - Precision Target Skills Event */
+/* Fonts: Share Tech Bold / Barlow Condensed Black display, IBM Plex Mono / Fira Mono Bold body */
+
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech&family=Barlow+Condensed:wght@700;800;900&family=IBM+Plex+Mono:wght@400;500;600;700&family=Fira+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --bg-primary: #1a0a0a;
+  --bg-secondary: #120606;
+  --bg-panel: #221010;
+  --text-primary: #e0c8c0;
+  --text-secondary: #a08070;
+  --text-muted: #551a1a;
+  --accent-red: #c0392b;
+  --accent-white: #e0c8c0;
+  --accent-dim: #802018;
+  --border-color: #2a1212;
+  --border-accent: #c0392b;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'IBM Plex Mono', 'Fira Mono', monospace;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Share Tech', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Barlow Condensed', sans-serif; font-weight: 900; text-transform: uppercase; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-red);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 1.4rem;
+  color: var(--accent-red);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-red);
+  border-bottom-color: var(--accent-red);
+}
+
+.nav-cta {
+  background-color: var(--accent-red) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 900;
+  font-size: 5.5rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hero-subtitle {
+  font-family: 'Fira Mono', monospace;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Lane Block */
+.lane-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.lane-number {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 900;
+  font-size: 0.9rem;
+  color: var(--accent-red);
+  min-width: 70px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.lane-info { flex: 1; }
+
+.lane-title {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.lane-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.lane-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Range Badge */
+.range-badge {
+  display: inline-block;
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-red);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.range-badge-outline {
+  display: inline-block;
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-red);
+  color: var(--accent-red);
+  text-transform: uppercase;
+}
+
+/* Score Row */
+.score-row {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.score-block {
+  flex: 1;
+  padding: 24px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.score-display {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 900;
+  font-size: 2.5rem;
+  color: var(--accent-red);
+  line-height: 1;
+}
+
+.score-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Mono', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-red);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-red);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Barlow Condensed', sans-serif;
+  text-transform: uppercase;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-red);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-red);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-red);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-red);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .lane-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .score-row { flex-direction: column; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/firing-range/templates/404.html
+++ b/firing-range/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Target -->
+        <circle cx="40" cy="40" r="28" stroke="#c0392b" stroke-width="2" fill="none" opacity="0.3"/>
+        <circle cx="40" cy="40" r="20" stroke="#c0392b" stroke-width="1.5" fill="none" opacity="0.2"/>
+        <circle cx="40" cy="40" r="12" stroke="#c0392b" stroke-width="1" fill="none" opacity="0.15"/>
+        <circle cx="40" cy="40" r="4" fill="#c0392b" opacity="0.3"/>
+        <!-- Crosshair -->
+        <line x1="40" y1="8" x2="40" y2="20" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+        <line x1="40" y1="60" x2="40" y2="72" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+        <line x1="8" y1="40" x2="20" y2="40" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+        <line x1="60" y1="40" x2="72" y2="40" stroke="#c0392b" stroke-width="1" opacity="0.2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Target Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-red); font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Range</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/firing-range/templates/footer.html
+++ b/firing-range/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">FIRING RANGE // PRECISION EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Range</a>
+        <a href="{{ base_url }}/lanes/">Lanes</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/firing-range/templates/header.html
+++ b/firing-range/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">FIRING RANGE</span>
+        <span class="logo-sub">precision skills</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Range</a>
+        <a href="{{ base_url }}/lanes/">Lanes</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/firing-range/templates/page.html
+++ b/firing-range/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/firing-range/templates/post.html
+++ b/firing-range/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("lane") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/firing-range/templates/section.html
+++ b/firing-range/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/firing-range/templates/taxonomy.html
+++ b/firing-range/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/firing-range/templates/taxonomy_term.html
+++ b/firing-range/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All lanes tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1168,6 +1168,13 @@
     "blog",
     "book-review"
   ],
+  "firing-range": [
+    "event",
+    "dark",
+    "precision",
+    "target",
+    "competitive"
+  ],
   "fireworks": [
     "dark",
     "elegant",


### PR DESCRIPTION
## Summary
- Add firing-range example site: precision target skills event theme
- Dark design with target-red (#c0392b) accent, Share Tech/Barlow Condensed display, IBM Plex Mono/Fira Mono body
- Lane-based competition with X/10/9/8 scoring zones, inline SVG concentric ring targets, lane dividers, crosshair patterns, scoring overlays
- Update tags.json with firing-range entry

Closes #1658