### PR TITLE
feat: add countdown-zero example site (closes #1659)

### DIFF
--- a/countdown-zero/config.toml
+++ b/countdown-zero/config.toml
@@ -1,0 +1,41 @@
+title = "Countdown Zero"
+description = "Zero hour convergence event where all paths lead to T-0"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["schedule"]
+
+[markdown]
+safe = false

--- a/countdown-zero/content/index.md
+++ b/countdown-zero/content/index.md
@@ -1,0 +1,145 @@
++++
+title = "Home"
+description = "Zero hour convergence event where all paths lead to T-0"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Zero Hour Convergence Event</div>
+    <h1>COUNTDOWN ZERO</h1>
+    <p class="hero-subtitle">All sessions converge on a single moment. The clock counts backward. When it hits zero, everything changes. Every minute before T-0 is preparation. T-0 is the point of no return.</p>
+    <p class="hero-date">2027.09.12 // MISSION CONTROL, HOUSTON</p>
+
+    <!-- SVG mission clock display -->
+    <svg width="320" height="120" viewBox="0 0 320 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Clock housing -->
+      <rect x="10" y="10" width="300" height="80" rx="4" stroke="#00ff88" stroke-width="2" fill="none" opacity="0.2"/>
+      <rect x="15" y="15" width="290" height="70" rx="2" stroke="#00ff88" stroke-width="0.5" fill="none" opacity="0.1"/>
+      <!-- Time display T-00:00:00 -->
+      <text x="50" y="60" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="900" font-size="12" opacity="0.3">T-</text>
+      <text x="85" y="65" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="900" font-size="32" opacity="0.4">00:00:00</text>
+      <!-- Colon separators glow -->
+      <circle cx="145" cy="48" r="2" fill="#00ff88" opacity="0.2"/>
+      <circle cx="145" cy="58" r="2" fill="#00ff88" opacity="0.2"/>
+      <circle cx="210" cy="48" r="2" fill="#00ff88" opacity="0.2"/>
+      <circle cx="210" cy="58" r="2" fill="#00ff88" opacity="0.2"/>
+      <!-- Labels -->
+      <text x="110" y="82" fill="#00ff88" font-family="Share Tech, sans-serif" font-size="6" letter-spacing="2" opacity="0.2">HRS</text>
+      <text x="175" y="82" fill="#00ff88" font-family="Share Tech, sans-serif" font-size="6" letter-spacing="2" opacity="0.2">MIN</text>
+      <text x="240" y="82" fill="#00ff88" font-family="Share Tech, sans-serif" font-size="6" letter-spacing="2" opacity="0.2">SEC</text>
+      <!-- Status indicator -->
+      <circle cx="30" cy="30" r="4" fill="#00ff88" opacity="0.25"/>
+      <text x="40" y="33" fill="#00ff88" font-family="Share Tech, sans-serif" font-size="6" letter-spacing="2" opacity="0.2">LIVE</text>
+      <!-- Convergence lines at bottom -->
+      <line x1="10" y1="100" x2="160" y2="105" stroke="#00ff88" stroke-width="0.5" opacity="0.15"/>
+      <line x1="310" y1="100" x2="160" y2="105" stroke="#00ff88" stroke-width="0.5" opacity="0.15"/>
+      <circle cx="160" cy="105" r="3" fill="#00ff88" opacity="0.15"/>
+      <text x="160" y="118" text-anchor="middle" fill="#00ff88" font-family="Orbitron, sans-serif" font-size="6" opacity="0.2" letter-spacing="3">T-0</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Mission Timeline</div>
+  <h2>Countdown Schedule</h2>
+
+  <div class="countdown-block">
+    <div class="countdown-time">T-4h</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Systems Check -- Pre-Launch Briefing</div>
+      <div class="countdown-meta">All stations report status. Final go/no-go decisions.</div>
+    </div>
+    <div class="countdown-badge-slot"><span class="zero-badge">HOLD</span></div>
+  </div>
+
+  <div class="countdown-block">
+    <div class="countdown-time">T-2h</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Fueling Sequence -- Deep Preparation</div>
+      <div class="countdown-meta">Critical resources loaded. No turning back after this point.</div>
+    </div>
+    <div class="countdown-badge-slot"><span class="zero-badge">ACTIVE</span></div>
+  </div>
+
+  <div class="countdown-block">
+    <div class="countdown-time">T-30m</div>
+    <div class="countdown-info">
+      <div class="countdown-title">Final Countdown -- Terminal Sequence</div>
+      <div class="countdown-meta">Automated sequence engaged. Human override only for abort.</div>
+    </div>
+    <div class="countdown-badge-slot"><span class="zero-badge-outline">ARMED</span></div>
+  </div>
+
+  <div class="countdown-block t-zero">
+    <div class="countdown-time t-zero-time">T-0</div>
+    <div class="countdown-info">
+      <div class="countdown-title t-zero-title">ZERO HOUR -- CONVERGENCE</div>
+      <div class="countdown-meta">All paths meet. All preparation culminates. This is the moment.</div>
+    </div>
+    <div class="countdown-badge-slot"><span class="zero-badge">LAUNCH</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Convergence</div>
+  <h2>Convergence Lines</h2>
+
+  <!-- SVG convergence line patterns pointing to T-0 -->
+  <svg width="100%" height="160" viewBox="0 0 600 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Convergence lines from multiple origins to center point -->
+    <line x1="0" y1="20" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.12"/>
+    <line x1="100" y1="10" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.15"/>
+    <line x1="200" y1="5" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <line x1="400" y1="5" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <line x1="500" y1="10" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.15"/>
+    <line x1="600" y1="20" x2="300" y2="130" stroke="#00ff88" stroke-width="1" opacity="0.12"/>
+    <!-- Milestone markers along lines -->
+    <circle cx="75" cy="45" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="175" cy="40" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.18"/>
+    <circle cx="250" cy="85" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="350" cy="85" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="425" cy="40" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.18"/>
+    <circle cx="525" cy="45" r="3" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- T-0 convergence point -->
+    <circle cx="300" cy="130" r="8" stroke="#00ff88" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="300" cy="130" r="3" fill="#00ff88" opacity="0.35"/>
+    <!-- T-0 label -->
+    <text x="300" y="155" text-anchor="middle" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="900" font-size="10" opacity="0.3" letter-spacing="3">T-0</text>
+    <!-- Time labels -->
+    <text x="50" y="15" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="7" letter-spacing="1">T-4H</text>
+    <text x="175" y="15" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="7" letter-spacing="1">T-2H</text>
+    <text x="425" y="15" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="7" letter-spacing="1">T-30M</text>
+    <text x="550" y="15" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="7" letter-spacing="1">T-10M</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Zero Hour</div>
+  <h2>T-0 Burst</h2>
+
+  <!-- SVG zero-hour burst pattern -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Burst rays from center -->
+    <line x1="100" y1="100" x2="100" y2="10" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="100" y1="100" x2="164" y2="27" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <line x1="100" y1="100" x2="190" y2="100" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="100" y1="100" x2="164" y2="173" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <line x1="100" y1="100" x2="100" y2="190" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="100" y1="100" x2="36" y2="173" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <line x1="100" y1="100" x2="10" y2="100" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="100" y1="100" x2="36" y2="27" stroke="#00ff88" stroke-width="1" opacity="0.18"/>
+    <!-- Concentric shock rings -->
+    <circle cx="100" cy="100" r="25" stroke="#00ff88" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="100" cy="100" r="50" stroke="#00ff88" stroke-width="0.8" fill="none" opacity="0.1"/>
+    <circle cx="100" cy="100" r="75" stroke="#00ff88" stroke-width="0.5" fill="none" opacity="0.08"/>
+    <!-- Center point -->
+    <circle cx="100" cy="100" r="8" fill="#00ff88" opacity="0.2"/>
+    <text x="100" y="104" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="8">0</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Orbitron', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">t-4h > t-2h > t-30m > t-0</p>
+</div>
+
+</div>

--- a/countdown-zero/content/protocol.md
+++ b/countdown-zero/content/protocol.md
@@ -1,0 +1,27 @@
++++
+title = "Protocol"
+description = "Mission protocol and countdown procedures"
++++
+
+<div class="section-block">
+  <div class="section-label">Mission Protocol</div>
+  <h2>Countdown Procedures</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The countdown follows a strict sequence of milestones measured in negative time relative to T-0. Each milestone has a designated hold point where the clock can be paused for unresolved issues. Once a hold is cleared, the countdown resumes and the next milestone becomes the focus. There is no going backward.</p>
+
+  <!-- SVG countdown milestone markers -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Vertical timeline -->
+    <line x1="100" y1="20" x2="100" y2="180" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <!-- Milestones -->
+    <circle cx="100" cy="35" r="6" stroke="#00ff88" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <text x="120" y="38" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="700" font-size="8" opacity="0.25">T-4H</text>
+    <circle cx="100" cy="75" r="6" stroke="#00ff88" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="120" y="78" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="700" font-size="8" opacity="0.3">T-2H</text>
+    <circle cx="100" cy="115" r="6" stroke="#00ff88" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="120" y="118" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="700" font-size="8" opacity="0.35">T-30M</text>
+    <!-- T-0 emphasis -->
+    <circle cx="100" cy="165" r="10" stroke="#00ff88" stroke-width="2" fill="none" opacity="0.35"/>
+    <circle cx="100" cy="165" r="4" fill="#00ff88" opacity="0.3"/>
+    <text x="120" y="168" fill="#00ff88" font-family="Orbitron, sans-serif" font-weight="900" font-size="10" opacity="0.4">T-0</text>
+  </svg>
+</div>

--- a/countdown-zero/content/register.md
+++ b/countdown-zero/content/register.md
@@ -1,0 +1,30 @@
++++
+title = "Register"
+description = "Register for the Countdown Zero convergence event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Join the Countdown</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register as mission crew to participate in all countdown milestones, or secure an observer seat in the control room gallery. All crew receive mission patches and post-launch debriefing access.</p>
+
+  <!-- SVG clock icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="50" cy="50" r="30" stroke="#00ff88" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <line x1="50" y1="50" x2="50" y2="28" stroke="#00ff88" stroke-width="2" opacity="0.2"/>
+    <line x1="50" y1="50" x2="65" y2="50" stroke="#00ff88" stroke-width="1.5" opacity="0.15"/>
+    <circle cx="50" cy="50" r="3" fill="#00ff88" opacity="0.3"/>
+    <!-- Tick marks -->
+    <line x1="50" y1="22" x2="50" y2="25" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="78" y1="50" x2="75" y2="50" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="50" y1="78" x2="50" y2="75" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+    <line x1="22" y1="50" x2="25" y2="50" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="zero-badge" style="font-size: 0.85rem; padding: 6px 20px;">CREW</span>
+    <span class="zero-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">OBSERVER</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Orbitron', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.09.12 // MISSION CONTROL, HOUSTON</p>
+</div>

--- a/countdown-zero/content/schedule/_index.md
+++ b/countdown-zero/content/schedule/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Schedule"
+description = "All countdown milestones leading to T-0"
+sort_by = "weight"
+template = "section"
++++
+
+Four milestones. Negative time. Everything converges on zero.

--- a/countdown-zero/content/schedule/t-minus-2h.md
+++ b/countdown-zero/content/schedule/t-minus-2h.md
@@ -1,0 +1,34 @@
++++
+title = "T-2h -- Fueling Sequence"
+date = "2027-09-12"
+description = "Critical resource loading and point-of-no-return preparation"
+weight = 2
+tags = ["fueling", "critical", "resources"]
+[extra]
+countdown = "T-2h"
+status = "ACTIVE"
+clearance = "Operations"
++++
+
+## T-2h -- Fueling Sequence
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1a10" stroke="#00ff88" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#00ff88" opacity="0.9"/>
+  <text x="40" y="35" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="8" letter-spacing="1">MARK</text>
+  <text x="40" y="55" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="14">T-2h</text>
+  <text x="180" y="35" text-anchor="middle" fill="#c0f0d0" font-family="Orbitron, sans-serif" font-weight="700" font-size="12" letter-spacing="1">FUELING SEQ</text>
+  <text x="180" y="55" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="8" letter-spacing="2">STATUS ACTIVE // OPERATIONS</text>
+</svg>
+
+<span class="zero-badge">ACTIVE</span>
+
+### Milestone Summary
+
+Two hours remain. Critical resources are loaded into the system. This is the phase where preparation becomes irreversible investment. The fuel is flowing. Commitments are being made that cannot be undone without significant cost. After this phase, the only options are forward to T-0 or a full abort with consequences.
+
+| Detail | Info |
+|--------|------|
+| Countdown | T-2h |
+| Status | ACTIVE |
+| Clearance | Operations |

--- a/countdown-zero/content/schedule/t-minus-30m.md
+++ b/countdown-zero/content/schedule/t-minus-30m.md
@@ -1,0 +1,34 @@
++++
+title = "T-30m -- Terminal Sequence"
+date = "2027-09-12"
+description = "Automated terminal countdown with human override for abort only"
+weight = 3
+tags = ["terminal", "automated", "final-check"]
+[extra]
+countdown = "T-30m"
+status = "ARMED"
+clearance = "Mission Director"
++++
+
+## T-30m -- Terminal Sequence
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1a10" stroke="#00ff88" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#00ff88" opacity="0.9"/>
+  <text x="40" y="35" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="7" letter-spacing="1">MARK</text>
+  <text x="40" y="55" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="12">T-30m</text>
+  <text x="180" y="35" text-anchor="middle" fill="#c0f0d0" font-family="Orbitron, sans-serif" font-weight="700" font-size="12" letter-spacing="1">TERMINAL SEQ</text>
+  <text x="180" y="55" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="8" letter-spacing="2">STATUS ARMED // DIRECTOR</text>
+</svg>
+
+<span class="zero-badge-outline">ARMED</span>
+
+### Milestone Summary
+
+Thirty minutes. The automated sequence takes control. Humans are now observers with a single remaining power: abort. Every system runs through its final self-check. The clock accelerates perceptually -- minutes feel like seconds. This is the terminal phase where momentum becomes unstoppable unless deliberately halted.
+
+| Detail | Info |
+|--------|------|
+| Countdown | T-30m |
+| Status | ARMED |
+| Clearance | Mission Director |

--- a/countdown-zero/content/schedule/t-minus-4h.md
+++ b/countdown-zero/content/schedule/t-minus-4h.md
@@ -1,0 +1,34 @@
++++
+title = "T-4h -- Systems Check"
+date = "2027-09-12"
+description = "Pre-launch briefing and all-stations status report"
+weight = 1
+tags = ["systems-check", "briefing", "preparation"]
+[extra]
+countdown = "T-4h"
+status = "HOLD"
+clearance = "All Stations"
++++
+
+## T-4h -- Systems Check
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1a10" stroke="#00ff88" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#00ff88" opacity="0.9"/>
+  <text x="40" y="35" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="8" letter-spacing="1">MARK</text>
+  <text x="40" y="55" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="14">T-4h</text>
+  <text x="180" y="35" text-anchor="middle" fill="#c0f0d0" font-family="Orbitron, sans-serif" font-weight="700" font-size="12" letter-spacing="1">SYSTEMS CHECK</text>
+  <text x="180" y="55" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="8" letter-spacing="2">STATUS HOLD // ALL STATIONS</text>
+</svg>
+
+<span class="zero-badge">HOLD</span>
+
+### Milestone Summary
+
+Four hours to zero. Every station reports readiness. This is the first formal checkpoint -- the moment where all teams confirm their systems are nominal. Go or no-go calls cascade through the chain. A single no-go halts the clock. The countdown pauses here until every system shows green.
+
+| Detail | Info |
+|--------|------|
+| Countdown | T-4h |
+| Status | HOLD |
+| Clearance | All Stations |

--- a/countdown-zero/content/schedule/t-zero.md
+++ b/countdown-zero/content/schedule/t-zero.md
@@ -1,0 +1,34 @@
++++
+title = "T-0 -- ZERO HOUR"
+date = "2027-09-12"
+description = "The convergence moment where all paths meet and everything changes"
+weight = 4
+tags = ["zero-hour", "convergence", "launch"]
+[extra]
+countdown = "T-0"
+status = "LAUNCH"
+clearance = "All Clear"
++++
+
+## T-0 -- ZERO HOUR
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1a10" stroke="#00ff88" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#00ff88"/>
+  <text x="40" y="35" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="8" letter-spacing="1">MARK</text>
+  <text x="40" y="58" text-anchor="middle" fill="#0a1a10" font-family="Orbitron, sans-serif" font-weight="900" font-size="18">T-0</text>
+  <text x="180" y="35" text-anchor="middle" fill="#c0f0d0" font-family="Orbitron, sans-serif" font-weight="900" font-size="14" letter-spacing="2">ZERO HOUR</text>
+  <text x="180" y="55" text-anchor="middle" fill="#006644" font-family="Share Tech, sans-serif" font-size="8" letter-spacing="2">STATUS LAUNCH // ALL CLEAR</text>
+</svg>
+
+<span class="zero-badge">LAUNCH</span>
+
+### Milestone Summary
+
+Zero. The clock stops. The moment arrives. Everything that was counting down has converged to this single point in time. Every preparation, every check, every resource loaded -- all of it was for this instant. T-0 is not a duration. It is a threshold. You cross it and there is no before anymore, only after.
+
+| Detail | Info |
+|--------|------|
+| Countdown | T-0 |
+| Status | LAUNCH |
+| Clearance | All Clear |

--- a/countdown-zero/static/css/style.css
+++ b/countdown-zero/static/css/style.css
@@ -1,0 +1,469 @@
+/* Countdown Zero - Zero Hour Convergence Event */
+/* Fonts: Orbitron / IBM Plex Mono Bold display, Share Tech / Exo 2 body */
+
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600;700&family=Share+Tech&family=Exo+2:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a1a10;
+  --bg-secondary: #061208;
+  --bg-panel: #0e2218;
+  --text-primary: #c0f0d0;
+  --text-secondary: #70a080;
+  --text-muted: #306040;
+  --accent-green: #00ff88;
+  --accent-white: #c0f0d0;
+  --accent-dim: #008844;
+  --border-color: #143020;
+  --border-accent: #00ff88;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Share Tech', 'Exo 2', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'IBM Plex Mono', monospace; font-weight: 700; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-green);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 1.3rem;
+  color: var(--accent-green);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-green);
+  border-bottom-color: var(--accent-green);
+}
+
+.nav-cta {
+  background-color: var(--accent-green) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 5.5rem;
+  color: var(--accent-green);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Exo 2', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Countdown Block */
+.countdown-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.countdown-block.t-zero {
+  border-color: var(--accent-green);
+  background: var(--bg-secondary);
+}
+
+.countdown-time {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--accent-green);
+  min-width: 70px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.countdown-time.t-zero-time {
+  font-size: 1.4rem;
+}
+
+.countdown-info { flex: 1; }
+
+.countdown-title {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.countdown-title.t-zero-title {
+  font-size: 1.15rem;
+  color: var(--accent-green);
+}
+
+.countdown-meta {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.countdown-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Zero Badge */
+.zero-badge {
+  display: inline-block;
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-green);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+  font-weight: 400;
+}
+
+.zero-badge-outline {
+  display: inline-block;
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-green);
+  color: var(--accent-green);
+  text-transform: uppercase;
+  font-weight: 400;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'IBM Plex Mono', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-green);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-green);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Share Tech', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-green);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-green);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-green);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-green);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .countdown-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/countdown-zero/templates/404.html
+++ b/countdown-zero/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Clock face -->
+        <circle cx="40" cy="40" r="28" stroke="#00ff88" stroke-width="2" fill="none" opacity="0.3"/>
+        <!-- Clock hands at 12 -->
+        <line x1="40" y1="40" x2="40" y2="18" stroke="#00ff88" stroke-width="2" opacity="0.25"/>
+        <line x1="40" y1="40" x2="40" y2="22" stroke="#00ff88" stroke-width="1.5" opacity="0.2"/>
+        <!-- Center dot -->
+        <circle cx="40" cy="40" r="3" fill="#00ff88" opacity="0.3"/>
+        <!-- Tick marks -->
+        <line x1="40" y1="14" x2="40" y2="17" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+        <line x1="66" y1="40" x2="63" y2="40" stroke="#00ff88" stroke-width="1" opacity="0.2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Signal Lost Before T-0</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-green); font-family: 'Orbitron', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Mission</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/countdown-zero/templates/footer.html
+++ b/countdown-zero/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">COUNTDOWN ZERO // CONVERGENCE EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Mission</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/countdown-zero/templates/header.html
+++ b/countdown-zero/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">COUNTDOWN ZERO</span>
+        <span class="logo-sub">convergence</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Mission</a>
+        <a href="{{ base_url }}/schedule/">Schedule</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/countdown-zero/templates/page.html
+++ b/countdown-zero/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/countdown-zero/templates/post.html
+++ b/countdown-zero/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("schedule") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/countdown-zero/templates/section.html
+++ b/countdown-zero/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/countdown-zero/templates/taxonomy.html
+++ b/countdown-zero/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/countdown-zero/templates/taxonomy_term.html
+++ b/countdown-zero/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All entries tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -802,6 +802,13 @@
     "space",
     "planetary"
   ],
+  "countdown-zero": [
+    "event",
+    "dark",
+    "countdown",
+    "convergence",
+    "climactic"
+  ],
   "creative-agency": [
     "dark",
     "portfolio",


### PR DESCRIPTION
## Summary
- Add countdown-zero example site: zero hour convergence event theme
- Dark mission-control design with terminal-green (#00ff88) accent, Orbitron/IBM Plex Mono display, Share Tech/Exo 2 body
- Schedule entries as negative time T-4h/T-2h/T-30m/T-0, inline SVG mission clock displays, convergence line patterns, countdown milestone markers, zero-hour burst patterns
- T-0 moment in maximum-scale type with special styling
- Update tags.json with countdown-zero entry

Closes #1659