### PR TITLE
feat: add chain-reaction example site (closes #1660)

### DIFF
--- a/chain-reaction/config.toml
+++ b/chain-reaction/config.toml
@@ -1,0 +1,41 @@
+title = "Chain Reaction"
+description = "Sequential trigger event where each session unlocks the next"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["triggers"]
+
+[markdown]
+safe = false

--- a/chain-reaction/content/index.md
+++ b/chain-reaction/content/index.md
@@ -1,0 +1,187 @@
++++
+title = "Home"
+description = "Sequential trigger event where each session unlocks the next"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Sequential Trigger Event</div>
+    <h1>CHAIN REACTION</h1>
+    <p class="hero-subtitle">Each stage triggers the next. No skipping ahead. Complete the trigger condition and the next domino falls. Four stages of cascading consequence.</p>
+    <p class="hero-date">2027.08.18 // KINETIC HALL, BERLIN</p>
+
+    <!-- SVG domino chain falling sequence diagram -->
+    <svg width="320" height="160" viewBox="0 0 320 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Domino 1 - standing -->
+      <rect x="30" y="60" width="18" height="50" rx="2" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.35"/>
+      <circle cx="39" cy="72" r="2.5" fill="#e67e22" opacity="0.25"/>
+      <circle cx="39" cy="82" r="2.5" fill="#e67e22" opacity="0.25"/>
+      <circle cx="39" cy="92" r="2.5" fill="#e67e22" opacity="0.25"/>
+      <text x="39" y="125" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.3">1</text>
+      <!-- Trigger arrow 1->2 -->
+      <line x1="52" y1="85" x2="75" y2="75" stroke="#e67e22" stroke-width="1" opacity="0.2" stroke-dasharray="4 3"/>
+      <polygon points="75,72 75,78 80,75" fill="#e67e22" opacity="0.2"/>
+      <!-- Domino 2 - tilting -->
+      <rect x="85" y="50" width="18" height="50" rx="2" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.3" transform="rotate(10 94 75)"/>
+      <circle cx="94" cy="62" r="2.5" fill="#e67e22" opacity="0.2"/>
+      <circle cx="94" cy="72" r="2.5" fill="#e67e22" opacity="0.2"/>
+      <text x="98" y="125" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.25">2</text>
+      <!-- Trigger arrow 2->3 -->
+      <line x1="112" y1="70" x2="138" y2="60" stroke="#e67e22" stroke-width="1" opacity="0.2" stroke-dasharray="4 3"/>
+      <polygon points="138,57 138,63 143,60" fill="#e67e22" opacity="0.2"/>
+      <!-- Domino 3 - more tilted -->
+      <rect x="148" y="40" width="18" height="50" rx="2" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.25" transform="rotate(25 157 65)"/>
+      <circle cx="157" cy="52" r="2.5" fill="#e67e22" opacity="0.18"/>
+      <text x="162" y="125" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.22">3</text>
+      <!-- Trigger arrow 3->4 -->
+      <line x1="175" y1="55" x2="205" y2="48" stroke="#e67e22" stroke-width="1" opacity="0.2" stroke-dasharray="4 3"/>
+      <polygon points="205,45 205,51 210,48" fill="#e67e22" opacity="0.2"/>
+      <!-- Domino 4 - fallen -->
+      <rect x="215" y="35" width="18" height="50" rx="2" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.2" transform="rotate(50 224 60)"/>
+      <text x="232" y="125" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.2">4</text>
+      <!-- Chain label -->
+      <text x="160" y="150" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="4">SEQUENTIAL CASCADE</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Trigger Sequence</div>
+  <h2>Stage Progression</h2>
+
+  <div class="trigger-block">
+    <div class="trigger-number">STAGE 1</div>
+    <div class="trigger-info">
+      <div class="trigger-title">Ignition -- Initial Spark</div>
+      <div class="trigger-meta">Trigger condition: attendance confirmed. Unlocks Stage 2.</div>
+    </div>
+    <div class="trigger-badge-slot"><span class="chain-badge">ACTIVE</span></div>
+  </div>
+
+  <!-- SVG dependency arrow -->
+  <div class="trigger-arrow">
+    <svg width="40" height="30" viewBox="0 0 40 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block; margin: 0 auto;">
+      <line x1="20" y1="0" x2="20" y2="22" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+      <polygon points="14,20 26,20 20,28" fill="#e67e22" opacity="0.2"/>
+    </svg>
+  </div>
+
+  <div class="trigger-block">
+    <div class="trigger-number">STAGE 2</div>
+    <div class="trigger-info">
+      <div class="trigger-title">Propagation -- Spreading Wave</div>
+      <div class="trigger-meta">Trigger condition: Stage 1 complete. Unlocks Stage 3.</div>
+    </div>
+    <div class="trigger-badge-slot"><span class="chain-badge-outline">LOCKED</span></div>
+  </div>
+
+  <div class="trigger-arrow">
+    <svg width="40" height="30" viewBox="0 0 40 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block; margin: 0 auto;">
+      <line x1="20" y1="0" x2="20" y2="22" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+      <polygon points="14,20 26,20 20,28" fill="#e67e22" opacity="0.2"/>
+    </svg>
+  </div>
+
+  <div class="trigger-block">
+    <div class="trigger-number">STAGE 3</div>
+    <div class="trigger-info">
+      <div class="trigger-title">Amplification -- Critical Mass</div>
+      <div class="trigger-meta">Trigger condition: Stages 1+2 complete. Unlocks Stage 4.</div>
+    </div>
+    <div class="trigger-badge-slot"><span class="chain-badge-outline">LOCKED</span></div>
+  </div>
+
+  <div class="trigger-arrow">
+    <svg width="40" height="30" viewBox="0 0 40 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block; margin: 0 auto;">
+      <line x1="20" y1="0" x2="20" y2="22" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+      <polygon points="14,20 26,20 20,28" fill="#e67e22" opacity="0.2"/>
+    </svg>
+  </div>
+
+  <div class="trigger-block">
+    <div class="trigger-number">STAGE 4</div>
+    <div class="trigger-info">
+      <div class="trigger-title">Detonation -- Full Cascade</div>
+      <div class="trigger-meta">Trigger condition: all stages complete. Final resolution.</div>
+    </div>
+    <div class="trigger-badge-slot"><span class="chain-badge-outline">FINAL</span></div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Dependencies</div>
+  <h2>Reaction Branching</h2>
+
+  <!-- SVG chain reaction branching pattern -->
+  <svg width="100%" height="160" viewBox="0 0 600 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Root node -->
+    <circle cx="80" cy="80" r="12" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.3"/>
+    <text x="80" y="84" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.3">1</text>
+    <!-- Branch to 2 -->
+    <line x1="92" y1="80" x2="188" y2="50" stroke="#e67e22" stroke-width="1" opacity="0.2"/>
+    <circle cx="200" cy="45" r="12" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.25"/>
+    <text x="200" y="49" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.25">2a</text>
+    <!-- Branch to 2b -->
+    <line x1="92" y1="80" x2="188" y2="115" stroke="#e67e22" stroke-width="1" opacity="0.2"/>
+    <circle cx="200" cy="120" r="12" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.25"/>
+    <text x="200" y="124" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.25">2b</text>
+    <!-- Converge to 3 -->
+    <line x1="212" y1="45" x2="348" y2="80" stroke="#e67e22" stroke-width="1" opacity="0.18"/>
+    <line x1="212" y1="120" x2="348" y2="80" stroke="#e67e22" stroke-width="1" opacity="0.18"/>
+    <circle cx="360" cy="80" r="12" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.22"/>
+    <text x="360" y="84" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.22">3</text>
+    <!-- Final to 4 -->
+    <line x1="372" y1="80" x2="498" y2="80" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+    <circle cx="510" cy="80" r="14" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.3"/>
+    <text x="510" y="84" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.3">4</text>
+    <!-- Connection labels -->
+    <text x="140" y="58" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-size="6" letter-spacing="1">TRIGGER</text>
+    <text x="140" y="115" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-size="6" letter-spacing="1">TRIGGER</text>
+    <text x="280" y="55" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-size="6" letter-spacing="1">MERGE</text>
+    <text x="435" y="73" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-size="6" letter-spacing="1">CASCADE</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Mechanism</div>
+  <h2>Rube Goldberg Machine</h2>
+
+  <!-- SVG Rube Goldberg machine illustration -->
+  <svg width="100%" height="120" viewBox="0 0 600 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Ball on ramp -->
+    <circle cx="40" cy="30" r="8" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <line x1="20" y1="40" x2="100" y2="55" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+    <!-- Lever -->
+    <line x1="100" y1="55" x2="100" y2="80" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+    <line x1="80" y1="80" x2="120" y2="80" stroke="#e67e22" stroke-width="2" opacity="0.2"/>
+    <!-- Cup and string -->
+    <path d="M150,50 L150,75 L175,75 L175,50" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.2"/>
+    <line x1="120" y1="60" x2="150" y2="55" stroke="#e67e22" stroke-width="0.8" opacity="0.15" stroke-dasharray="3 2"/>
+    <!-- Wheel -->
+    <circle cx="240" cy="60" r="20" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="225" y1="48" x2="255" y2="72" stroke="#e67e22" stroke-width="0.8" opacity="0.15"/>
+    <line x1="255" y1="48" x2="225" y2="72" stroke="#e67e22" stroke-width="0.8" opacity="0.15"/>
+    <line x1="175" y1="65" x2="220" y2="60" stroke="#e67e22" stroke-width="0.8" opacity="0.15" stroke-dasharray="3 2"/>
+    <!-- Pendulum -->
+    <line x1="320" y1="20" x2="340" y2="70" stroke="#e67e22" stroke-width="1.5" opacity="0.2"/>
+    <circle cx="340" cy="75" r="8" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="260" y1="55" x2="320" y2="25" stroke="#e67e22" stroke-width="0.8" opacity="0.15" stroke-dasharray="3 2"/>
+    <!-- Domino sequence -->
+    <rect x="390" y="50" width="8" height="30" rx="1" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="410" y="48" width="8" height="30" rx="1" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.18" transform="rotate(5 414 63)"/>
+    <rect x="430" y="44" width="8" height="30" rx="1" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.15" transform="rotate(15 434 59)"/>
+    <line x1="348" y1="75" x2="390" y2="65" stroke="#e67e22" stroke-width="0.8" opacity="0.15" stroke-dasharray="3 2"/>
+    <!-- Final trigger -->
+    <circle cx="520" cy="65" r="15" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.25"/>
+    <text x="520" y="69" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="8" opacity="0.2">END</text>
+    <line x1="440" y1="55" x2="505" y2="65" stroke="#e67e22" stroke-width="0.8" opacity="0.15" stroke-dasharray="3 2"/>
+    <!-- Labels -->
+    <text x="300" y="110" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="4">CAUSE AND EFFECT</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Inter', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">stage 1 > stage 2 > stage 3 > stage 4</p>
+</div>
+
+</div>

--- a/chain-reaction/content/mechanism.md
+++ b/chain-reaction/content/mechanism.md
@@ -1,0 +1,29 @@
++++
+title = "Mechanism"
+description = "How the chain reaction trigger system works"
++++
+
+<div class="section-block">
+  <div class="section-label">Mechanism</div>
+  <h2>How Triggers Work</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Each stage has a trigger condition -- a specific outcome that must be achieved before the next stage unlocks. Dependency arrows show which stages must complete first. Some stages branch into parallel tracks that reconverge later. The sequence is strict. No stage can be skipped.</p>
+
+  <!-- SVG domino chain with connection lines -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Vertical chain -->
+    <rect x="88" y="20" width="24" height="32" rx="3" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="100" y="40" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="10" opacity="0.3">1</text>
+    <line x1="100" y1="52" x2="100" y2="65" stroke="#e67e22" stroke-width="1" opacity="0.2"/>
+    <polygon points="95,62 105,62 100,68" fill="#e67e22" opacity="0.2"/>
+    <rect x="88" y="70" width="24" height="32" rx="3" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="100" y="90" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="10" opacity="0.25">2</text>
+    <line x1="100" y1="102" x2="100" y2="115" stroke="#e67e22" stroke-width="1" opacity="0.18"/>
+    <polygon points="95,112 105,112 100,118" fill="#e67e22" opacity="0.18"/>
+    <rect x="88" y="120" width="24" height="32" rx="3" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.22"/>
+    <text x="100" y="140" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="10" opacity="0.22">3</text>
+    <line x1="100" y1="152" x2="100" y2="165" stroke="#e67e22" stroke-width="1" opacity="0.15"/>
+    <polygon points="95,162 105,162 100,168" fill="#e67e22" opacity="0.15"/>
+    <rect x="88" y="170" width="24" height="24" rx="3" stroke="#e67e22" stroke-width="2" fill="none" opacity="0.3"/>
+    <text x="100" y="186" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="10" opacity="0.3">4</text>
+  </svg>
+</div>

--- a/chain-reaction/content/register.md
+++ b/chain-reaction/content/register.md
@@ -1,0 +1,27 @@
++++
+title = "Register"
+description = "Register for the Chain Reaction sequential trigger event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Start the Chain</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register as a reactor to participate in the full trigger sequence, or sign up as an observer to watch the dominoes fall from the gallery. All reactors receive dependency maps and trigger status trackers.</p>
+
+  <!-- SVG domino icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <rect x="30" y="20" width="20" height="40" rx="3" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <circle cx="40" cy="32" r="2.5" fill="#e67e22" opacity="0.2"/>
+    <line x1="32" y1="40" x2="48" y2="40" stroke="#e67e22" stroke-width="0.8" opacity="0.15"/>
+    <circle cx="40" cy="48" r="2.5" fill="#e67e22" opacity="0.2"/>
+    <!-- Second domino tilting -->
+    <rect x="55" y="22" width="20" height="40" rx="3" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.2" transform="rotate(15 65 42)"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="chain-badge" style="font-size: 0.85rem; padding: 6px 20px;">REACTOR</span>
+    <span class="chain-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">OBSERVER</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Poppins', sans-serif; font-weight: 700; font-size: 0.85rem; letter-spacing: 0.15em;">2027.08.18 // KINETIC HALL, BERLIN</p>
+</div>

--- a/chain-reaction/content/triggers/_index.md
+++ b/chain-reaction/content/triggers/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Triggers"
+description = "All sequential trigger stages in the Chain Reaction"
+sort_by = "weight"
+template = "section"
++++
+
+Four stages. Each unlocks the next. No shortcuts. Only sequence.

--- a/chain-reaction/content/triggers/amplification.md
+++ b/chain-reaction/content/triggers/amplification.md
@@ -1,0 +1,34 @@
++++
+title = "STAGE 3 -- Amplification"
+date = "2027-08-18"
+description = "Critical mass reached as parallel threads converge"
+weight = 3
+tags = ["amplification", "critical-mass", "convergence"]
+[extra]
+trigger_condition = "Stages 1+2 complete"
+unlocks = "Stage 4"
+status = "Locked"
++++
+
+## STAGE 3 -- Amplification
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1008" stroke="#e67e22" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#e67e22"/>
+  <text x="40" y="33" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" letter-spacing="1">STAGE</text>
+  <text x="40" y="55" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">3</text>
+  <text x="180" y="35" text-anchor="middle" fill="#f0d8b0" font-family="Montserrat, sans-serif" font-weight="900" font-size="12" letter-spacing="1">AMPLIFICATION</text>
+  <text x="180" y="55" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">UNLOCKS STAGE 4</text>
+</svg>
+
+<span class="chain-badge-outline">LOCKED</span>
+
+### Stage Summary
+
+All parallel branches reconverge here. The energy from Stages 1 and 2 combines and amplifies. What was manageable individually becomes overwhelming together. This is the critical mass moment -- the point where the chain reaction becomes self-sustaining and unstoppable.
+
+| Detail | Info |
+|--------|------|
+| Trigger Condition | Stages 1+2 complete |
+| Unlocks | Stage 4 |
+| Status | Locked |

--- a/chain-reaction/content/triggers/detonation.md
+++ b/chain-reaction/content/triggers/detonation.md
@@ -1,0 +1,34 @@
++++
+title = "STAGE 4 -- Detonation"
+date = "2027-08-18"
+description = "The full cascade completes and all chains resolve"
+weight = 4
+tags = ["detonation", "cascade", "resolution"]
+[extra]
+trigger_condition = "All stages complete"
+unlocks = "Resolution"
+status = "Final"
++++
+
+## STAGE 4 -- Detonation
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1008" stroke="#e67e22" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#e67e22"/>
+  <text x="40" y="33" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" letter-spacing="1">STAGE</text>
+  <text x="40" y="55" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">4</text>
+  <text x="180" y="35" text-anchor="middle" fill="#f0d8b0" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">DETONATION</text>
+  <text x="180" y="55" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">FULL CASCADE // FINAL</text>
+</svg>
+
+<span class="chain-badge-outline">FINAL</span>
+
+### Stage Summary
+
+The last domino falls. Every chain, every branch, every trigger condition has been met. The full cascade completes. What began as a single spark in Stage 1 has propagated, amplified, and now detonates into its final form. The chain reaction is complete. The sequence resolves.
+
+| Detail | Info |
+|--------|------|
+| Trigger Condition | All stages complete |
+| Unlocks | Resolution |
+| Status | Final |

--- a/chain-reaction/content/triggers/ignition.md
+++ b/chain-reaction/content/triggers/ignition.md
@@ -1,0 +1,34 @@
++++
+title = "STAGE 1 -- Ignition"
+date = "2027-08-18"
+description = "The initial spark that begins the chain reaction sequence"
+weight = 1
+tags = ["ignition", "initial", "trigger"]
+[extra]
+trigger_condition = "Attendance confirmed"
+unlocks = "Stage 2"
+status = "Active"
++++
+
+## STAGE 1 -- Ignition
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1008" stroke="#e67e22" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#e67e22"/>
+  <text x="40" y="33" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" letter-spacing="1">STAGE</text>
+  <text x="40" y="55" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">1</text>
+  <text x="180" y="35" text-anchor="middle" fill="#f0d8b0" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">IGNITION</text>
+  <text x="180" y="55" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">UNLOCKS STAGE 2</text>
+</svg>
+
+<span class="chain-badge">ACTIVE</span>
+
+### Stage Summary
+
+The first domino. Everything begins here. The trigger condition is simple: show up and commit. Once attendance is confirmed and the opening challenge is accepted, Stage 1 completes and the chain begins to move. There is no going back once the first piece falls.
+
+| Detail | Info |
+|--------|------|
+| Trigger Condition | Attendance confirmed |
+| Unlocks | Stage 2 |
+| Status | Active |

--- a/chain-reaction/content/triggers/propagation.md
+++ b/chain-reaction/content/triggers/propagation.md
@@ -1,0 +1,51 @@
++++
+title = "STAGE 2 -- Propagation"
+date = "2027-08-18"
+description = "The spreading wave as the reaction gains momentum"
+weight = 2
+tags = ["propagation", "spread", "momentum"]
+[extra]
+trigger_condition = "Stage 1 complete"
+unlocks = "Stage 3"
+status = "Locked"
++++
+
+## STAGE 2 -- Propagation
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#1a1008" stroke="#e67e22" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#e67e22"/>
+  <text x="40" y="33" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" letter-spacing="1">STAGE</text>
+  <text x="40" y="55" text-anchor="middle" fill="#1a1008" font-family="Montserrat, sans-serif" font-weight="900" font-size="20">2</text>
+  <text x="180" y="35" text-anchor="middle" fill="#f0d8b0" font-family="Montserrat, sans-serif" font-weight="900" font-size="13" letter-spacing="1">PROPAGATION</text>
+  <text x="180" y="55" text-anchor="middle" fill="#7a4010" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">UNLOCKS STAGE 3</text>
+</svg>
+
+<span class="chain-badge-outline">LOCKED</span>
+
+### Stage Summary
+
+The reaction spreads. What started as a single trigger now branches into parallel tracks. Teams split and work on connected challenges where the output of one feeds the input of another. The dependency web grows. Every completion sends a signal forward through the chain.
+
+<!-- SVG trigger-to-effect connection lines -->
+<svg width="200" height="100" viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="30" cy="50" r="10" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.25"/>
+  <text x="30" y="54" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.25">2</text>
+  <line x1="40" y1="42" x2="100" y2="25" stroke="#e67e22" stroke-width="1" opacity="0.15"/>
+  <line x1="40" y1="50" x2="100" y2="50" stroke="#e67e22" stroke-width="1" opacity="0.15"/>
+  <line x1="40" y1="58" x2="100" y2="75" stroke="#e67e22" stroke-width="1" opacity="0.15"/>
+  <circle cx="110" cy="25" r="6" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="110" cy="50" r="6" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="110" cy="75" r="6" stroke="#e67e22" stroke-width="1" fill="none" opacity="0.15"/>
+  <line x1="116" y1="25" x2="160" y2="50" stroke="#e67e22" stroke-width="1" opacity="0.12"/>
+  <line x1="116" y1="50" x2="160" y2="50" stroke="#e67e22" stroke-width="1" opacity="0.12"/>
+  <line x1="116" y1="75" x2="160" y2="50" stroke="#e67e22" stroke-width="1" opacity="0.12"/>
+  <circle cx="170" cy="50" r="10" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.2"/>
+  <text x="170" y="54" text-anchor="middle" fill="#e67e22" font-family="Montserrat, sans-serif" font-weight="900" font-size="7" opacity="0.2">3</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Trigger Condition | Stage 1 complete |
+| Unlocks | Stage 3 |
+| Status | Locked |

--- a/chain-reaction/static/css/style.css
+++ b/chain-reaction/static/css/style.css
@@ -1,0 +1,466 @@
+/* Chain Reaction - Sequential Trigger Event */
+/* Fonts: Montserrat Black / Poppins Bold display, Inter / Roboto body */
+
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800;900&family=Poppins:wght@500;600;700&family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap');
+
+:root {
+  --bg-primary: #1a1008;
+  --bg-secondary: #120c04;
+  --bg-panel: #221808;
+  --text-primary: #f0d8b0;
+  --text-secondary: #b09060;
+  --text-muted: #7a4010;
+  --accent-amber: #e67e22;
+  --accent-white: #f0d8b0;
+  --accent-dim: #a05510;
+  --border-color: #2a1a08;
+  --border-accent: #e67e22;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Roboto', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Poppins', sans-serif; font-weight: 700; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-amber);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.4rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-amber);
+  border-bottom-color: var(--accent-amber);
+}
+
+.nav-cta {
+  background-color: var(--accent-amber) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 5.5rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  letter-spacing: 0.04em;
+}
+
+.hero-subtitle {
+  font-family: 'Roboto', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Trigger Block */
+.trigger-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+}
+
+.trigger-arrow {
+  padding: 4px 0;
+}
+
+.trigger-number {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.85rem;
+  color: var(--accent-amber);
+  min-width: 80px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.trigger-info { flex: 1; }
+
+.trigger-title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.trigger-meta {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.trigger-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Chain Badge */
+.chain-badge {
+  display: inline-block;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-amber);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.chain-badge-outline {
+  display: inline-block;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-amber);
+  color: var(--accent-amber);
+  text-transform: uppercase;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-amber);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-amber);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+}
+
+.listing-title a {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-amber);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-amber);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-amber);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-amber);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .trigger-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/chain-reaction/templates/404.html
+++ b/chain-reaction/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Domino -->
+        <rect x="25" y="15" width="14" height="28" rx="2" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <circle cx="32" cy="25" r="2" fill="#e67e22" opacity="0.2"/>
+        <circle cx="32" cy="35" r="2" fill="#e67e22" opacity="0.2"/>
+        <!-- Fallen domino -->
+        <rect x="42" y="25" width="14" height="28" rx="2" stroke="#e67e22" stroke-width="1.5" fill="none" opacity="0.2" transform="rotate(30 49 39)"/>
+        <!-- Connection line -->
+        <line x1="39" y1="40" x2="45" y2="35" stroke="#e67e22" stroke-width="1" opacity="0.15" stroke-dasharray="3 2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Chain Broken</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-amber); font-family: 'Inter', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Sequence</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/chain-reaction/templates/footer.html
+++ b/chain-reaction/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">CHAIN REACTION // SEQUENTIAL EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Sequence</a>
+        <a href="{{ base_url }}/triggers/">Triggers</a>
+        <a href="{{ base_url }}/mechanism/">Mechanism</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/chain-reaction/templates/header.html
+++ b/chain-reaction/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">CHAIN REACTION</span>
+        <span class="logo-sub">sequential trigger</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Sequence</a>
+        <a href="{{ base_url }}/triggers/">Triggers</a>
+        <a href="{{ base_url }}/mechanism/">Mechanism</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/chain-reaction/templates/page.html
+++ b/chain-reaction/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/chain-reaction/templates/post.html
+++ b/chain-reaction/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("trigger") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/chain-reaction/templates/section.html
+++ b/chain-reaction/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/chain-reaction/templates/taxonomy.html
+++ b/chain-reaction/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/chain-reaction/templates/taxonomy_term.html
+++ b/chain-reaction/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All triggers tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -563,6 +563,13 @@
     "celestial",
     "trendy"
   ],
+  "chain-reaction": [
+    "event",
+    "dark",
+    "sequential",
+    "cascade",
+    "connected"
+  ],
   "chalkboard": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Add chain-reaction example site: sequential trigger event theme
- Dark design with amber (#e67e22) accent, Montserrat Black/Poppins Bold display, Inter/Roboto body
- Sessions labeled STAGE 1/2/3/4 with trigger conditions, inline SVG domino chain sequences, reaction branching patterns, Rube Goldberg machine illustrations, trigger-to-effect connection lines
- Dependency arrows showing which sessions unlock others
- Update tags.json with chain-reaction entry

Closes #1660