### PR TITLE
feat: add avalanche-event example site (closes #1661)

### DIFF
--- a/avalanche-event/config.toml
+++ b/avalanche-event/config.toml
@@ -1,0 +1,41 @@
+title = "Avalanche Event"
+description = "Cascading momentum event that builds from whisper to roar"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["sessions"]
+
+[markdown]
+safe = false

--- a/avalanche-event/content/index.md
+++ b/avalanche-event/content/index.md
@@ -1,0 +1,155 @@
++++
+title = "Home"
+description = "Cascading momentum event that builds from whisper to roar"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Cascading Momentum Event</div>
+    <h1>AVALANCHE</h1>
+    <p class="hero-subtitle">It starts with a single crack in the snowfield. Then movement. Then mass. Four sessions that build from intimate whisper to overwhelming roar. The mountain does not stop.</p>
+    <p class="hero-date">2027.12.20 // THE SUMMIT, CHAMONIX</p>
+
+    <!-- SVG avalanche fracture line pattern -->
+    <svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Mountain outline -->
+      <path d="M20,160 L100,30 L160,80 L220,20 L300,160" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.2"/>
+      <!-- Snow line -->
+      <path d="M70,100 L100,30 L160,80 L220,20 L250,100" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.15"/>
+      <!-- Fracture line at trigger point -->
+      <path d="M80,90 L110,85 L130,92 L155,83 L175,88 L200,82 L230,90" stroke="#8fb8d0" stroke-width="2" fill="none" opacity="0.3" stroke-dasharray="6 3"/>
+      <!-- Trigger point -->
+      <circle cx="155" cy="83" r="5" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.3"/>
+      <circle cx="155" cy="83" r="2" fill="#8fb8d0" opacity="0.25"/>
+      <!-- Crack propagation lines -->
+      <line x1="155" y1="88" x2="140" y2="105" stroke="#8fb8d0" stroke-width="0.8" opacity="0.15"/>
+      <line x1="155" y1="88" x2="170" y2="108" stroke="#8fb8d0" stroke-width="0.8" opacity="0.15"/>
+      <line x1="155" y1="88" x2="155" y2="110" stroke="#8fb8d0" stroke-width="0.8" opacity="0.12"/>
+      <!-- Mass movement flow lines -->
+      <path d="M100,110 Q120,125 110,145" stroke="#8fb8d0" stroke-width="0.8" fill="none" opacity="0.1"/>
+      <path d="M140,110 Q155,130 145,150" stroke="#8fb8d0" stroke-width="0.8" fill="none" opacity="0.12"/>
+      <path d="M180,108 Q195,128 185,148" stroke="#8fb8d0" stroke-width="0.8" fill="none" opacity="0.1"/>
+      <!-- Debris scatter at bottom -->
+      <circle cx="90" cy="155" r="3" fill="#8fb8d0" opacity="0.08"/>
+      <circle cx="120" cy="158" r="4" fill="#8fb8d0" opacity="0.1"/>
+      <circle cx="155" cy="155" r="5" fill="#8fb8d0" opacity="0.12"/>
+      <circle cx="190" cy="157" r="4" fill="#8fb8d0" opacity="0.1"/>
+      <circle cx="220" cy="155" r="3" fill="#8fb8d0" opacity="0.08"/>
+      <!-- Labels -->
+      <text x="155" y="75" text-anchor="middle" fill="#8fb8d0" font-family="Anton, sans-serif" font-size="7" opacity="0.25" letter-spacing="2">TRIGGER</text>
+      <text x="160" y="170" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="6" letter-spacing="3">DEBRIS FIELD</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Momentum Build</div>
+  <h2>Session Progression</h2>
+
+  <div class="session-block session-sm">
+    <div class="session-number">SESSION I</div>
+    <div class="session-info">
+      <div class="session-title session-title-sm">First Crack -- The Whisper</div>
+      <div class="session-meta">Small and quiet. 12 attendees. The fracture begins.</div>
+    </div>
+    <div class="session-badge-slot">
+      <span class="avalanche-badge-outline">12</span>
+    </div>
+  </div>
+
+  <div class="session-block session-md">
+    <div class="session-number">SESSION II</div>
+    <div class="session-info">
+      <div class="session-title session-title-md">Propagation -- The Rumble</div>
+      <div class="session-meta">Cracks spread. 48 attendees. Momentum builds.</div>
+    </div>
+    <div class="session-badge-slot">
+      <span class="avalanche-badge-outline">48</span>
+    </div>
+  </div>
+
+  <div class="session-block session-lg">
+    <div class="session-number">SESSION III</div>
+    <div class="session-info">
+      <div class="session-title session-title-lg">Mass Movement -- The Roar</div>
+      <div class="session-meta">The mountain moves. 200 attendees. Unstoppable force.</div>
+    </div>
+    <div class="session-badge-slot">
+      <span class="avalanche-badge">200</span>
+    </div>
+  </div>
+
+  <div class="session-block session-xl">
+    <div class="session-number">SESSION IV</div>
+    <div class="session-info">
+      <div class="session-title session-title-xl">Debris Field -- The Aftermath</div>
+      <div class="session-meta">Total coverage. 1,000 attendees. Everything changed.</div>
+    </div>
+    <div class="session-badge-slot">
+      <span class="avalanche-badge">1,000</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Scale</div>
+  <h2>Attendee Growth</h2>
+
+  <!-- SVG snowfield crack propagation showing exponential growth -->
+  <svg width="100%" height="140" viewBox="0 0 600 140" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Growth bars -->
+    <rect x="60" y="105" width="80" height="15" fill="#8fb8d0" opacity="0.1"/>
+    <rect x="180" y="85" width="80" height="35" fill="#8fb8d0" opacity="0.15"/>
+    <rect x="300" y="45" width="80" height="75" fill="#8fb8d0" opacity="0.2"/>
+    <rect x="420" y="10" width="80" height="110" fill="#8fb8d0" opacity="0.25"/>
+    <!-- Bar outlines -->
+    <rect x="60" y="105" width="80" height="15" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="180" y="85" width="80" height="35" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="300" y="45" width="80" height="75" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="420" y="10" width="80" height="110" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Labels -->
+    <text x="100" y="100" text-anchor="middle" fill="#8fb8d0" font-family="Anton, sans-serif" font-size="9" opacity="0.25">12</text>
+    <text x="220" y="78" text-anchor="middle" fill="#8fb8d0" font-family="Anton, sans-serif" font-size="11" opacity="0.3">48</text>
+    <text x="340" y="38" text-anchor="middle" fill="#8fb8d0" font-family="Anton, sans-serif" font-size="13" opacity="0.35">200</text>
+    <text x="460" y="30" text-anchor="middle" fill="#8fb8d0" font-family="Anton, sans-serif" font-size="15" opacity="0.4">1,000</text>
+    <!-- Session labels -->
+    <text x="100" y="135" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="1">I</text>
+    <text x="220" y="135" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="1">II</text>
+    <text x="340" y="135" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="1">III</text>
+    <text x="460" y="135" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="7" letter-spacing="1">IV</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Debris</div>
+  <h2>Scatter Pattern</h2>
+
+  <!-- SVG debris field scatter pattern -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Central impact -->
+    <circle cx="100" cy="80" r="8" fill="#8fb8d0" opacity="0.15"/>
+    <!-- Scatter debris -->
+    <circle cx="65" cy="110" r="6" fill="#8fb8d0" opacity="0.12"/>
+    <circle cx="135" cy="105" r="7" fill="#8fb8d0" opacity="0.13"/>
+    <circle cx="45" cy="140" r="5" fill="#8fb8d0" opacity="0.1"/>
+    <circle cx="100" cy="135" r="9" fill="#8fb8d0" opacity="0.14"/>
+    <circle cx="155" cy="138" r="6" fill="#8fb8d0" opacity="0.11"/>
+    <circle cx="30" cy="165" r="4" fill="#8fb8d0" opacity="0.08"/>
+    <circle cx="75" cy="165" r="7" fill="#8fb8d0" opacity="0.1"/>
+    <circle cx="125" cy="168" r="5" fill="#8fb8d0" opacity="0.09"/>
+    <circle cx="170" cy="162" r="6" fill="#8fb8d0" opacity="0.1"/>
+    <!-- Flow lines from impact -->
+    <line x1="100" y1="88" x2="65" y2="104" stroke="#8fb8d0" stroke-width="0.5" opacity="0.1"/>
+    <line x1="100" y1="88" x2="135" y2="98" stroke="#8fb8d0" stroke-width="0.5" opacity="0.1"/>
+    <line x1="100" y1="88" x2="100" y2="126" stroke="#8fb8d0" stroke-width="0.5" opacity="0.1"/>
+    <!-- Mountain source -->
+    <path d="M80,30 L100,10 L120,30" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.15"/>
+    <line x1="100" y1="30" x2="100" y2="72" stroke="#8fb8d0" stroke-width="0.8" opacity="0.12"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Inter', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">whisper > rumble > roar > aftermath</p>
+</div>
+
+</div>

--- a/avalanche-event/content/register.md
+++ b/avalanche-event/content/register.md
@@ -1,0 +1,29 @@
++++
+title = "Register"
+description = "Register for the Avalanche cascading momentum event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Join the Descent</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register early for Session I to be part of the initial twelve, or join later sessions as the momentum builds. Early registrants experience the intimate beginning. Late arrivals feel the overwhelming finale. All attendees receive terrain analysis maps and momentum tracking badges.</p>
+
+  <!-- SVG mountain icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <path d="M15,75 L50,20 L85,75 Z" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <path d="M35,50 L50,20 L65,50" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Fracture -->
+    <line x1="32" y1="48" x2="68" y2="48" stroke="#8fb8d0" stroke-width="1" opacity="0.2" stroke-dasharray="4 2"/>
+    <!-- Small debris -->
+    <circle cx="40" cy="68" r="2" fill="#8fb8d0" opacity="0.12"/>
+    <circle cx="55" cy="70" r="2" fill="#8fb8d0" opacity="0.1"/>
+    <circle cx="65" cy="68" r="2" fill="#8fb8d0" opacity="0.08"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="avalanche-badge" style="font-size: 0.85rem; padding: 6px 20px;">EARLY (I-II)</span>
+    <span class="avalanche-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">LATE (III-IV)</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Anton', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.12.20 // THE SUMMIT, CHAMONIX</p>
+</div>

--- a/avalanche-event/content/sessions/_index.md
+++ b/avalanche-event/content/sessions/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Sessions"
+description = "All sessions in the Avalanche momentum event"
+sort_by = "weight"
+template = "section"
++++
+
+Four sessions. Exponential growth. Small start, massive finish.

--- a/avalanche-event/content/sessions/debris-field.md
+++ b/avalanche-event/content/sessions/debris-field.md
@@ -1,0 +1,34 @@
++++
+title = "Session IV -- Debris Field"
+date = "2027-12-20"
+description = "The aftermath as 1,000 attendees witness total transformation"
+weight = 4
+tags = ["debris-field", "aftermath", "massive"]
+[extra]
+attendees = "1,000"
+momentum = "Total"
+scale = "Overwhelming"
++++
+
+## Session IV -- Debris Field
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1420" stroke="#8fb8d0" stroke-width="2"/>
+  <rect x="0" y="0" width="90" height="80" fill="#8fb8d0"/>
+  <text x="45" y="28" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">SESSION</text>
+  <text x="45" y="60" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="26">IV</text>
+  <text x="185" y="30" text-anchor="middle" fill="#c0d8e8" font-family="Bebas Neue, sans-serif" font-size="20" letter-spacing="3">DEBRIS FIELD</text>
+  <text x="185" y="55" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">1,000 ATTENDEES // TOTAL</text>
+</svg>
+
+<span class="avalanche-badge">1,000</span>
+
+### Session Summary
+
+One thousand. The avalanche has run its full course. The entire mountainside has been reshaped. What remains is a debris field of transformed ideas, new connections, and permanent change. The landscape before and after are unrecognizable. This was not a gradual shift -- it was a cascading, overwhelming event that started with a single crack.
+
+| Detail | Info |
+|--------|------|
+| Attendees | 1,000 |
+| Momentum | Total |
+| Scale | Overwhelming |

--- a/avalanche-event/content/sessions/first-crack.md
+++ b/avalanche-event/content/sessions/first-crack.md
@@ -1,0 +1,40 @@
++++
+title = "Session I -- First Crack"
+date = "2027-12-20"
+description = "The whisper that starts the avalanche with 12 attendees"
+weight = 1
+tags = ["first-crack", "whisper", "intimate"]
+[extra]
+attendees = "12"
+momentum = "Minimal"
+scale = "Intimate"
++++
+
+## Session I -- First Crack
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1420" stroke="#8fb8d0" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#8fb8d0" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">SESSION</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="16">I</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c0d8e8" font-family="Anton, sans-serif" font-size="12" letter-spacing="1">FIRST CRACK</text>
+  <text x="170" y="55" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">12 ATTENDEES // WHISPER</text>
+</svg>
+
+<span class="avalanche-badge-outline">12</span>
+
+### Session Summary
+
+Twelve people in a small room. This is how avalanches begin -- not with thunder, but with a quiet crack that nobody notices at first. The content is intimate, the discussion close. Seeds are planted. The fracture line forms in the snowfield above, invisible but inevitable.
+
+<!-- SVG fracture line pattern -->
+<svg width="200" height="40" viewBox="0 0 200 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M10,20 L40,18 L70,22 L100,17 L130,21 L160,19 L190,20" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.2" stroke-dasharray="6 3"/>
+  <circle cx="100" cy="17" r="3" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Attendees | 12 |
+| Momentum | Minimal |
+| Scale | Intimate |

--- a/avalanche-event/content/sessions/mass-movement.md
+++ b/avalanche-event/content/sessions/mass-movement.md
@@ -1,0 +1,42 @@
++++
+title = "Session III -- Mass Movement"
+date = "2027-12-20"
+description = "The roar as 200 attendees experience unstoppable momentum"
+weight = 3
+tags = ["mass-movement", "roar", "unstoppable"]
+[extra]
+attendees = "200"
+momentum = "Overwhelming"
+scale = "Massive"
++++
+
+## Session III -- Mass Movement
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1420" stroke="#8fb8d0" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#8fb8d0"/>
+  <text x="40" y="30" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">SESSION</text>
+  <text x="40" y="58" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="22">III</text>
+  <text x="180" y="33" text-anchor="middle" fill="#c0d8e8" font-family="Bebas Neue, sans-serif" font-size="16" letter-spacing="2">MASS MOVEMENT</text>
+  <text x="180" y="55" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">200 ATTENDEES // ROAR</text>
+</svg>
+
+<span class="avalanche-badge">200</span>
+
+### Session Summary
+
+Two hundred people. The venue had to scale. The energy is deafening. What started as twelve in a quiet room is now a mass movement -- snow, ice, rock, all sliding together at speed. Individual voices merge into a collective roar. The mountain is coming down and nothing can stop it.
+
+<!-- SVG mass-movement flow pattern -->
+<svg width="200" height="80" viewBox="0 0 200 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M20,10 Q60,30 50,50 Q40,70 80,75" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.2"/>
+  <path d="M60,5 Q100,25 90,45 Q80,65 120,70" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.18"/>
+  <path d="M100,8 Q140,28 130,48 Q120,68 160,73" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.15"/>
+  <path d="M140,12 Q180,32 170,52 Q160,72 190,75" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.12"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Attendees | 200 |
+| Momentum | Overwhelming |
+| Scale | Massive |

--- a/avalanche-event/content/sessions/propagation.md
+++ b/avalanche-event/content/sessions/propagation.md
@@ -1,0 +1,34 @@
++++
+title = "Session II -- Propagation"
+date = "2027-12-20"
+description = "The rumble as cracks spread and 48 attendees feel the momentum"
+weight = 2
+tags = ["propagation", "rumble", "growing"]
+[extra]
+attendees = "48"
+momentum = "Building"
+scale = "Growing"
++++
+
+## Session II -- Propagation
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a1420" stroke="#8fb8d0" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#8fb8d0" opacity="0.9"/>
+  <text x="35" y="33" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">SESSION</text>
+  <text x="35" y="57" text-anchor="middle" fill="#0a1420" font-family="Anton, sans-serif" font-size="18">II</text>
+  <text x="175" y="35" text-anchor="middle" fill="#c0d8e8" font-family="Anton, sans-serif" font-size="14" letter-spacing="1">PROPAGATION</text>
+  <text x="175" y="55" text-anchor="middle" fill="#4a6878" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">48 ATTENDEES // RUMBLE</text>
+</svg>
+
+<span class="avalanche-badge-outline">48</span>
+
+### Session Summary
+
+The cracks have spread. Word traveled from the first twelve and now forty-eight are here. The room is larger, the energy higher. You can feel the floor vibrate. The snowfield above has fractured across its full width. The slab is moving. There is a low rumble that everyone can hear now.
+
+| Detail | Info |
+|--------|------|
+| Attendees | 48 |
+| Momentum | Building |
+| Scale | Growing |

--- a/avalanche-event/content/terrain.md
+++ b/avalanche-event/content/terrain.md
@@ -1,0 +1,36 @@
++++
+title = "Terrain"
+description = "Understanding the avalanche terrain and momentum dynamics"
++++
+
+<div class="section-block">
+  <div class="section-label">Terrain Analysis</div>
+  <h2>The Snowfield</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Avalanches require specific conditions: a steep slope, a weak layer in the snowpack, and a trigger. Our event replicates this dynamic. The slope is the progression curve. The weak layer is complacency. The trigger is the first session. Once it releases, momentum is physics -- mass times velocity, growing with every meter of descent.</p>
+
+  <!-- SVG snowfield crack propagation diagram -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Snowfield layers -->
+    <rect x="20" y="30" width="160" height="20" fill="#8fb8d0" opacity="0.06"/>
+    <rect x="20" y="50" width="160" height="15" fill="#8fb8d0" opacity="0.08"/>
+    <rect x="20" y="65" width="160" height="20" fill="#8fb8d0" opacity="0.1"/>
+    <rect x="20" y="85" width="160" height="15" fill="#8fb8d0" opacity="0.12"/>
+    <!-- Layer labels -->
+    <text x="190" y="44" fill="#4a6878" font-family="Inter, sans-serif" font-size="5" letter-spacing="1">SURFACE</text>
+    <text x="190" y="61" fill="#4a6878" font-family="Inter, sans-serif" font-size="5" letter-spacing="1">WEAK</text>
+    <text x="190" y="79" fill="#4a6878" font-family="Inter, sans-serif" font-size="5" letter-spacing="1">SLAB</text>
+    <text x="190" y="96" fill="#4a6878" font-family="Inter, sans-serif" font-size="5" letter-spacing="1">BASE</text>
+    <!-- Fracture line through weak layer -->
+    <path d="M25,57 L50,55 L80,59 L110,54 L140,58 L170,56" stroke="#8fb8d0" stroke-width="2" fill="none" opacity="0.3" stroke-dasharray="5 3"/>
+    <!-- Trigger point -->
+    <circle cx="110" cy="54" r="4" stroke="#8fb8d0" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <!-- Movement arrows below -->
+    <path d="M60,100 L60,140 L80,160" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.15"/>
+    <path d="M100,100 L100,150 L110,170" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.18"/>
+    <path d="M140,100 L140,145 L130,165" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Debris at bottom -->
+    <circle cx="80" cy="170" r="4" fill="#8fb8d0" opacity="0.1"/>
+    <circle cx="110" cy="175" r="5" fill="#8fb8d0" opacity="0.12"/>
+    <circle cx="135" cy="172" r="4" fill="#8fb8d0" opacity="0.1"/>
+  </svg>
+</div>

--- a/avalanche-event/static/css/style.css
+++ b/avalanche-event/static/css/style.css
@@ -1,0 +1,467 @@
+/* Avalanche Event - Cascading Momentum Event */
+/* Fonts: Anton / Bebas Neue display growing larger, Inter / Source Sans Pro body */
+
+@import url('https://fonts.googleapis.com/css2?family=Anton&family=Bebas+Neue&family=Inter:wght@400;500;600;700&family=Source+Sans+Pro:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a1420;
+  --bg-secondary: #060e18;
+  --bg-panel: #0e1c2a;
+  --text-primary: #c0d8e8;
+  --text-secondary: #7098b0;
+  --text-muted: #4a6878;
+  --accent-ice: #8fb8d0;
+  --accent-white: #c0d8e8;
+  --accent-dim: #5a8898;
+  --border-color: #142838;
+  --border-accent: #8fb8d0;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Source Sans Pro', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Anton', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Bebas Neue', sans-serif; letter-spacing: 0.08em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-ice);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Anton', sans-serif;
+  font-size: 1.4rem;
+  color: var(--accent-ice);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-ice);
+  border-bottom-color: var(--accent-ice);
+}
+
+.nav-cta {
+  background-color: var(--accent-ice) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-ice);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Anton', sans-serif;
+  font-size: 6rem;
+  color: var(--accent-ice);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Source Sans Pro', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-ice);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Session Block - grows with each session */
+.session-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.session-block.session-sm { padding: 14px 18px; }
+.session-block.session-md { padding: 18px 20px; }
+.session-block.session-lg { padding: 24px 24px; border-color: var(--accent-dim); }
+.session-block.session-xl { padding: 30px 28px; border-color: var(--accent-ice); background: var(--bg-secondary); }
+
+.session-number {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.9rem;
+  color: var(--accent-ice);
+  min-width: 90px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.session-info { flex: 1; }
+
+/* Growing title sizes */
+.session-title {
+  font-family: 'Anton', sans-serif;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+.session-title-sm { font-size: 0.95rem; }
+.session-title-md { font-size: 1.1rem; }
+.session-title-lg { font-size: 1.3rem; }
+.session-title-xl { font-size: 1.6rem; font-family: 'Bebas Neue', sans-serif; letter-spacing: 0.06em; color: var(--accent-ice); }
+
+.session-meta {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.session-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Avalanche Badge */
+.avalanche-badge {
+  display: inline-block;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-ice);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.avalanche-badge-outline {
+  display: inline-block;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-ice);
+  color: var(--accent-ice);
+  text-transform: uppercase;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-ice);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-ice);
+  font-weight: 400;
+  font-size: 0.85rem;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Anton', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-ice);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-ice);
+  color: var(--accent-ice);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-ice);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-ice);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Anton', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-ice);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3.5rem; }
+  h1 { font-size: 2rem; }
+  .session-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+  .session-title-xl { font-size: 1.3rem; }
+}

--- a/avalanche-event/templates/404.html
+++ b/avalanche-event/templates/404.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Mountain peak -->
+        <path d="M10,65 L40,15 L70,65 Z" stroke="#8fb8d0" stroke-width="2" fill="none" opacity="0.3"/>
+        <!-- Snow line -->
+        <path d="M25,45 L40,15 L55,45" stroke="#8fb8d0" stroke-width="1" fill="none" opacity="0.2"/>
+        <!-- Fracture line -->
+        <line x1="28" y1="40" x2="52" y2="42" stroke="#8fb8d0" stroke-width="1.5" opacity="0.25" stroke-dasharray="4 2"/>
+        <!-- Debris dots -->
+        <circle cx="30" cy="58" r="2" fill="#8fb8d0" opacity="0.15"/>
+        <circle cx="45" cy="60" r="2" fill="#8fb8d0" opacity="0.12"/>
+        <circle cx="55" cy="57" r="2" fill="#8fb8d0" opacity="0.1"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Lost in the Snow</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-ice); font-family: 'Inter', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Summit</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/avalanche-event/templates/footer.html
+++ b/avalanche-event/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">AVALANCHE // MOMENTUM EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Summit</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/terrain/">Terrain</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/avalanche-event/templates/header.html
+++ b/avalanche-event/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">AVALANCHE</span>
+        <span class="logo-sub">momentum event</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Summit</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/terrain/">Terrain</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Register</a>
+      </nav>
+    </div>
+  </header>

--- a/avalanche-event/templates/page.html
+++ b/avalanche-event/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/avalanche-event/templates/post.html
+++ b/avalanche-event/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("session") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/avalanche-event/templates/section.html
+++ b/avalanche-event/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/avalanche-event/templates/taxonomy.html
+++ b/avalanche-event/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/avalanche-event/templates/taxonomy_term.html
+++ b/avalanche-event/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All sessions tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -246,6 +246,13 @@
     "dark",
     "animation"
   ],
+  "avalanche-event": [
+    "event",
+    "dark",
+    "momentum",
+    "cascading",
+    "overwhelming"
+  ],
   "axiom": [
     "light",
     "design-system",


### PR DESCRIPTION
## Summary
- Add avalanche-event example site: cascading momentum event theme
- Dark icy design with ice-blue (#8fb8d0) accent, Anton/Bebas Neue display growing larger section by section, Inter/Source Sans Pro body
- Sessions build from intimate (12) to massive (1,000) with exponential attendee growth, inline SVG avalanche fracture line patterns, snowfield crack propagation, mass-movement flow patterns, debris field scatter
- Typography and padding scale up per session to visually convey building momentum
- Update tags.json with avalanche-event entry

Closes #1661