### PR TITLE
feat: add opening-night example site

### DIFF
--- a/opening-night/config.toml
+++ b/opening-night/config.toml
@@ -1,0 +1,41 @@
+title = "Opening Night"
+description = "Premiere opening night event with red carpet glamour and theater marquee grandeur"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["program"]
+
+[markdown]
+safe = false

--- a/opening-night/content/index.md
+++ b/opening-night/content/index.md
@@ -1,0 +1,193 @@
++++
+title = "Home"
+description = "Premiere opening night event with red carpet glamour and theater marquee grandeur"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">A Premiere Event</div>
+    <h1>OPENING NIGHT</h1>
+    <p class="hero-subtitle">The lights dim. The curtain rises. Four acts of premiere presentations under the glow of marquee bulbs and the hush of velvet. This is the night everything begins.</p>
+    <p class="hero-date">PREMIERE // 2027.11.14 // THE GRAND THEATER, NEW YORK</p>
+
+    <!-- SVG marquee lightbulb border pattern -->
+    <svg width="320" height="60" viewBox="0 0 320 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Top row of bulbs -->
+      <circle cx="20" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="20" cy="15" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="52" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="52" cy="15" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="84" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="84" cy="15" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="116" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="116" cy="15" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="148" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="148" cy="15" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="180" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="180" cy="15" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="212" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="212" cy="15" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="244" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="244" cy="15" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="276" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="276" cy="15" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="300" cy="15" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="300" cy="15" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <!-- Bottom row of bulbs -->
+      <circle cx="36" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="36" cy="45" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="68" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="68" cy="45" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="100" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="100" cy="45" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="132" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="132" cy="45" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="164" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="164" cy="45" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="196" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="196" cy="45" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="228" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="228" cy="45" r="2.5" fill="#d4a843" opacity="0.25"/>
+      <circle cx="260" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <circle cx="260" cy="45" r="2.5" fill="#d4a843" opacity="0.3"/>
+      <circle cx="292" cy="45" r="6" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <circle cx="292" cy="45" r="2.5" fill="#d4a843" opacity="0.25"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">The Program</div>
+  <h2>Red Carpet Timeline</h2>
+
+  <!-- SVG red carpet path diagram -->
+  <svg width="100%" height="30" viewBox="0 0 600 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 20px auto 28px; display: block; max-width: 600px;">
+    <rect x="0" y="10" width="600" height="10" fill="#8b2020" opacity="0.15"/>
+    <rect x="0" y="10" width="600" height="10" stroke="#8b2020" stroke-width="1" fill="none" opacity="0.25"/>
+    <!-- Velvet rope posts -->
+    <circle cx="10" cy="15" r="4" fill="#d4a843" opacity="0.3"/>
+    <circle cx="150" cy="15" r="4" fill="#d4a843" opacity="0.3"/>
+    <circle cx="300" cy="15" r="4" fill="#d4a843" opacity="0.3"/>
+    <circle cx="450" cy="15" r="4" fill="#d4a843" opacity="0.3"/>
+    <circle cx="590" cy="15" r="4" fill="#d4a843" opacity="0.3"/>
+    <!-- Rope lines -->
+    <path d="M14,15 Q80,8 146,15" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M154,15 Q225,8 296,15" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M304,15 Q375,8 446,15" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M454,15 Q520,8 586,15" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+  </svg>
+
+  <div class="program-block">
+    <div class="program-number">ACT I</div>
+    <div class="program-info">
+      <div class="program-title">The Arrival -- Red Carpet Reception</div>
+      <div class="program-meta">Doors open. Cameras flash. The red carpet unfurls.</div>
+    </div>
+    <div class="program-badge-slot">
+      <span class="premiere-badge">19:00</span>
+    </div>
+  </div>
+
+  <div class="program-block">
+    <div class="program-number">ACT II</div>
+    <div class="program-info">
+      <div class="program-title">The Reveal -- Keynote Premiere</div>
+      <div class="program-meta">The marquee lights spell the name. The curtain rises.</div>
+    </div>
+    <div class="program-badge-slot">
+      <span class="premiere-badge">20:00</span>
+    </div>
+  </div>
+
+  <div class="program-block">
+    <div class="program-number">ACT III</div>
+    <div class="program-info">
+      <div class="program-title">The Performance -- Live Presentations</div>
+      <div class="program-meta">Four speakers. Four spotlights. The stage belongs to them.</div>
+    </div>
+    <div class="program-badge-slot">
+      <span class="premiere-badge">21:00</span>
+    </div>
+  </div>
+
+  <div class="program-block">
+    <div class="program-number">ACT IV</div>
+    <div class="program-info">
+      <div class="program-title">The Encore -- Closing Gala</div>
+      <div class="program-meta">Champagne. Applause. The night belongs to everyone.</div>
+    </div>
+    <div class="program-badge-slot">
+      <span class="premiere-badge-outline">23:00</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Venue</div>
+  <h2>Theater Marquee</h2>
+
+  <!-- SVG theater marquee frame -->
+  <svg width="300" height="180" viewBox="0 0 300 180" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Marquee outer frame -->
+    <rect x="20" y="20" width="260" height="140" stroke="#d4a843" stroke-width="2" fill="none" opacity="0.25"/>
+    <rect x="28" y="28" width="244" height="124" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Bulbs around frame top -->
+    <circle cx="40" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="65" cy="20" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="90" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="115" cy="20" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="140" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="165" cy="20" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="190" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="215" cy="20" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="240" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="265" cy="20" r="4" fill="#d4a843" opacity="0.25"/>
+    <!-- Bulbs around frame bottom -->
+    <circle cx="40" cy="160" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="65" cy="160" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="90" cy="160" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="115" cy="160" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="140" cy="160" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="165" cy="160" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="190" cy="160" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="215" cy="160" r="4" fill="#d4a843" opacity="0.25"/>
+    <circle cx="240" cy="160" r="4" fill="#d4a843" opacity="0.2"/>
+    <circle cx="265" cy="160" r="4" fill="#d4a843" opacity="0.25"/>
+    <!-- Marquee text -->
+    <text x="150" y="75" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="14" letter-spacing="4" opacity="0.35">OPENING</text>
+    <text x="150" y="105" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="14" letter-spacing="4" opacity="0.35">NIGHT</text>
+    <text x="150" y="135" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="8" letter-spacing="2" opacity="0.3">THE GRAND THEATER</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Velvet Rope</div>
+  <h2>VIP Access</h2>
+
+  <!-- SVG velvet rope barrier pattern -->
+  <svg width="100%" height="80" viewBox="0 0 600 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Posts -->
+    <rect x="48" y="20" width="4" height="45" fill="#d4a843" opacity="0.3"/>
+    <circle cx="50" cy="18" r="6" fill="#d4a843" opacity="0.2"/>
+    <rect x="198" y="20" width="4" height="45" fill="#d4a843" opacity="0.3"/>
+    <circle cx="200" cy="18" r="6" fill="#d4a843" opacity="0.2"/>
+    <rect x="348" y="20" width="4" height="45" fill="#d4a843" opacity="0.3"/>
+    <circle cx="350" cy="18" r="6" fill="#d4a843" opacity="0.2"/>
+    <rect x="498" y="20" width="4" height="45" fill="#d4a843" opacity="0.3"/>
+    <circle cx="500" cy="18" r="6" fill="#d4a843" opacity="0.2"/>
+    <!-- Rope catenary -->
+    <path d="M56,30 Q125,50 194,30" stroke="#8b2020" stroke-width="2.5" fill="none" opacity="0.25"/>
+    <path d="M206,30 Q275,50 344,30" stroke="#8b2020" stroke-width="2.5" fill="none" opacity="0.25"/>
+    <path d="M356,30 Q425,50 494,30" stroke="#8b2020" stroke-width="2.5" fill="none" opacity="0.25"/>
+    <!-- Labels -->
+    <text x="125" y="75" text-anchor="middle" fill="#6b5a30" font-family="Playfair Display SC, serif" font-size="7" letter-spacing="3" opacity="0.25">GENERAL</text>
+    <text x="275" y="75" text-anchor="middle" fill="#d4a843" font-family="Playfair Display SC, serif" font-size="7" letter-spacing="3" opacity="0.35">VIP</text>
+    <text x="425" y="75" text-anchor="middle" fill="#d4a843" font-family="Playfair Display SC, serif" font-size="7" letter-spacing="3" opacity="0.35">PREMIERE</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Cormorant', serif; font-size: 0.9rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">arrival > red carpet > theater > gala</p>
+</div>
+
+</div>

--- a/opening-night/content/program/_index.md
+++ b/opening-night/content/program/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Program"
+description = "All acts in the Opening Night premiere event"
+sort_by = "weight"
+template = "section"
++++
+
+Four acts. One unforgettable night. From red carpet to closing gala.

--- a/opening-night/content/program/the-arrival.md
+++ b/opening-night/content/program/the-arrival.md
@@ -1,0 +1,42 @@
++++
+title = "Act I -- The Arrival"
+date = "2027-11-14"
+description = "Red carpet reception as doors open and cameras flash"
+weight = 1
+tags = ["arrival", "red-carpet", "reception"]
+[extra]
+time = "19:00"
+dress_code = "Black Tie"
+capacity = "200"
++++
+
+## Act I -- The Arrival
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a08" stroke="#d4a843" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#d4a843" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="7" letter-spacing="1">ACT</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="16">I</text>
+  <text x="170" y="35" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="11" letter-spacing="2">THE ARRIVAL</text>
+  <text x="170" y="55" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="8" letter-spacing="2">19:00 // RED CARPET</text>
+</svg>
+
+<span class="premiere-badge">19:00</span>
+
+### Red Carpet Reception
+
+The velvet ropes part. The cameras flash. Two hundred guests arrive along the red carpet, greeted by the warm glow of marquee lights overhead. This is the overture -- the moment before the music begins. Cocktails are served. Programs are distributed. The theater buzzes with anticipation.
+
+<!-- SVG red carpet path -->
+<svg width="200" height="40" viewBox="0 0 200 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="10" y="15" width="180" height="10" fill="#8b2020" opacity="0.15"/>
+  <circle cx="15" cy="20" r="3" fill="#d4a843" opacity="0.25"/>
+  <circle cx="100" cy="20" r="3" fill="#d4a843" opacity="0.25"/>
+  <circle cx="185" cy="20" r="3" fill="#d4a843" opacity="0.25"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Time | 19:00 |
+| Dress Code | Black Tie |
+| Capacity | 200 |

--- a/opening-night/content/program/the-encore.md
+++ b/opening-night/content/program/the-encore.md
@@ -1,0 +1,44 @@
++++
+title = "Act IV -- The Encore"
+date = "2027-11-14"
+description = "Closing gala with champagne, applause, and celebration"
+weight = 4
+tags = ["encore", "gala", "closing"]
+[extra]
+time = "23:00"
+format = "Gala Reception"
+dress_code = "Black Tie"
++++
+
+## Act IV -- The Encore
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a08" stroke="#d4a843" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#d4a843" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="7" letter-spacing="1">ACT</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="16">IV</text>
+  <text x="170" y="35" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="11" letter-spacing="2">THE ENCORE</text>
+  <text x="170" y="55" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="8" letter-spacing="2">23:00 // GALA</text>
+</svg>
+
+<span class="premiere-badge-outline">23:00</span>
+
+### Closing Gala
+
+The final curtain has fallen but the night is far from over. Champagne glasses rise. The theater transforms into a gala space where the audience becomes the cast. Conversations flow. Connections are made. The marquee lights outside still glow, but now they belong to everyone who was there when it all began.
+
+<!-- SVG champagne glass outlines -->
+<svg width="200" height="60" viewBox="0 0 200 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M60,50 L60,30 L50,5 L70,5 L60,30" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+  <path d="M100,50 L100,30 L90,5 L110,5 L100,30" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+  <path d="M140,50 L140,30 L130,5 L150,5 L140,30" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+  <line x1="50" y1="50" x2="70" y2="50" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="90" y1="50" x2="110" y2="50" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+  <line x1="130" y1="50" x2="150" y2="50" stroke="#d4a843" stroke-width="1" opacity="0.15"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Time | 23:00 |
+| Format | Gala Reception |
+| Dress Code | Black Tie |

--- a/opening-night/content/program/the-performance.md
+++ b/opening-night/content/program/the-performance.md
@@ -1,0 +1,46 @@
++++
+title = "Act III -- The Performance"
+date = "2027-11-14"
+description = "Live presentations from four speakers under four spotlights"
+weight = 3
+tags = ["performance", "presentations", "spotlight"]
+[extra]
+time = "21:00"
+speakers = "4"
+format = "Lightning Talks"
++++
+
+## Act III -- The Performance
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a08" stroke="#d4a843" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#d4a843" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="7" letter-spacing="1">ACT</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="16">III</text>
+  <text x="170" y="35" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="11" letter-spacing="2">THE PERFORMANCE</text>
+  <text x="170" y="55" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="8" letter-spacing="2">21:00 // SPOTLIGHT</text>
+</svg>
+
+<span class="premiere-badge">21:00</span>
+
+### Live Presentations
+
+Four speakers take the stage in succession. Each claims a spotlight, a moment, a piece of the audience. The presentations are sharp, polished, and electrifying -- curated to match the grandeur of the venue. Between acts, the marquee bulbs pulse in sequence, counting down to the next name.
+
+<!-- SVG spotlight circles -->
+<svg width="200" height="40" viewBox="0 0 200 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="35" cy="20" r="12" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="35" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+  <circle cx="80" cy="20" r="12" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="80" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+  <circle cx="125" cy="20" r="12" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="125" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+  <circle cx="170" cy="20" r="12" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.15"/>
+  <circle cx="170" cy="20" r="4" fill="#d4a843" opacity="0.2"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Time | 21:00 |
+| Speakers | 4 |
+| Format | Lightning Talks |

--- a/opening-night/content/program/the-reveal.md
+++ b/opening-night/content/program/the-reveal.md
@@ -1,0 +1,46 @@
++++
+title = "Act II -- The Reveal"
+date = "2027-11-14"
+description = "Keynote premiere as the marquee lights spell the name and the curtain rises"
+weight = 2
+tags = ["keynote", "premiere", "reveal"]
+[extra]
+time = "20:00"
+speaker = "Featured Keynote"
+capacity = "200"
++++
+
+## Act II -- The Reveal
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a08" stroke="#d4a843" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#d4a843" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="7" letter-spacing="1">ACT</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0a08" font-family="Cinzel Decorative, serif" font-size="16">II</text>
+  <text x="170" y="35" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="11" letter-spacing="2">THE REVEAL</text>
+  <text x="170" y="55" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="8" letter-spacing="2">20:00 // KEYNOTE</text>
+</svg>
+
+<span class="premiere-badge">20:00</span>
+
+### Keynote Premiere
+
+The house lights dim to black. A single spotlight illuminates the stage. The marquee outside now spells a name the world will remember. The curtain rises on the keynote -- the centerpiece of Opening Night. One speaker. One hour. Everything changes from this moment forward.
+
+<!-- SVG marquee frame -->
+<svg width="200" height="50" viewBox="0 0 200 50" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="10" y="5" width="180" height="40" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.2"/>
+  <circle cx="20" cy="5" r="3" fill="#d4a843" opacity="0.2"/>
+  <circle cx="50" cy="5" r="3" fill="#d4a843" opacity="0.15"/>
+  <circle cx="80" cy="5" r="3" fill="#d4a843" opacity="0.2"/>
+  <circle cx="110" cy="5" r="3" fill="#d4a843" opacity="0.15"/>
+  <circle cx="140" cy="5" r="3" fill="#d4a843" opacity="0.2"/>
+  <circle cx="170" cy="5" r="3" fill="#d4a843" opacity="0.15"/>
+  <text x="100" y="30" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="8" letter-spacing="3" opacity="0.3">PREMIERE</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Time | 20:00 |
+| Speaker | Featured Keynote |
+| Capacity | 200 |

--- a/opening-night/content/register.md
+++ b/opening-night/content/register.md
@@ -1,0 +1,28 @@
++++
+title = "Register"
+description = "RSVP for the Opening Night premiere event"
++++
+
+<div class="section-block">
+  <div class="section-label">RSVP</div>
+  <h2>Reserve Your Seat</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Secure your place on the red carpet. General admission grants access to the theater and closing gala. VIP and Premiere tiers include priority seating, backstage access, and a commemorative program signed by all speakers.</p>
+
+  <!-- SVG ticket stub -->
+  <svg width="200" height="80" viewBox="0 0 200 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <rect x="10" y="10" width="180" height="60" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="140" y1="10" x2="140" y2="70" stroke="#d4a843" stroke-width="1" opacity="0.15" stroke-dasharray="4 3"/>
+    <text x="70" y="35" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="8" letter-spacing="2" opacity="0.3">OPENING</text>
+    <text x="70" y="52" text-anchor="middle" fill="#d4a843" font-family="Cinzel Decorative, serif" font-size="8" letter-spacing="2" opacity="0.3">NIGHT</text>
+    <text x="165" y="42" text-anchor="middle" fill="#6b5a30" font-family="Cormorant, serif" font-size="7" letter-spacing="1" opacity="0.25">ADMIT</text>
+    <text x="165" y="54" text-anchor="middle" fill="#d4a843" font-family="Playfair Display SC, serif" font-size="12" opacity="0.3">ONE</text>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="premiere-badge" style="font-size: 0.85rem; padding: 6px 20px;">GENERAL</span>
+    <span class="premiere-badge" style="font-size: 0.85rem; padding: 6px 20px;">VIP</span>
+    <span class="premiere-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">PREMIERE</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Cinzel Decorative', serif; font-size: 0.8rem; letter-spacing: 0.15em;">2027.11.14 // THE GRAND THEATER, NEW YORK</p>
+</div>

--- a/opening-night/content/venue.md
+++ b/opening-night/content/venue.md
@@ -1,0 +1,35 @@
++++
+title = "Venue"
+description = "The Grand Theater venue details and seating information"
++++
+
+<div class="section-block">
+  <div class="section-label">The Venue</div>
+  <h2>The Grand Theater</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">A historic 1,200-seat theater in the heart of New York's theater district. Gilt-framed boxes rise in tiers above the orchestra. The marquee outside has spelled legendary names for over a century. Tonight, it spells yours.</p>
+
+  <!-- SVG theater architecture illustration -->
+  <svg width="240" height="160" viewBox="0 0 240 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Stage -->
+    <rect x="40" y="100" width="160" height="8" fill="#d4a843" opacity="0.1"/>
+    <rect x="40" y="100" width="160" height="8" stroke="#d4a843" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Curtain left -->
+    <path d="M40,20 L40,100 Q55,95 60,100 L60,20" stroke="#8b2020" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Curtain right -->
+    <path d="M180,20 L180,100 Q185,95 200,100 L200,20" stroke="#8b2020" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Proscenium arch -->
+    <path d="M30,108 L30,15 Q120,0 210,15 L210,108" stroke="#d4a843" stroke-width="2" fill="none" opacity="0.2"/>
+    <!-- Marquee bulbs across top -->
+    <circle cx="50" cy="14" r="3" fill="#d4a843" opacity="0.15"/>
+    <circle cx="75" cy="9" r="3" fill="#d4a843" opacity="0.2"/>
+    <circle cx="100" cy="6" r="3" fill="#d4a843" opacity="0.15"/>
+    <circle cx="120" cy="5" r="3" fill="#d4a843" opacity="0.2"/>
+    <circle cx="140" cy="6" r="3" fill="#d4a843" opacity="0.15"/>
+    <circle cx="165" cy="9" r="3" fill="#d4a843" opacity="0.2"/>
+    <circle cx="190" cy="14" r="3" fill="#d4a843" opacity="0.15"/>
+    <!-- Seating rows -->
+    <path d="M60,125 Q120,120 180,125" stroke="#6b5a30" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <path d="M50,135 Q120,128 190,135" stroke="#6b5a30" stroke-width="0.8" fill="none" opacity="0.1"/>
+    <path d="M40,145 Q120,136 200,145" stroke="#6b5a30" stroke-width="0.8" fill="none" opacity="0.08"/>
+  </svg>
+</div>

--- a/opening-night/static/css/style.css
+++ b/opening-night/static/css/style.css
@@ -1,0 +1,457 @@
+/* Opening Night - Premiere Event */
+/* Fonts: Cinzel Decorative / Playfair Display SC display in gold on black, Cormorant / EB Garamond body */
+
+@import url('https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=Playfair+Display+SC:wght@400;700&family=Cormorant:ital,wght@0,400;0,600;0,700;1,400&family=EB+Garamond:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0a08;
+  --bg-secondary: #080806;
+  --bg-panel: #12110e;
+  --text-primary: #e8dcc8;
+  --text-secondary: #a89878;
+  --text-muted: #6b5a30;
+  --accent-gold: #d4a843;
+  --accent-bright: #e8c560;
+  --accent-dim: #9a7830;
+  --accent-red: #8b2020;
+  --border-color: #2a2418;
+  --border-accent: #d4a843;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'EB Garamond', 'Cormorant', serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Cinzel Decorative', serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--accent-gold);
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Playfair Display SC', serif; letter-spacing: 0.08em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-gold);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 1.2rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Cormorant', serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-gold);
+  border-bottom-color: var(--accent-gold);
+}
+
+.nav-cta {
+  background-color: var(--accent-gold) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 5rem;
+  color: var(--accent-gold);
+  margin-bottom: 8px;
+  letter-spacing: 0.08em;
+}
+
+.hero-subtitle {
+  font-family: 'Cormorant', serif;
+  font-weight: 500;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Playfair Display SC', serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Program Block */
+.program-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.program-number {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 0.85rem;
+  color: var(--accent-gold);
+  min-width: 80px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.program-info { flex: 1; }
+
+.program-title {
+  font-family: 'Playfair Display SC', serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.program-meta {
+  font-family: 'Cormorant', serif;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.program-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Premiere Badge */
+.premiere-badge {
+  display: inline-block;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-gold);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.premiere-badge-outline {
+  display: inline-block;
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-gold);
+  color: var(--accent-gold);
+  text-transform: uppercase;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Cormorant', serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-gold);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-gold);
+  font-weight: 400;
+  font-size: 0.85rem;
+  font-family: 'Playfair Display SC', serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'EB Garamond', serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Playfair Display SC', serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-gold);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Cormorant', serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-gold);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 0.85rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Cormorant', serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-gold);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 8rem;
+  color: var(--accent-gold);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Cormorant', serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .program-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/opening-night/templates/404.html
+++ b/opening-night/templates/404.html
@@ -1,0 +1,18 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Theater curtain -->
+        <path d="M15,10 L15,60 Q25,55 35,60 L35,10" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <path d="M45,10 L45,60 Q55,55 65,60 L65,10" stroke="#d4a843" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <!-- Marquee bulbs -->
+        <circle cx="20" cy="8" r="3" fill="#d4a843" opacity="0.2"/>
+        <circle cx="40" cy="8" r="3" fill="#d4a843" opacity="0.25"/>
+        <circle cx="60" cy="8" r="3" fill="#d4a843" opacity="0.2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Lost in the Wings</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-gold); font-family: 'Cormorant', serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Marquee</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/opening-night/templates/footer.html
+++ b/opening-night/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">OPENING NIGHT // PREMIERE EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Marquee</a>
+        <a href="{{ base_url }}/program/">Program</a>
+        <a href="{{ base_url }}/venue/">Venue</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/opening-night/templates/header.html
+++ b/opening-night/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">OPENING NIGHT</span>
+        <span class="logo-sub">premiere event</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Marquee</a>
+        <a href="{{ base_url }}/program/">Program</a>
+        <a href="{{ base_url }}/venue/">Venue</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">RSVP</a>
+      </nav>
+    </div>
+  </header>

--- a/opening-night/templates/page.html
+++ b/opening-night/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/opening-night/templates/post.html
+++ b/opening-night/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("program") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/opening-night/templates/section.html
+++ b/opening-night/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/opening-night/templates/taxonomy.html
+++ b/opening-night/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/opening-night/templates/taxonomy_term.html
+++ b/opening-night/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All acts tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1189,18 +1189,18 @@
     "blog",
     "book-review"
   ],
+  "fireworks": [
+    "dark",
+    "elegant",
+    "animation",
+    "glow"
+  ],
   "firing-range": [
     "event",
     "dark",
     "precision",
     "target",
     "competitive"
-  ],
-  "fireworks": [
-    "dark",
-    "elegant",
-    "animation",
-    "glow"
   ],
   "fjord": [
     "light",
@@ -2429,6 +2429,13 @@
     "blog",
     "glamorous"
   ],
+  "opening-night": [
+    "event",
+    "dark",
+    "premiere",
+    "formal",
+    "electric"
+  ],
   "opulent": [
     "light",
     "elegant",
@@ -2838,13 +2845,6 @@
     "docs",
     "reactive"
   ],
-  "red-alert": [
-    "event",
-    "dark",
-    "emergency",
-    "crisis",
-    "urgent"
-  ],
   "realty": [
     "light",
     "realestate",
@@ -2855,6 +2855,13 @@
     "light",
     "blog",
     "recipe"
+  ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
   ],
   "reef": [
     "dark",


### PR DESCRIPTION
Closes #1656

## Summary
- Add opening-night example site: premiere opening night event with red carpet glamour and theater marquee grandeur
- SVG marquee lightbulb border patterns (circles), red carpet path diagrams, velvet rope barrier patterns, theater marquee frame illustrations
- Typography: Cinzel Decorative/Playfair Display SC display in gold on black, Cormorant/EB Garamond body
- PREMIERE/OPENING NIGHT banner in tracked-out capitals, red carpet timeline layout

## Test plan
- [ ] Verify `hwaro build` completes without errors for the opening-night directory
- [ ] Check all SVG illustrations render correctly (marquee bulbs, red carpet, velvet ropes, theater frame)
- [ ] Confirm gold-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes opening-night with correct tags