### PR TITLE
feat: add cage-match example site

### DIFF
--- a/cage-match/config.toml
+++ b/cage-match/config.toml
@@ -1,0 +1,41 @@
+title = "Cage Match"
+description = "Competitive debate and battle event in the enclosed arena"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["bouts"]
+
+[markdown]
+safe = false

--- a/cage-match/content/bouts/_index.md
+++ b/cage-match/content/bouts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Bouts"
+description = "All bouts in the Cage Match battle event"
+sort_by = "weight"
+template = "section"
++++
+
+Four bouts. Head-to-head. No mercy. Only one walks out champion.

--- a/cage-match/content/bouts/championship.md
+++ b/cage-match/content/bouts/championship.md
@@ -1,0 +1,35 @@
++++
+title = "Championship -- The Final Cage"
+date = "2027-10-18"
+description = "The championship bout where only one walks out with the title"
+weight = 4
+tags = ["championship", "final", "title"]
+[extra]
+fighter_a = "TBD"
+fighter_b = "TBD"
+stakes = "Championship Title"
+rounds = "5"
++++
+
+## Championship -- The Final Cage
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0808" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="80" height="80" fill="#c03030" opacity="0.9"/>
+  <text x="40" y="35" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="6" letter-spacing="1">CHAMPIONSHIP</text>
+  <text x="40" y="55" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="14">FINAL</text>
+  <text x="185" y="35" text-anchor="middle" fill="#e8c0c0" font-family="Anton, sans-serif" font-size="11" letter-spacing="2">THE FINAL CAGE</text>
+  <text x="185" y="55" text-anchor="middle" fill="#884040" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="8" letter-spacing="2">TBD vs TBD // 5 ROUNDS</text>
+</svg>
+
+<span class="cage-badge-outline">CHAMPIONSHIP</span>
+
+### Bout Summary
+
+Five rounds. No judges. No escape. The survivors of Rounds 1-3 meet inside the final cage for the championship. The chain-link door locks behind them. When the last bell rings, only one name will be etched into the cage wall. This is what they all came for.
+
+| Detail | Info |
+|--------|------|
+| Stakes | Championship Title |
+| Rounds | 5 |
+| Format | No Judges, Finish Only |

--- a/cage-match/content/bouts/round-1.md
+++ b/cage-match/content/bouts/round-1.md
@@ -1,0 +1,45 @@
++++
+title = "Round 1 -- Alpha vs Omega"
+date = "2027-10-18"
+description = "Opening bout pitting Alpha Team against Omega Squad"
+weight = 1
+tags = ["round-1", "alpha", "omega"]
+[extra]
+fighter_a = "Alpha Team"
+fighter_b = "Omega Squad"
+record_a = "12-2"
+record_b = "10-4"
++++
+
+## Round 1 -- Alpha vs Omega
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0808" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#c03030" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">ROUND</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="18">1</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c0c0" font-family="Anton, sans-serif" font-size="11" letter-spacing="2">ALPHA vs OMEGA</text>
+  <text x="170" y="55" text-anchor="middle" fill="#884040" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="8" letter-spacing="2">12-2 // 10-4</text>
+</svg>
+
+<span class="cage-badge">ROUND 1</span>
+
+### Bout Summary
+
+The opening bell rings. Alpha Team enters from the red corner with a dominant 12-2 record. Omega Squad answers from the blue corner, hungry to prove their 10-4 record understates their power. This is where reputations are built or destroyed.
+
+<!-- SVG chain-link divider -->
+<svg width="200" height="30" viewBox="0 0 200 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M0,15 L15,0 L30,15 L15,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+  <path d="M30,15 L45,0 L60,15 L45,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+  <path d="M60,15 L75,0 L90,15 L75,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+  <path d="M90,15 L105,0 L120,15 L105,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+  <path d="M120,15 L135,0 L150,15 L135,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+  <path d="M150,15 L165,0 L180,15 L165,30 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+</svg>
+
+| Stat | Alpha Team | Omega Squad |
+|------|-----------|-------------|
+| Record | 12-2 | 10-4 |
+| Win Streak | 5 | 3 |
+| KO Rate | 75% | 60% |

--- a/cage-match/content/bouts/round-2.md
+++ b/cage-match/content/bouts/round-2.md
@@ -1,0 +1,35 @@
++++
+title = "Round 2 -- Iron Will vs Dark Horse"
+date = "2027-10-18"
+description = "Undefeated Iron Will faces the unpredictable Dark Horse"
+weight = 2
+tags = ["round-2", "iron-will", "dark-horse"]
+[extra]
+fighter_a = "Iron Will"
+fighter_b = "Dark Horse"
+record_a = "14-0"
+record_b = "9-5"
++++
+
+## Round 2 -- Iron Will vs Dark Horse
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0808" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#c03030" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">ROUND</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="18">2</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c0c0" font-family="Anton, sans-serif" font-size="10" letter-spacing="1">IRON WILL vs DARK HORSE</text>
+  <text x="170" y="55" text-anchor="middle" fill="#884040" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="8" letter-spacing="2">14-0 // 9-5</text>
+</svg>
+
+<span class="cage-badge">ROUND 2</span>
+
+### Bout Summary
+
+The undefeated meets the unpredictable. Iron Will carries a perfect 14-0 record into the cage. Dark Horse has nothing to lose and everything to prove. Records mean nothing once the bell rings -- only will and instinct survive inside the chain-link.
+
+| Stat | Iron Will | Dark Horse |
+|------|----------|------------|
+| Record | 14-0 | 9-5 |
+| Win Streak | 14 | 2 |
+| KO Rate | 85% | 55% |

--- a/cage-match/content/bouts/round-3.md
+++ b/cage-match/content/bouts/round-3.md
@@ -1,0 +1,35 @@
++++
+title = "Round 3 -- Vanguard vs Onslaught"
+date = "2027-10-18"
+description = "Two elite competitors clash in the semi-final showdown"
+weight = 3
+tags = ["round-3", "vanguard", "onslaught"]
+[extra]
+fighter_a = "Vanguard"
+fighter_b = "Onslaught"
+record_a = "11-3"
+record_b = "13-1"
++++
+
+## Round 3 -- Vanguard vs Onslaught
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0808" stroke="#c03030" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#c03030" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="8" letter-spacing="1">ROUND</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0808" font-family="Anton, sans-serif" font-size="18">3</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c0c0" font-family="Anton, sans-serif" font-size="10" letter-spacing="1">VANGUARD vs ONSLAUGHT</text>
+  <text x="170" y="55" text-anchor="middle" fill="#884040" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="8" letter-spacing="2">11-3 // 13-1</text>
+</svg>
+
+<span class="cage-badge">ROUND 3</span>
+
+### Bout Summary
+
+This is the bout the crowd came to see. Vanguard's tactical precision against Onslaught's relentless pressure. Both have championship caliber. Only one advances to the final cage. The other goes home with nothing but bruises.
+
+| Stat | Vanguard | Onslaught |
+|------|---------|-----------|
+| Record | 11-3 | 13-1 |
+| Win Streak | 4 | 8 |
+| KO Rate | 65% | 90% |

--- a/cage-match/content/index.md
+++ b/cage-match/content/index.md
@@ -1,0 +1,183 @@
++++
+title = "Home"
+description = "Competitive debate and battle event in the enclosed arena"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Competitive Battle Event</div>
+    <h1>CAGE MATCH</h1>
+    <p class="hero-subtitle">Two enter. One wins. Four rounds of head-to-head debate inside the chain-link arena. No escape. No mercy. The bell decides everything.</p>
+    <p class="hero-date">FIGHT NIGHT // 2027.10.18 // THE OCTAGON, LAS VEGAS</p>
+
+    <!-- SVG chain-link fence pattern -->
+    <svg width="320" height="80" viewBox="0 0 320 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Chain-link diamond pattern -->
+      <path d="M0,20 L20,0 L40,20 L20,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M40,20 L60,0 L80,20 L60,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M80,20 L100,0 L120,20 L100,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M120,20 L140,0 L160,20 L140,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M160,20 L180,0 L200,20 L180,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M200,20 L220,0 L240,20 L220,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M240,20 L260,0 L280,20 L260,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M280,20 L300,0 L320,20 L300,40 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <!-- Second row -->
+      <path d="M20,40 L40,20 L60,40 L40,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M60,40 L80,20 L100,40 L80,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M100,40 L120,20 L140,40 L120,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M140,40 L160,20 L180,40 L160,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M180,40 L200,20 L220,40 L200,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M220,40 L240,20 L260,40 L240,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M260,40 L280,20 L300,40 L280,60 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <!-- Third row -->
+      <path d="M0,60 L20,40 L40,60 L20,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M40,60 L60,40 L80,60 L60,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M80,60 L100,40 L120,60 L100,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M120,60 L140,40 L160,60 L140,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M160,60 L180,40 L200,60 L180,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M200,60 L220,40 L240,60 L220,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+      <path d="M240,60 L260,40 L280,60 L260,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.15"/>
+      <path d="M280,60 L300,40 L320,60 L300,80 Z" stroke="#c03030" stroke-width="1" fill="none" opacity="0.12"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Fight Card</div>
+  <h2>VS Matchups</h2>
+
+  <!-- SVG octagon ring outline for matchup frames -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Octagon outline -->
+    <polygon points="70,15 130,15 175,55 175,125 130,165 70,165 25,125 25,55" stroke="#c03030" stroke-width="2" fill="none" opacity="0.2"/>
+    <polygon points="75,25 125,25 165,60 165,120 125,155 75,155 35,120 35,60" stroke="#c03030" stroke-width="1" fill="none" opacity="0.1"/>
+    <!-- VS text -->
+    <text x="100" y="98" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="28" letter-spacing="2" opacity="0.3">VS</text>
+    <!-- Corner posts -->
+    <circle cx="70" cy="15" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="130" cy="15" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="175" cy="55" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="175" cy="125" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="130" cy="165" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="70" cy="165" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="25" cy="125" r="3" fill="#c03030" opacity="0.2"/>
+    <circle cx="25" cy="55" r="3" fill="#c03030" opacity="0.2"/>
+  </svg>
+
+  <div class="bout-block">
+    <div class="bout-round">ROUND 1</div>
+    <div class="bout-matchup">
+      <div class="bout-fighter">
+        <div class="fighter-name">ALPHA TEAM</div>
+        <div class="fighter-stat">Record: 12-2</div>
+      </div>
+      <div class="bout-vs"><span class="cage-badge">VS</span></div>
+      <div class="bout-fighter bout-fighter-right">
+        <div class="fighter-name">OMEGA SQUAD</div>
+        <div class="fighter-stat">Record: 10-4</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="bout-block">
+    <div class="bout-round">ROUND 2</div>
+    <div class="bout-matchup">
+      <div class="bout-fighter">
+        <div class="fighter-name">IRON WILL</div>
+        <div class="fighter-stat">Record: 14-0</div>
+      </div>
+      <div class="bout-vs"><span class="cage-badge">VS</span></div>
+      <div class="bout-fighter bout-fighter-right">
+        <div class="fighter-name">DARK HORSE</div>
+        <div class="fighter-stat">Record: 9-5</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="bout-block">
+    <div class="bout-round">ROUND 3</div>
+    <div class="bout-matchup">
+      <div class="bout-fighter">
+        <div class="fighter-name">VANGUARD</div>
+        <div class="fighter-stat">Record: 11-3</div>
+      </div>
+      <div class="bout-vs"><span class="cage-badge">VS</span></div>
+      <div class="bout-fighter bout-fighter-right">
+        <div class="fighter-name">ONSLAUGHT</div>
+        <div class="fighter-stat">Record: 13-1</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="bout-block">
+    <div class="bout-round">CHAMPIONSHIP</div>
+    <div class="bout-matchup">
+      <div class="bout-fighter">
+        <div class="fighter-name">TBD</div>
+        <div class="fighter-stat">Winner R1/R2</div>
+      </div>
+      <div class="bout-vs"><span class="cage-badge-outline">VS</span></div>
+      <div class="bout-fighter bout-fighter-right">
+        <div class="fighter-name">TBD</div>
+        <div class="fighter-stat">Winner R3/Wildcard</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Tale of the Tape</div>
+  <h2>Competitor Stats</h2>
+
+  <!-- SVG tale-of-the-tape comparison bar charts -->
+  <svg width="100%" height="160" viewBox="0 0 600 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Labels -->
+    <text x="300" y="20" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" letter-spacing="2" opacity="0.4">AGGRESSION</text>
+    <rect x="100" y="28" width="190" height="12" fill="#c03030" opacity="0.2"/>
+    <rect x="310" y="28" width="160" height="12" fill="#c03030" opacity="0.15"/>
+    <text x="95" y="38" text-anchor="end" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">ALPHA</text>
+    <text x="475" y="38" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">OMEGA</text>
+
+    <text x="300" y="65" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" letter-spacing="2" opacity="0.4">STRATEGY</text>
+    <rect x="130" y="73" width="160" height="12" fill="#c03030" opacity="0.15"/>
+    <rect x="310" y="73" width="180" height="12" fill="#c03030" opacity="0.2"/>
+    <text x="125" y="83" text-anchor="end" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">ALPHA</text>
+    <text x="495" y="83" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">OMEGA</text>
+
+    <text x="300" y="110" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" letter-spacing="2" opacity="0.4">ENDURANCE</text>
+    <rect x="110" y="118" width="180" height="12" fill="#c03030" opacity="0.18"/>
+    <rect x="310" y="118" width="170" height="12" fill="#c03030" opacity="0.17"/>
+    <text x="105" y="128" text-anchor="end" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">ALPHA</text>
+    <text x="485" y="128" fill="#888" font-family="Barlow Condensed, sans-serif" font-size="8">OMEGA</text>
+
+    <!-- Center line -->
+    <line x1="300" y1="10" x2="300" y2="145" stroke="#c03030" stroke-width="1" opacity="0.15"/>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">The Bell</div>
+  <h2>Round Markers</h2>
+
+  <!-- SVG bell and round marker illustrations -->
+  <svg width="200" height="100" viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Bell shape -->
+    <path d="M80,25 Q80,10 100,10 Q120,10 120,25 L125,55 L75,55 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="75" y1="55" x2="125" y2="55" stroke="#c03030" stroke-width="2" opacity="0.25"/>
+    <circle cx="100" cy="48" r="3" fill="#c03030" opacity="0.2"/>
+    <!-- Strike hammer -->
+    <line x1="130" y1="30" x2="145" y2="25" stroke="#c03030" stroke-width="1.5" opacity="0.15"/>
+    <circle cx="148" cy="24" r="4" fill="#c03030" opacity="0.15"/>
+    <!-- Round markers -->
+    <text x="40" y="80" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" opacity="0.2">R1</text>
+    <text x="80" y="80" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" opacity="0.25">R2</text>
+    <text x="120" y="80" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="10" opacity="0.3">R3</text>
+    <text x="160" y="80" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="12" opacity="0.35">FINAL</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Barlow Condensed', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">round 1 > round 2 > round 3 > championship</p>
+</div>
+
+</div>

--- a/cage-match/content/register.md
+++ b/cage-match/content/register.md
@@ -1,0 +1,26 @@
++++
+title = "Register"
+description = "Enter the Cage Match battle event"
++++
+
+<div class="section-block">
+  <div class="section-label">Entry</div>
+  <h2>Enter the Cage</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register as a competitor or spectator. Competitors must submit a record and ranking. Spectators choose their seat -- cageside for the impacts, upper tier for the overview. All attendees sign the waiver. The cage does not discriminate.</p>
+
+  <!-- SVG chain-link icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <path d="M20,30 L35,15 L50,30 L35,45 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <path d="M50,30 L65,15 L80,30 L65,45 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <path d="M35,45 L50,30 L65,45 L50,60 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.18"/>
+    <path d="M20,60 L35,45 L50,60 L35,75 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <path d="M50,60 L65,45 L80,60 L65,75 Z" stroke="#c03030" stroke-width="1.5" fill="none" opacity="0.2"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="cage-badge" style="font-size: 0.85rem; padding: 6px 20px;">COMPETITOR</span>
+    <span class="cage-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">SPECTATOR</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Anton', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.10.18 // THE OCTAGON, LAS VEGAS</p>
+</div>

--- a/cage-match/content/rules.md
+++ b/cage-match/content/rules.md
@@ -1,0 +1,19 @@
++++
+title = "Rules"
+description = "Cage Match rules and bout regulations"
++++
+
+<div class="section-block">
+  <div class="section-label">Regulations</div>
+  <h2>Rules of Engagement</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">All bouts follow Cage Match Federation rules. Competitors enter the octagon. The chain-link fence seals behind them. Three standard rounds plus a championship final of five rounds. No outside interference. No mercy calls. The bell starts it. The bell ends it.</p>
+
+  <!-- SVG octagon with rules -->
+  <svg width="200" height="160" viewBox="0 0 200 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <polygon points="70,10 130,10 170,45 170,105 130,140 70,140 30,105 30,45" stroke="#c03030" stroke-width="2" fill="none" opacity="0.15"/>
+    <text x="100" y="55" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="8" letter-spacing="2" opacity="0.3">NO ESCAPE</text>
+    <text x="100" y="75" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="8" letter-spacing="2" opacity="0.25">NO MERCY</text>
+    <text x="100" y="95" text-anchor="middle" fill="#c03030" font-family="Anton, sans-serif" font-size="8" letter-spacing="2" opacity="0.2">NO JUDGES</text>
+    <text x="100" y="115" text-anchor="middle" fill="#884040" font-family="Barlow Condensed, sans-serif" font-size="7" letter-spacing="1" opacity="0.3">FINISH ONLY</text>
+  </svg>
+</div>

--- a/cage-match/static/css/style.css
+++ b/cage-match/static/css/style.css
@@ -1,0 +1,468 @@
+/* Cage Match - Competitive Battle Event */
+/* Fonts: Anton / Bebas Neue display in aggression-red on black, Barlow Condensed Bold / Oswald body */
+
+@import url('https://fonts.googleapis.com/css2?family=Anton&family=Bebas+Neue&family=Barlow+Condensed:wght@400;500;600;700&family=Oswald:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0c0808;
+  --bg-secondary: #080505;
+  --bg-panel: #140e0e;
+  --text-primary: #e8c0c0;
+  --text-secondary: #a07070;
+  --text-muted: #884040;
+  --accent-red: #c03030;
+  --accent-bright: #e04040;
+  --accent-dim: #802020;
+  --border-color: #2a1818;
+  --border-accent: #c03030;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Barlow Condensed', 'Oswald', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Anton', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Bebas Neue', sans-serif; letter-spacing: 0.08em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-red);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Anton', sans-serif;
+  font-size: 1.4rem;
+  color: var(--accent-red);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-red);
+  border-bottom-color: var(--accent-red);
+}
+
+.nav-cta {
+  background-color: var(--accent-red) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Anton', sans-serif;
+  font-size: 6rem;
+  color: var(--accent-red);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-red);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Bout Block - VS matchup layout */
+.bout-block {
+  padding: 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.bout-round {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.8rem;
+  color: var(--accent-red);
+  letter-spacing: 0.15em;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.bout-matchup {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.bout-fighter {
+  flex: 1;
+  text-align: right;
+}
+
+.bout-fighter-right {
+  text-align: left;
+}
+
+.fighter-name {
+  font-family: 'Anton', sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.fighter-stat {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.bout-vs {
+  flex-shrink: 0;
+  text-align: center;
+}
+
+/* Cage Badge */
+.cage-badge {
+  display: inline-block;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-red);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.cage-badge-outline {
+  display: inline-block;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-red);
+  color: var(--accent-red);
+  text-transform: uppercase;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-red);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-red);
+  font-weight: 400;
+  font-size: 0.85rem;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Barlow Condensed', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Anton', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-red);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-red);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Anton', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-red);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Anton', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-red);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3.5rem; }
+  h1 { font-size: 2rem; }
+  .bout-matchup { flex-direction: column; gap: 8px; }
+  .bout-fighter, .bout-fighter-right { text-align: center; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/cage-match/templates/404.html
+++ b/cage-match/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Octagon -->
+        <polygon points="28,10 52,10 68,28 68,52 52,68 28,68 12,52 12,28" stroke="#c03030" stroke-width="2" fill="none" opacity="0.3"/>
+        <!-- X mark -->
+        <line x1="28" y1="28" x2="52" y2="52" stroke="#c03030" stroke-width="2" opacity="0.2"/>
+        <line x1="52" y1="28" x2="28" y2="52" stroke="#c03030" stroke-width="2" opacity="0.2"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">No Contest</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-red); font-family: 'Barlow Condensed', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Arena</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cage-match/templates/footer.html
+++ b/cage-match/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">CAGE MATCH // BATTLE EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Arena</a>
+        <a href="{{ base_url }}/bouts/">Bouts</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cage-match/templates/header.html
+++ b/cage-match/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">CAGE MATCH</span>
+        <span class="logo-sub">battle event</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Arena</a>
+        <a href="{{ base_url }}/bouts/">Bouts</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Enter</a>
+      </nav>
+    </div>
+  </header>

--- a/cage-match/templates/page.html
+++ b/cage-match/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cage-match/templates/post.html
+++ b/cage-match/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("bout") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cage-match/templates/section.html
+++ b/cage-match/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cage-match/templates/taxonomy.html
+++ b/cage-match/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/cage-match/templates/taxonomy_term.html
+++ b/cage-match/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All bouts tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -480,6 +480,13 @@
     "landing",
     "menu"
   ],
+  "cage-match": [
+    "event",
+    "dark",
+    "competition",
+    "fight",
+    "enclosed"
+  ],
   "calligraphy": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1655

## Summary
- Add cage-match example site: competitive debate/battle event in the enclosed arena
- SVG chain-link fence patterns, octagon/ring outline shapes, tale-of-the-tape comparison bar charts, bell and round marker illustrations
- Typography: Anton/Bebas Neue display in aggression-red on black, Barlow Condensed Bold/Oswald body
- VS matchup layouts with competitor stats in facing columns

## Test plan
- [ ] Verify `hwaro build` completes without errors for the cage-match directory
- [ ] Check all SVG illustrations render correctly (chain-link, octagon, bars, bell)
- [ ] Confirm red-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes cage-match with correct tags