### PR TITLE
feat: add ticker-board example site

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -3451,6 +3451,13 @@
     "competition",
     "ultimate"
   ],
+  "ticker-board": [
+    "event",
+    "dark",
+    "transit",
+    "departure",
+    "mechanical"
+  ],
   "tidal": [
     "light",
     "blog",

--- a/ticker-board/config.toml
+++ b/ticker-board/config.toml
@@ -1,0 +1,41 @@
+title = "Ticker Board"
+description = "Airport departure board conference with split-flap display aesthetics"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["sessions"]
+
+[markdown]
+safe = false

--- a/ticker-board/content/concourse.md
+++ b/ticker-board/content/concourse.md
@@ -1,0 +1,29 @@
++++
+title = "Concourse"
+description = "Conference concourse and venue navigation"
++++
+
+<div class="section-block">
+  <div class="section-label">Navigation</div>
+  <h2>Terminal Map</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The conference center operates like an airport terminal. Gates are arranged along the main concourse. Follow the amber signage to your departure gate. Refreshments available at the central hub between Gates B and C.</p>
+
+  <!-- SVG terminal layout -->
+  <svg width="240" height="140" viewBox="0 0 240 140" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Main concourse -->
+    <rect x="20" y="55" width="200" height="30" fill="#1a1500" opacity="0.15"/>
+    <rect x="20" y="55" width="200" height="30" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Gate branches -->
+    <rect x="30" y="15" width="30" height="40" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.15"/>
+    <text x="45" y="38" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.3">A1</text>
+    <rect x="80" y="15" width="30" height="40" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.15"/>
+    <text x="95" y="38" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.3">B3</text>
+    <rect x="130" y="85" width="30" height="40" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.15"/>
+    <text x="145" y="108" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.3">C2</text>
+    <rect x="180" y="85" width="30" height="40" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.15"/>
+    <text x="195" y="108" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.3">D4</text>
+    <!-- Central hub -->
+    <circle cx="120" cy="70" r="8" stroke="#d4a020" stroke-width="1" fill="none" opacity="0.2"/>
+    <text x="120" y="73" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="5" opacity="0.3">HUB</text>
+  </svg>
+</div>

--- a/ticker-board/content/index.md
+++ b/ticker-board/content/index.md
@@ -1,0 +1,150 @@
++++
+title = "Home"
+description = "Airport departure board conference with split-flap display aesthetics"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Conference Departures</div>
+    <h1>TICKER BOARD</h1>
+    <p class="hero-subtitle">Sessions depart on schedule. Check your gate. Find your track. The board updates in real time. Do not miss your departure.</p>
+    <p class="hero-date">TERMINAL C // 2027.09.22 // CONFERENCE CENTER, ZURICH</p>
+
+    <!-- SVG split-flap letter display panel -->
+    <svg width="320" height="60" viewBox="0 0 320 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Split-flap character boxes -->
+      <rect x="10" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="10" y1="30" x2="40" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="25" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">D</text>
+
+      <rect x="48" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="48" y1="30" x2="78" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="63" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">E</text>
+
+      <rect x="86" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="86" y1="30" x2="116" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="101" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">P</text>
+
+      <rect x="124" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="124" y1="30" x2="154" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="139" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">A</text>
+
+      <rect x="162" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="162" y1="30" x2="192" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="177" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">R</text>
+
+      <rect x="200" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="200" y1="30" x2="230" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="215" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">T</text>
+
+      <rect x="246" y="8" width="30" height="44" fill="#1a1500" stroke="#d4a020" stroke-width="1" opacity="0.3"/>
+      <line x1="246" y1="30" x2="276" y2="30" stroke="#0a0a00" stroke-width="1.5" opacity="0.4"/>
+      <text x="261" y="26" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="16" font-weight="700" opacity="0.5">S</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Departures</div>
+  <h2>Session Board</h2>
+
+  <!-- SVG departure board frame with row dividers -->
+  <svg width="100%" height="24" viewBox="0 0 600 24" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px auto 8px; display: block; max-width: 600px;">
+    <rect x="0" y="0" width="600" height="24" fill="#1a1500" opacity="0.3"/>
+    <text x="20" y="16" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="9" font-weight="700" letter-spacing="2" opacity="0.5">TIME</text>
+    <text x="140" y="16" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="9" font-weight="700" letter-spacing="2" opacity="0.5">SESSION</text>
+    <text x="360" y="16" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="9" font-weight="700" letter-spacing="2" opacity="0.5">ROOM</text>
+    <text x="470" y="16" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="9" font-weight="700" letter-spacing="2" opacity="0.5">STATUS</text>
+  </svg>
+
+  <div class="departure-row">
+    <div class="departure-time">09:00</div>
+    <div class="departure-session">Keynote: Platform Architecture</div>
+    <div class="departure-room">GATE A1</div>
+    <div class="departure-status status-ontime">ON TIME</div>
+  </div>
+
+  <div class="departure-row">
+    <div class="departure-time">10:30</div>
+    <div class="departure-session">Workshop: API Design Patterns</div>
+    <div class="departure-room">GATE B3</div>
+    <div class="departure-status status-ontime">ON TIME</div>
+  </div>
+
+  <div class="departure-row">
+    <div class="departure-time">13:00</div>
+    <div class="departure-session">Panel: Infrastructure at Scale</div>
+    <div class="departure-room">GATE C2</div>
+    <div class="departure-status status-delayed">DELAYED</div>
+  </div>
+
+  <div class="departure-row">
+    <div class="departure-time">15:30</div>
+    <div class="departure-session">Closing: Future of Distributed Systems</div>
+    <div class="departure-room">GATE A1</div>
+    <div class="departure-status status-boarding">BOARDING</div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Gates</div>
+  <h2>Platform Indicators</h2>
+
+  <!-- SVG platform/gate number indicators -->
+  <svg width="100%" height="80" viewBox="0 0 600 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <rect x="20" y="10" width="80" height="60" fill="#1a1500" stroke="#d4a020" stroke-width="1.5" opacity="0.3"/>
+    <text x="60" y="35" text-anchor="middle" fill="#d4a020" font-family="IBM Plex Mono, monospace" font-size="8" letter-spacing="2" opacity="0.4">GATE</text>
+    <text x="60" y="55" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="18" font-weight="700" opacity="0.5">A1</text>
+
+    <rect x="140" y="10" width="80" height="60" fill="#1a1500" stroke="#d4a020" stroke-width="1.5" opacity="0.3"/>
+    <text x="180" y="35" text-anchor="middle" fill="#d4a020" font-family="IBM Plex Mono, monospace" font-size="8" letter-spacing="2" opacity="0.4">GATE</text>
+    <text x="180" y="55" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="18" font-weight="700" opacity="0.5">B3</text>
+
+    <rect x="260" y="10" width="80" height="60" fill="#1a1500" stroke="#d4a020" stroke-width="1.5" opacity="0.3"/>
+    <text x="300" y="35" text-anchor="middle" fill="#d4a020" font-family="IBM Plex Mono, monospace" font-size="8" letter-spacing="2" opacity="0.4">GATE</text>
+    <text x="300" y="55" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="18" font-weight="700" opacity="0.5">C2</text>
+
+    <rect x="380" y="10" width="80" height="60" fill="#1a1500" stroke="#d4a020" stroke-width="1.5" opacity="0.3"/>
+    <text x="420" y="35" text-anchor="middle" fill="#d4a020" font-family="IBM Plex Mono, monospace" font-size="8" letter-spacing="2" opacity="0.4">GATE</text>
+    <text x="420" y="55" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="18" font-weight="700" opacity="0.5">D4</text>
+
+    <rect x="500" y="10" width="80" height="60" fill="#1a1500" stroke="#d4a020" stroke-width="1.5" opacity="0.3"/>
+    <text x="540" y="35" text-anchor="middle" fill="#d4a020" font-family="IBM Plex Mono, monospace" font-size="8" letter-spacing="2" opacity="0.4">GATE</text>
+    <text x="540" y="55" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="18" font-weight="700" opacity="0.5">E1</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Transit</div>
+  <h2>Route Map</h2>
+
+  <!-- SVG transit route map diagram -->
+  <svg width="300" height="120" viewBox="0 0 300 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Route line -->
+    <line x1="30" y1="60" x2="270" y2="60" stroke="#d4a020" stroke-width="2" opacity="0.2"/>
+    <!-- Station stops -->
+    <circle cx="30" cy="60" r="8" stroke="#d4a020" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="30" cy="60" r="3" fill="#d4a020" opacity="0.3"/>
+    <circle cx="110" cy="60" r="8" stroke="#d4a020" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="110" cy="60" r="3" fill="#d4a020" opacity="0.3"/>
+    <circle cx="190" cy="60" r="8" stroke="#d4a020" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="190" cy="60" r="3" fill="#d4a020" opacity="0.3"/>
+    <circle cx="270" cy="60" r="8" stroke="#d4a020" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="270" cy="60" r="3" fill="#d4a020" opacity="0.3"/>
+    <!-- Labels -->
+    <text x="30" y="90" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.4">09:00</text>
+    <text x="30" y="100" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="6" opacity="0.3">GATE A1</text>
+    <text x="110" y="90" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.4">10:30</text>
+    <text x="110" y="100" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="6" opacity="0.3">GATE B3</text>
+    <text x="190" y="90" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.4">13:00</text>
+    <text x="190" y="100" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="6" opacity="0.3">GATE C2</text>
+    <text x="270" y="90" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="7" font-weight="700" opacity="0.4">15:30</text>
+    <text x="270" y="100" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="6" opacity="0.3">GATE A1</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Roboto Mono', monospace; font-weight: 700; font-size: 0.75rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">gate a1 > gate b3 > gate c2 > gate a1</p>
+</div>
+
+</div>

--- a/ticker-board/content/register.md
+++ b/ticker-board/content/register.md
@@ -1,0 +1,27 @@
++++
+title = "Register"
+description = "Board the Ticker Board conference"
++++
+
+<div class="section-block">
+  <div class="section-label">Boarding</div>
+  <h2>Get Your Pass</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register for a boarding pass. All-access passes grant entry to every gate. Track-specific passes limit you to one concourse. Early boarding available for registered attendees. Check the departure board for real-time updates on the day.</p>
+
+  <!-- SVG boarding pass -->
+  <svg width="200" height="80" viewBox="0 0 200 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <rect x="10" y="10" width="180" height="60" stroke="#d4a020" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="140" y1="10" x2="140" y2="70" stroke="#d4a020" stroke-width="1" opacity="0.15" stroke-dasharray="4 3"/>
+    <text x="70" y="35" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="2" opacity="0.3">TICKER</text>
+    <text x="70" y="52" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="2" opacity="0.3">BOARD</text>
+    <text x="165" y="38" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-size="6" letter-spacing="1" opacity="0.25">BOARDING</text>
+    <text x="165" y="52" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="12" font-weight="700" opacity="0.3">PASS</text>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="ticker-badge-ontime" style="font-size: 0.85rem; padding: 6px 20px;">ALL ACCESS</span>
+    <span class="ticker-badge-boarding" style="font-size: 0.85rem; padding: 6px 20px;">TRACK PASS</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Roboto Mono', monospace; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em;">2027.09.22 // TERMINAL C, ZURICH</p>
+</div>

--- a/ticker-board/content/sessions/_index.md
+++ b/ticker-board/content/sessions/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Sessions"
+description = "All departures on the Ticker Board conference schedule"
+sort_by = "weight"
+template = "section"
++++
+
+Four departures. Check your gate. Board on time.

--- a/ticker-board/content/sessions/closing.md
+++ b/ticker-board/content/sessions/closing.md
@@ -1,0 +1,36 @@
++++
+title = "15:30 -- Future of Distributed Systems"
+date = "2027-09-22"
+description = "Closing session on distributed systems now boarding at Gate A1"
+weight = 4
+tags = ["closing", "distributed", "boarding"]
+[extra]
+time = "15:30"
+room = "GATE A1"
+track = "MAIN"
+status = "BOARDING"
++++
+
+## 15:30 -- Future of Distributed Systems
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a00" stroke="#d4a020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d4a020" opacity="0.9"/>
+  <text x="35" y="35" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="1">GATE</text>
+  <text x="35" y="55" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="18" font-weight="700">A1</text>
+  <text x="180" y="35" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="9" font-weight="700" letter-spacing="1">DISTRIBUTED SYSTEMS</text>
+  <text x="180" y="55" text-anchor="middle" fill="#40a040" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">15:30 // BOARDING</text>
+</svg>
+
+<span class="ticker-badge-boarding">BOARDING</span>
+
+### Departure Summary
+
+Final departure. Gate A1 is now boarding. The closing session connects every thread from the day into a unified vision for distributed systems. Where we are. Where we go. The board clicks one final time.
+
+| Detail | Info |
+|--------|------|
+| Time | 15:30 |
+| Room | GATE A1 |
+| Track | MAIN |
+| Status | BOARDING |

--- a/ticker-board/content/sessions/keynote.md
+++ b/ticker-board/content/sessions/keynote.md
@@ -1,0 +1,36 @@
++++
+title = "09:00 -- Platform Architecture Keynote"
+date = "2027-09-22"
+description = "Opening keynote on platform architecture departing from Gate A1"
+weight = 1
+tags = ["keynote", "architecture", "on-time"]
+[extra]
+time = "09:00"
+room = "GATE A1"
+track = "MAIN"
+status = "ON TIME"
++++
+
+## 09:00 -- Platform Architecture Keynote
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a00" stroke="#d4a020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d4a020" opacity="0.9"/>
+  <text x="35" y="35" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="1">GATE</text>
+  <text x="35" y="55" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="18" font-weight="700">A1</text>
+  <text x="180" y="35" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="10" font-weight="700" letter-spacing="1">PLATFORM ARCHITECTURE</text>
+  <text x="180" y="55" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">09:00 // ON TIME</text>
+</svg>
+
+<span class="ticker-badge-ontime">ON TIME</span>
+
+### Departure Summary
+
+The first departure of the day. Gate A1 opens at 08:45. The keynote boards promptly at 09:00. Platform architecture, distributed systems, the infrastructure that holds everything together. This sets the tone for every session that follows.
+
+| Detail | Info |
+|--------|------|
+| Time | 09:00 |
+| Room | GATE A1 |
+| Track | MAIN |
+| Status | ON TIME |

--- a/ticker-board/content/sessions/panel.md
+++ b/ticker-board/content/sessions/panel.md
@@ -1,0 +1,36 @@
++++
+title = "13:00 -- Infrastructure at Scale Panel"
+date = "2027-09-22"
+description = "Panel discussion on infrastructure at scale -- DELAYED to Gate C2"
+weight = 3
+tags = ["panel", "infrastructure", "delayed"]
+[extra]
+time = "13:00"
+room = "GATE C2"
+track = "PANEL"
+status = "DELAYED"
++++
+
+## 13:00 -- Infrastructure at Scale Panel
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a00" stroke="#d4a020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d4a020" opacity="0.6"/>
+  <text x="35" y="35" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="1">GATE</text>
+  <text x="35" y="55" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="18" font-weight="700">C2</text>
+  <text x="180" y="35" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="10" font-weight="700" letter-spacing="1">INFRA AT SCALE</text>
+  <text x="180" y="55" text-anchor="middle" fill="#a04040" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">13:00 // DELAYED</text>
+</svg>
+
+<span class="ticker-badge-delayed">DELAYED</span>
+
+### Departure Summary
+
+Gate change and delay. Originally scheduled for 12:30, now departing at 13:00 from Gate C2. Five panelists discuss infrastructure at planetary scale -- the systems that never sleep, the deploys that cannot fail.
+
+| Detail | Info |
+|--------|------|
+| Time | 13:00 (was 12:30) |
+| Room | GATE C2 |
+| Track | PANEL |
+| Status | DELAYED |

--- a/ticker-board/content/sessions/workshop.md
+++ b/ticker-board/content/sessions/workshop.md
@@ -1,0 +1,36 @@
++++
+title = "10:30 -- API Design Patterns Workshop"
+date = "2027-09-22"
+description = "Hands-on workshop on API design departing from Gate B3"
+weight = 2
+tags = ["workshop", "api", "on-time"]
+[extra]
+time = "10:30"
+room = "GATE B3"
+track = "WORKSHOP"
+status = "ON TIME"
++++
+
+## 10:30 -- API Design Patterns Workshop
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0a0a00" stroke="#d4a020" stroke-width="2"/>
+  <rect x="0" y="0" width="70" height="80" fill="#d4a020" opacity="0.9"/>
+  <text x="35" y="35" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="8" font-weight="700" letter-spacing="1">GATE</text>
+  <text x="35" y="55" text-anchor="middle" fill="#0a0a00" font-family="Roboto Mono, monospace" font-size="18" font-weight="700">B3</text>
+  <text x="180" y="35" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="10" font-weight="700" letter-spacing="1">API DESIGN PATTERNS</text>
+  <text x="180" y="55" text-anchor="middle" fill="#8a7020" font-family="Inter, sans-serif" font-weight="700" font-size="8" letter-spacing="2">10:30 // ON TIME</text>
+</svg>
+
+<span class="ticker-badge-ontime">ON TIME</span>
+
+### Departure Summary
+
+Hands-on workshop at Gate B3. Bring your laptop. RESTful design, versioning strategies, error handling patterns. Three hours of intensive, practical API architecture work.
+
+| Detail | Info |
+|--------|------|
+| Time | 10:30 |
+| Room | GATE B3 |
+| Track | WORKSHOP |
+| Status | ON TIME |

--- a/ticker-board/static/css/style.css
+++ b/ticker-board/static/css/style.css
@@ -1,0 +1,486 @@
+/* Ticker Board - Departure Board Conference */
+/* Fonts: Roboto Mono / IBM Plex Mono Bold display in amber on black, Inter / Barlow body */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Barlow:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0a00;
+  --bg-secondary: #080800;
+  --bg-panel: #141400;
+  --text-primary: #e8d8a0;
+  --text-secondary: #a09060;
+  --text-muted: #8a7020;
+  --accent-amber: #d4a020;
+  --accent-bright: #e8b830;
+  --accent-dim: #9a7818;
+  --status-ontime: #d4a020;
+  --status-delayed: #c04040;
+  --status-boarding: #40a040;
+  --status-cancelled: #808080;
+  --border-color: #2a2400;
+  --border-accent: #d4a020;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', 'Barlow', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+}
+
+h1 { font-size: 2.4rem; }
+h2 { font-size: 1.6rem; }
+h3 { font-size: 1.1rem; font-family: 'IBM Plex Mono', monospace; letter-spacing: 0.06em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-amber);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-amber);
+  border-bottom-color: var(--accent-amber);
+}
+
+.nav-cta {
+  background-color: var(--accent-amber) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 4.5rem;
+  color: var(--accent-amber);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Barlow', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-amber);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Departure Row */
+.departure-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 20px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 4px;
+  font-family: 'Roboto Mono', monospace;
+}
+
+.departure-time {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--accent-amber);
+  min-width: 60px;
+  letter-spacing: 0.02em;
+}
+
+.departure-session {
+  flex: 1;
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.departure-room {
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  min-width: 80px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.departure-status {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  min-width: 90px;
+  text-align: center;
+  padding: 4px 10px;
+}
+
+.status-ontime { color: var(--status-ontime); border: 1px solid var(--status-ontime); }
+.status-delayed { color: var(--status-delayed); border: 1px solid var(--status-delayed); }
+.status-boarding { color: var(--status-boarding); border: 1px solid var(--status-boarding); }
+.status-cancelled { color: var(--status-cancelled); border: 1px solid var(--status-cancelled); }
+
+/* Ticker Badges */
+.ticker-badge-ontime {
+  display: inline-block;
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--status-ontime);
+  color: var(--bg-primary);
+}
+
+.ticker-badge-delayed {
+  display: inline-block;
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--status-delayed);
+  color: #fff;
+}
+
+.ticker-badge-boarding {
+  display: inline-block;
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--status-boarding);
+  color: #fff;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Roboto Mono', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-amber);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-amber);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Inter', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-amber);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-amber);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-amber);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: 700;
+  font-size: 8rem;
+  color: var(--accent-amber);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 2.5rem; }
+  h1 { font-size: 1.8rem; }
+  .departure-row { flex-direction: column; align-items: flex-start; gap: 6px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/ticker-board/templates/404.html
+++ b/ticker-board/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="10" y="15" width="60" height="50" stroke="#d4a020" stroke-width="2" fill="none" opacity="0.3"/>
+        <line x1="10" y1="40" x2="70" y2="40" stroke="#0a0a00" stroke-width="2" opacity="0.3"/>
+        <text x="40" y="34" text-anchor="middle" fill="#d4a020" font-family="Roboto Mono, monospace" font-size="12" font-weight="700" opacity="0.3">ERR</text>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Gate Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-amber); font-family: 'Roboto Mono', monospace; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Terminal</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ticker-board/templates/footer.html
+++ b/ticker-board/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">TICKER BOARD // DEPARTURES</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Terminal</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/concourse/">Concourse</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/ticker-board/templates/header.html
+++ b/ticker-board/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">TICKER BOARD</span>
+        <span class="logo-sub">departures</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Terminal</a>
+        <a href="{{ base_url }}/sessions/">Sessions</a>
+        <a href="{{ base_url }}/concourse/">Concourse</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Board</a>
+      </nav>
+    </div>
+  </header>

--- a/ticker-board/templates/page.html
+++ b/ticker-board/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ticker-board/templates/post.html
+++ b/ticker-board/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("session") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ticker-board/templates/section.html
+++ b/ticker-board/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ticker-board/templates/taxonomy.html
+++ b/ticker-board/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/ticker-board/templates/taxonomy_term.html
+++ b/ticker-board/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All sessions tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Closes #1654

## Summary
- Add ticker-board example site: airport/train departure board conference
- SVG split-flap letter/number display panels, departure board frame with row dividers, platform/gate number indicators, transit route map diagrams
- Typography: Roboto Mono/IBM Plex Mono Bold display in amber on black, Inter/Barlow body
- Session entries as departures with TIME/ROOM/TRACK/STATUS, status indicators (ON TIME/DELAYED/BOARDING)

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm amber-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes ticker-board with correct tags