### PR TITLE
feat: add demolition-derby example site

### DIFF
--- a/demolition-derby/config.toml
+++ b/demolition-derby/config.toml
@@ -1,0 +1,41 @@
+title = "Demolition Derby"
+description = "Competitive destruction event with impact collisions and wreckage"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["competitors"]
+
+[markdown]
+safe = false

--- a/demolition-derby/content/competitors/_index.md
+++ b/demolition-derby/content/competitors/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Competitors"
+description = "All competitors in the Demolition Derby destruction event"
+sort_by = "weight"
+template = "section"
++++
+
+Four machines. One arena. Last one running takes the trophy.

--- a/demolition-derby/content/competitors/crusher.md
+++ b/demolition-derby/content/competitors/crusher.md
@@ -1,0 +1,35 @@
++++
+title = "#03 -- Crusher"
+date = "2027-08-30"
+description = "Eliminated competitor with 65% damage output -- mechanical failure in round 3"
+weight = 3
+tags = ["eliminated", "mechanical-failure", "offensive"]
+[extra]
+number = "#03"
+damage_dealt = "65%"
+status = "ELIMINATED"
+strategy = "Full Offense"
++++
+
+## #03 -- Crusher
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0a08" stroke="#e08020" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#e08020" opacity="0.5"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="8" letter-spacing="1">ENTRY</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="18">#03</text>
+  <text x="170" y="35" text-anchor="middle" fill="#806050" font-family="Impact, sans-serif" font-size="12" letter-spacing="2">CRUSHER</text>
+  <text x="170" y="55" text-anchor="middle" fill="#604030" font-family="Work Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">65% DAMAGE // ELIMINATED</text>
+</svg>
+
+<span class="derby-badge-eliminated">X ELIMINATED</span>
+
+### Competitor Profile
+
+All offense, no defense. Crusher went full throttle from the first bell and paid for it in round 3. Mechanical failure after a head-on collision with Wrecking Ball. 65% damage output before the engine seized. A cautionary tale about sustainability.
+
+| Stat | Value |
+|------|-------|
+| Damage Dealt | 65% |
+| Status | ELIMINATED |
+| Strategy | Full Offense |

--- a/demolition-derby/content/competitors/iron-maiden.md
+++ b/demolition-derby/content/competitors/iron-maiden.md
@@ -1,0 +1,35 @@
++++
+title = "#02 -- Iron Maiden"
+date = "2027-08-30"
+description = "Armored survivor with 72% damage output and defensive counter strategy"
+weight = 2
+tags = ["active", "armored", "defensive"]
+[extra]
+number = "#02"
+damage_dealt = "72%"
+status = "ACTIVE"
+strategy = "Defensive Counter"
++++
+
+## #02 -- Iron Maiden
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0a08" stroke="#e08020" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#e08020" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="8" letter-spacing="1">ENTRY</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="18">#02</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c098" font-family="Impact, sans-serif" font-size="12" letter-spacing="2">IRON MAIDEN</text>
+  <text x="170" y="55" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">72% DAMAGE // ACTIVE</text>
+</svg>
+
+<span class="derby-badge">ACTIVE</span>
+
+### Competitor Profile
+
+Built to absorb punishment and strike back. Iron Maiden lets others come to it, absorbs the impact, then delivers devastating counters. 72% damage output, but the real stat is survival -- this machine has never been eliminated.
+
+| Stat | Value |
+|------|-------|
+| Damage Dealt | 72% |
+| Status | ACTIVE |
+| Strategy | Defensive Counter |

--- a/demolition-derby/content/competitors/scrapyard-king.md
+++ b/demolition-derby/content/competitors/scrapyard-king.md
@@ -1,0 +1,35 @@
++++
+title = "#04 -- Scrapyard King"
+date = "2027-08-30"
+description = "Defending champion with 91% damage output and calculated chaos strategy"
+weight = 4
+tags = ["active", "champion", "calculated"]
+[extra]
+number = "#04"
+damage_dealt = "91%"
+status = "ACTIVE"
+strategy = "Calculated Chaos"
++++
+
+## #04 -- Scrapyard King
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0a08" stroke="#e08020" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#e08020" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="8" letter-spacing="1">ENTRY</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="18">#04</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c098" font-family="Impact, sans-serif" font-size="12" letter-spacing="2">SCRAPYARD KING</text>
+  <text x="170" y="55" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">91% DAMAGE // CHAMPION</text>
+</svg>
+
+<span class="derby-badge">ACTIVE</span>
+
+### Competitor Profile
+
+The defending champion. Scrapyard King has the highest damage output of any competitor -- 91%. But its real weapon is calculation. Every collision is planned. Every angle is measured. Chaos with purpose. The crown is not given; it is torn from the wreckage.
+
+| Stat | Value |
+|------|-------|
+| Damage Dealt | 91% |
+| Status | ACTIVE |
+| Strategy | Calculated Chaos |

--- a/demolition-derby/content/competitors/wrecking-ball.md
+++ b/demolition-derby/content/competitors/wrecking-ball.md
@@ -1,0 +1,35 @@
++++
+title = "#01 -- Wrecking Ball"
+date = "2027-08-30"
+description = "Heavy hitter with 87% damage output and aggressive ramming strategy"
+weight = 1
+tags = ["active", "heavy", "aggressive"]
+[extra]
+number = "#01"
+damage_dealt = "87%"
+status = "ACTIVE"
+strategy = "Aggressive Ram"
++++
+
+## #01 -- Wrecking Ball
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0c0a08" stroke="#e08020" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#e08020" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="8" letter-spacing="1">ENTRY</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0c0a08" font-family="Impact, sans-serif" font-size="18">#01</text>
+  <text x="170" y="35" text-anchor="middle" fill="#e8c098" font-family="Impact, sans-serif" font-size="12" letter-spacing="2">WRECKING BALL</text>
+  <text x="170" y="55" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-weight="700" font-size="8" letter-spacing="2">87% DAMAGE // ACTIVE</text>
+</svg>
+
+<span class="derby-badge">ACTIVE</span>
+
+### Competitor Profile
+
+The heaviest machine in the arena. Wrecking Ball does not dodge. It does not weave. It finds the nearest target and hits it at full speed. 87% damage output in qualifying rounds. Three competitors have already been retired by this machine alone.
+
+| Stat | Value |
+|------|-------|
+| Damage Dealt | 87% |
+| Status | ACTIVE |
+| Strategy | Aggressive Ram |

--- a/demolition-derby/content/index.md
+++ b/demolition-derby/content/index.md
@@ -1,0 +1,169 @@
++++
+title = "Home"
+description = "Competitive destruction event with impact collisions and wreckage"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Competitive Destruction Event</div>
+    <h1>DEMOLITION DERBY</h1>
+    <p class="hero-subtitle">Last machine standing wins. Four competitors enter the arena. Collisions are mandatory. Survival is optional. The wreckage tells the story.</p>
+    <p class="hero-date">IMPACT NIGHT // 2027.08.30 // THE ARENA, DETROIT</p>
+
+    <!-- SVG impact collision pattern -->
+    <svg width="320" height="100" viewBox="0 0 320 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Impact starburst -->
+      <line x1="160" y1="50" x2="160" y2="10" stroke="#e08020" stroke-width="2" opacity="0.3"/>
+      <line x1="160" y1="50" x2="195" y2="18" stroke="#e08020" stroke-width="2" opacity="0.25"/>
+      <line x1="160" y1="50" x2="210" y2="40" stroke="#e08020" stroke-width="2" opacity="0.3"/>
+      <line x1="160" y1="50" x2="200" y2="75" stroke="#e08020" stroke-width="2" opacity="0.25"/>
+      <line x1="160" y1="50" x2="160" y2="90" stroke="#e08020" stroke-width="2" opacity="0.3"/>
+      <line x1="160" y1="50" x2="120" y2="80" stroke="#e08020" stroke-width="2" opacity="0.25"/>
+      <line x1="160" y1="50" x2="110" y2="40" stroke="#e08020" stroke-width="2" opacity="0.3"/>
+      <line x1="160" y1="50" x2="125" y2="18" stroke="#e08020" stroke-width="2" opacity="0.25"/>
+      <!-- Impact center -->
+      <circle cx="160" cy="50" r="12" stroke="#e08020" stroke-width="2" fill="none" opacity="0.3"/>
+      <circle cx="160" cy="50" r="5" fill="#e08020" opacity="0.2"/>
+      <!-- Debris fragments -->
+      <rect x="80" y="25" width="8" height="4" fill="#e08020" opacity="0.15" transform="rotate(25 84 27)"/>
+      <rect x="220" y="20" width="10" height="3" fill="#e08020" opacity="0.12" transform="rotate(-15 225 22)"/>
+      <rect x="90" y="70" width="7" height="3" fill="#e08020" opacity="0.1" transform="rotate(40 93 72)"/>
+      <rect x="230" y="65" width="9" height="4" fill="#e08020" opacity="0.13" transform="rotate(-30 234 67)"/>
+      <!-- Dent marks -->
+      <path d="M50,40 Q55,35 60,40" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.15"/>
+      <path d="M260,55 Q265,50 270,55" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.15"/>
+      <path d="M70,65 Q75,60 80,65" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.12"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Competitors</div>
+  <h2>Elimination Bracket</h2>
+
+  <!-- SVG demolition arena boundary fence -->
+  <svg width="100%" height="40" viewBox="0 0 600 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px auto 24px; display: block; max-width: 600px;">
+    <!-- Fence posts -->
+    <rect x="10" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <rect x="110" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <rect x="210" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <rect x="310" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <rect x="410" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <rect x="510" y="5" width="4" height="30" fill="#e08020" opacity="0.2"/>
+    <!-- Fence rails -->
+    <line x1="14" y1="12" x2="110" y2="12" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="14" y1="24" x2="110" y2="24" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="114" y1="12" x2="210" y2="12" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="114" y1="24" x2="210" y2="24" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="214" y1="12" x2="310" y2="12" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="214" y1="24" x2="310" y2="24" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="314" y1="12" x2="410" y2="12" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="314" y1="24" x2="410" y2="24" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="414" y1="12" x2="510" y2="12" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="414" y1="24" x2="510" y2="24" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <!-- Dent in fence -->
+    <path d="M260,12 Q265,18 260,24" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.2"/>
+  </svg>
+
+  <div class="competitor-block">
+    <div class="competitor-number">#01</div>
+    <div class="competitor-info">
+      <div class="competitor-name">WRECKING BALL</div>
+      <div class="competitor-meta">Damage dealt: 87% // Status: ACTIVE</div>
+    </div>
+    <div class="competitor-badge-slot">
+      <span class="derby-badge">ACTIVE</span>
+    </div>
+  </div>
+
+  <div class="competitor-block">
+    <div class="competitor-number">#02</div>
+    <div class="competitor-info">
+      <div class="competitor-name">IRON MAIDEN</div>
+      <div class="competitor-meta">Damage dealt: 72% // Status: ACTIVE</div>
+    </div>
+    <div class="competitor-badge-slot">
+      <span class="derby-badge">ACTIVE</span>
+    </div>
+  </div>
+
+  <div class="competitor-block">
+    <div class="competitor-number">#03</div>
+    <div class="competitor-info">
+      <div class="competitor-name">CRUSHER</div>
+      <div class="competitor-meta">Damage dealt: 65% // Status: ELIMINATED</div>
+    </div>
+    <div class="competitor-badge-slot">
+      <span class="derby-badge-eliminated">X ELIMINATED</span>
+    </div>
+  </div>
+
+  <div class="competitor-block">
+    <div class="competitor-number">#04</div>
+    <div class="competitor-info">
+      <div class="competitor-name">SCRAPYARD KING</div>
+      <div class="competitor-meta">Damage dealt: 91% // Status: ACTIVE</div>
+    </div>
+    <div class="competitor-badge-slot">
+      <span class="derby-badge">ACTIVE</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Damage Report</div>
+  <h2>Wreckage Assessment</h2>
+
+  <!-- SVG dent and wreckage texture effects -->
+  <svg width="300" height="120" viewBox="0 0 300 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Vehicle outline with dents -->
+    <rect x="40" y="30" width="220" height="60" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Dent marks -->
+    <path d="M80,30 Q85,40 90,30" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <path d="M140,90 Q148,80 155,90" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <path d="M200,30 Q210,42 220,30" stroke="#e08020" stroke-width="2" fill="none" opacity="0.3"/>
+    <path d="M40,55 Q50,50 40,45" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Crack lines -->
+    <line x1="110" y1="30" x2="125" y2="55" stroke="#e08020" stroke-width="1" opacity="0.15"/>
+    <line x1="125" y1="55" x2="118" y2="70" stroke="#e08020" stroke-width="1" opacity="0.12"/>
+    <line x1="180" y1="30" x2="175" y2="50" stroke="#e08020" stroke-width="1" opacity="0.15"/>
+    <!-- Debris scatter -->
+    <rect x="60" y="100" width="6" height="3" fill="#e08020" opacity="0.1" transform="rotate(15 63 101)"/>
+    <rect x="140" y="105" width="8" height="3" fill="#e08020" opacity="0.12" transform="rotate(-20 144 106)"/>
+    <rect x="210" y="100" width="5" height="3" fill="#e08020" opacity="0.1" transform="rotate(30 212 101)"/>
+    <!-- Damage percentage -->
+    <text x="150" y="68" text-anchor="middle" fill="#e08020" font-family="Impact, sans-serif" font-size="16" opacity="0.2">87%</text>
+    <text x="150" y="18" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-size="7" font-weight="700" letter-spacing="2" opacity="0.25">DAMAGE ASSESSMENT</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Trophy</div>
+  <h2>Last Machine Standing</h2>
+
+  <!-- SVG trophy from wreckage illustration -->
+  <svg width="200" height="160" viewBox="0 0 200 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Trophy cup shape made from wreckage -->
+    <path d="M70,40 L60,90 L80,100 L120,100 L140,90 L130,40 Z" stroke="#e08020" stroke-width="2" fill="none" opacity="0.2"/>
+    <!-- Trophy handles -->
+    <path d="M70,50 Q45,60 55,80" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <path d="M130,50 Q155,60 145,80" stroke="#e08020" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <!-- Dents in trophy -->
+    <path d="M80,55 Q85,60 80,65" stroke="#e08020" stroke-width="1" fill="none" opacity="0.15"/>
+    <path d="M120,70 Q125,75 120,80" stroke="#e08020" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Base -->
+    <rect x="80" y="100" width="40" height="8" fill="#e08020" opacity="0.1"/>
+    <rect x="75" y="108" width="50" height="6" fill="#e08020" opacity="0.08"/>
+    <!-- Star -->
+    <polygon points="100,48 103,56 112,56 105,61 108,70 100,65 92,70 95,61 88,56 97,56" fill="#e08020" opacity="0.15"/>
+    <!-- Label -->
+    <text x="100" y="135" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-size="7" font-weight="700" letter-spacing="2" opacity="0.25">CHAMPION</text>
+    <text x="100" y="148" text-anchor="middle" fill="#e08020" font-family="Impact, sans-serif" font-size="8" letter-spacing="1" opacity="0.2">LAST STANDING</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Work Sans', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">enter > collide > survive > champion</p>
+</div>
+
+</div>

--- a/demolition-derby/content/register.md
+++ b/demolition-derby/content/register.md
@@ -1,0 +1,29 @@
++++
+title = "Register"
+description = "Enter the Demolition Derby destruction event"
++++
+
+<div class="section-block">
+  <div class="section-label">Entry</div>
+  <h2>Enter the Arena</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Register as a competitor or spectator. Competitors must pass machine inspection -- roll cage, fuel cutoff, driver harness. Spectators get arena-side or grandstand seating. All seats feel the impact.</p>
+
+  <!-- SVG impact icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <circle cx="50" cy="50" r="15" stroke="#e08020" stroke-width="2" fill="none" opacity="0.2"/>
+    <circle cx="50" cy="50" r="6" fill="#e08020" opacity="0.15"/>
+    <line x1="50" y1="50" x2="50" y2="20" stroke="#e08020" stroke-width="1.5" opacity="0.2"/>
+    <line x1="50" y1="50" x2="75" y2="35" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="50" y1="50" x2="75" y2="65" stroke="#e08020" stroke-width="1.5" opacity="0.2"/>
+    <line x1="50" y1="50" x2="50" y2="80" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+    <line x1="50" y1="50" x2="25" y2="65" stroke="#e08020" stroke-width="1.5" opacity="0.2"/>
+    <line x1="50" y1="50" x2="25" y2="35" stroke="#e08020" stroke-width="1.5" opacity="0.15"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="derby-badge" style="font-size: 0.85rem; padding: 6px 20px;">COMPETITOR</span>
+    <span class="derby-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">SPECTATOR</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Impact', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">2027.08.30 // THE ARENA, DETROIT</p>
+</div>

--- a/demolition-derby/content/rules.md
+++ b/demolition-derby/content/rules.md
@@ -1,0 +1,18 @@
++++
+title = "Rules"
+description = "Demolition Derby rules and arena regulations"
++++
+
+<div class="section-block">
+  <div class="section-label">Regulations</div>
+  <h2>Arena Rules</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">All competitors enter the arena fence. Collisions are mandatory -- no hiding, no stalling. If your machine stops moving for 30 seconds, you are eliminated. Last machine with a functioning engine wins. Driver doors must face inward. No targeting driver doors. Everything else is fair game.</p>
+
+  <!-- SVG arena boundary -->
+  <svg width="200" height="140" viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <rect x="20" y="20" width="160" height="100" stroke="#e08020" stroke-width="2" fill="none" opacity="0.2"/>
+    <rect x="25" y="25" width="150" height="90" stroke="#e08020" stroke-width="1" fill="none" opacity="0.1" stroke-dasharray="6 3"/>
+    <text x="100" y="65" text-anchor="middle" fill="#e08020" font-family="Impact, sans-serif" font-size="10" letter-spacing="2" opacity="0.2">NO ESCAPE</text>
+    <text x="100" y="82" text-anchor="middle" fill="#a06020" font-family="Work Sans, sans-serif" font-size="7" font-weight="700" letter-spacing="1" opacity="0.2">LAST STANDING WINS</text>
+  </svg>
+</div>

--- a/demolition-derby/static/css/style.css
+++ b/demolition-derby/static/css/style.css
@@ -1,0 +1,457 @@
+/* Demolition Derby - Competitive Destruction Event */
+/* Fonts: Impact / Anton display with distortion effects, Archivo Black / Work Sans Bold body */
+
+@import url('https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Work+Sans:wght@400;500;600;700;800&display=swap');
+
+:root {
+  --bg-primary: #0c0a08;
+  --bg-secondary: #080605;
+  --bg-panel: #141008;
+  --text-primary: #e8c098;
+  --text-secondary: #a08060;
+  --text-muted: #a06020;
+  --accent-orange: #e08020;
+  --accent-bright: #f09030;
+  --accent-dim: #a06018;
+  --border-color: #2a1e10;
+  --border-accent: #e08020;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 500;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: Impact, 'Anton', sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Archivo Black', sans-serif; letter-spacing: 0.06em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-orange);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 1.3rem;
+  color: var(--accent-orange);
+  letter-spacing: 0.04em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-orange);
+  border-bottom-color: var(--accent-orange);
+}
+
+.nav-cta {
+  background-color: var(--accent-orange) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-orange);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 5.5rem;
+  color: var(--accent-orange);
+  margin-bottom: 8px;
+  letter-spacing: 0.06em;
+}
+
+.hero-subtitle {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Archivo Black', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-orange);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.competitor-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.competitor-number {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 1.1rem;
+  color: var(--accent-orange);
+  min-width: 60px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.competitor-info { flex: 1; }
+
+.competitor-name {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.competitor-meta {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.competitor-badge-slot {
+  flex-shrink: 0;
+}
+
+.derby-badge {
+  display: inline-block;
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-orange);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.derby-badge-outline {
+  display: inline-block;
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-orange);
+  color: var(--accent-orange);
+  text-transform: uppercase;
+}
+
+.derby-badge-eliminated {
+  display: inline-block;
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid #804030;
+  color: #804030;
+  text-transform: uppercase;
+}
+
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-orange);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-orange);
+  font-weight: 400;
+  font-size: 0.85rem;
+  font-family: 'Archivo Black', sans-serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Work Sans', sans-serif;
+}
+
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Archivo Black', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-orange);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-orange);
+  color: var(--accent-orange);
+}
+
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-orange);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-orange);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: Impact, 'Anton', sans-serif;
+  font-size: 8rem;
+  color: var(--accent-orange);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Work Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3rem; }
+  h1 { font-size: 2rem; }
+  .competitor-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+}

--- a/demolition-derby/templates/404.html
+++ b/demolition-derby/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="40" cy="40" r="20" stroke="#e08020" stroke-width="2" fill="none" opacity="0.3"/>
+        <line x1="25" y1="25" x2="55" y2="55" stroke="#e08020" stroke-width="3" opacity="0.25"/>
+        <line x1="55" y1="25" x2="25" y2="55" stroke="#e08020" stroke-width="3" opacity="0.25"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Total Wreck</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-orange); font-family: 'Work Sans', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Arena</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/demolition-derby/templates/footer.html
+++ b/demolition-derby/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">DEMOLITION DERBY // DESTRUCTION EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Arena</a>
+        <a href="{{ base_url }}/competitors/">Competitors</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/demolition-derby/templates/header.html
+++ b/demolition-derby/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">DEMOLITION DERBY</span>
+        <span class="logo-sub">destruction event</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Arena</a>
+        <a href="{{ base_url }}/competitors/">Competitors</a>
+        <a href="{{ base_url }}/rules/">Rules</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Enter</a>
+      </nav>
+    </div>
+  </header>

--- a/demolition-derby/templates/page.html
+++ b/demolition-derby/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/demolition-derby/templates/post.html
+++ b/demolition-derby/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("competitor") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/demolition-derby/templates/section.html
+++ b/demolition-derby/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/demolition-derby/templates/taxonomy.html
+++ b/demolition-derby/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/demolition-derby/templates/taxonomy_term.html
+++ b/demolition-derby/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All competitors tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -926,6 +926,13 @@
     "deconstructivist",
     "architecture"
   ],
+  "demolition-derby": [
+    "event",
+    "dark",
+    "competition",
+    "destruction",
+    "chaotic"
+  ],
   "depot": [
     "light",
     "landing",


### PR DESCRIPTION
Closes #1653

## Summary
- Add demolition-derby example site: competitive destruction event with impact collisions and wreckage
- SVG impact collision patterns, dent and wreckage texture effects, demolition arena boundary fence, trophy from wreckage illustrations
- Typography: Impact/Anton display with distortion effects, Archivo Black/Work Sans Bold body
- Competitor entries with damage/survival status, elimination brackets with X marks

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm orange-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes demolition-derby with correct tags