### PR TITLE
feat: add war-room example site

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -3697,6 +3697,13 @@
     "blog",
     "travel"
   ],
+  "war-room": [
+    "event",
+    "dark",
+    "strategy",
+    "military",
+    "command"
+  ],
   "warpzone": [
     "dark",
     "portfolio",

--- a/war-room/config.toml
+++ b/war-room/config.toml
@@ -1,0 +1,41 @@
+title = "War Room"
+description = "Military strategy summit and command center"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["briefings"]
+
+[markdown]
+safe = false

--- a/war-room/content/briefings/_index.md
+++ b/war-room/content/briefings/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Briefings"
+description = "All operational briefings in the War Room strategy summit"
+sort_by = "weight"
+template = "section"
++++
+
+Four operational briefings. Escalating classification. From strategic overview to final mission orders.

--- a/war-room/content/briefings/sitrep-alpha.md
+++ b/war-room/content/briefings/sitrep-alpha.md
@@ -1,0 +1,47 @@
++++
+title = "SITREP Alpha -- Strategic Overview"
+date = "2027-08-22"
+description = "Theater-wide strategic assessment and operational picture"
+weight = 1
+tags = ["strategic", "overview", "confidential"]
+[extra]
+classification = "CONFIDENTIAL"
+dtg = "220800ZAUG2027"
+phase = "Assessment"
++++
+
+## SITREP Alpha -- Strategic Overview
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0e160e" stroke="#30c060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#30c060" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="7" font-weight="700" letter-spacing="1">SITREP</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="16" font-weight="700">A</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c0e8c0" font-family="Orbitron, sans-serif" font-size="11" font-weight="700" letter-spacing="1">STRATEGIC OVERVIEW</text>
+  <text x="170" y="55" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">DTG: 220800ZAUG2027</text>
+</svg>
+
+<span class="war-badge-outline">CONFIDENTIAL</span>
+
+<div class="sitrep-header">DTG: 220800ZAUG2027 // CLASSIFICATION: CONFIDENTIAL // PHASE: ASSESSMENT</div>
+
+### Briefing Summary
+
+The theater-wide strategic assessment begins here. This is the foundation upon which all subsequent operations are built. Command personnel receive the complete operational picture -- current force disposition, threat analysis, and strategic objectives. The big picture is drawn before the details are filled in. Every commander needs context before they can act.
+
+<!-- SVG tactical overview display -->
+<svg width="240" height="60" viewBox="0 0 240 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="240" height="60" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.3"/>
+  <line x1="0" y1="30" x2="240" y2="30" stroke="#1a2e1a" stroke-width="0.5" opacity="0.2"/>
+  <path d="M10,45 L40,35 L70,40 L100,20 L130,25 L160,15 L190,22 L220,18 L240,20" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+  <circle cx="100" cy="20" r="3" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+  <circle cx="160" cy="15" r="3" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+  <text x="120" y="55" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="5" letter-spacing="2">THREAT ASSESSMENT TREND</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Classification | CONFIDENTIAL |
+| DTG | 220800ZAUG2027 |
+| Phase | Assessment |
+| Scope | Theater-wide |

--- a/war-room/content/briefings/sitrep-bravo.md
+++ b/war-room/content/briefings/sitrep-bravo.md
@@ -1,0 +1,56 @@
++++
+title = "SITREP Bravo -- Intelligence Analysis"
+date = "2027-08-22"
+description = "Deep reconnaissance findings and intelligence synthesis"
+weight = 2
+tags = ["intelligence", "reconnaissance", "secret"]
+[extra]
+classification = "SECRET"
+dtg = "221000ZAUG2027"
+phase = "Intelligence"
++++
+
+## SITREP Bravo -- Intelligence Analysis
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0e160e" stroke="#30c060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#30c060" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="7" font-weight="700" letter-spacing="1">SITREP</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="16" font-weight="700">B</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c0e8c0" font-family="Orbitron, sans-serif" font-size="11" font-weight="700" letter-spacing="1">INTEL ANALYSIS</text>
+  <text x="170" y="55" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">DTG: 221000ZAUG2027</text>
+</svg>
+
+<span class="war-badge-outline">SECRET</span>
+
+<div class="sitrep-header">DTG: 221000ZAUG2027 // CLASSIFICATION: SECRET // PHASE: INTELLIGENCE</div>
+
+### Briefing Summary
+
+Intelligence drives operations. This briefing synthesizes deep reconnaissance findings, signals intelligence, and human intelligence into a coherent picture of the operational environment. Know the terrain before you commit forces. Know the adversary before you engage. Every data point is cross-referenced, every source evaluated. The fog of war begins to clear.
+
+<!-- SVG intelligence network diagram -->
+<svg width="200" height="80" viewBox="0 0 200 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="200" height="80" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Intelligence nodes -->
+  <circle cx="40" cy="25" r="8" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+  <text x="40" y="28" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.3">SIGINT</text>
+  <circle cx="100" cy="25" r="8" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+  <text x="100" y="28" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.3">HUMINT</text>
+  <circle cx="160" cy="25" r="8" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+  <text x="160" y="28" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.3">IMINT</text>
+  <!-- Fusion point -->
+  <circle cx="100" cy="60" r="10" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <text x="100" y="63" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.35">FUSION</text>
+  <!-- Connection lines -->
+  <line x1="44" y1="33" x2="92" y2="52" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+  <line x1="100" y1="33" x2="100" y2="50" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+  <line x1="156" y1="33" x2="108" y2="52" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Classification | SECRET |
+| DTG | 221000ZAUG2027 |
+| Phase | Intelligence |
+| Sources | SIGINT, HUMINT, IMINT |

--- a/war-room/content/briefings/sitrep-charlie.md
+++ b/war-room/content/briefings/sitrep-charlie.md
@@ -1,0 +1,60 @@
++++
+title = "SITREP Charlie -- Force Deployment"
+date = "2027-08-22"
+description = "Full deployment manifest and force positioning orders"
+weight = 3
+tags = ["deployment", "force-posture", "secret"]
+[extra]
+classification = "SECRET"
+dtg = "221200ZAUG2027"
+phase = "Deployment"
++++
+
+## SITREP Charlie -- Force Deployment
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0e160e" stroke="#30c060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#30c060" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="7" font-weight="700" letter-spacing="1">SITREP</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="16" font-weight="700">C</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c0e8c0" font-family="Orbitron, sans-serif" font-size="11" font-weight="700" letter-spacing="1">FORCE DEPLOYMENT</text>
+  <text x="170" y="55" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">DTG: 221200ZAUG2027</text>
+</svg>
+
+<span class="war-badge">SECRET</span>
+
+<div class="sitrep-header">DTG: 221200ZAUG2027 // CLASSIFICATION: SECRET // PHASE: DEPLOYMENT</div>
+
+### Briefing Summary
+
+Assets are positioned. This briefing covers the full deployment manifest -- every unit, every position, every line of advance. Force disposition determines the shape of the battle. Reserves are identified, flanks are secured, supply lines are established. The chessboard is set. Commanders receive their sector assignments and coordination measures.
+
+<!-- SVG deployment grid -->
+<svg width="220" height="100" viewBox="0 0 220 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="220" height="100" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Deployment zones -->
+  <rect x="10" y="10" width="60" height="35" stroke="#30c060" stroke-width="1" fill="none" opacity="0.15"/>
+  <text x="40" y="30" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.25">SECTOR 1</text>
+  <rect x="80" y="10" width="60" height="35" stroke="#30c060" stroke-width="1" fill="none" opacity="0.15"/>
+  <text x="110" y="30" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.25">SECTOR 2</text>
+  <rect x="150" y="10" width="60" height="35" stroke="#30c060" stroke-width="1" fill="none" opacity="0.15"/>
+  <text x="180" y="30" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.25">SECTOR 3</text>
+  <!-- Unit positions -->
+  <rect x="25" y="20" width="8" height="6" fill="#30c060" opacity="0.2"/>
+  <rect x="100" y="18" width="8" height="6" fill="#30c060" opacity="0.2"/>
+  <rect x="170" y="22" width="8" height="6" fill="#30c060" opacity="0.2"/>
+  <!-- Reserve zone -->
+  <rect x="60" y="55" width="100" height="35" stroke="#408040" stroke-width="1" fill="none" opacity="0.12" stroke-dasharray="4 3"/>
+  <text x="110" y="76" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="5" opacity="0.2">RESERVE</text>
+  <!-- Movement arrows -->
+  <line x1="40" y1="45" x2="40" y2="55" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+  <line x1="110" y1="45" x2="110" y2="55" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+  <line x1="180" y1="45" x2="180" y2="55" stroke="#30c060" stroke-width="0.8" opacity="0.15"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Classification | SECRET |
+| DTG | 221200ZAUG2027 |
+| Phase | Deployment |
+| Sectors | 3 Active + Reserve |

--- a/war-room/content/briefings/sitrep-delta.md
+++ b/war-room/content/briefings/sitrep-delta.md
@@ -1,0 +1,60 @@
++++
+title = "SITREP Delta -- Operations Planning"
+date = "2027-08-22"
+description = "Final mission orders and full-scale operations execution plan"
+weight = 4
+tags = ["operations", "execution", "top-secret"]
+[extra]
+classification = "TOP SECRET"
+dtg = "221400ZAUG2027"
+phase = "Execution"
++++
+
+## SITREP Delta -- Operations Planning
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#0e160e" stroke="#30c060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#30c060" opacity="0.9"/>
+  <text x="30" y="35" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="7" font-weight="700" letter-spacing="1">SITREP</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a100a" font-family="Orbitron, sans-serif" font-size="16" font-weight="700">D</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c0e8c0" font-family="Orbitron, sans-serif" font-size="11" font-weight="700" letter-spacing="1">OPS PLANNING</text>
+  <text x="170" y="55" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="2">DTG: 221400ZAUG2027</text>
+</svg>
+
+<span class="war-badge">TOP SECRET</span>
+
+<div class="sitrep-header">DTG: 221400ZAUG2027 // CLASSIFICATION: TOP SECRET // PHASE: EXECUTION</div>
+
+### Briefing Summary
+
+This is the final briefing. All previous intelligence, analysis, and deployment orders converge into the master operations plan. Mission objectives are assigned, timelines are locked, contingencies are briefed. Every commander knows their role, every unit knows their mission. H-hour is set. The War Room has done its work -- now the strategy becomes action. Execute.
+
+<!-- SVG operations timeline -->
+<svg width="240" height="80" viewBox="0 0 240 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="240" height="80" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Timeline base -->
+  <line x1="20" y1="40" x2="220" y2="40" stroke="#30c060" stroke-width="1" opacity="0.2"/>
+  <!-- Phase markers -->
+  <circle cx="50" cy="40" r="6" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+  <text x="50" y="43" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.3">H-4</text>
+  <circle cx="100" cy="40" r="6" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <text x="100" y="43" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.35">H-2</text>
+  <circle cx="150" cy="40" r="6" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.35"/>
+  <text x="150" y="43" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4" opacity="0.4">H-1</text>
+  <circle cx="200" cy="40" r="8" stroke="#30c060" stroke-width="2" fill="#30c060" fill-opacity="0.15" opacity="0.45"/>
+  <text x="200" y="43" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" font-weight="700" opacity="0.5">H</text>
+  <!-- Phase labels -->
+  <text x="50" y="60" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="4" letter-spacing="1">PREP</text>
+  <text x="100" y="60" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="4" letter-spacing="1">STAGE</text>
+  <text x="150" y="60" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="4" letter-spacing="1">READY</text>
+  <text x="200" y="60" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="4" letter-spacing="1">EXECUTE</text>
+  <!-- Title bar -->
+  <text x="120" y="15" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="5" letter-spacing="2">OPERATIONS TIMELINE</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Classification | TOP SECRET |
+| DTG | 221400ZAUG2027 |
+| Phase | Execution |
+| Status | Final Orders |

--- a/war-room/content/index.md
+++ b/war-room/content/index.md
@@ -1,0 +1,175 @@
++++
+title = "Home"
+description = "Military strategy summit and command center"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Strategy Summit</div>
+    <h1>WAR ROOM</h1>
+    <p class="hero-subtitle">Four operational briefings. One unified strategy. Command personnel assemble for a high-intensity summit that moves from strategic overview through intelligence analysis to full-scale operations planning. All stations report.</p>
+    <p class="hero-date">DTG: 221400ZAUG2027 // COMMAND CENTER BRAVO</p>
+
+    <!-- SVG situation map with unit position markers -->
+    <svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Map grid -->
+      <rect x="10" y="10" width="300" height="180" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.4"/>
+      <line x1="10" y1="55" x2="310" y2="55" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <line x1="10" y1="100" x2="310" y2="100" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <line x1="10" y1="145" x2="310" y2="145" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <line x1="85" y1="10" x2="85" y2="190" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <line x1="160" y1="10" x2="160" y2="190" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <line x1="235" y1="10" x2="235" y2="190" stroke="#1a2e1a" stroke-width="0.5" opacity="0.3"/>
+      <!-- Terrain contour lines -->
+      <path d="M30,80 Q80,60 130,75 Q180,90 230,70 Q280,50 300,65" stroke="#30c060" stroke-width="0.8" fill="none" opacity="0.12"/>
+      <path d="M30,110 Q90,95 140,105 Q190,115 240,100 Q290,85 300,95" stroke="#30c060" stroke-width="0.8" fill="none" opacity="0.1"/>
+      <path d="M30,140 Q100,130 150,135 Q200,140 260,128 Q290,120 300,130" stroke="#30c060" stroke-width="0.8" fill="none" opacity="0.08"/>
+      <!-- Unit markers - friendly (rectangles) -->
+      <rect x="55" y="60" width="16" height="12" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <text x="63" y="69" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.4">A</text>
+      <rect x="130" y="40" width="16" height="12" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <text x="138" y="49" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.4">B</text>
+      <rect x="220" y="55" width="16" height="12" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.4"/>
+      <text x="228" y="64" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.4">C</text>
+      <!-- Unit markers - HQ (diamond) -->
+      <polygon points="160,130 170,140 160,150 150,140" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.35"/>
+      <text x="160" y="143" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.35">HQ</text>
+      <!-- Movement arrows -->
+      <path d="M71,66 L125,46" stroke="#30c060" stroke-width="0.8" fill="none" opacity="0.2" marker-end="url(#arrowhead)"/>
+      <path d="M146,46 L215,61" stroke="#30c060" stroke-width="0.8" fill="none" opacity="0.2"/>
+      <path d="M160,130 L63,72" stroke="#408040" stroke-width="0.5" fill="none" opacity="0.15" stroke-dasharray="4 3"/>
+      <path d="M160,130 L138,52" stroke="#408040" stroke-width="0.5" fill="none" opacity="0.15" stroke-dasharray="4 3"/>
+      <path d="M160,130 L228,67" stroke="#408040" stroke-width="0.5" fill="none" opacity="0.15" stroke-dasharray="4 3"/>
+      <!-- Grid labels -->
+      <text x="47" y="22" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="5" letter-spacing="1" opacity="0.3">GRID A</text>
+      <text x="122" y="22" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="5" letter-spacing="1" opacity="0.3">GRID B</text>
+      <text x="197" y="22" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="5" letter-spacing="1" opacity="0.3">GRID C</text>
+      <text x="272" y="22" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="5" letter-spacing="1" opacity="0.3">GRID D</text>
+      <text x="160" y="196" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="6" letter-spacing="3">SITUATION MAP // OPERATIONAL OVERLAY</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Operations Order</div>
+  <h2>Briefing Sequence</h2>
+
+  <div class="briefing-block briefing-alpha">
+    <div class="briefing-number">SITREP ALPHA</div>
+    <div class="briefing-info">
+      <div class="briefing-title briefing-title-alpha">Strategic Overview -- The Big Picture</div>
+      <div class="briefing-meta">DTG: 220800ZAUG2027. Classification: CONFIDENTIAL. Theater-wide assessment.</div>
+    </div>
+    <div class="briefing-badge-slot">
+      <span class="war-badge-outline">CONF</span>
+    </div>
+  </div>
+
+  <div class="briefing-block briefing-bravo">
+    <div class="briefing-number">SITREP BRAVO</div>
+    <div class="briefing-info">
+      <div class="briefing-title briefing-title-bravo">Intelligence Analysis -- Know the Terrain</div>
+      <div class="briefing-meta">DTG: 221000ZAUG2027. Classification: SECRET. Deep reconnaissance findings.</div>
+    </div>
+    <div class="briefing-badge-slot">
+      <span class="war-badge-outline">SEC</span>
+    </div>
+  </div>
+
+  <div class="briefing-block briefing-charlie">
+    <div class="briefing-number">SITREP CHARLIE</div>
+    <div class="briefing-info">
+      <div class="briefing-title briefing-title-charlie">Force Deployment -- Position the Assets</div>
+      <div class="briefing-meta">DTG: 221200ZAUG2027. Classification: SECRET. Full deployment manifest.</div>
+    </div>
+    <div class="briefing-badge-slot">
+      <span class="war-badge">SEC</span>
+    </div>
+  </div>
+
+  <div class="briefing-block briefing-delta">
+    <div class="briefing-number">SITREP DELTA</div>
+    <div class="briefing-info">
+      <div class="briefing-title briefing-title-delta">Operations Planning -- Execute the Mission</div>
+      <div class="briefing-meta">DTG: 221400ZAUG2027. Classification: TOP SECRET. Final mission orders.</div>
+    </div>
+    <div class="briefing-badge-slot">
+      <span class="war-badge">TS</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Tactical Display</div>
+  <h2>Force Readiness</h2>
+
+  <!-- SVG tactical display panel -->
+  <svg width="100%" height="160" viewBox="0 0 600 160" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Panel frame -->
+    <rect x="5" y="5" width="590" height="150" stroke="#1a2e1a" stroke-width="2" fill="none" opacity="0.4"/>
+    <rect x="10" y="10" width="580" height="140" stroke="#30c060" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Readiness bars -->
+    <rect x="60" y="110" width="80" height="20" fill="#30c060" opacity="0.1"/>
+    <rect x="180" y="90" width="80" height="40" fill="#30c060" opacity="0.15"/>
+    <rect x="300" y="55" width="80" height="75" fill="#30c060" opacity="0.2"/>
+    <rect x="420" y="25" width="80" height="105" fill="#30c060" opacity="0.25"/>
+    <!-- Bar outlines -->
+    <rect x="60" y="110" width="80" height="20" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="180" y="90" width="80" height="40" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="300" y="55" width="80" height="75" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <rect x="420" y="25" width="80" height="105" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Readiness percentages -->
+    <text x="100" y="105" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="9" opacity="0.3">25%</text>
+    <text x="220" y="83" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="11" opacity="0.35">50%</text>
+    <text x="340" y="48" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="13" opacity="0.4">75%</text>
+    <text x="460" y="20" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="15" opacity="0.45">100%</text>
+    <!-- Phase labels -->
+    <text x="100" y="145" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">ALPHA</text>
+    <text x="220" y="145" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">BRAVO</text>
+    <text x="340" y="145" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">CHARLIE</text>
+    <text x="460" y="145" text-anchor="middle" fill="#408040" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="7" letter-spacing="1">DELTA</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Comms Network</div>
+  <h2>Communication Lines</h2>
+
+  <!-- SVG communication line diagram -->
+  <svg width="280" height="240" viewBox="0 0 280 240" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Central command node -->
+    <circle cx="140" cy="120" r="20" stroke="#30c060" stroke-width="2" fill="none" opacity="0.3"/>
+    <circle cx="140" cy="120" r="10" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <text x="140" y="123" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="6" opacity="0.4">CMD</text>
+    <!-- Satellite nodes -->
+    <circle cx="60" cy="50" r="14" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="60" y="53" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.3">ALPHA</text>
+    <circle cx="220" cy="50" r="14" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="220" y="53" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.3">BRAVO</text>
+    <circle cx="50" cy="190" r="14" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="50" y="193" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="4.5" opacity="0.3">CHARLIE</text>
+    <circle cx="230" cy="190" r="14" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="230" y="193" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="5" opacity="0.3">DELTA</text>
+    <!-- Communication lines to central command -->
+    <line x1="72" y1="60" x2="125" y2="108" stroke="#30c060" stroke-width="1" opacity="0.15"/>
+    <line x1="208" y1="60" x2="155" y2="108" stroke="#30c060" stroke-width="1" opacity="0.15"/>
+    <line x1="62" y1="178" x2="130" y2="132" stroke="#30c060" stroke-width="1" opacity="0.15"/>
+    <line x1="218" y1="178" x2="150" y2="132" stroke="#30c060" stroke-width="1" opacity="0.15"/>
+    <!-- Cross-links between satellite nodes -->
+    <line x1="74" y1="50" x2="206" y2="50" stroke="#408040" stroke-width="0.5" opacity="0.1" stroke-dasharray="4 3"/>
+    <line x1="60" y1="64" x2="50" y2="176" stroke="#408040" stroke-width="0.5" opacity="0.1" stroke-dasharray="4 3"/>
+    <line x1="220" y1="64" x2="230" y2="176" stroke="#408040" stroke-width="0.5" opacity="0.1" stroke-dasharray="4 3"/>
+    <line x1="64" y1="190" x2="216" y2="190" stroke="#408040" stroke-width="0.5" opacity="0.1" stroke-dasharray="4 3"/>
+    <!-- Signal pulse indicators -->
+    <circle cx="98" cy="84" r="3" fill="#30c060" opacity="0.12"/>
+    <circle cx="182" cy="84" r="3" fill="#30c060" opacity="0.12"/>
+    <circle cx="96" cy="156" r="3" fill="#30c060" opacity="0.12"/>
+    <circle cx="184" cy="156" r="3" fill="#30c060" opacity="0.12"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">alpha > bravo > charlie > delta</p>
+</div>
+
+</div>

--- a/war-room/content/protocol.md
+++ b/war-room/content/protocol.md
@@ -1,0 +1,42 @@
++++
+title = "Protocol"
+description = "Operational protocols and standing orders for the War Room strategy summit"
++++
+
+<div class="section-block">
+  <div class="section-label">Standing Orders</div>
+  <h2>Operational Protocols</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The War Room operates under strict operational security protocols. All attendees are briefed on classification handling, communication procedures, and conduct requirements before entering the command center. These protocols ensure the integrity of the summit and the security of all strategic discussions.</p>
+
+  <!-- SVG briefing screen frame -->
+  <svg width="260" height="180" viewBox="0 0 260 180" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Outer frame -->
+    <rect x="5" y="5" width="250" height="170" stroke="#30c060" stroke-width="2" fill="none" opacity="0.25"/>
+    <!-- Inner frame -->
+    <rect x="15" y="15" width="230" height="150" stroke="#1a2e1a" stroke-width="1" fill="none" opacity="0.3"/>
+    <!-- Header bar -->
+    <rect x="15" y="15" width="230" height="20" fill="#30c060" opacity="0.08"/>
+    <text x="130" y="29" text-anchor="middle" fill="#30c060" font-family="Orbitron, sans-serif" font-size="7" font-weight="700" letter-spacing="2" opacity="0.4">PROTOCOL DOCUMENT</text>
+    <!-- Protocol lines -->
+    <line x1="30" y1="50" x2="200" y2="50" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="48" fill="#30c060" font-family="IBM Plex Sans, sans-serif" font-size="5" font-weight="700" opacity="0.3">01. CLASSIFICATION HANDLING</text>
+    <line x1="30" y1="70" x2="200" y2="70" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="68" fill="#30c060" font-family="IBM Plex Sans, sans-serif" font-size="5" font-weight="700" opacity="0.3">02. COMMUNICATION SECURITY</text>
+    <line x1="30" y1="90" x2="200" y2="90" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="88" fill="#30c060" font-family="IBM Plex Sans, sans-serif" font-size="5" font-weight="700" opacity="0.3">03. NEED-TO-KNOW BASIS</text>
+    <line x1="30" y1="110" x2="200" y2="110" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="108" fill="#30c060" font-family="IBM Plex Sans, sans-serif" font-size="5" font-weight="700" opacity="0.3">04. PHYSICAL SECURITY</text>
+    <line x1="30" y1="130" x2="200" y2="130" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="128" fill="#30c060" font-family="IBM Plex Sans, sans-serif" font-size="5" font-weight="700" opacity="0.3">05. CONDUCT OF BRIEFINGS</text>
+    <!-- Classification stamp -->
+    <text x="130" y="155" text-anchor="middle" fill="#408040" font-family="Orbitron, sans-serif" font-size="6" font-weight="700" letter-spacing="3" opacity="0.25">UNCLASSIFIED // FOUO</text>
+  </svg>
+
+  <div style="margin-top: 32px;">
+    <span class="war-badge-outline" style="font-size: 0.75rem; padding: 5px 16px; margin-right: 8px;">OPSEC</span>
+    <span class="war-badge-outline" style="font-size: 0.75rem; padding: 5px 16px; margin-right: 8px;">COMSEC</span>
+    <span class="war-badge-outline" style="font-size: 0.75rem; padding: 5px 16px;">PHYSEC</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Rajdhani', sans-serif; font-weight: 700; font-size: 0.85rem; letter-spacing: 0.15em;">DTG: 221400ZAUG2027 // COMMAND CENTER BRAVO</p>
+</div>

--- a/war-room/content/register.md
+++ b/war-room/content/register.md
@@ -1,0 +1,30 @@
++++
+title = "Register"
+description = "Enlist for the War Room strategy summit"
++++
+
+<div class="section-block">
+  <div class="section-label">Enlistment</div>
+  <h2>Join the Operation</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Enlist for the War Room Strategy Summit. All command personnel must register for their assigned briefing sequence. Early enlistment ensures access to the full SITREP cycle from Alpha through Delta. Late arrivals will be assigned to available briefing slots based on operational need and classification clearance.</p>
+
+  <!-- SVG command center icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <!-- Command star -->
+    <polygon points="50,15 58,38 82,38 63,52 70,75 50,62 30,75 37,52 18,38 42,38" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <!-- Inner circle -->
+    <circle cx="50" cy="48" r="12" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Center dot -->
+    <circle cx="50" cy="48" r="3" fill="#30c060" opacity="0.2"/>
+    <!-- Rank lines -->
+    <line x1="30" y1="85" x2="70" y2="85" stroke="#1a2e1a" stroke-width="1" opacity="0.3"/>
+    <line x1="35" y1="90" x2="65" y2="90" stroke="#1a2e1a" stroke-width="1" opacity="0.2"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="war-badge" style="font-size: 0.85rem; padding: 6px 20px;">COMMAND STAFF</span>
+    <span class="war-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">FIELD OFFICERS</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Rajdhani', sans-serif; font-weight: 700; font-size: 0.85rem; letter-spacing: 0.15em;">DTG: 221400ZAUG2027 // COMMAND CENTER BRAVO</p>
+</div>

--- a/war-room/static/css/style.css
+++ b/war-room/static/css/style.css
@@ -1,0 +1,512 @@
+/* War Room - Military Strategy Summit */
+/* Fonts: Orbitron / Rajdhani Bold display, IBM Plex Sans / Roboto Condensed body */
+
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Rajdhani:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=Roboto+Condensed:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a100a;
+  --bg-secondary: #080e08;
+  --bg-panel: #0e160e;
+  --text-primary: #c0e8c0;
+  --text-secondary: #70a870;
+  --text-muted: #408040;
+  --accent-green: #30c060;
+  --accent-bright: #40d070;
+  --accent-dim: #208040;
+  --border-color: #1a2e1a;
+  --border-accent: #30c060;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'IBM Plex Sans', 'Roboto Condensed', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Rajdhani', sans-serif; font-weight: 700; letter-spacing: 0.08em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-green);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-green);
+  border-bottom-color: var(--accent-green);
+}
+
+.nav-cta {
+  background-color: var(--accent-green) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 6rem;
+  font-weight: 900;
+  color: var(--accent-green);
+  margin-bottom: 8px;
+  letter-spacing: 0.08em;
+}
+
+.hero-subtitle {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 16px auto 24px;
+}
+
+.hero-date {
+  font-family: 'Rajdhani', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Briefing Block */
+.briefing-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.briefing-block.briefing-alpha { padding: 16px 18px; }
+.briefing-block.briefing-bravo { padding: 18px 20px; }
+.briefing-block.briefing-charlie { padding: 22px 24px; border-color: var(--accent-dim); }
+.briefing-block.briefing-delta { padding: 26px 28px; border-color: var(--accent-green); background: var(--bg-secondary); }
+
+.briefing-number {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  min-width: 100px;
+  text-align: center;
+  letter-spacing: 0.06em;
+}
+
+.briefing-info { flex: 1; }
+
+.briefing-title {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.03em;
+}
+
+.briefing-title-alpha { font-size: 0.95rem; }
+.briefing-title-bravo { font-size: 1.1rem; }
+.briefing-title-charlie { font-size: 1.3rem; }
+.briefing-title-delta { font-size: 1.5rem; font-family: 'Rajdhani', sans-serif; font-weight: 700; letter-spacing: 0.06em; color: var(--accent-green); }
+
+.briefing-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.briefing-badge-slot {
+  flex-shrink: 0;
+}
+
+/* War Badge */
+.war-badge {
+  display: inline-block;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-green);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.war-badge-outline {
+  display: inline-block;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-green);
+  color: var(--accent-green);
+  text-transform: uppercase;
+}
+
+/* Classification Stamps */
+.classification-stamp {
+  display: inline-block;
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 700;
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  padding: 3px 12px;
+  border: 2px solid var(--accent-green);
+  color: var(--accent-green);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.classification-stamp.confidential {
+  border-color: var(--accent-dim);
+  color: var(--accent-dim);
+}
+
+.classification-stamp.secret {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+/* SITREP Header */
+.sitrep-header {
+  font-family: 'Rajdhani', sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-green);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-green);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Rajdhani', sans-serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Rajdhani', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.03em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-green);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-green);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-green);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 8rem;
+  font-weight: 900;
+  color: var(--accent-green);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3.5rem; }
+  h1 { font-size: 2rem; }
+  .briefing-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+  .briefing-title-delta { font-size: 1.3rem; }
+}

--- a/war-room/templates/404.html
+++ b/war-room/templates/404.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Tactical crosshair -->
+        <circle cx="40" cy="40" r="25" stroke="#30c060" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <circle cx="40" cy="40" r="15" stroke="#30c060" stroke-width="1" fill="none" opacity="0.2"/>
+        <line x1="40" y1="10" x2="40" y2="30" stroke="#30c060" stroke-width="1" opacity="0.25"/>
+        <line x1="40" y1="50" x2="40" y2="70" stroke="#30c060" stroke-width="1" opacity="0.25"/>
+        <line x1="10" y1="40" x2="30" y2="40" stroke="#30c060" stroke-width="1" opacity="0.25"/>
+        <line x1="50" y1="40" x2="70" y2="40" stroke="#30c060" stroke-width="1" opacity="0.25"/>
+        <!-- Center dot -->
+        <circle cx="40" cy="40" r="2" fill="#30c060" opacity="0.3"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Target Not Acquired</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-green); font-family: 'IBM Plex Sans', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Command</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/war-room/templates/footer.html
+++ b/war-room/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">WAR ROOM // STRATEGY SUMMIT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Command</a>
+        <a href="{{ base_url }}/briefings/">Briefings</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/war-room/templates/header.html
+++ b/war-room/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">WAR ROOM</span>
+        <span class="logo-sub">strategy summit</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Command</a>
+        <a href="{{ base_url }}/briefings/">Briefings</a>
+        <a href="{{ base_url }}/protocol/">Protocol</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Enlist</a>
+      </nav>
+    </div>
+  </header>

--- a/war-room/templates/page.html
+++ b/war-room/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/war-room/templates/post.html
+++ b/war-room/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("briefing") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/war-room/templates/section.html
+++ b/war-room/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/war-room/templates/taxonomy.html
+++ b/war-room/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/war-room/templates/taxonomy_term.html
+++ b/war-room/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All briefings tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Closes #1652

## Summary
- Add war-room example site: military strategy summit with ops-room aesthetics
- SVG situation map overlays with unit position markers, tactical display panels, communication line diagrams, briefing screen frame borders
- Typography: Orbitron/Rajdhani Bold display in ops-room green, IBM Plex Sans/Roboto Condensed body
- SITREP headers with time-date groups, CONFIDENTIAL/SECRET track labels

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm green-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes war-room with correct tags