### PR TITLE
feat: add bell-tower example site

### DIFF
--- a/bell-tower/config.toml
+++ b/bell-tower/config.toml
@@ -1,0 +1,41 @@
+title = "Bell Tower"
+description = "Hourly chime schedule-driven event from a historic clock tower"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["chimes"]
+
+[markdown]
+safe = false

--- a/bell-tower/content/chimes/_index.md
+++ b/bell-tower/content/chimes/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Chimes"
+description = "All hourly chime sessions from the Bell Tower"
+sort_by = "weight"
+template = "section"
++++
+
+Four hours of the great bell. Each chime counted, each hour marked.

--- a/bell-tower/content/chimes/eleven-oclock.md
+++ b/bell-tower/content/chimes/eleven-oclock.md
@@ -1,0 +1,49 @@
++++
+title = "Hour XI -- Eleven O'Clock"
+date = "2027-09-14"
+description = "The eleventh hour rising resonance with eleven chimes building toward the apex"
+weight = 3
+tags = ["event", "light", "scheduled", "clock", "traditional"]
+[extra]
+chimes = "11"
+numeral = "XI"
+character = "Anticipation"
++++
+
+## Hour XI -- Rising Resonance
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="none" stroke="#8b6914" stroke-width="2" opacity="0.25"/>
+  <rect x="0" y="0" width="60" height="80" fill="#8b6914" opacity="0.16"/>
+  <text x="30" y="35" text-anchor="middle" fill="#2a2018" font-family="'Cormorant SC', serif" font-size="8" letter-spacing="1" opacity="0.6">HOUR</text>
+  <text x="30" y="58" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="20" opacity="0.7">XI</text>
+  <text x="170" y="35" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="12" letter-spacing="1">ELEVEN O'CLOCK</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-weight="700" font-size="8" letter-spacing="2">11 CHIMES // RISING RESONANCE</text>
+</svg>
+
+<span class="bell-badge">11 chimes</span>
+
+### Session Summary
+
+The penultimate hour. Eleven strokes carry a different quality -- the listener knows that only one more hour remains before the grand carillon. The bell seems to ring with greater urgency, though the bellringer maintains the same tempo. It is the anticipation of the twelfth that transforms the eleventh. The stone walls of the belfry have absorbed centuries of vibration at this hour, and the resonance deepens. Each chime hangs in the air a moment longer, as if reluctant to yield to silence before the final hour arrives.
+
+<!-- SVG chime count indicator -->
+<svg width="240" height="30" viewBox="0 0 240 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="12" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="34" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="56" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="78" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="100" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="122" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="144" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="166" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="188" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="210" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="232" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Chimes | 11 |
+| Numeral | XI |
+| Character | Anticipation |

--- a/bell-tower/content/chimes/nine-oclock.md
+++ b/bell-tower/content/chimes/nine-oclock.md
@@ -1,0 +1,47 @@
++++
+title = "Hour IX -- Nine O'Clock"
+date = "2027-09-14"
+description = "The ninth hour morning toll with nine chimes across the valley"
+weight = 1
+tags = ["event", "light", "scheduled", "clock", "traditional"]
+[extra]
+chimes = "9"
+numeral = "IX"
+character = "Opening"
++++
+
+## Hour IX -- The Morning Toll
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="none" stroke="#8b6914" stroke-width="2" opacity="0.2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#8b6914" opacity="0.12"/>
+  <text x="30" y="35" text-anchor="middle" fill="#2a2018" font-family="'Cormorant SC', serif" font-size="8" letter-spacing="1" opacity="0.6">HOUR</text>
+  <text x="30" y="58" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="20" opacity="0.7">IX</text>
+  <text x="170" y="35" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="12" letter-spacing="1">NINE O'CLOCK</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-weight="700" font-size="8" letter-spacing="2">9 CHIMES // MORNING TOLL</text>
+</svg>
+
+<span class="bell-badge-outline">9 chimes</span>
+
+### Session Summary
+
+Nine strikes of the bell open the day's schedule. The first chime breaks the morning silence -- a single brass note that lingers in the stone archways before the second follows. By the ninth stroke, the valley below has received the tower's announcement. The day has been formally declared. Listeners gather in the courtyard, counting each resonation against the echo that returns from the hillside opposite.
+
+<!-- SVG chime count indicator -->
+<svg width="200" height="30" viewBox="0 0 200 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="12" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="34" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="56" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="78" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="100" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="122" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="144" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="166" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="188" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Chimes | 9 |
+| Numeral | IX |
+| Character | Opening |

--- a/bell-tower/content/chimes/ten-oclock.md
+++ b/bell-tower/content/chimes/ten-oclock.md
@@ -1,0 +1,48 @@
++++
+title = "Hour X -- Ten O'Clock"
+date = "2027-09-14"
+description = "The tenth hour steady peal with ten measured chimes"
+weight = 2
+tags = ["event", "light", "scheduled", "clock", "traditional"]
+[extra]
+chimes = "10"
+numeral = "X"
+character = "Steady"
++++
+
+## Hour X -- The Steady Peal
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="none" stroke="#8b6914" stroke-width="2" opacity="0.2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#8b6914" opacity="0.14"/>
+  <text x="30" y="35" text-anchor="middle" fill="#2a2018" font-family="'Cormorant SC', serif" font-size="8" letter-spacing="1" opacity="0.6">HOUR</text>
+  <text x="30" y="58" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="20" opacity="0.7">X</text>
+  <text x="170" y="35" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="12" letter-spacing="1">TEN O'CLOCK</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-weight="700" font-size="8" letter-spacing="2">10 CHIMES // STEADY PEAL</text>
+</svg>
+
+<span class="bell-badge-outline">10 chimes</span>
+
+### Session Summary
+
+The tenth hour bell follows the established rhythm without hurry. One additional stroke beyond the ninth -- a single note more, yet it shifts the character from opening to sustained. The bellringer pulls the rope with practiced consistency. Each tone carries the same weight, the same duration, the same measured interval. This is the hour of constancy, where the tower demonstrates its reliability. The bell has been sounding for centuries. This hour, like every hour before it, falls precisely on time.
+
+<!-- SVG chime count indicator -->
+<svg width="220" height="30" viewBox="0 0 220 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="12" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="34" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="56" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="78" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="100" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="122" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="144" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="166" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="188" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+  <circle cx="210" cy="15" r="5" fill="#8b6914" opacity="0.2"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Chimes | 10 |
+| Numeral | X |
+| Character | Steady |

--- a/bell-tower/content/chimes/twelve-oclock.md
+++ b/bell-tower/content/chimes/twelve-oclock.md
@@ -1,0 +1,50 @@
++++
+title = "Hour XII -- Twelve O'Clock"
+date = "2027-09-14"
+description = "The twelfth hour grand carillon with twelve full strokes of the great bell"
+weight = 4
+tags = ["event", "light", "scheduled", "clock", "traditional"]
+[extra]
+chimes = "12"
+numeral = "XII"
+character = "Grand Carillon"
++++
+
+## Hour XII -- The Grand Carillon
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="none" stroke="#8b6914" stroke-width="2" opacity="0.3"/>
+  <rect x="0" y="0" width="60" height="80" fill="#8b6914" opacity="0.2"/>
+  <text x="30" y="35" text-anchor="middle" fill="#2a2018" font-family="'Cormorant SC', serif" font-size="8" letter-spacing="1" opacity="0.7">HOUR</text>
+  <text x="30" y="58" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="18" opacity="0.8">XII</text>
+  <text x="170" y="35" text-anchor="middle" fill="#2a2018" font-family="'Playfair Display', serif" font-size="12" letter-spacing="1">TWELVE O'CLOCK</text>
+  <text x="170" y="55" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-weight="700" font-size="8" letter-spacing="2">12 CHIMES // GRAND CARILLON</text>
+</svg>
+
+<span class="bell-badge">12 chimes</span>
+
+### Session Summary
+
+The twelfth stroke completes the cycle. Twelve full measures of the great bell, each one a declaration that the day has reached its zenith. The first chime arrives with the authority of a pronouncement. By the sixth, the accumulated sound fills the tower chamber. By the ninth, the valley below has gone still. The tenth, eleventh, and twelfth are not simply additions -- they are the culmination of all hours that preceded them. When the final resonance fades into silence, the listener understands what it means to mark time with bronze and stone.
+
+<!-- SVG chime count indicator -->
+<svg width="260" height="30" viewBox="0 0 260 30" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <circle cx="12" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="34" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="56" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="78" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="100" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="122" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="144" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="166" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="188" cy="15" r="5" fill="#8b6914" opacity="0.25"/>
+  <circle cx="210" cy="15" r="5" fill="#8b6914" opacity="0.3"/>
+  <circle cx="232" cy="15" r="5" fill="#8b6914" opacity="0.3"/>
+  <circle cx="254" cy="15" r="5" fill="#8b6914" opacity="0.35"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Chimes | 12 |
+| Numeral | XII |
+| Character | Grand Carillon |

--- a/bell-tower/content/grounds.md
+++ b/bell-tower/content/grounds.md
@@ -1,0 +1,46 @@
++++
+title = "Grounds"
+description = "The tower grounds, courtyard, and surrounding architecture"
++++
+
+<div class="section-block">
+  <div class="section-label">Tower Grounds</div>
+  <h2>The Campanile Courtyard</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The bell tower stands at the center of a walled courtyard paved in limestone worn smooth by centuries of passage. From the north approach, the tower rises above the roofline of the cloister, its belfry arches open to the wind. The courtyard offers four listening positions, each with a distinct acoustic character shaped by the surrounding walls and the angle of the bell's swing.</p>
+
+  <!-- SVG courtyard plan view -->
+  <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto; display: block;">
+    <!-- Courtyard walls -->
+    <rect x="20" y="20" width="160" height="160" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <!-- Tower footprint (center) -->
+    <rect x="75" y="75" width="50" height="50" stroke="#8b6914" stroke-width="2" fill="none" opacity="0.25"/>
+    <!-- Cross inside tower -->
+    <line x1="100" y1="78" x2="100" y2="122" stroke="#8b6914" stroke-width="0.8" opacity="0.12"/>
+    <line x1="78" y1="100" x2="122" y2="100" stroke="#8b6914" stroke-width="0.8" opacity="0.12"/>
+    <!-- Listening positions -->
+    <circle cx="100" cy="40" r="4" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="160" cy="100" r="4" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="100" cy="160" r="4" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <circle cx="40" cy="100" r="4" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Sound propagation lines -->
+    <line x1="100" y1="75" x2="100" y2="44" stroke="#8b6914" stroke-width="0.5" opacity="0.1" stroke-dasharray="3 2"/>
+    <line x1="125" y1="100" x2="156" y2="100" stroke="#8b6914" stroke-width="0.5" opacity="0.1" stroke-dasharray="3 2"/>
+    <line x1="100" y1="125" x2="100" y2="156" stroke="#8b6914" stroke-width="0.5" opacity="0.1" stroke-dasharray="3 2"/>
+    <line x1="75" y1="100" x2="44" y2="100" stroke="#8b6914" stroke-width="0.5" opacity="0.1" stroke-dasharray="3 2"/>
+    <!-- Labels -->
+    <text x="100" y="35" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-size="6" letter-spacing="1">NORTH</text>
+    <text x="100" y="172" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-size="6" letter-spacing="1">SOUTH</text>
+    <!-- Gate -->
+    <line x1="90" y1="180" x2="110" y2="180" stroke="#8b6914" stroke-width="2" opacity="0.2"/>
+  </svg>
+
+  <h3>Acoustic Positions</h3>
+
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;"><strong style="color: var(--text-primary);">North Approach</strong> -- The bell sound arrives first here, direct and unobstructed. The clapper's initial strike is clearest from this position. Recommended for those attending Hour IX.</p>
+
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;"><strong style="color: var(--text-primary);">East Cloister</strong> -- The stone arcade creates a natural reverberation chamber. Each chime lingers two beats longer than from other positions. Suited to the steady rhythm of Hour X.</p>
+
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;"><strong style="color: var(--text-primary);">South Garden</strong> -- Open to the sky, the sound expands here. The eleventh hour chimes seem to rise rather than fall. Best for experiencing Hour XI's anticipation.</p>
+
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;"><strong style="color: var(--text-primary);">West Gallery</strong> -- The gallery's vaulted ceiling captures the full harmonic spectrum of the great bell. Reserved for the twelfth hour grand carillon. The twelve strokes fill this space completely.</p>
+</div>

--- a/bell-tower/content/index.md
+++ b/bell-tower/content/index.md
@@ -1,0 +1,196 @@
++++
+title = "Home"
+description = "Hourly chime schedule-driven event from a historic clock tower"
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Hourly Chime Schedule Event</div>
+    <h1>BELL TOWER</h1>
+    <p class="hero-subtitle">Four hours marked by the great bell. From the ninth hour to the twelfth, each chime reverberates through stone and sky. The tower keeps time. The bell speaks for all who listen.</p>
+    <p class="hero-date">2027.09.14 // THE CAMPANILE, FLORENCE</p>
+
+    <!-- SVG clock face dial -->
+    <svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Clock face circle -->
+      <circle cx="120" cy="120" r="100" stroke="#8b6914" stroke-width="2" fill="none" opacity="0.2"/>
+      <circle cx="120" cy="120" r="95" stroke="#8b6914" stroke-width="0.5" fill="none" opacity="0.12"/>
+      <circle cx="120" cy="120" r="6" fill="#8b6914" opacity="0.2"/>
+      <!-- Hour markers -->
+      <line x1="120" y1="25" x2="120" y2="35" stroke="#8b6914" stroke-width="2" opacity="0.3"/>
+      <line x1="170" y1="33" x2="165" y2="42" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="207" y1="70" x2="199" y2="75" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="215" y1="120" x2="205" y2="120" stroke="#8b6914" stroke-width="2" opacity="0.3"/>
+      <line x1="207" y1="170" x2="199" y2="165" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="170" y1="207" x2="165" y2="198" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="120" y1="215" x2="120" y2="205" stroke="#8b6914" stroke-width="2" opacity="0.3"/>
+      <line x1="70" y1="207" x2="75" y2="198" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="33" y1="170" x2="41" y2="165" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="25" y1="120" x2="35" y2="120" stroke="#8b6914" stroke-width="2" opacity="0.3"/>
+      <line x1="33" y1="70" x2="41" y2="75" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <line x1="70" y1="33" x2="75" y2="42" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+      <!-- Roman numerals at key positions -->
+      <text x="120" y="50" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="12" opacity="0.3">XII</text>
+      <text x="197" y="124" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="12" opacity="0.3">III</text>
+      <text x="120" y="202" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="12" opacity="0.3">VI</text>
+      <text x="43" y="124" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="12" opacity="0.3">IX</text>
+      <!-- Clock hands pointing to XII -->
+      <line x1="120" y1="120" x2="120" y2="58" stroke="#8b6914" stroke-width="2.5" opacity="0.25" stroke-linecap="round"/>
+      <line x1="120" y1="120" x2="120" y2="78" stroke="#8b6914" stroke-width="3.5" opacity="0.3" stroke-linecap="round"/>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Hourly Schedule</div>
+  <h2>Chime Sessions</h2>
+
+  <div class="chime-block chime-ix">
+    <div class="chime-numeral">IX</div>
+    <div class="chime-info">
+      <div class="chime-title chime-title-sm">The Ninth Hour -- Morning Toll</div>
+      <div class="chime-meta">Nine chimes ring across the valley. The day's first full measure.</div>
+    </div>
+    <div class="chime-count-slot">
+      <span class="bell-badge-outline">9</span>
+    </div>
+  </div>
+
+  <div class="chime-block chime-x">
+    <div class="chime-numeral">X</div>
+    <div class="chime-info">
+      <div class="chime-title chime-title-md">The Tenth Hour -- Steady Peal</div>
+      <div class="chime-meta">Ten strikes mark the mid-morning. Rhythm established.</div>
+    </div>
+    <div class="chime-count-slot">
+      <span class="bell-badge-outline">10</span>
+    </div>
+  </div>
+
+  <div class="chime-block chime-xi">
+    <div class="chime-numeral">XI</div>
+    <div class="chime-info">
+      <div class="chime-title chime-title-lg">The Eleventh Hour -- Rising Resonance</div>
+      <div class="chime-meta">Eleven chimes build toward the apex. Anticipation grows.</div>
+    </div>
+    <div class="chime-count-slot">
+      <span class="bell-badge">11</span>
+    </div>
+  </div>
+
+  <div class="chime-block chime-xii">
+    <div class="chime-numeral">XII</div>
+    <div class="chime-info">
+      <div class="chime-title chime-title-xl">The Twelfth Hour -- Grand Carillon</div>
+      <div class="chime-meta">Twelve strokes of the great bell. The full measure sounds.</div>
+    </div>
+    <div class="chime-count-slot">
+      <span class="bell-badge">12</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Bell</div>
+  <h2>The Great Bell</h2>
+
+  <!-- SVG bell silhouette icon -->
+  <svg width="160" height="200" viewBox="0 0 160 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Bell body -->
+    <path d="M40,130 Q40,50 80,30 Q120,50 120,130 L40,130 Z" stroke="#8b6914" stroke-width="2" fill="none" opacity="0.2"/>
+    <!-- Bell crown / yoke -->
+    <line x1="80" y1="30" x2="80" y2="16" stroke="#8b6914" stroke-width="2" opacity="0.25"/>
+    <rect x="68" y="10" width="24" height="8" rx="2" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Bell lip flare -->
+    <path d="M32,130 Q32,140 42,144 L118,144 Q128,140 128,130" stroke="#8b6914" stroke-width="2" fill="none" opacity="0.25"/>
+    <!-- Clapper -->
+    <line x1="80" y1="100" x2="80" y2="140" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+    <circle cx="80" cy="144" r="5" fill="#8b6914" opacity="0.15"/>
+    <!-- Sound rings -->
+    <path d="M26,110 Q16,120 26,130" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.1"/>
+    <path d="M18,105 Q6,120 18,135" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.07"/>
+    <path d="M134,110 Q144,120 134,130" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.1"/>
+    <path d="M142,105 Q154,120 142,135" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.07"/>
+    <!-- Inscription band -->
+    <path d="M50,90 L110,90" stroke="#8b6914" stroke-width="0.5" opacity="0.12"/>
+    <path d="M48,96 L112,96" stroke="#8b6914" stroke-width="0.5" opacity="0.12"/>
+    <text x="80" y="94" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="5" opacity="0.15" letter-spacing="3">ANNO DOMINI</text>
+    <!-- Chime count markers -->
+    <text x="80" y="174" text-anchor="middle" fill="#5a4a38" font-family="'Cormorant SC', serif" font-weight="700" font-size="8" letter-spacing="4">IX . X . XI . XII</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Architecture</div>
+  <h2>Tower Profile</h2>
+
+  <!-- SVG tower architecture illustration -->
+  <svg width="200" height="280" viewBox="0 0 200 280" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Tower base -->
+    <rect x="50" y="180" width="100" height="80" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.15"/>
+    <!-- Tower shaft -->
+    <rect x="55" y="80" width="90" height="100" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.18"/>
+    <!-- Belfry arches -->
+    <path d="M62,80 L62,50 Q80,35 98,50 L98,80" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <path d="M102,80 L102,50 Q120,35 138,50 L138,80" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Spire -->
+    <path d="M75,50 L100,10 L125,50" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <!-- Cross at top -->
+    <line x1="100" y1="10" x2="100" y2="2" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+    <line x1="96" y1="5" x2="104" y2="5" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+    <!-- Windows on shaft -->
+    <rect x="72" y="100" width="12" height="20" rx="6" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <rect x="116" y="100" width="12" height="20" rx="6" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <rect x="72" y="140" width="12" height="20" rx="6" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <rect x="116" y="140" width="12" height="20" rx="6" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <!-- Door -->
+    <path d="M88,260 L88,230 Q100,218 112,230 L112,260" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.15"/>
+    <!-- Bell inside belfry (small) -->
+    <path d="M76,72 Q76,60 80,58 Q84,60 84,72" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <path d="M116,72 Q116,60 120,58 Q124,60 124,72" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+    <!-- Cornice lines -->
+    <line x1="48" y1="180" x2="152" y2="180" stroke="#8b6914" stroke-width="1" opacity="0.12"/>
+    <line x1="53" y1="80" x2="147" y2="80" stroke="#8b6914" stroke-width="1" opacity="0.12"/>
+    <!-- Ground line -->
+    <line x1="30" y1="260" x2="170" y2="260" stroke="#8b6914" stroke-width="1" opacity="0.1"/>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Cormorant SC', serif; font-weight: 700; font-size: 0.85rem; color: var(--text-muted); letter-spacing: 0.25em; text-transform: uppercase;">IX . X . XI . XII -- the hours ring true</p>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Dial</div>
+  <h2>Clock Hand Positions</h2>
+
+  <!-- SVG clock hand positions for each session hour -->
+  <svg width="100%" height="140" viewBox="0 0 560 140" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 560px;">
+    <!-- IX o'clock -->
+    <circle cx="70" cy="60" r="40" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="70" cy="60" r="2" fill="#8b6914" opacity="0.2"/>
+    <line x1="70" y1="60" x2="70" y2="30" stroke="#8b6914" stroke-width="1.5" opacity="0.2" stroke-linecap="round"/>
+    <line x1="70" y1="60" x2="42" y2="60" stroke="#8b6914" stroke-width="2" opacity="0.25" stroke-linecap="round"/>
+    <text x="70" y="120" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="14" opacity="0.3">IX</text>
+    <!-- X o'clock -->
+    <circle cx="210" cy="60" r="40" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="210" cy="60" r="2" fill="#8b6914" opacity="0.2"/>
+    <line x1="210" y1="60" x2="210" y2="30" stroke="#8b6914" stroke-width="1.5" opacity="0.2" stroke-linecap="round"/>
+    <line x1="210" y1="60" x2="193" y2="30" stroke="#8b6914" stroke-width="2" opacity="0.25" stroke-linecap="round"/>
+    <text x="210" y="120" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="14" opacity="0.3">X</text>
+    <!-- XI o'clock -->
+    <circle cx="350" cy="60" r="40" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="350" cy="60" r="2" fill="#8b6914" opacity="0.2"/>
+    <line x1="350" y1="60" x2="350" y2="30" stroke="#8b6914" stroke-width="1.5" opacity="0.2" stroke-linecap="round"/>
+    <line x1="350" y1="60" x2="340" y2="26" stroke="#8b6914" stroke-width="2" opacity="0.25" stroke-linecap="round"/>
+    <text x="350" y="120" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="14" opacity="0.3">XI</text>
+    <!-- XII o'clock -->
+    <circle cx="490" cy="60" r="40" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.15"/>
+    <circle cx="490" cy="60" r="2" fill="#8b6914" opacity="0.2"/>
+    <line x1="490" y1="60" x2="490" y2="30" stroke="#8b6914" stroke-width="1.5" opacity="0.2" stroke-linecap="round"/>
+    <line x1="490" y1="60" x2="490" y2="33" stroke="#8b6914" stroke-width="2.5" opacity="0.3" stroke-linecap="round"/>
+    <text x="490" y="120" text-anchor="middle" fill="#8b6914" font-family="'Playfair Display', serif" font-size="14" opacity="0.35">XII</text>
+  </svg>
+</div>
+
+</div>

--- a/bell-tower/content/register.md
+++ b/bell-tower/content/register.md
@@ -1,0 +1,27 @@
++++
+title = "Register"
+description = "Attend the Bell Tower hourly chime schedule event"
++++
+
+<div class="section-block">
+  <div class="section-label">Registration</div>
+  <h2>Attend the Chime Schedule</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">Select your hour and listening position. Each session admits a limited number of attendees to preserve the acoustic experience. Early hours offer intimate observation of the bellringer's craft. The twelfth hour grand carillon is open to all registered attendees regardless of session.</p>
+
+  <!-- SVG bell icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <path d="M32,65 Q32,30 50,20 Q68,30 68,65 L32,65 Z" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <line x1="50" y1="20" x2="50" y2="12" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+    <circle cx="50" cy="10" r="3" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <path d="M28,65 Q28,70 33,72 L67,72 Q72,70 72,65" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+    <line x1="50" y1="55" x2="50" y2="68" stroke="#8b6914" stroke-width="1" opacity="0.15"/>
+    <circle cx="50" cy="70" r="2.5" fill="#8b6914" opacity="0.12"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="bell-badge" style="font-size: 0.85rem; padding: 6px 20px;">IX -- X (EARLY)</span>
+    <span class="bell-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">XI -- XII (LATE)</span>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Cormorant SC', serif; font-size: 0.9rem; letter-spacing: 0.15em;">2027.09.14 // THE CAMPANILE, FLORENCE</p>
+</div>

--- a/bell-tower/static/css/style.css
+++ b/bell-tower/static/css/style.css
@@ -1,0 +1,582 @@
+/* Bell Tower - Hourly Chime Schedule Event */
+/* Fonts: Playfair Display / Cormorant SC display for hour markers, EB Garamond / Crimson Pro body */
+
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Cormorant+SC:wght@400;500;600;700&family=EB+Garamond:wght@400;500;600;700&family=Crimson+Pro:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #f5f0e8;
+  --bg-secondary: #ede6d8;
+  --bg-panel: #e8e0d0;
+  --text-primary: #2a2018;
+  --text-secondary: #5a4a38;
+  --text-muted: #8a7a60;
+  --accent-bell: #8b6914;
+  --border-color: #d0c8b8;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'EB Garamond', 'Crimson Pro', Georgia, serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.7;
+  font-size: 17px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+}
+
+h1 { font-size: 2.4rem; }
+h2 { font-size: 1.6rem; }
+h3 {
+  font-size: 1.1rem;
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+a {
+  color: var(--accent-bell);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Layout */
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 3px solid var(--accent-bell);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.site-logo:hover {
+  text-decoration: none;
+}
+
+.site-logo .logo-main {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--accent-bell);
+  letter-spacing: 0.06em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-bell);
+  border-bottom-color: var(--accent-bell);
+  text-decoration: none;
+}
+
+.nav-cta {
+  background-color: var(--accent-bell) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+.nav-cta:hover {
+  opacity: 0.9;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 3px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--accent-bell);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 5rem;
+  color: var(--accent-bell);
+  margin-bottom: 8px;
+  letter-spacing: 0.08em;
+}
+
+.hero-subtitle {
+  font-family: 'EB Garamond', serif;
+  font-weight: 400;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 16px auto 24px;
+  line-height: 1.7;
+}
+
+.hero-date {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-bell);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Chime Block - grows with each hour */
+.chime-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.chime-block.chime-ix {
+  padding: 14px 18px;
+}
+
+.chime-block.chime-x {
+  padding: 18px 20px;
+}
+
+.chime-block.chime-xi {
+  padding: 22px 24px;
+  border-color: var(--accent-bell);
+  border-width: 1px;
+}
+
+.chime-block.chime-xii {
+  padding: 28px 28px;
+  border-color: var(--accent-bell);
+  border-width: 2px;
+  background: var(--bg-secondary);
+}
+
+.chime-numeral {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--accent-bell);
+  min-width: 60px;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.chime-info {
+  flex: 1;
+}
+
+/* Growing title sizes by hour */
+.chime-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+}
+
+.chime-title-sm { font-size: 0.95rem; }
+.chime-title-md { font-size: 1.1rem; }
+.chime-title-lg { font-size: 1.25rem; }
+
+.chime-title-xl {
+  font-size: 1.45rem;
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent-bell);
+}
+
+.chime-meta {
+  font-family: 'Crimson Pro', serif;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 3px;
+}
+
+.chime-count-slot {
+  flex-shrink: 0;
+}
+
+/* Bell Badge */
+.bell-badge {
+  display: inline-block;
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  background: var(--accent-bell);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.bell-badge-outline {
+  display: inline-block;
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-bell);
+  color: var(--accent-bell);
+  text-transform: uppercase;
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Cormorant SC', serif;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 {
+  margin-top: 40px;
+  margin-bottom: 14px;
+}
+
+.prose h3 {
+  margin-top: 28px;
+  margin-bottom: 10px;
+}
+
+.prose p {
+  margin-bottom: 16px;
+}
+
+.prose ul, .prose ol {
+  margin-bottom: 14px;
+  padding-left: 24px;
+}
+
+.prose li {
+  margin-bottom: 4px;
+}
+
+.prose code {
+  font-family: 'Fira Code', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.88em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-bell);
+  text-decoration: underline;
+}
+
+.prose a:hover {
+  color: var(--text-primary);
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 2px solid var(--accent-bell);
+  font-weight: 600;
+  font-size: 0.85rem;
+  font-family: 'Cormorant SC', serif;
+  letter-spacing: 0.06em;
+  color: var(--text-primary);
+}
+
+.prose td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'EB Garamond', serif;
+  color: var(--text-secondary);
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Playfair Display', serif;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.01em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-bell);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+  font-family: 'Crimson Pro', serif;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Cormorant SC', serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-bell);
+  color: var(--accent-bell);
+  text-decoration: none;
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 3px solid var(--accent-bell);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Cormorant SC', serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-bell);
+  text-decoration: none;
+}
+
+.footer-powered {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-family: 'Crimson Pro', serif;
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.footer-powered a:hover {
+  color: var(--accent-bell);
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 7rem;
+  color: var(--accent-bell);
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.error-msg {
+  font-family: 'Cormorant SC', serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 {
+    font-size: 3rem;
+  }
+
+  h1 {
+    font-size: 1.8rem;
+  }
+
+  .chime-block {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .listing-item {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .header-inner {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .site-nav {
+    gap: 14px;
+  }
+
+  .chime-title-xl {
+    font-size: 1.2rem;
+  }
+
+  .chime-numeral {
+    min-width: auto;
+  }
+}

--- a/bell-tower/templates/404.html
+++ b/bell-tower/templates/404.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Bell silhouette -->
+        <path d="M28,50 Q28,25 40,18 Q52,25 52,50 L28,50 Z" stroke="#8b6914" stroke-width="1.5" fill="none" opacity="0.25"/>
+        <!-- Bell crown -->
+        <line x1="40" y1="18" x2="40" y2="12" stroke="#8b6914" stroke-width="1.5" opacity="0.2"/>
+        <circle cx="40" cy="10" r="3" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+        <!-- Clapper -->
+        <line x1="40" y1="42" x2="40" y2="52" stroke="#8b6914" stroke-width="1" opacity="0.2"/>
+        <circle cx="40" cy="54" r="2.5" fill="#8b6914" opacity="0.15"/>
+        <!-- Bell lip -->
+        <path d="M24,50 Q24,54 28,56 L52,56 Q56,54 56,50" stroke="#8b6914" stroke-width="1" fill="none" opacity="0.2"/>
+        <!-- Sound waves -->
+        <path d="M22,38 Q18,40 22,42" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+        <path d="M58,38 Q62,40 58,42" stroke="#8b6914" stroke-width="0.8" fill="none" opacity="0.12"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Silence in the Tower</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-bell); font-family: 'Cormorant SC', serif; font-weight: 700; font-size: 0.85rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Tower</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/bell-tower/templates/footer.html
+++ b/bell-tower/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">BELL TOWER // CHIME SCHEDULE</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Tower</a>
+        <a href="{{ base_url }}/chimes/">Chimes</a>
+        <a href="{{ base_url }}/grounds/">Grounds</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/bell-tower/templates/header.html
+++ b/bell-tower/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">BELL TOWER</span>
+        <span class="logo-sub">chime schedule</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Tower</a>
+        <a href="{{ base_url }}/chimes/">Chimes</a>
+        <a href="{{ base_url }}/grounds/">Grounds</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Attend</a>
+      </nav>
+    </div>
+  </header>

--- a/bell-tower/templates/page.html
+++ b/bell-tower/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/bell-tower/templates/post.html
+++ b/bell-tower/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("chime") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/bell-tower/templates/section.html
+++ b/bell-tower/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/bell-tower/templates/taxonomy.html
+++ b/bell-tower/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/bell-tower/templates/taxonomy_term.html
+++ b/bell-tower/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All chimes tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -316,6 +316,13 @@
     "glamorous",
     "luxury"
   ],
+  "bell-tower": [
+    "event",
+    "light",
+    "scheduled",
+    "clock",
+    "traditional"
+  ],
   "bijou": [
     "dark",
     "elegant",


### PR DESCRIPTION
Closes #1651

## Summary
- Add bell-tower example site: hourly chime schedule-driven event with clock tower aesthetics
- SVG clock face dial illustrations, bell silhouette icons, clock hand position illustrations, tower architecture illustrations
- Typography: Playfair Display/Cormorant SC display for hour markers, EB Garamond/Crimson Pro body
- Sessions marked by Roman numerals IX/X/XI/XII, chime count indicators
- Light theme with warm cream/parchment palette

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm light color scheme with no CSS gradients
- [ ] Verify tags.json includes bell-tower with correct tags