### PR TITLE
feat: add reveille example site

### DIFF
--- a/reveille/config.toml
+++ b/reveille/config.toml
@@ -1,0 +1,41 @@
+title = "Reveille"
+description = "Military dawn assembly event"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["formations"]
+
+[markdown]
+safe = false

--- a/reveille/content/formations/_index.md
+++ b/reveille/content/formations/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Formations"
+description = "All formation stages in the Reveille dawn assembly"
+sort_by = "weight"
+template = "section"
++++
+
+Four formation stages. Escalating assembly. From pre-dawn muster through full parade at first light.

--- a/reveille/content/formations/battalion-assembly.md
+++ b/reveille/content/formations/battalion-assembly.md
@@ -1,0 +1,53 @@
++++
+title = "Battalion Assembly -- Colors"
+date = "2026-04-12"
+description = "Battalion-level assembly with colors posted at 0530 Zulu"
+weight = 3
+tags = ["battalion", "colors", "assembly"]
+[extra]
+zulu_time = "0530Z"
+unit = "Battalion"
+phase = "Colors"
++++
+
+## Battalion Assembly -- Colors
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101808" stroke="#a0b060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#a0b060" opacity="0.9"/>
+  <text x="30" y="32" text-anchor="middle" fill="#0a0e08" font-family="Allerta Stencil, sans-serif" font-size="7" letter-spacing="1">COLORS</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0e08" font-family="Black Ops One, cursive" font-size="14">III</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c8d0b0" font-family="Black Ops One, cursive" font-size="11" letter-spacing="1">BATTALION ASSEMBLY</text>
+  <text x="170" y="55" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="7" letter-spacing="2">TIME: 0530Z // PARADE GROUND ALPHA</text>
+</svg>
+
+<span class="rank-insignia bn">BATTALION LEVEL</span>
+
+<div class="duty-header">TIME: 0530Z // UNIT: BATTALION // PHASE: COLORS</div>
+
+### Formation Summary
+
+At 0530 Zulu the battalion assembles as a single formation. Company commanders report to the Battalion Executive Officer. The color guard posts the battalion colors at the center of the formation. The Command Sergeant Major opens the formation with the battalion motto. All eyes forward. The sky begins to lighten on the eastern horizon. The formation holds in silence, waiting for the final command.
+
+<!-- SVG color guard / flag element -->
+<svg width="120" height="100" viewBox="0 0 120 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <!-- Flagpole -->
+  <line x1="30" y1="10" x2="30" y2="90" stroke="#a0b060" stroke-width="2" opacity="0.3"/>
+  <!-- Flag -->
+  <rect x="30" y="10" width="60" height="40" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.25"/>
+  <line x1="30" y1="30" x2="90" y2="30" stroke="#a0b060" stroke-width="0.5" opacity="0.15"/>
+  <!-- Battalion crest in flag center -->
+  <circle cx="60" cy="30" r="8" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.2"/>
+  <text x="60" y="33" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="5" opacity="0.3">BN</text>
+  <!-- Pole finial -->
+  <circle cx="30" cy="8" r="3" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.2"/>
+  <!-- Base -->
+  <line x1="20" y1="90" x2="40" y2="90" stroke="#a0b060" stroke-width="1.5" opacity="0.2"/>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Zulu Time | 0530Z |
+| Unit Level | Battalion |
+| Phase | Colors |
+| Location | Parade Ground Alpha, Center Mass |

--- a/reveille/content/formations/company-formation.md
+++ b/reveille/content/formations/company-formation.md
@@ -1,0 +1,64 @@
++++
+title = "Company Formation -- Assembly"
+date = "2026-04-12"
+description = "Company-level formation and assembly at 0500 Zulu"
+weight = 2
+tags = ["formation", "company", "assembly"]
+[extra]
+zulu_time = "0500Z"
+unit = "Company"
+phase = "Assembly"
++++
+
+## Company Formation -- Assembly
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101808" stroke="#a0b060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#a0b060" opacity="0.9"/>
+  <text x="30" y="32" text-anchor="middle" fill="#0a0e08" font-family="Allerta Stencil, sans-serif" font-size="7" letter-spacing="1">FORM</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0e08" font-family="Black Ops One, cursive" font-size="16">II</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c8d0b0" font-family="Black Ops One, cursive" font-size="11" letter-spacing="1">COMPANY FORMATION</text>
+  <text x="170" y="55" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="7" letter-spacing="2">TIME: 0500Z // PARADE GROUND ALPHA</text>
+</svg>
+
+<span class="rank-insignia co">COMPANY LEVEL</span>
+
+<div class="duty-header">TIME: 0500Z // UNIT: COMPANY // PHASE: ASSEMBLY</div>
+
+### Formation Summary
+
+Companies form on the parade ground at 0500 Zulu. Platoons merge into company blocks. First Sergeants take the report from platoon sergeants and verify full accountability. The company commander receives the status report. Guidon bearers post colors at the company position. Each company forms in its designated lane, dress-right-dress, maintaining proper intervals and alignment.
+
+<!-- SVG formation block pattern -->
+<svg width="240" height="80" viewBox="0 0 240 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="10" y="10" width="220" height="60" stroke="#1e2818" stroke-width="1" fill="none" opacity="0.3"/>
+  <!-- Soldiers in formation rows -->
+  <circle cx="40" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="60" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="80" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="100" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="120" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="140" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="160" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="180" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="200" cy="30" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="40" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="60" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="80" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="100" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="120" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="140" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="160" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="180" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <circle cx="200" cy="50" r="3" fill="#a0b060" opacity="0.15"/>
+  <!-- Company commander position -->
+  <rect x="108" y="65" width="24" height="8" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.25"/>
+  <text x="120" y="72" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="4" opacity="0.3">CDR</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Zulu Time | 0500Z |
+| Unit Level | Company |
+| Phase | Assembly |
+| Location | Parade Ground Alpha, Company Lanes |

--- a/reveille/content/formations/full-parade.md
+++ b/reveille/content/formations/full-parade.md
@@ -1,0 +1,58 @@
++++
+title = "Full Parade -- Reveille"
+date = "2026-04-12"
+description = "Full battalion parade with bugle reveille at 0600 Zulu"
+weight = 4
+tags = ["parade", "reveille", "ceremony"]
+[extra]
+zulu_time = "0600Z"
+unit = "Brigade"
+phase = "Reveille"
++++
+
+## Full Parade -- Reveille
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101808" stroke="#a0b060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#a0b060" opacity="0.9"/>
+  <text x="30" y="32" text-anchor="middle" fill="#0a0e08" font-family="Allerta Stencil, sans-serif" font-size="6" letter-spacing="1">REVEILLE</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0e08" font-family="Black Ops One, cursive" font-size="14">IV</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c8d0b0" font-family="Black Ops One, cursive" font-size="11" letter-spacing="1">FULL PARADE</text>
+  <text x="170" y="55" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="7" letter-spacing="2">TIME: 0600Z // PARADE GROUND ALPHA</text>
+</svg>
+
+<span class="rev-badge">REVEILLE</span>
+
+<div class="duty-header">TIME: 0600Z // UNIT: BRIGADE // PHASE: REVEILLE</div>
+
+### Formation Summary
+
+At 0600 Zulu, first light. The bugler sounds reveille from the reviewing stand. The notes carry across the silent parade ground. Every soldier stands at attention. The color guard raises the colors as the sun crests the horizon. The Battalion Commander addresses the formation. This is the moment -- the full battalion parade, the culmination of the dawn assembly sequence. After the bugle's last note fades, the day begins.
+
+<!-- SVG bugle with dawn rays -->
+<svg width="200" height="120" viewBox="0 0 200 120" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <!-- Dawn rays from horizon -->
+  <line x1="100" y1="100" x2="40" y2="20" stroke="#a0b060" stroke-width="0.5" opacity="0.1"/>
+  <line x1="100" y1="100" x2="70" y2="15" stroke="#a0b060" stroke-width="0.5" opacity="0.1"/>
+  <line x1="100" y1="100" x2="100" y2="10" stroke="#a0b060" stroke-width="0.5" opacity="0.12"/>
+  <line x1="100" y1="100" x2="130" y2="15" stroke="#a0b060" stroke-width="0.5" opacity="0.1"/>
+  <line x1="100" y1="100" x2="160" y2="20" stroke="#a0b060" stroke-width="0.5" opacity="0.1"/>
+  <!-- Horizon line -->
+  <line x1="10" y1="100" x2="190" y2="100" stroke="#a0b060" stroke-width="1" opacity="0.2"/>
+  <!-- Small bugle silhouette -->
+  <path d="M70,65 L110,65 L110,55 L70,55 Z" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <path d="M110,55 Q130,48 140,52 Q144,58 144,60 Q144,62 140,68 Q130,72 110,65" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+  <ellipse cx="144" cy="60" rx="8" ry="10" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.2"/>
+  <!-- Sound waves -->
+  <path d="M152,54 Q160,60 152,66" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+  <path d="M158,48 Q170,60 158,72" stroke="#a0b060" stroke-width="0.6" fill="none" opacity="0.1"/>
+  <!-- Label -->
+  <text x="100" y="115" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="5" letter-spacing="2">FIRST LIGHT // COLORS RAISED</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Zulu Time | 0600Z |
+| Unit Level | Brigade |
+| Phase | Reveille |
+| Location | Parade Ground Alpha, Reviewing Stand |

--- a/reveille/content/formations/pre-dawn-muster.md
+++ b/reveille/content/formations/pre-dawn-muster.md
@@ -1,0 +1,44 @@
++++
+title = "Pre-Dawn Muster -- First Call"
+date = "2026-04-12"
+description = "Platoon-level accountability check at 0430 Zulu"
+weight = 1
+tags = ["muster", "platoon", "accountability"]
+[extra]
+zulu_time = "0430Z"
+unit = "Platoon"
+phase = "First Call"
++++
+
+## Pre-Dawn Muster -- First Call
+
+<svg width="280" height="80" viewBox="0 0 280 80" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <rect x="0" y="0" width="280" height="80" fill="#101808" stroke="#a0b060" stroke-width="2"/>
+  <rect x="0" y="0" width="60" height="80" fill="#a0b060" opacity="0.9"/>
+  <text x="30" y="32" text-anchor="middle" fill="#0a0e08" font-family="Allerta Stencil, sans-serif" font-size="7" letter-spacing="1">MUSTER</text>
+  <text x="30" y="55" text-anchor="middle" fill="#0a0e08" font-family="Black Ops One, cursive" font-size="16">I</text>
+  <text x="170" y="35" text-anchor="middle" fill="#c8d0b0" font-family="Black Ops One, cursive" font-size="11" letter-spacing="1">PRE-DAWN MUSTER</text>
+  <text x="170" y="55" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="7" letter-spacing="2">TIME: 0430Z // PARADE GROUND ALPHA</text>
+</svg>
+
+<span class="rank-insignia plt">PLATOON LEVEL</span>
+
+<div class="duty-header">TIME: 0430Z // UNIT: PLATOON // PHASE: FIRST CALL</div>
+
+### Formation Summary
+
+Pre-dawn muster is the first accountability formation of the day. All section leaders conduct headcount at the platoon level before the sun breaks the horizon. This is the backbone of military discipline -- knowing where every soldier is before the day begins. Squad leaders verify personnel status. Any discrepancies are reported up the chain immediately.
+
+<!-- SVG rank insignia - single chevron (Private First Class) -->
+<svg width="80" height="60" viewBox="0 0 80 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 16px 0;">
+  <path d="M20,40 L40,25 L60,40" stroke="#a0b060" stroke-width="2" fill="none" opacity="0.3"/>
+  <path d="M20,48 L40,33 L60,48" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.2"/>
+  <text x="40" y="16" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="5" letter-spacing="2">SECTION LEADER</text>
+</svg>
+
+| Detail | Info |
+|--------|------|
+| Zulu Time | 0430Z |
+| Unit Level | Platoon |
+| Phase | First Call |
+| Location | Parade Ground Alpha, Sector 1 |

--- a/reveille/content/index.md
+++ b/reveille/content/index.md
@@ -1,0 +1,196 @@
++++
+title = "Home"
+description = "Military dawn assembly event"
+tags = ["event", "dark", "military", "assembly", "urgent"]
++++
+
+<div class="hero">
+  <div class="site-wrapper">
+    <div class="hero-label">Dawn Assembly</div>
+    <h1>REVEILLE</h1>
+    <p class="hero-subtitle">All personnel report for dawn formation. Four assembly stages from pre-dawn muster through full parade. Unit sections form by designation. Report times in Zulu. No exceptions. No delays.</p>
+    <p class="hero-date">ASSEMBLY: 120430ZAPR2026 // PARADE GROUND ALPHA</p>
+
+    <!-- SVG bugle / trumpet call illustration -->
+    <svg width="300" height="100" viewBox="0 0 300 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 32px auto 0; display: block;">
+      <!-- Bugle body -->
+      <path d="M30,55 L110,55 L110,45 L30,45 Z" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+      <path d="M110,45 Q160,32 200,38 Q210,45 210,50 Q210,55 200,62 Q160,68 110,55" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+      <!-- Bell of bugle -->
+      <ellipse cx="210" cy="50" rx="14" ry="18" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.25"/>
+      <ellipse cx="214" cy="50" rx="10" ry="14" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+      <!-- Mouthpiece -->
+      <rect x="16" y="47" width="16" height="6" rx="3" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.25"/>
+      <!-- Sound waves from bell -->
+      <path d="M224,42 Q238,50 224,58" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.2"/>
+      <path d="M232,36 Q250,50 232,64" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+      <path d="M240,30 Q262,50 240,70" stroke="#a0b060" stroke-width="0.6" fill="none" opacity="0.1"/>
+      <!-- Stencil text -->
+      <text x="150" y="92" text-anchor="middle" fill="#607048" font-family="Allerta Stencil, sans-serif" font-size="7" letter-spacing="4">BUGLE CALL // FIRST LIGHT</text>
+    </svg>
+  </div>
+</div>
+
+<div class="site-wrapper">
+
+<div class="section-block">
+  <div class="section-label">Assembly Schedule</div>
+  <h2>Formation Sequence</h2>
+
+  <div class="formation-block formation-0430">
+    <div class="formation-time">0430Z</div>
+    <div class="formation-info">
+      <div class="formation-title formation-title-0430">Pre-Dawn Muster -- First Call</div>
+      <div class="formation-meta">Platoon-level accountability check. Section leaders report headcount.</div>
+    </div>
+    <div class="formation-badge-slot">
+      <span class="rev-badge-outline">PLT</span>
+    </div>
+  </div>
+
+  <div class="formation-block formation-0500">
+    <div class="formation-time">0500Z</div>
+    <div class="formation-info">
+      <div class="formation-title formation-title-0500">Company Formation -- Assembly</div>
+      <div class="formation-meta">Companies form on the parade ground. First Sergeants report to Commander.</div>
+    </div>
+    <div class="formation-badge-slot">
+      <span class="rev-badge-outline">CO</span>
+    </div>
+  </div>
+
+  <div class="formation-block formation-0530">
+    <div class="formation-time">0530Z</div>
+    <div class="formation-info">
+      <div class="formation-title formation-title-0530">Battalion Assembly -- Colors</div>
+      <div class="formation-meta">Battalion colors posted. Command Sergeant Major opens formation.</div>
+    </div>
+    <div class="formation-badge-slot">
+      <span class="rev-badge">BN</span>
+    </div>
+  </div>
+
+  <div class="formation-block formation-0600">
+    <div class="formation-time">0600Z</div>
+    <div class="formation-info">
+      <div class="formation-title formation-title-0600">Full Parade -- Reveille</div>
+      <div class="formation-meta">Full battalion parade. Bugle sounds reveille. Colors raised at dawn.</div>
+    </div>
+    <div class="formation-badge-slot">
+      <span class="rev-badge">BDE</span>
+    </div>
+  </div>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Formation Grid</div>
+  <h2>Unit Disposition</h2>
+
+  <!-- SVG formation grid pattern -->
+  <svg width="100%" height="200" viewBox="0 0 600 200" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block; max-width: 600px;">
+    <!-- Grid lines -->
+    <rect x="10" y="10" width="580" height="180" stroke="#1e2818" stroke-width="2" fill="none" opacity="0.4"/>
+    <line x1="10" y1="55" x2="590" y2="55" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <line x1="10" y1="100" x2="590" y2="100" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <line x1="10" y1="145" x2="590" y2="145" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <line x1="155" y1="10" x2="155" y2="190" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <line x1="300" y1="10" x2="300" y2="190" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <line x1="445" y1="10" x2="445" y2="190" stroke="#1e2818" stroke-width="0.5" opacity="0.3"/>
+    <!-- Alpha Company block -->
+    <rect x="30" y="25" width="105" height="20" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="82" y="38" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="7" opacity="0.4">A CO</text>
+    <!-- Platoon dots Alpha -->
+    <circle cx="45" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="60" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="75" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="90" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="105" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="120" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <!-- Bravo Company block -->
+    <rect x="175" y="25" width="105" height="20" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="227" y="38" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="7" opacity="0.4">B CO</text>
+    <!-- Platoon dots Bravo -->
+    <circle cx="190" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="205" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="220" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="235" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="250" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="265" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <!-- Charlie Company block -->
+    <rect x="320" y="25" width="105" height="20" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="372" y="38" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="7" opacity="0.4">C CO</text>
+    <!-- Platoon dots Charlie -->
+    <circle cx="335" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="350" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="365" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="380" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="395" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="410" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <!-- HQ Element block -->
+    <rect x="465" y="25" width="105" height="20" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="517" y="38" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="7" opacity="0.4">HHC</text>
+    <!-- Platoon dots HQ -->
+    <circle cx="480" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="495" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="510" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="525" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="540" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <circle cx="555" cy="65" r="3" fill="#a0b060" opacity="0.15"/>
+    <!-- Command position (diamond) -->
+    <polygon points="300,130 315,145 300,160 285,145" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="300" y="148" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="5" opacity="0.35">BN CDR</text>
+    <!-- Alignment lines from companies to command -->
+    <line x1="82" y1="45" x2="290" y2="135" stroke="#788840" stroke-width="0.5" fill="none" opacity="0.12" stroke-dasharray="4 3"/>
+    <line x1="227" y1="45" x2="296" y2="135" stroke="#788840" stroke-width="0.5" fill="none" opacity="0.12" stroke-dasharray="4 3"/>
+    <line x1="372" y1="45" x2="304" y2="135" stroke="#788840" stroke-width="0.5" fill="none" opacity="0.12" stroke-dasharray="4 3"/>
+    <line x1="517" y1="45" x2="310" y2="135" stroke="#788840" stroke-width="0.5" fill="none" opacity="0.12" stroke-dasharray="4 3"/>
+    <!-- Label -->
+    <text x="300" y="186" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="6" letter-spacing="3">PARADE FORMATION // BATTALION FRONT</text>
+  </svg>
+</div>
+
+<div class="section-block">
+  <div class="section-label">Time Zones</div>
+  <h2>Zulu Clock</h2>
+
+  <!-- SVG military time zone clock display -->
+  <svg width="280" height="280" viewBox="0 0 280 280" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px auto; display: block;">
+    <!-- Outer ring -->
+    <circle cx="140" cy="140" r="120" stroke="#a0b060" stroke-width="2" fill="none" opacity="0.2"/>
+    <circle cx="140" cy="140" r="110" stroke="#1e2818" stroke-width="1" fill="none" opacity="0.3"/>
+    <!-- Hour tick marks (24hr) -->
+    <line x1="140" y1="24" x2="140" y2="34" stroke="#a0b060" stroke-width="1.5" opacity="0.3"/>
+    <line x1="140" y1="246" x2="140" y2="256" stroke="#a0b060" stroke-width="1.5" opacity="0.3"/>
+    <line x1="24" y1="140" x2="34" y2="140" stroke="#a0b060" stroke-width="1.5" opacity="0.3"/>
+    <line x1="246" y1="140" x2="256" y2="140" stroke="#a0b060" stroke-width="1.5" opacity="0.3"/>
+    <!-- Diagonal ticks -->
+    <line x1="58" y1="58" x2="65" y2="65" stroke="#a0b060" stroke-width="1" opacity="0.2"/>
+    <line x1="215" y1="58" x2="222" y2="65" stroke="#a0b060" stroke-width="1" opacity="0.2"/>
+    <line x1="58" y1="222" x2="65" y2="215" stroke="#a0b060" stroke-width="1" opacity="0.2"/>
+    <line x1="215" y1="222" x2="222" y2="215" stroke="#a0b060" stroke-width="1" opacity="0.2"/>
+    <!-- Hour labels -->
+    <text x="140" y="50" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="10" opacity="0.35">0000</text>
+    <text x="245" y="144" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="10" opacity="0.35">0600</text>
+    <text x="140" y="240" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="10" opacity="0.35">1200</text>
+    <text x="36" y="144" text-anchor="middle" fill="#a0b060" font-family="Black Ops One, cursive" font-size="10" opacity="0.35">1800</text>
+    <!-- Center hub -->
+    <circle cx="140" cy="140" r="18" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.2"/>
+    <circle cx="140" cy="140" r="4" fill="#a0b060" opacity="0.25"/>
+    <text x="140" y="144" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="6" opacity="0.4">Z</text>
+    <!-- Assembly time markers (0430-0600 arc area) -->
+    <circle cx="218" cy="72" r="5" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="218" y="75" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="4" opacity="0.35">0430</text>
+    <circle cx="240" cy="100" r="5" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="240" y="103" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="4" opacity="0.35">0500</text>
+    <circle cx="248" cy="120" r="5" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.3"/>
+    <text x="248" y="123" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="4" opacity="0.35">0530</text>
+    <circle cx="245" cy="140" r="6" stroke="#a0b060" stroke-width="2" fill="none" opacity="0.4"/>
+    <text x="245" y="143" text-anchor="middle" fill="#a0b060" font-family="Allerta Stencil, sans-serif" font-size="4" opacity="0.45">0600</text>
+    <!-- Clock label -->
+    <text x="140" y="275" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="7" letter-spacing="3">ZULU TIME // 24HR DISPLAY</text>
+  </svg>
+
+  <p style="text-align: center; font-family: 'Barlow Condensed', sans-serif; font-weight: 700; font-size: 0.8rem; color: var(--text-muted); letter-spacing: 0.2em; text-transform: uppercase;">0430z > 0500z > 0530z > 0600z</p>
+</div>
+
+</div>

--- a/reveille/content/orders.md
+++ b/reveille/content/orders.md
@@ -1,0 +1,31 @@
++++
+title = "Standing Orders"
+description = "Standing orders for the Reveille dawn assembly"
++++
+
+<div class="section-block">
+  <div class="section-label">Operations</div>
+  <h2>Standing Orders</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">The following standing orders govern all dawn assembly formations. All personnel are expected to know and follow these orders without exception. Ignorance of standing orders is not a defense. These orders remain in effect until rescinded by the Battalion Commander.</p>
+
+  <!-- SVG rank insignia icon - Captain bars -->
+  <svg width="80" height="60" viewBox="0 0 80 60" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <!-- Double bar captain insignia -->
+    <rect x="20" y="18" width="40" height="8" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <rect x="20" y="32" width="40" height="8" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <text x="40" y="54" text-anchor="middle" fill="#607048" font-family="Barlow Condensed, sans-serif" font-weight="700" font-size="5" letter-spacing="2">CPT</text>
+  </svg>
+
+  <ul class="orders-list">
+    <li><strong>ORDER 001 //</strong> All personnel will be at their designated formation area no later than 15 minutes prior to the published Zulu time. Early is on time. On time is late.</li>
+    <li><strong>ORDER 002 //</strong> Uniform of the day will be as published in the daily operations order. Deviations require written approval from the Company Commander or above.</li>
+    <li><strong>ORDER 003 //</strong> Section leaders will conduct a headcount at each formation stage and report discrepancies immediately to the next higher echelon.</li>
+    <li><strong>ORDER 004 //</strong> No personnel will fall out of formation without authorization from their immediate supervisor. Medical emergencies are the sole exception.</li>
+    <li><strong>ORDER 005 //</strong> The bugle call sequence is sacrosanct. All personnel will render appropriate honors during reveille and the raising of colors.</li>
+    <li><strong>ORDER 006 //</strong> Reporting times are in 24-hour Zulu format. Local time conversions are the responsibility of individual units. There is one standard: Zulu.</li>
+    <li><strong>ORDER 007 //</strong> The Battalion Commander retains authority to modify the formation sequence based on weather, operational requirements, or threat conditions.</li>
+    <li><strong>ORDER 008 //</strong> Post-formation duty assignments will be published at the conclusion of the full parade. All personnel will remain in the assembly area until dismissed.</li>
+  </ul>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Allerta Stencil', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">EFFECTIVE: 120001ZAPR2026 // AUTHORITY: BN CDR</p>
+</div>

--- a/reveille/content/register.md
+++ b/reveille/content/register.md
@@ -1,0 +1,52 @@
++++
+title = "Report for Duty"
+description = "Report for the Reveille dawn assembly"
++++
+
+<div class="section-block">
+  <div class="section-label">Personnel</div>
+  <h2>Report for Duty</h2>
+  <p style="color: var(--text-secondary); line-height: 1.8; max-width: 720px;">All personnel must report for the dawn assembly formation. Report your unit designation and confirm your formation stage assignment. Pre-dawn muster begins at 0430 Zulu. Full parade concludes at 0600 Zulu. Late arrivals will be noted in the duty log and reported to the Company Commander.</p>
+
+  <!-- SVG dog tag / ID icon -->
+  <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin: 24px 0;">
+    <!-- Dog tag shape -->
+    <rect x="25" y="20" width="50" height="65" rx="8" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.25"/>
+    <rect x="30" y="25" width="40" height="55" rx="6" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+    <!-- Chain hole -->
+    <circle cx="50" cy="28" r="4" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.2"/>
+    <!-- Text lines on tag -->
+    <line x1="35" y1="42" x2="65" y2="42" stroke="#a0b060" stroke-width="0.8" opacity="0.15"/>
+    <line x1="35" y1="50" x2="65" y2="50" stroke="#a0b060" stroke-width="0.8" opacity="0.15"/>
+    <line x1="35" y1="58" x2="55" y2="58" stroke="#a0b060" stroke-width="0.8" opacity="0.15"/>
+    <line x1="35" y1="66" x2="60" y2="66" stroke="#a0b060" stroke-width="0.8" opacity="0.15"/>
+    <!-- Chain -->
+    <path d="M50,16 Q50,10 45,8 Q35,5 30,10" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+  </svg>
+
+  <div style="margin-top: 32px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+    <span class="rev-badge" style="font-size: 0.85rem; padding: 6px 20px;">ENLISTED</span>
+    <span class="rev-badge-outline" style="font-size: 0.85rem; padding: 6px 20px;">OFFICERS</span>
+  </div>
+
+  <div class="zulu-clock" style="margin-top: 32px;">
+    <div class="zulu-time-block">
+      <div class="zulu-time-value">0430Z</div>
+      <div class="zulu-time-label">Muster</div>
+    </div>
+    <div class="zulu-time-block">
+      <div class="zulu-time-value">0500Z</div>
+      <div class="zulu-time-label">Formation</div>
+    </div>
+    <div class="zulu-time-block">
+      <div class="zulu-time-value">0530Z</div>
+      <div class="zulu-time-label">Colors</div>
+    </div>
+    <div class="zulu-time-block">
+      <div class="zulu-time-value">0600Z</div>
+      <div class="zulu-time-label">Reveille</div>
+    </div>
+  </div>
+
+  <p style="color: var(--text-muted); margin-top: 24px; font-family: 'Allerta Stencil', sans-serif; font-size: 0.85rem; letter-spacing: 0.15em;">ASSEMBLY: 120430ZAPR2026 // PARADE GROUND ALPHA</p>
+</div>

--- a/reveille/static/css/style.css
+++ b/reveille/static/css/style.css
@@ -1,0 +1,558 @@
+/* Reveille - Military Dawn Assembly Event */
+/* Fonts: Black Ops One / Allerta Stencil display, Share Tech / Barlow Condensed body */
+
+@import url('https://fonts.googleapis.com/css2?family=Black+Ops+One&family=Allerta+Stencil&family=Share+Tech&family=Barlow+Condensed:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e08;
+  --bg-secondary: #080c06;
+  --bg-panel: #101808;
+  --text-primary: #c8d0b0;
+  --text-secondary: #889870;
+  --text-muted: #607048;
+  --accent-khaki: #a0b060;
+  --accent-bright: #b8c870;
+  --accent-dim: #788840;
+  --border-color: #1e2818;
+  --border-accent: #a0b060;
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Share Tech', 'Barlow Condensed', sans-serif;
+  font-weight: 400;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Black Ops One', cursive;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+h1 { font-size: 2.8rem; }
+h2 { font-size: 1.8rem; }
+h3 { font-size: 1.2rem; font-family: 'Allerta Stencil', sans-serif; letter-spacing: 0.08em; }
+
+.site-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  background: var(--bg-secondary);
+  border-bottom: 4px solid var(--accent-khaki);
+  padding: 0;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.site-logo .logo-main {
+  font-family: 'Black Ops One', cursive;
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: var(--accent-khaki);
+  letter-spacing: 0.08em;
+}
+
+.site-logo .logo-sub {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent-khaki);
+  border-bottom-color: var(--accent-khaki);
+}
+
+.nav-cta {
+  background-color: var(--accent-khaki) !important;
+  color: var(--bg-primary) !important;
+  padding: 8px 18px !important;
+  border: none !important;
+  font-weight: 700 !important;
+}
+
+/* Hero */
+.hero {
+  background: var(--bg-secondary);
+  padding: 80px 0 60px;
+  text-align: center;
+  border-bottom: 4px solid var(--border-color);
+}
+
+.hero-label {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-khaki);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  font-family: 'Black Ops One', cursive;
+  font-size: 6rem;
+  font-weight: 400;
+  color: var(--accent-khaki);
+  margin-bottom: 8px;
+  letter-spacing: 0.1em;
+}
+
+.hero-subtitle {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: 520px;
+  margin: 16px auto 24px;
+  line-height: 1.7;
+}
+
+.hero-date {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+}
+
+/* Section Block */
+.section-block {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--accent-khaki);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+/* Formation Block */
+.formation-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 2px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 8px;
+}
+
+.formation-block.formation-0430 { padding: 16px 18px; }
+.formation-block.formation-0500 { padding: 18px 20px; }
+.formation-block.formation-0530 { padding: 22px 24px; border-color: var(--accent-dim); }
+.formation-block.formation-0600 { padding: 26px 28px; border-color: var(--accent-khaki); background: var(--bg-secondary); }
+
+.formation-time {
+  font-family: 'Black Ops One', cursive;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--accent-khaki);
+  min-width: 100px;
+  text-align: center;
+  letter-spacing: 0.06em;
+}
+
+.formation-info { flex: 1; }
+
+.formation-title {
+  font-family: 'Black Ops One', cursive;
+  font-weight: 400;
+  color: var(--text-primary);
+  letter-spacing: 0.03em;
+}
+
+.formation-title-0430 { font-size: 0.95rem; }
+.formation-title-0500 { font-size: 1.1rem; }
+.formation-title-0530 { font-size: 1.3rem; }
+.formation-title-0600 { font-size: 1.5rem; font-family: 'Allerta Stencil', sans-serif; letter-spacing: 0.06em; color: var(--accent-khaki); }
+
+.formation-meta {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.formation-badge-slot {
+  flex-shrink: 0;
+}
+
+/* Reveille Badge */
+.rev-badge {
+  display: inline-block;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  background: var(--accent-khaki);
+  color: var(--bg-primary);
+  text-transform: uppercase;
+}
+
+.rev-badge-outline {
+  display: inline-block;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  padding: 4px 14px;
+  border: 2px solid var(--accent-khaki);
+  color: var(--accent-khaki);
+  text-transform: uppercase;
+}
+
+/* Rank Insignia Inline */
+.rank-insignia {
+  display: inline-block;
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  padding: 3px 12px;
+  border: 2px solid var(--accent-khaki);
+  color: var(--accent-khaki);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.rank-insignia.plt { border-color: var(--accent-dim); color: var(--accent-dim); }
+.rank-insignia.co { border-color: var(--accent-khaki); color: var(--accent-khaki); }
+.rank-insignia.bn { border-color: var(--accent-bright); color: var(--accent-bright); }
+
+/* Duty Header */
+.duty-header {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* Page Content */
+.page-content {
+  padding: 48px 0;
+}
+
+.page-content h1 {
+  margin-bottom: 8px;
+}
+
+.page-meta {
+  font-family: 'Share Tech', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.1em;
+}
+
+.prose {
+  max-width: 720px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.prose h2 { margin-top: 40px; margin-bottom: 14px; }
+.prose h3 { margin-top: 28px; margin-bottom: 10px; }
+.prose p { margin-bottom: 14px; }
+.prose ul, .prose ol { margin-bottom: 14px; padding-left: 24px; }
+.prose li { margin-bottom: 4px; }
+
+.prose code {
+  font-family: 'Share Tech', monospace;
+  background: var(--bg-panel);
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border: 1px solid var(--border-color);
+}
+
+.prose a {
+  color: var(--accent-khaki);
+  text-decoration: underline;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+}
+
+.prose th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--accent-khaki);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-family: 'Allerta Stencil', sans-serif;
+  letter-spacing: 0.06em;
+}
+
+.prose td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: 'Share Tech', sans-serif;
+}
+
+/* Listing */
+.listing-item {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 20px;
+  align-items: baseline;
+}
+
+.listing-date {
+  font-family: 'Allerta Stencil', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-width: 100px;
+  letter-spacing: 0.06em;
+}
+
+.listing-title a {
+  font-family: 'Black Ops One', cursive;
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--text-primary);
+  text-decoration: none;
+  letter-spacing: 0.03em;
+}
+
+.listing-title a:hover {
+  color: var(--accent-khaki);
+}
+
+.listing-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+/* Tags */
+.tag-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tag {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.tag:hover {
+  border-color: var(--accent-khaki);
+  color: var(--accent-khaki);
+}
+
+/* Zulu Clock Display */
+.zulu-clock {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  margin: 24px 0;
+  flex-wrap: wrap;
+}
+
+.zulu-time-block {
+  text-align: center;
+}
+
+.zulu-time-value {
+  font-family: 'Black Ops One', cursive;
+  font-size: 2rem;
+  color: var(--accent-khaki);
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.zulu-time-label {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.6rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 6px;
+}
+
+/* Orders List */
+.orders-list {
+  list-style: none;
+  padding: 0;
+  margin: 24px 0;
+}
+
+.orders-list li {
+  padding: 14px 18px;
+  border-left: 4px solid var(--border-color);
+  background: var(--bg-panel);
+  margin-bottom: 6px;
+  font-family: 'Share Tech', sans-serif;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.orders-list li strong {
+  color: var(--text-primary);
+  font-family: 'Allerta Stencil', sans-serif;
+  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+}
+
+/* Footer */
+.site-footer {
+  background: var(--bg-secondary);
+  border-top: 4px solid var(--accent-khaki);
+  padding: 40px 0;
+  text-align: center;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.footer-brand {
+  font-family: 'Black Ops One', cursive;
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--text-primary);
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover {
+  color: var(--accent-khaki);
+}
+
+.footer-powered {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 100px 0;
+}
+
+.error-code {
+  font-family: 'Black Ops One', cursive;
+  font-size: 8rem;
+  font-weight: 400;
+  color: var(--accent-khaki);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.error-msg {
+  font-family: 'Barlow Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  margin-top: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero h1 { font-size: 3.5rem; }
+  h1 { font-size: 2rem; }
+  .formation-block { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .listing-item { flex-direction: column; gap: 4px; }
+  .header-inner { flex-direction: column; gap: 12px; }
+  .site-nav { gap: 14px; }
+  .formation-title-0600 { font-size: 1.3rem; }
+  .zulu-clock { gap: 16px; }
+  .zulu-time-value { font-size: 1.5rem; }
+}

--- a/reveille/templates/404.html
+++ b/reveille/templates/404.html
@@ -1,0 +1,19 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="error-page">
+      <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Bugle silhouette -->
+        <ellipse cx="40" cy="40" rx="28" ry="28" stroke="#a0b060" stroke-width="1.5" fill="none" opacity="0.2"/>
+        <path d="M22,42 L38,42 L38,36 L22,36 Z" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.25"/>
+        <path d="M38,36 Q52,30 60,34 Q62,40 60,44 Q52,48 38,42" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.25"/>
+        <circle cx="60" cy="39" r="6" stroke="#a0b060" stroke-width="1" fill="none" opacity="0.15"/>
+        <!-- Sound waves -->
+        <path d="M64,32 Q70,39 64,46" stroke="#a0b060" stroke-width="0.8" fill="none" opacity="0.15"/>
+        <path d="M68,28 Q76,39 68,50" stroke="#a0b060" stroke-width="0.6" fill="none" opacity="0.1"/>
+      </svg>
+      <div class="error-code">404</div>
+      <div class="error-msg">Formation Not Found</div>
+      <p style="margin-top: 20px;"><a href="{{ base_url }}/" style="color: var(--accent-khaki); font-family: 'Barlow Condensed', sans-serif; font-weight: 700; font-size: 0.8rem; letter-spacing: 0.15em; text-transform: uppercase;">Return to Assembly</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/reveille/templates/footer.html
+++ b/reveille/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">REVEILLE // DAWN ASSEMBLY</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Assembly</a>
+        <a href="{{ base_url }}/formations/">Formations</a>
+        <a href="{{ base_url }}/orders/">Orders</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/reveille/templates/header.html
+++ b/reveille/templates/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">REVEILLE</span>
+        <span class="logo-sub">dawn assembly</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Assembly</a>
+        <a href="{{ base_url }}/formations/">Formations</a>
+        <a href="{{ base_url }}/orders/">Orders</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Report</a>
+      </nav>
+    </div>
+  </header>

--- a/reveille/templates/page.html
+++ b/reveille/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/reveille/templates/post.html
+++ b/reveille/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("formation") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/reveille/templates/section.html
+++ b/reveille/templates/section.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content | safe }}
+      {% for post in section.pages %}
+      <div class="listing-item">
+        <span class="listing-date">{{ post.date | date("%Y-%m-%d") }}</span>
+        <div>
+          <div class="listing-title"><a href="{{ post.url }}">{{ post.title }}</a></div>
+          {% if post.description %}
+          <div class="listing-desc">{{ post.description }}</div>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/reveille/templates/taxonomy.html
+++ b/reveille/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">Classification</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All categories:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/reveille/templates/taxonomy_term.html
+++ b/reveille/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.title | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <p style="color: var(--text-secondary); margin-bottom: 28px;">All formations tagged "{{ page.title }}":</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2935,6 +2935,13 @@
     "retro",
     "synthwave"
   ],
+  "reveille": [
+    "event",
+    "dark",
+    "military",
+    "assembly",
+    "urgent"
+  ],
   "ridgeline": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1650

## Summary
- Add reveille example site: military dawn assembly event with bugle call aesthetics
- SVG bugle/trumpet call illustrations, formation grid patterns, military time zone clock displays, rank insignia icons
- Typography: Black Ops One/Allerta Stencil display, Share Tech/Barlow Condensed body
- Reporting times in 24hr Zulu format, unit/section designations as organizing hierarchy

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm dark olive/khaki color scheme with no CSS gradients
- [ ] Verify tags.json includes reveille with correct tags