### PR TITLE
feat: add launchpad-event example site

### DIFF
--- a/launchpad-event/config.toml
+++ b/launchpad-event/config.toml
@@ -1,0 +1,41 @@
+title = "Launchpad Event"
+description = "Rocket launch product event with mission control countdown"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["missions"]
+
+[markdown]
+safe = false

--- a/launchpad-event/content/index.md
+++ b/launchpad-event/content/index.md
@@ -1,0 +1,163 @@
++++
+title = "LAUNCHPAD"
+description = "Rocket launch product event - mission control countdown"
+tags = ["event", "dark", "launch", "space", "countdown"]
++++
+
+<section class="hero">
+  <div class="hero-inner">
+    <svg class="hero-tower" viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" aria-label="Launch tower and gantry structure">
+      <rect x="88" y="40" width="24" height="320" fill="none" stroke="#30d060" stroke-width="1.5"/>
+      <rect x="80" y="360" width="40" height="10" fill="none" stroke="#30d060" stroke-width="1.5"/>
+      <line x1="60" y1="370" x2="80" y2="360" stroke="#30d060" stroke-width="1"/>
+      <line x1="140" y1="370" x2="120" y2="360" stroke="#30d060" stroke-width="1"/>
+      <rect x="60" y="370" width="80" height="6" fill="none" stroke="#30d060" stroke-width="1.5"/>
+      <line x1="88" y1="100" x2="60" y2="130" stroke="#30d060" stroke-width="1"/>
+      <line x1="112" y1="100" x2="140" y2="130" stroke="#30d060" stroke-width="1"/>
+      <line x1="88" y1="180" x2="50" y2="220" stroke="#30d060" stroke-width="1"/>
+      <line x1="112" y1="180" x2="150" y2="220" stroke="#30d060" stroke-width="1"/>
+      <line x1="88" y1="260" x2="45" y2="310" stroke="#30d060" stroke-width="1"/>
+      <line x1="112" y1="260" x2="155" y2="310" stroke="#30d060" stroke-width="1"/>
+      <rect x="120" y="80" width="40" height="60" fill="none" stroke="#30d060" stroke-width="1" stroke-dasharray="3,3"/>
+      <rect x="120" y="180" width="40" height="60" fill="none" stroke="#30d060" stroke-width="1" stroke-dasharray="3,3"/>
+      <rect x="120" y="280" width="40" height="60" fill="none" stroke="#30d060" stroke-width="1" stroke-dasharray="3,3"/>
+      <polygon points="100,10 88,40 112,40" fill="none" stroke="#30d060" stroke-width="1.5"/>
+      <line x1="100" y1="10" x2="100" y2="0" stroke="#30d060" stroke-width="1"/>
+      <circle cx="100" cy="25" r="3" fill="#30d060" opacity="0.6"/>
+    </svg>
+    <div class="hero-text">
+      <div class="hero-pre">MISSION CONTROL PRESENTS</div>
+      <h1 class="hero-title">LAUNCHPAD</h1>
+      <div class="hero-sub">ROCKET LAUNCH PRODUCT EVENT</div>
+      <div class="hero-date">T-MINUS COUNTDOWN INITIATED</div>
+      <a href="/register/" class="hero-cta">INITIATE LAUNCH SEQUENCE</a>
+    </div>
+  </div>
+</section>
+
+<section class="countdown-display">
+  <h2 class="section-heading">COUNTDOWN CLOCK</h2>
+  <svg class="countdown-svg" viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg" aria-label="T-minus countdown clock display">
+    <rect x="0" y="0" width="600" height="120" fill="none" stroke="#1a2e1e" stroke-width="2"/>
+    <rect x="10" y="10" width="140" height="100" fill="none" stroke="#30d060" stroke-width="1" opacity="0.3"/>
+    <text x="80" y="55" fill="#30d060" font-family="monospace" font-size="14" text-anchor="middle">T-120:00</text>
+    <text x="80" y="80" fill="#408848" font-family="monospace" font-size="10" text-anchor="middle">PRE-LAUNCH</text>
+    <rect x="160" y="10" width="140" height="100" fill="none" stroke="#30d060" stroke-width="1" opacity="0.3"/>
+    <text x="230" y="55" fill="#30d060" font-family="monospace" font-size="14" text-anchor="middle">T-060:00</text>
+    <text x="230" y="80" fill="#408848" font-family="monospace" font-size="10" text-anchor="middle">FUELING</text>
+    <rect x="310" y="10" width="140" height="100" fill="none" stroke="#30d060" stroke-width="1" opacity="0.3"/>
+    <text x="380" y="55" fill="#30d060" font-family="monospace" font-size="14" text-anchor="middle">T-010:00</text>
+    <text x="380" y="80" fill="#408848" font-family="monospace" font-size="10" text-anchor="middle">FINAL COUNT</text>
+    <rect x="460" y="10" width="130" height="100" fill="none" stroke="#30d060" stroke-width="1.5"/>
+    <text x="525" y="55" fill="#30d060" font-family="monospace" font-size="14" text-anchor="middle">T-000:00</text>
+    <text x="525" y="80" fill="#30d060" font-family="monospace" font-size="10" text-anchor="middle" font-weight="bold">LIFTOFF</text>
+    <line x1="150" y1="60" x2="160" y2="60" stroke="#30d060" stroke-width="1" stroke-dasharray="2,2"/>
+    <line x1="300" y1="60" x2="310" y2="60" stroke="#30d060" stroke-width="1" stroke-dasharray="2,2"/>
+    <line x1="450" y1="60" x2="460" y2="60" stroke="#30d060" stroke-width="1" stroke-dasharray="2,2"/>
+  </svg>
+</section>
+
+<section class="mission-phases">
+  <h2 class="section-heading">MISSION PHASES</h2>
+  <div class="phase-grid">
+    <div class="phase-card">
+      <div class="phase-time">T-120:00</div>
+      <h3 class="phase-name">Pre-Launch Checks</h3>
+      <p>All systems verification and readiness confirmation. Vehicle health monitoring, ground support equipment checks, and range safety clearance protocols.</p>
+      <a href="/missions/pre-launch-checks/" class="phase-link">VIEW TELEMETRY</a>
+    </div>
+    <div class="phase-card">
+      <div class="phase-time">T-060:00</div>
+      <h3 class="phase-name">Fueling Sequence</h3>
+      <p>Propellant loading operations commence. LOX and RP-1 transfer to flight tanks, cryogenic conditioning, and tank pressurization procedures.</p>
+      <a href="/missions/fueling-sequence/" class="phase-link">VIEW TELEMETRY</a>
+    </div>
+    <div class="phase-card">
+      <div class="phase-time">T-010:00</div>
+      <h3 class="phase-name">Final Countdown</h3>
+      <p>Terminal count sequence engaged. Autonomous flight computer assumes control, engine chill procedures, and final go/no-go polling from all stations.</p>
+      <a href="/missions/final-countdown/" class="phase-link">VIEW TELEMETRY</a>
+    </div>
+    <div class="phase-card phase-card--active">
+      <div class="phase-time">T-000:00</div>
+      <h3 class="phase-name">Liftoff</h3>
+      <p>Main engine start and liftoff. Vehicle clears the tower, begins pitch and roll programs, and commences powered ascent to orbit.</p>
+      <a href="/missions/liftoff/" class="phase-link">VIEW TELEMETRY</a>
+    </div>
+  </div>
+</section>
+
+<section class="mission-patch">
+  <h2 class="section-heading">MISSION PATCH</h2>
+  <div class="patch-container">
+    <svg class="patch-svg" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg" aria-label="Mission patch circular badge">
+      <circle cx="150" cy="150" r="140" fill="none" stroke="#30d060" stroke-width="2"/>
+      <circle cx="150" cy="150" r="130" fill="none" stroke="#30d060" stroke-width="0.5" opacity="0.4"/>
+      <circle cx="150" cy="150" r="120" fill="none" stroke="#1a2e1e" stroke-width="1"/>
+      <path d="M150,50 L143,90 L157,90 Z" fill="none" stroke="#30d060" stroke-width="1.5"/>
+      <line x1="150" y1="50" x2="150" y2="35" stroke="#30d060" stroke-width="1"/>
+      <rect x="143" y="90" width="14" height="80" fill="none" stroke="#30d060" stroke-width="1"/>
+      <polygon points="135,170 143,90 157,90 165,170" fill="none" stroke="#30d060" stroke-width="1" opacity="0.5"/>
+      <path d="M135,170 Q130,180 120,190" fill="none" stroke="#30d060" stroke-width="1"/>
+      <path d="M165,170 Q170,180 180,190" fill="none" stroke="#30d060" stroke-width="1"/>
+      <path d="M120,190 Q105,210 100,240" fill="none" stroke="#30d060" stroke-width="0.8" opacity="0.5"/>
+      <path d="M180,190 Q195,210 200,240" fill="none" stroke="#30d060" stroke-width="0.8" opacity="0.5"/>
+      <ellipse cx="150" cy="175" rx="30" ry="8" fill="none" stroke="#30d060" stroke-width="1" opacity="0.6"/>
+      <circle cx="130" cy="210" r="2" fill="#30d060" opacity="0.3"/>
+      <circle cx="175" cy="220" r="1.5" fill="#30d060" opacity="0.3"/>
+      <circle cx="110" cy="230" r="1" fill="#30d060" opacity="0.2"/>
+      <circle cx="190" cy="205" r="1" fill="#30d060" opacity="0.2"/>
+      <circle cx="145" cy="240" r="1.5" fill="#30d060" opacity="0.2"/>
+      <path d="M 50,150 A 100,100 0 0,1 250,150" fill="none" stroke="none"/>
+      <text fill="#30d060" font-family="monospace" font-size="11" letter-spacing="4">
+        <textPath href="#patchArcTop" startOffset="50%" text-anchor="middle">LAUNCHPAD EVENT</textPath>
+      </text>
+      <defs>
+        <path id="patchArcTop" d="M 40,160 A 110,110 0 0,1 260,160"/>
+        <path id="patchArcBottom" d="M 40,160 A 110,110 0 0,0 260,160"/>
+      </defs>
+      <text fill="#408848" font-family="monospace" font-size="9" letter-spacing="3">
+        <textPath href="#patchArcBottom" startOffset="50%" text-anchor="middle">MISSION CONTROL</textPath>
+      </text>
+    </svg>
+  </div>
+</section>
+
+<section class="trajectory">
+  <h2 class="section-heading">TRAJECTORY ARC</h2>
+  <div class="trajectory-container">
+    <svg class="trajectory-svg" viewBox="0 0 700 250" xmlns="http://www.w3.org/2000/svg" aria-label="Trajectory arc diagram showing flight path">
+      <line x1="50" y1="220" x2="650" y2="220" stroke="#1a2e1e" stroke-width="1"/>
+      <line x1="50" y1="220" x2="50" y2="20" stroke="#1a2e1e" stroke-width="1"/>
+      <text x="30" y="225" fill="#408848" font-family="monospace" font-size="8">0</text>
+      <text x="15" y="170" fill="#408848" font-family="monospace" font-size="8">50km</text>
+      <text x="12" y="120" fill="#408848" font-family="monospace" font-size="8">100km</text>
+      <text x="12" y="70" fill="#408848" font-family="monospace" font-size="8">200km</text>
+      <text x="12" y="35" fill="#408848" font-family="monospace" font-size="8">400km</text>
+      <line x1="50" y1="170" x2="650" y2="170" stroke="#1a2e1e" stroke-width="0.5" stroke-dasharray="4,4"/>
+      <line x1="50" y1="120" x2="650" y2="120" stroke="#1a2e1e" stroke-width="0.5" stroke-dasharray="4,4"/>
+      <line x1="50" y1="70" x2="650" y2="70" stroke="#1a2e1e" stroke-width="0.5" stroke-dasharray="4,4"/>
+      <path d="M 70,220 Q 100,218 130,200 Q 180,160 250,100 Q 350,40 500,35 Q 580,35 640,40" fill="none" stroke="#30d060" stroke-width="2"/>
+      <circle cx="70" cy="220" r="4" fill="#30d060"/>
+      <text x="60" y="238" fill="#30d060" font-family="monospace" font-size="8">T-0:00</text>
+      <circle cx="130" cy="200" r="3" fill="#30d060" opacity="0.7"/>
+      <text x="115" y="198" fill="#408848" font-family="monospace" font-size="7">MECO</text>
+      <circle cx="250" cy="100" r="3" fill="#30d060" opacity="0.7"/>
+      <text x="235" y="98" fill="#408848" font-family="monospace" font-size="7">SEP</text>
+      <circle cx="500" cy="35" r="3" fill="#30d060" opacity="0.7"/>
+      <text x="485" y="30" fill="#408848" font-family="monospace" font-size="7">SECO</text>
+      <circle cx="640" cy="40" r="4" fill="#30d060"/>
+      <text x="620" y="55" fill="#30d060" font-family="monospace" font-size="8">ORBIT</text>
+      <path d="M 70,220 L 65,225 L 75,225 Z" fill="#30d060"/>
+    </svg>
+  </div>
+</section>
+
+<section class="register-cta">
+  <div class="cta-inner">
+    <div class="cta-label">LAUNCH WINDOW OPEN</div>
+    <h2>Join Mission Control</h2>
+    <p>Secure your position in the launch viewing gallery. Limited clearance available for this orbital insertion event.</p>
+    <a href="/register/" class="cta-button">REGISTER FOR LAUNCH</a>
+  </div>
+</section>

--- a/launchpad-event/content/missions/_index.md
+++ b/launchpad-event/content/missions/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Mission Phases"
+description = "All mission phases from pre-launch checks through liftoff"
+sort_by = "weight"
++++
+
+All mission phases are sequenced by T-minus countdown. Each phase represents a critical milestone in the launch timeline from initial systems verification through main engine ignition and tower clearance.

--- a/launchpad-event/content/missions/final-countdown.md
+++ b/launchpad-event/content/missions/final-countdown.md
@@ -1,0 +1,64 @@
++++
+title = "Final Countdown"
+description = "T-010:00 - Terminal count sequence and autonomous flight computer control"
+date = "2026-04-12"
+weight = 3
+tags = ["countdown", "terminal-count", "autonomous"]
++++
+
+## T-010:00 -- Final Countdown
+
+Terminal count sequence engaged. The autonomous flight computer has assumed primary control of all vehicle systems.
+
+### Terminal Count Sequence
+
+The final ten minutes before launch represent the most critical phase of the countdown. The vehicle transitions from ground-controlled to autonomous operations. Every system must be in a go state, and every station must confirm readiness.
+
+**Go/No-Go Poll**
+
+The launch director conducts a final polling of all console positions:
+
+- Flight dynamics -- GO
+- Propulsion -- GO
+- Guidance and navigation -- GO
+- Range safety -- GO
+- Weather -- GO
+- Ground systems -- GO
+- Launch director -- GO FOR LAUNCH
+
+### Engine Chill Sequence
+
+Beginning at T-007:00, cryogenic propellant is circulated through the engine turbopump bearings and combustion chamber jacket. This thermal conditioning prevents thermal shock at ignition and ensures the turbopumps spin up smoothly when the start command is issued.
+
+### Automated Sequence Events
+
+| Time Mark | Event |
+|-----------|-------|
+| T-010:00 | Terminal count begins |
+| T-007:00 | Engine chill sequence start |
+| T-005:00 | Flight computer final self-test |
+| T-004:00 | Arm flight termination system |
+| T-003:00 | Transfer to internal power |
+| T-002:00 | Retract crew access arm |
+| T-001:00 | Flight computer assumes control |
+| T-000:31 | Auto-sequence start |
+| T-000:10 | Ignition hydrogen burnoff igniters |
+| T-000:03 | Main engine start command |
+
+### Vehicle Configuration at T-001:00
+
+At one minute to launch, the vehicle stands on internal power and internal pneumatics. All umbilical connections except the tail service mast have been retracted. The flight computer is running its final pre-ignition checks at 100 cycles per second.
+
+The sound suppression system activates at T-000:06, flooding the flame trench with hundreds of thousands of gallons of water to attenuate acoustic energy during engine ignition.
+
+### Hold Criteria
+
+An automatic hold will be triggered by:
+
+- Any engine parameter outside nominal range during chill
+- Loss of redundant telemetry link
+- Range safety track loss
+- Weather violation (lightning, upper winds)
+- Flight termination system anomaly
+
+The countdown clock will recycle to T-010:00 for any hold, with a minimum 10-minute recycle time to re-establish cryogenic conditioning.

--- a/launchpad-event/content/missions/fueling-sequence.md
+++ b/launchpad-event/content/missions/fueling-sequence.md
@@ -1,0 +1,49 @@
++++
+title = "Fueling Sequence"
+description = "T-060:00 - Propellant loading and cryogenic conditioning"
+date = "2026-04-12"
+weight = 2
+tags = ["fueling", "cryogenic", "propellant"]
++++
+
+## T-060:00 -- Fueling Sequence
+
+Propellant loading operations have commenced. LOX and RP-1 transfer to flight tanks is underway. Cryogenic conditioning active.
+
+### Propellant Operations
+
+The fueling sequence is the most thermally dynamic phase of the countdown. Liquid oxygen at minus 183 degrees Celsius flows into the oxidizer tank while refined kerosene fills the fuel tank. Both operations must proceed in a carefully choreographed sequence to maintain vehicle center-of-gravity within limits.
+
+**LOX Loading**
+
+Liquid oxygen transfer begins with a slow-fill phase to thermally condition the tank walls and plumbing. Once the tank structure reaches cryogenic equilibrium, the flow rate increases to fast-fill. The tank is filled to approximately 98 percent capacity, with the remaining volume reserved for thermal expansion management.
+
+**RP-1 Loading**
+
+Refined kerosene is loaded at ambient temperature through a separate set of umbilicals. The fuel is filtered through 10-micron screens to prevent any particulate contamination of the turbopump inlet. Tank level is monitored by capacitance probes along the tank wall.
+
+### Tank Pressurization
+
+Following propellant loading, both tanks are pressurized to flight levels:
+
+- Oxidizer tank: helium pressurant to 45 PSI
+- Fuel tank: helium pressurant to 32 PSI
+- Pressure decay test: 60-second hold with zero leakage tolerance
+
+### Cryogenic Conditioning Timeline
+
+| Time Mark | Operation |
+|-----------|-----------|
+| T-060:00 | Begin LOX slow-fill |
+| T-050:00 | LOX fast-fill transition |
+| T-045:00 | Begin RP-1 loading |
+| T-035:00 | LOX topping complete |
+| T-030:00 | RP-1 loading complete |
+| T-025:00 | Tank pressurization |
+| T-020:00 | Pressure decay verification |
+
+### Thermal Management
+
+The vehicle skin temperature is monitored at 24 points across the airframe. Ice formation on the LOX tank exterior is expected and acceptable within defined limits. Excessive ice buildup triggers a review by the launch director before proceeding.
+
+All propellant loading operations are conducted remotely with the pad cleared of all personnel. The launch control center monitors all parameters through redundant telemetry links.

--- a/launchpad-event/content/missions/liftoff.md
+++ b/launchpad-event/content/missions/liftoff.md
@@ -1,0 +1,64 @@
++++
+title = "Liftoff"
+description = "T-000:00 - Main engine ignition and launch"
+date = "2026-04-12"
+weight = 4
+tags = ["liftoff", "ignition", "ascent"]
++++
+
+## T-000:00 -- Liftoff
+
+Main engines at full thrust. Hold-down clamps released. The vehicle has cleared the tower.
+
+### Ignition Sequence
+
+At T-000:03, the main engine start command is issued by the flight computer. The turbopumps spin up to operating speed in 2.8 seconds, drawing propellant from both tanks through the feedlines. Combustion chamber pressure rises to nominal operating level, and thrust builds to 100 percent within 0.2 seconds of turbopump start.
+
+**Engine Health Check**
+
+During the 3-second interval between engine start and hold-down release, the flight computer performs a rapid health assessment of all engine parameters:
+
+- Chamber pressure: within 3% of nominal
+- Turbopump speed: within 2% of target RPM
+- Nozzle gimbal response: confirmed
+- Propellant inlet pressure: nominal
+- No anomalous vibration signatures detected
+
+If any parameter falls outside limits, an automatic engine shutdown and safing sequence is initiated.
+
+### Tower Clearance
+
+At hold-down release (T-000:00), the vehicle rises on a column of thrust. The critical tower clearance phase lasts approximately 8 seconds, during which the vehicle must ascend vertically with minimal lateral drift.
+
+The launch tower instrumentation tracks the vehicle during this phase, providing backup trajectory data to the flight computer until the vehicle acquires the downrange tracking stations.
+
+### Ascent Profile
+
+| Time After Liftoff | Event |
+|---------------------|-------|
+| T+000:00 | Hold-down release |
+| T+000:08 | Tower clearance |
+| T+000:12 | Begin pitch program |
+| T+000:15 | Begin roll program |
+| T+001:10 | Max-Q (maximum dynamic pressure) |
+| T+002:30 | Main engine cutoff (MECO) |
+| T+002:33 | Stage separation |
+| T+002:36 | Second stage ignition |
+| T+008:45 | Second engine cutoff (SECO) |
+| T+009:00 | Orbit insertion confirmed |
+
+### Flight Dynamics
+
+The vehicle follows a gravity turn trajectory, gradually pitching downrange while maintaining a near-zero angle of attack through the dense lower atmosphere. At Max-Q, the vehicle experiences peak aerodynamic loading. The flight computer may throttle engines to reduce structural loads during this phase.
+
+After main engine cutoff and stage separation, the second stage ignites in the vacuum of near-space. The second burn circularizes the orbit at the target altitude.
+
+### Mission Success Criteria
+
+- Nominal orbit insertion at target altitude and inclination
+- All payload deployment sequences confirmed
+- Second stage deorbit burn completed
+- Telemetry coverage maintained throughout ascent
+- No range safety actions required
+
+Mission control will confirm orbital parameters and hand off to the mission operations team for on-orbit activities.

--- a/launchpad-event/content/missions/pre-launch-checks.md
+++ b/launchpad-event/content/missions/pre-launch-checks.md
@@ -1,0 +1,50 @@
++++
+title = "Pre-Launch Checks"
+description = "T-120:00 - Vehicle systems verification and readiness confirmation"
+date = "2026-04-12"
+weight = 1
+tags = ["pre-launch", "systems", "verification"]
++++
+
+## T-120:00 -- Pre-Launch Checks
+
+All stations report readiness status. Ground support equipment connections verified. Range safety systems armed and tracking.
+
+### Systems Verification Matrix
+
+The pre-launch check sequence begins two hours before the planned liftoff window. Every subsystem on the vehicle and ground infrastructure must pass a series of automated and manual verification steps before the countdown can proceed.
+
+**Flight Computer Diagnostics**
+
+The onboard flight computer runs a complete self-test cycle, verifying memory integrity, sensor calibration offsets, and navigation database checksums. Any anomaly triggers an automatic hold at this point in the count.
+
+**Structural Integrity**
+
+Strain gauges across the vehicle airframe are polled for baseline readings. These values establish the reference state against which all subsequent loading events -- propellant fill, wind gusts, engine gimbal tests -- will be measured.
+
+**Communications Check**
+
+Uplink and downlink frequencies are verified through the ground station network. Telemetry streams are confirmed at full bandwidth. Voice loops between the vehicle, launch control, and range safety are tested.
+
+### Ground Support Equipment
+
+- Umbilical connections: power, data, pneumatics, propellant
+- Launch mount hold-down clamp preload verification
+- Sound suppression water system armed
+- Flame trench deflector position confirmed
+
+### Weather Constraints
+
+Upper-level wind profiles must fall within vehicle structural limits. Lightning advisory zones must be clear for the prescribed radius. Cloud ceiling and visibility must meet range safety minimums.
+
+### Milestone Status
+
+| Check | Status |
+|-------|--------|
+| Flight computer self-test | NOMINAL |
+| Structural baseline | NOMINAL |
+| Communications | NOMINAL |
+| Ground support | NOMINAL |
+| Weather | MONITORING |
+
+Countdown proceeds to fueling sequence upon completion of all pre-launch verifications.

--- a/launchpad-event/content/register.md
+++ b/launchpad-event/content/register.md
@@ -1,0 +1,70 @@
++++
+title = "Register"
+description = "Register for the launch event - secure your viewing position"
+tags = ["register", "launch", "event"]
++++
+
+<div class="register-page">
+
+## Launch Registration
+
+Secure your position in the mission control viewing gallery for this orbital insertion event. All registered personnel receive mission briefing materials and real-time telemetry access.
+
+<div class="register-tiers">
+  <div class="register-card">
+    <div class="register-tier">OBSERVER</div>
+    <div class="register-price">FREE</div>
+    <ul class="register-features">
+      <li>Public viewing area access</li>
+      <li>Live audio feed from mission control</li>
+      <li>Digital mission patch</li>
+      <li>Post-launch debrief recording</li>
+    </ul>
+    <a href="#" class="register-button">REGISTER</a>
+  </div>
+  <div class="register-card register-card--featured">
+    <div class="register-tier">MISSION SPECIALIST</div>
+    <div class="register-price">$199</div>
+    <ul class="register-features">
+      <li>VIP viewing gallery access</li>
+      <li>Real-time telemetry dashboard</li>
+      <li>Pre-launch facility tour</li>
+      <li>Physical mission patch and certificate</li>
+      <li>Direct audio feed from all voice loops</li>
+    </ul>
+    <a href="#" class="register-button register-button--primary">REGISTER</a>
+  </div>
+  <div class="register-card">
+    <div class="register-tier">FLIGHT DIRECTOR</div>
+    <div class="register-price">$499</div>
+    <ul class="register-features">
+      <li>Mission control room access</li>
+      <li>Assigned console position</li>
+      <li>Full telemetry and voice loop access</li>
+      <li>Launch director meet and brief</li>
+      <li>Exclusive post-mission data package</li>
+      <li>Commemorative flight hardware</li>
+    </ul>
+    <a href="#" class="register-button">REGISTER</a>
+  </div>
+</div>
+
+### Launch Window
+
+The primary launch window opens at the designated time. A backup window is available 24 hours later should a hold or scrub occur during the primary attempt.
+
+All registered attendees will receive notifications via the mission communication system regarding countdown status, holds, and schedule changes.
+
+### Venue Information
+
+- Location: Launch Complex, Pad 01
+- Check-in opens: T-180:00 (three hours before launch)
+- Viewing area opens: T-120:00
+- Mandatory safety briefing: T-150:00
+- Pad clear for fueling: T-090:00
+
+### Requirements
+
+All attendees must present valid identification at check-in. Observer tier attendees remain in the public viewing area at all times. Mission Specialist and Flight Director tier attendees must complete a safety orientation before accessing restricted areas.
+
+</div>

--- a/launchpad-event/content/telemetry.md
+++ b/launchpad-event/content/telemetry.md
@@ -1,0 +1,68 @@
++++
+title = "Telemetry"
+description = "Mission telemetry data and monitoring systems"
+tags = ["telemetry", "data", "monitoring"]
++++
+
+<div class="telemetry-page">
+
+## Mission Telemetry
+
+Real-time telemetry data streams from vehicle and ground systems. All parameters are monitored continuously from pre-launch through orbit insertion.
+
+### Vehicle Telemetry Channels
+
+<div class="telemetry-grid">
+  <div class="telemetry-card">
+    <div class="telemetry-label">PROPULSION</div>
+    <div class="telemetry-value">NOMINAL</div>
+    <div class="telemetry-detail">Chamber pressure, turbopump RPM, propellant flow rates, nozzle temperature, gimbal position</div>
+  </div>
+  <div class="telemetry-card">
+    <div class="telemetry-label">GUIDANCE</div>
+    <div class="telemetry-value">TRACKING</div>
+    <div class="telemetry-detail">Inertial navigation, GPS cross-check, attitude quaternion, rate gyro outputs, star tracker</div>
+  </div>
+  <div class="telemetry-card">
+    <div class="telemetry-label">STRUCTURAL</div>
+    <div class="telemetry-value">NOMINAL</div>
+    <div class="telemetry-detail">Airframe strain, vibration spectra, acoustic levels, thermal profiles, tank pressure</div>
+  </div>
+  <div class="telemetry-card">
+    <div class="telemetry-label">ELECTRICAL</div>
+    <div class="telemetry-value">NOMINAL</div>
+    <div class="telemetry-detail">Bus voltage, battery state-of-charge, power distribution, avionics temperature, current draw</div>
+  </div>
+</div>
+
+### Ground Station Network
+
+Telemetry is received through a network of ground stations positioned along the flight azimuth. Handoff between stations occurs automatically as the vehicle moves downrange.
+
+| Station | Range (km) | Status |
+|---------|-----------|--------|
+| PAD-01 | 0 | ACTIVE |
+| DOWN-01 | 200 | STANDBY |
+| DOWN-02 | 800 | STANDBY |
+| DOWN-03 | 2400 | STANDBY |
+| TDRS-EAST | GEO | STANDBY |
+| TDRS-WEST | GEO | STANDBY |
+
+### Data Rates
+
+- S-band telemetry downlink: 2 Mbps
+- C-band tracking beacon: continuous
+- Flight termination system: encrypted, redundant
+- Voice loop uplink: 16 kbps
+
+### Monitoring Protocol
+
+All telemetry parameters are compared against pre-defined limit sets. Three tiers of limits are defined for each parameter:
+
+- **Green**: nominal operating range
+- **Yellow**: approaching limit, requires attention
+- **Red**: out-of-limit, immediate action required
+
+Console operators monitor their assigned subsystems and call out any yellow or red conditions to the flight director. The flight director has authority to call a hold or initiate abort procedures based on telemetry indications.
+
+</div>

--- a/launchpad-event/static/css/style.css
+++ b/launchpad-event/static/css/style.css
@@ -1,0 +1,1066 @@
+/* ==========================================================================
+   LAUNCHPAD EVENT -- Launch Control Theme
+   Dark with launch-control green
+   ========================================================================== */
+
+:root {
+  --bg-primary: #080c0a;
+  --bg-secondary: #060a08;
+  --bg-panel: #0c140e;
+  --text-primary: #c0e0c8;
+  --text-secondary: #70a078;
+  --text-muted: #408848;
+  --accent-green: #30d060;
+  --border-color: #1a2e1e;
+  --font-display: 'Orbitron', 'Share Tech', sans-serif;
+  --font-body: 'IBM Plex Mono', 'Fira Mono', monospace;
+}
+
+/* ==========================================================================
+   Reset and Base
+   ========================================================================== */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+img, svg {
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: var(--accent-green);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: #50ff80;
+}
+
+/* ==========================================================================
+   Header
+   ========================================================================== */
+
+.site-header {
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--bg-secondary);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  line-height: 1.1;
+}
+
+.logo-main {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  letter-spacing: 0.15em;
+}
+
+.logo-sub {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.site-nav a:hover {
+  color: var(--accent-green);
+  border-bottom-color: var(--accent-green);
+}
+
+.site-nav .nav-cta {
+  color: var(--bg-primary);
+  background-color: var(--accent-green);
+  padding: 0.4rem 1rem;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.site-nav .nav-cta:hover {
+  color: var(--bg-primary);
+  background-color: #50ff80;
+}
+
+/* ==========================================================================
+   Layout
+   ========================================================================== */
+
+.site-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem;
+  min-height: calc(100vh - 180px);
+}
+
+.page-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  background-color: var(--bg-secondary);
+  margin-top: 4rem;
+}
+
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-brand {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.footer-links a {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.footer-links a:hover {
+  color: var(--accent-green);
+}
+
+.footer-powered {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.footer-powered a {
+  color: var(--text-muted);
+}
+
+.footer-powered a:hover {
+  color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Hero Section
+   ========================================================================== */
+
+.hero {
+  padding: 4rem 0 3rem;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+
+.hero-inner {
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hero-tower {
+  width: 160px;
+  flex-shrink: 0;
+}
+
+.hero-text {
+  flex: 1;
+}
+
+.hero-pre {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  margin-bottom: 0.75rem;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  font-weight: 900;
+  color: var(--accent-green);
+  letter-spacing: 0.08em;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.hero-sub {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.2em;
+  margin-bottom: 0.5rem;
+}
+
+.hero-date {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  margin-bottom: 2rem;
+}
+
+.hero-cta {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--bg-primary);
+  background-color: var(--accent-green);
+  padding: 0.75rem 2rem;
+  letter-spacing: 0.1em;
+  border: 2px solid var(--accent-green);
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.hero-cta:hover {
+  background-color: transparent;
+  color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Section Headings
+   ========================================================================== */
+
+.section-heading {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-label {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+/* ==========================================================================
+   Countdown Display
+   ========================================================================== */
+
+.countdown-display {
+  padding: 3rem 0;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+
+.countdown-svg {
+  width: 100%;
+  max-width: 600px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* ==========================================================================
+   Mission Phases
+   ========================================================================== */
+
+.mission-phases {
+  padding: 3rem 0;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+
+.phase-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.phase-card {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 1.5rem;
+  transition: border-color 0.2s;
+}
+
+.phase-card:hover {
+  border-color: var(--text-muted);
+}
+
+.phase-card--active {
+  border-color: var(--accent-green);
+}
+
+.phase-time {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.phase-name {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.phase-card p {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.phase-link {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  color: var(--accent-green);
+  letter-spacing: 0.15em;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 2px;
+}
+
+.phase-link:hover {
+  border-bottom-color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Mission Patch
+   ========================================================================== */
+
+.mission-patch {
+  padding: 3rem 0;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+
+.patch-container {
+  display: flex;
+  justify-content: center;
+}
+
+.patch-svg {
+  width: 260px;
+  height: 260px;
+}
+
+/* ==========================================================================
+   Trajectory
+   ========================================================================== */
+
+.trajectory {
+  padding: 3rem 0;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 3rem;
+}
+
+.trajectory-container {
+  overflow-x: auto;
+}
+
+.trajectory-svg {
+  width: 100%;
+  max-width: 700px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* ==========================================================================
+   Register CTA
+   ========================================================================== */
+
+.register-cta {
+  padding: 3rem 0;
+  text-align: center;
+}
+
+.cta-inner {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.cta-label {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.3em;
+  margin-bottom: 1rem;
+}
+
+.cta-inner h2 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+}
+
+.cta-inner p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.cta-button {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--bg-primary);
+  background-color: var(--accent-green);
+  padding: 0.75rem 2.5rem;
+  letter-spacing: 0.1em;
+  border: 2px solid var(--accent-green);
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.cta-button:hover {
+  background-color: transparent;
+  color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Section List (Missions listing)
+   ========================================================================== */
+
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.75rem;
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  transition: border-color 0.2s;
+}
+
+.section-list li:hover {
+  border-color: var(--text-muted);
+}
+
+.section-list li a {
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--accent-green);
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================================================
+   Post / Article Styles
+   ========================================================================== */
+
+.page-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tag-list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  padding: 0.15rem 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tag:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Prose (Article body)
+   ========================================================================== */
+
+.prose h2 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.prose h3 {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.03em;
+}
+
+.prose p {
+  margin-bottom: 1.25rem;
+  color: var(--text-secondary);
+}
+
+.prose strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.prose ul, .prose ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.prose li {
+  margin-bottom: 0.35rem;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.85rem;
+}
+
+.prose th {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--border-color);
+  background-color: var(--bg-panel);
+}
+
+.prose td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.prose tr:hover td {
+  background-color: var(--bg-panel);
+}
+
+.prose code {
+  font-family: var(--font-body);
+  font-size: 0.85em;
+  color: var(--accent-green);
+  background-color: var(--bg-panel);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--border-color);
+}
+
+.prose pre {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-primary);
+}
+
+.prose blockquote {
+  border-left: 3px solid var(--accent-green);
+  padding-left: 1rem;
+  margin: 1.5rem 0;
+  color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Page-level typography (non-prose context)
+   ========================================================================== */
+
+.page-content h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--accent-green);
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+}
+
+.page-content h2 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.page-content h3 {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.page-content p {
+  margin-bottom: 1.25rem;
+  color: var(--text-secondary);
+}
+
+.page-content ul, .page-content ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.page-content li {
+  margin-bottom: 0.35rem;
+}
+
+.page-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.85rem;
+}
+
+.page-content th {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--border-color);
+  background-color: var(--bg-panel);
+}
+
+.page-content td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.page-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* ==========================================================================
+   Taxonomy
+   ========================================================================== */
+
+.taxonomy-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+/* ==========================================================================
+   404 Error Page
+   ========================================================================== */
+
+.error-page {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-code {
+  font-family: var(--font-display);
+  font-size: 5rem;
+  font-weight: 900;
+  color: var(--border-color);
+  line-height: 1;
+  margin-bottom: 1rem;
+  letter-spacing: 0.1em;
+}
+
+.error-page h1 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.error-page p {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 2rem;
+}
+
+.error-link {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  letter-spacing: 0.1em;
+  border: 1px solid var(--accent-green);
+  padding: 0.5rem 1.5rem;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.error-link:hover {
+  background-color: var(--accent-green);
+  color: var(--bg-primary);
+}
+
+/* ==========================================================================
+   Telemetry Page
+   ========================================================================== */
+
+.telemetry-page {
+  max-width: 800px;
+}
+
+.telemetry-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.telemetry-card {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 1.25rem;
+}
+
+.telemetry-label {
+  font-family: var(--font-display);
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  margin-bottom: 0.5rem;
+}
+
+.telemetry-value {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+
+.telemetry-detail {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ==========================================================================
+   Register Page
+   ========================================================================== */
+
+.register-page {
+  max-width: 900px;
+}
+
+.register-tiers {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin: 2rem 0 3rem;
+}
+
+.register-card {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.register-card--featured {
+  border-color: var(--accent-green);
+}
+
+.register-tier {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  margin-bottom: 0.75rem;
+}
+
+.register-price {
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--accent-green);
+  margin-bottom: 1.25rem;
+}
+
+.register-features {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1.5rem;
+  flex: 1;
+}
+
+.register-features li {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.register-features li:last-child {
+  border-bottom: none;
+}
+
+.register-button {
+  display: block;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  border: 1px solid var(--border-color);
+  padding: 0.6rem;
+  letter-spacing: 0.15em;
+  text-decoration: none;
+  transition: border-color 0.2s, background-color 0.2s, color 0.2s;
+}
+
+.register-button:hover {
+  border-color: var(--accent-green);
+}
+
+.register-button--primary {
+  background-color: var(--accent-green);
+  color: var(--bg-primary);
+  border-color: var(--accent-green);
+}
+
+.register-button--primary:hover {
+  background-color: transparent;
+  color: var(--accent-green);
+}
+
+/* ==========================================================================
+   Pagination
+   ========================================================================== */
+
+nav.pagination {
+  margin: 2rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-family: var(--font-body);
+}
+
+nav.pagination a:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--accent-green);
+  color: var(--accent-green);
+  font-size: 0.8rem;
+  font-family: var(--font-body);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  opacity: 0.5;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  .header-inner {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 0.75rem 1.25rem;
+  }
+
+  .site-nav {
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .hero-inner {
+    flex-direction: column;
+    text-align: center;
+    gap: 2rem;
+  }
+
+  .hero-tower {
+    width: 120px;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .phase-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .telemetry-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .register-tiers {
+    grid-template-columns: 1fr;
+  }
+
+  .site-wrapper {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .footer-inner {
+    padding: 1.5rem 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: 2rem;
+  }
+
+  .hero-tower {
+    width: 100px;
+  }
+
+  .page-content h1 {
+    font-size: 1.5rem;
+  }
+
+  .countdown-svg {
+    min-width: 500px;
+  }
+
+  .countdown-display {
+    overflow-x: auto;
+  }
+}

--- a/launchpad-event/templates/404.html
+++ b/launchpad-event/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content error-page">
+      <div class="error-code">404</div>
+      <h1>SIGNAL LOST</h1>
+      <p>Telemetry link terminated. The requested trajectory does not exist in the flight computer database.</p>
+      <a href="{{ base_url }}/" class="error-link">RETURN TO MISSION CONTROL</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/launchpad-event/templates/footer.html
+++ b/launchpad-event/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">LAUNCHPAD // LAUNCH EVENT</div>
+      <div class="footer-links">
+        <a href="{{ base_url }}/">Control</a>
+        <a href="{{ base_url }}/missions/">Missions</a>
+        <a href="{{ base_url }}/telemetry/">Telemetry</a>
+      </div>
+      <div class="footer-powered">
+        Powered by <a href="https://hwaro.hahwul.com">Hwaro</a>
+      </div>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/launchpad-event/templates/header.html
+++ b/launchpad-event/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} | {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500;600&family=Orbitron:wght@400;500;600;700;800;900&family=Share+Tech&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-main">LAUNCHPAD</span>
+        <span class="logo-sub">launch event</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Control</a>
+        <a href="{{ base_url }}/missions/">Missions</a>
+        <a href="{{ base_url }}/telemetry/">Telemetry</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Launch</a>
+      </nav>
+    </div>
+  </header>

--- a/launchpad-event/templates/page.html
+++ b/launchpad-event/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/launchpad-event/templates/post.html
+++ b/launchpad-event/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("mission") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      <div class="page-meta">
+        {{ page.date | date("%Y-%m-%d") }}
+        {% if page.tags %}
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+      <div class="prose">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/launchpad-event/templates/section.html
+++ b/launchpad-event/templates/section.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">{{ page.section | default("missions") | upper }}</div>
+      <h1>{{ page.title }}</h1>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/launchpad-event/templates/taxonomy.html
+++ b/launchpad-event/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">TAXONOMY</div>
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all classification terms:</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/launchpad-event/templates/taxonomy_term.html
+++ b/launchpad-event/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-wrapper">
+    <div class="page-content">
+      <div class="section-label">TAGGED</div>
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Missions classified under this term:</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1808,6 +1808,13 @@
     "landing",
     "saas"
   ],
+  "launchpad-event": [
+    "event",
+    "dark",
+    "launch",
+    "space",
+    "countdown"
+  ],
   "lava-flow": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1649

## Summary
- Add launchpad-event example site: rocket launch product event with mission control aesthetics
- SVG launch tower and gantry structure diagrams, countdown clock T-minus displays, mission patch circular badge illustrations, trajectory arc diagrams
- Typography: Orbitron/Share Tech Bold display in launch-control green, IBM Plex Mono/Fira Mono body
- T-minus countdown format for all schedule entries

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm green-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes launchpad-event with correct tags