### PR TITLE
feat: add pit-stop example site

### DIFF
--- a/pit-stop/config.toml
+++ b/pit-stop/config.toml
@@ -1,0 +1,39 @@
+title = "Pit Stop"
+description = "Motorsport pit event"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] }
+]
+
+[feeds]
+enabled = true
+type = "rss"
+full_content = true
+limit = 20
+sections = ["positions"]

--- a/pit-stop/content/index.md
+++ b/pit-stop/content/index.md
@@ -1,0 +1,152 @@
++++
+title = "Pit Stop"
+tags = ["event", "dark", "motorsport", "speed", "frantic"]
++++
+
+<section class="hero-section">
+  <div class="hero-inner">
+    <svg class="hero-tire-tracks" viewBox="0 0 1200 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <defs>
+        <pattern id="tirePattern1" x="0" y="0" width="24" height="12" patternUnits="userSpaceOnUse">
+          <rect x="2" y="1" width="8" height="4" rx="1" fill="#2a2818"/>
+          <rect x="14" y="6" width="8" height="4" rx="1" fill="#2a2818"/>
+        </pattern>
+        <pattern id="tirePattern2" x="0" y="0" width="20" height="10" patternUnits="userSpaceOnUse">
+          <rect x="1" y="1" width="6" height="3" rx="1" fill="#1a1808"/>
+          <rect x="11" y="5" width="6" height="3" rx="1" fill="#1a1808"/>
+        </pattern>
+      </defs>
+      <rect x="80" y="10" width="1040" height="28" fill="url(#tirePattern1)" opacity="0.6"/>
+      <rect x="120" y="50" width="960" height="22" fill="url(#tirePattern2)" opacity="0.4"/>
+      <rect x="60" y="85" width="1080" height="25" fill="url(#tirePattern1)" opacity="0.3"/>
+      <line x1="80" y1="24" x2="1120" y2="24" stroke="#2a2818" stroke-width="1" stroke-dasharray="4,8" opacity="0.5"/>
+      <line x1="120" y1="61" x2="1080" y2="61" stroke="#1a1808" stroke-width="1" stroke-dasharray="3,10" opacity="0.35"/>
+    </svg>
+    <h1 class="hero-title">PIT STOP</h1>
+    <p class="hero-subtitle">MOTORSPORT PIT EVENT</p>
+    <p class="hero-tagline">Where milliseconds decide everything</p>
+  </div>
+</section>
+
+<section class="pit-board-section">
+  <h2 class="section-heading">PIT BOARD</h2>
+  <svg class="pit-board-svg" viewBox="0 0 800 320" xmlns="http://www.w3.org/2000/svg" aria-label="Pit board display">
+    <rect x="0" y="0" width="800" height="320" rx="4" fill="#141410" stroke="#2a2818" stroke-width="2"/>
+    <rect x="20" y="15" width="760" height="50" rx="2" fill="#0a0a08" stroke="#e0c020" stroke-width="1"/>
+    <text x="400" y="48" text-anchor="middle" font-family="Orbitron, monospace" font-size="22" fill="#e0c020" font-weight="700">PIT STOP // LIVE TIMING</text>
+    <rect x="20" y="80" width="180" height="100" rx="2" fill="#0a0a08" stroke="#2a2818" stroke-width="1"/>
+    <text x="110" y="115" text-anchor="middle" font-family="Orbitron, monospace" font-size="14" fill="#807830">LAP</text>
+    <text x="110" y="160" text-anchor="middle" font-family="Orbitron, monospace" font-size="42" fill="#e0c020" font-weight="700">47</text>
+    <rect x="220" y="80" width="180" height="100" rx="2" fill="#0a0a08" stroke="#2a2818" stroke-width="1"/>
+    <text x="310" y="115" text-anchor="middle" font-family="Orbitron, monospace" font-size="14" fill="#807830">GAP</text>
+    <text x="310" y="160" text-anchor="middle" font-family="Orbitron, monospace" font-size="42" fill="#e0e0e0" font-weight="700">+1.2</text>
+    <rect x="420" y="80" width="180" height="100" rx="2" fill="#0a0a08" stroke="#2a2818" stroke-width="1"/>
+    <text x="510" y="115" text-anchor="middle" font-family="Orbitron, monospace" font-size="14" fill="#807830">TIRE</text>
+    <text x="510" y="160" text-anchor="middle" font-family="Orbitron, monospace" font-size="42" fill="#c03030" font-weight="700">SOFT</text>
+    <rect x="620" y="80" width="160" height="100" rx="2" fill="#0a0a08" stroke="#2a2818" stroke-width="1"/>
+    <text x="700" y="115" text-anchor="middle" font-family="Orbitron, monospace" font-size="14" fill="#807830">PIT IN</text>
+    <text x="700" y="160" text-anchor="middle" font-family="Orbitron, monospace" font-size="42" fill="#e0c020" font-weight="700">NOW</text>
+    <rect x="20" y="200" width="760" height="100" rx="2" fill="#0a0a08" stroke="#2a2818" stroke-width="1"/>
+    <text x="40" y="240" font-family="'IBM Plex Mono', monospace" font-size="16" fill="#b0a880">SECTOR 1: 28.441</text>
+    <text x="300" y="240" font-family="'IBM Plex Mono', monospace" font-size="16" fill="#b0a880">SECTOR 2: 34.112</text>
+    <text x="560" y="240" font-family="'IBM Plex Mono', monospace" font-size="16" fill="#b0a880">SECTOR 3: 31.887</text>
+    <text x="40" y="275" font-family="Orbitron, monospace" font-size="20" fill="#e0c020" font-weight="700">TOTAL: 1:34.440</text>
+    <text x="560" y="275" font-family="'IBM Plex Mono', monospace" font-size="16" fill="#807830">BEST: 1:33.201</text>
+  </svg>
+</section>
+
+<section class="positions-section">
+  <h2 class="section-heading">CLASSIFICATION</h2>
+  <div class="position-grid">
+    <div class="position-card position-p1">
+      <div class="position-number">P1</div>
+      <div class="position-details">
+        <span class="driver-name">LEADER</span>
+        <span class="gap-time">+0.000</span>
+        <span class="tire-indicator tire-soft">S</span>
+      </div>
+      <a href="/positions/position-1/" class="position-link">View Details</a>
+    </div>
+    <div class="position-card position-p2">
+      <div class="position-number">P2</div>
+      <div class="position-details">
+        <span class="driver-name">CHALLENGER</span>
+        <span class="gap-time">+1.247</span>
+        <span class="tire-indicator tire-medium">M</span>
+      </div>
+      <a href="/positions/position-2/" class="position-link">View Details</a>
+    </div>
+    <div class="position-card position-p3">
+      <div class="position-number">P3</div>
+      <div class="position-details">
+        <span class="driver-name">PURSUER</span>
+        <span class="gap-time">+3.891</span>
+        <span class="tire-indicator tire-hard">H</span>
+      </div>
+      <a href="/positions/position-3/" class="position-link">View Details</a>
+    </div>
+    <div class="position-card position-p4">
+      <div class="position-number">P4</div>
+      <div class="position-details">
+        <span class="driver-name">CONTENDER</span>
+        <span class="gap-time">+8.432</span>
+        <span class="tire-indicator tire-soft">S</span>
+      </div>
+      <a href="/positions/position-4/" class="position-link">View Details</a>
+    </div>
+  </div>
+</section>
+
+<section class="checkered-section">
+  <svg class="checkered-flag-svg" viewBox="0 0 960 80" xmlns="http://www.w3.org/2000/svg" aria-label="Checkered flag pattern">
+    <defs>
+      <pattern id="checkered" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+        <rect x="0" y="0" width="20" height="20" fill="#e8e0c0"/>
+        <rect x="20" y="0" width="20" height="20" fill="#0a0a08"/>
+        <rect x="0" y="20" width="20" height="20" fill="#0a0a08"/>
+        <rect x="20" y="20" width="20" height="20" fill="#e8e0c0"/>
+      </pattern>
+    </defs>
+    <rect x="0" y="0" width="960" height="80" fill="url(#checkered)" opacity="0.15"/>
+    <rect x="0" y="0" width="960" height="2" fill="#e0c020" opacity="0.4"/>
+    <rect x="0" y="78" width="960" height="2" fill="#e0c020" opacity="0.4"/>
+  </svg>
+</section>
+
+<section class="tire-compound-section">
+  <h2 class="section-heading">TIRE COMPOUNDS</h2>
+  <svg class="tire-compounds-svg" viewBox="0 0 900 200" xmlns="http://www.w3.org/2000/svg" aria-label="Tire compound selection">
+    <rect x="0" y="0" width="280" height="200" rx="4" fill="#141410" stroke="#c03030" stroke-width="2"/>
+    <circle cx="80" cy="100" r="55" fill="none" stroke="#c03030" stroke-width="8"/>
+    <circle cx="80" cy="100" r="30" fill="#0a0a08" stroke="#c03030" stroke-width="2"/>
+    <text x="80" y="108" text-anchor="middle" font-family="Orbitron, monospace" font-size="20" fill="#c03030" font-weight="700">S</text>
+    <text x="200" y="60" font-family="Orbitron, monospace" font-size="18" fill="#c03030" font-weight="700">SOFT</text>
+    <text x="200" y="90" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">Peak grip</text>
+    <text x="200" y="115" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">High degradation</text>
+    <text x="200" y="145" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#807830">~18 lap life</text>
+    <rect x="310" y="0" width="280" height="200" rx="4" fill="#141410" stroke="#d09020" stroke-width="2"/>
+    <circle cx="390" cy="100" r="55" fill="none" stroke="#d09020" stroke-width="8"/>
+    <circle cx="390" cy="100" r="30" fill="#0a0a08" stroke="#d09020" stroke-width="2"/>
+    <text x="390" y="108" text-anchor="middle" font-family="Orbitron, monospace" font-size="20" fill="#d09020" font-weight="700">M</text>
+    <text x="510" y="60" font-family="Orbitron, monospace" font-size="18" fill="#d09020" font-weight="700">MEDIUM</text>
+    <text x="510" y="90" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">Balanced grip</text>
+    <text x="510" y="115" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">Medium wear rate</text>
+    <text x="510" y="145" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#807830">~28 lap life</text>
+    <rect x="620" y="0" width="280" height="200" rx="4" fill="#141410" stroke="#e0e0e0" stroke-width="2"/>
+    <circle cx="700" cy="100" r="55" fill="none" stroke="#e0e0e0" stroke-width="8"/>
+    <circle cx="700" cy="100" r="30" fill="#0a0a08" stroke="#e0e0e0" stroke-width="2"/>
+    <text x="700" y="108" text-anchor="middle" font-family="Orbitron, monospace" font-size="20" fill="#e0e0e0" font-weight="700">H</text>
+    <text x="820" y="60" font-family="Orbitron, monospace" font-size="18" fill="#e0e0e0" font-weight="700">HARD</text>
+    <text x="820" y="90" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">Low grip</text>
+    <text x="820" y="115" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#b0a880">Low degradation</text>
+    <text x="820" y="145" font-family="'IBM Plex Mono', monospace" font-size="13" fill="#807830">~38 lap life</text>
+  </svg>
+</section>
+
+<section class="cta-section">
+  <div class="cta-inner">
+    <h2 class="cta-heading">PIT IN</h2>
+    <p class="cta-text">Register for the motorsport pit event. Milliseconds matter.</p>
+    <a href="/register/" class="cta-button">REGISTER NOW</a>
+  </div>
+</section>

--- a/pit-stop/content/positions/_index.md
+++ b/pit-stop/content/positions/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Positions"
+description = "Race classification and position standings"
+sort_by = "weight"
++++
+
+## CLASSIFICATION
+
+Current standings from the pit lane timing board. All positions updated live from pit wall telemetry.

--- a/pit-stop/content/positions/position-1.md
+++ b/pit-stop/content/positions/position-1.md
@@ -1,0 +1,36 @@
++++
+title = "Position 1 -- Leader"
+description = "P1 race leader position and telemetry"
+tags = ["event", "motorsport", "speed"]
+weight = 1
+
+[extra]
+position = "P1"
+gap = "+0.000"
+tire = "soft"
++++
+
+<div class="position-detail-card">
+  <div class="position-badge position-badge-p1">P1</div>
+  <div class="gap-display">+0.000</div>
+</div>
+
+## Race Leader
+
+Setting the pace from the front. The leader holds position with clean air advantage and optimal pit strategy timing.
+
+### Telemetry
+
+| Metric | Value |
+|--------|-------|
+| Position | P1 |
+| Gap to Leader | +0.000 |
+| Tire Compound | SOFT |
+| Pit Stops | 1 |
+| Last Lap | 1:33.201 |
+| Best Lap | 1:33.201 |
+| Top Speed | 328.4 km/h |
+
+### Strategy Notes
+
+Running soft compound tires with a single pit stop strategy. Tire degradation is within acceptable limits through sector two. Pit window opens on lap 52.

--- a/pit-stop/content/positions/position-2.md
+++ b/pit-stop/content/positions/position-2.md
@@ -1,0 +1,36 @@
++++
+title = "Position 2 -- Challenger"
+description = "P2 challenger position and telemetry"
+tags = ["event", "motorsport", "speed"]
+weight = 2
+
+[extra]
+position = "P2"
+gap = "+1.247"
+tire = "medium"
++++
+
+<div class="position-detail-card">
+  <div class="position-badge position-badge-p2">P2</div>
+  <div class="gap-display">+1.247</div>
+</div>
+
+## Challenger
+
+Closing the gap lap by lap. Running a medium compound strategy that may pay off in the final stint.
+
+### Telemetry
+
+| Metric | Value |
+|--------|-------|
+| Position | P2 |
+| Gap to Leader | +1.247 |
+| Tire Compound | MEDIUM |
+| Pit Stops | 1 |
+| Last Lap | 1:33.612 |
+| Best Lap | 1:33.389 |
+| Top Speed | 326.1 km/h |
+
+### Strategy Notes
+
+Medium compound tires offering longer life at the cost of outright pace. Undercut opportunity exists if the leader pits first. DRS activation zone approach within 1.0 second window is the target.

--- a/pit-stop/content/positions/position-3.md
+++ b/pit-stop/content/positions/position-3.md
@@ -1,0 +1,36 @@
++++
+title = "Position 3 -- Pursuer"
+description = "P3 pursuer position and telemetry"
+tags = ["event", "motorsport", "speed"]
+weight = 3
+
+[extra]
+position = "P3"
+gap = "+3.891"
+tire = "hard"
++++
+
+<div class="position-detail-card">
+  <div class="position-badge position-badge-p3">P3</div>
+  <div class="gap-display">+3.891</div>
+</div>
+
+## Pursuer
+
+Holding a steady third. Hard compound strategy prioritizes consistency over raw pace through the middle stint.
+
+### Telemetry
+
+| Metric | Value |
+|--------|-------|
+| Position | P3 |
+| Gap to Leader | +3.891 |
+| Tire Compound | HARD |
+| Pit Stops | 0 |
+| Last Lap | 1:34.102 |
+| Best Lap | 1:33.780 |
+| Top Speed | 325.8 km/h |
+
+### Strategy Notes
+
+Zero-stop strategy gamble on hard compound tires. No pit stop required if degradation remains linear. Track position advantage over those who pit twice. Fuel load is managed for a long final stint.

--- a/pit-stop/content/positions/position-4.md
+++ b/pit-stop/content/positions/position-4.md
@@ -1,0 +1,36 @@
++++
+title = "Position 4 -- Contender"
+description = "P4 contender position and telemetry"
+tags = ["event", "motorsport", "speed"]
+weight = 4
+
+[extra]
+position = "P4"
+gap = "+8.432"
+tire = "soft"
++++
+
+<div class="position-detail-card">
+  <div class="position-badge position-badge-p4">P4</div>
+  <div class="gap-display">+8.432</div>
+</div>
+
+## Contender
+
+Fighting back through the field on fresh soft tires. Second pit stop completed, now hunting the podium.
+
+### Telemetry
+
+| Metric | Value |
+|--------|-------|
+| Position | P4 |
+| Gap to Leader | +8.432 |
+| Tire Compound | SOFT |
+| Pit Stops | 2 |
+| Last Lap | 1:33.044 |
+| Best Lap | 1:32.998 |
+| Top Speed | 329.2 km/h |
+
+### Strategy Notes
+
+Aggressive two-stop strategy on fresh soft tires. Currently posting the fastest laps on the grid. Closing gap to P3 at approximately 0.8 seconds per lap. Overtake window opens in 6 laps if pace differential holds.

--- a/pit-stop/content/register.md
+++ b/pit-stop/content/register.md
@@ -1,0 +1,65 @@
++++
+title = "Register"
+description = "Pit In -- register for the motorsport pit event"
+tags = ["event", "motorsport"]
++++
+
+<div class="register-header">
+  <h1 class="page-title">PIT IN</h1>
+  <p class="page-subtitle">Register for the motorsport pit event</p>
+</div>
+
+## Event Registration
+
+Enter the pit lane. Registration is open for the next scheduled motorsport pit event.
+
+### Event Details
+
+| Detail | Information |
+|--------|------------|
+| Event | PIT STOP Motorsport Event |
+| Format | Full race weekend |
+| Sessions | Practice / Qualifying / Race |
+| Duration | 58 laps |
+| Location | Pit Lane Circuit |
+
+### Registration Form
+
+<form class="register-form" onsubmit="return false;">
+  <div class="form-group">
+    <label class="form-label" for="reg-name">DRIVER NAME</label>
+    <input class="form-input" type="text" id="reg-name" placeholder="Enter driver name" />
+  </div>
+  <div class="form-group">
+    <label class="form-label" for="reg-team">TEAM</label>
+    <input class="form-input" type="text" id="reg-team" placeholder="Enter team name" />
+  </div>
+  <div class="form-group">
+    <label class="form-label" for="reg-number">CAR NUMBER</label>
+    <input class="form-input" type="text" id="reg-number" placeholder="00" />
+  </div>
+  <div class="form-group">
+    <label class="form-label" for="reg-compound">PREFERRED STARTING COMPOUND</label>
+    <select class="form-input" id="reg-compound">
+      <option value="soft">SOFT (Red)</option>
+      <option value="medium" selected>MEDIUM (Amber)</option>
+      <option value="hard">HARD (White)</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label class="form-label" for="reg-email">CONTACT</label>
+    <input class="form-input" type="email" id="reg-email" placeholder="driver@team.com" />
+  </div>
+  <button class="form-button" type="submit">PIT IN</button>
+</form>
+
+### What to Expect
+
+Upon registration you will receive pit lane credentials and access to the following:
+
+- Pit garage allocation and equipment
+- Telemetry data feed access
+- Tire allocation (13 sets per weekend)
+- Fuel rig and pneumatic gun assignment
+- Radio channel frequency
+- Pit wall timing monitor access

--- a/pit-stop/content/strategy.md
+++ b/pit-stop/content/strategy.md
@@ -1,0 +1,60 @@
++++
+title = "Strategy"
+description = "Pit strategy analysis and planning"
+tags = ["event", "motorsport", "speed"]
++++
+
+<div class="strategy-header">
+  <h1 class="page-title">PIT STRATEGY</h1>
+  <p class="page-subtitle">Race strategy analysis and pit window calculations</p>
+</div>
+
+## Tire Strategy Matrix
+
+Understanding compound selection and pit window timing is critical. Every second in the pit lane costs approximately 22 seconds of track time.
+
+### One-Stop Strategy
+
+| Phase | Compound | Laps | Expected Pace |
+|-------|----------|------|---------------|
+| Stint 1 | MEDIUM | 1-30 | 1:34.2 avg |
+| Pit Stop | -- | -- | ~22.0s |
+| Stint 2 | HARD | 31-58 | 1:34.8 avg |
+
+Total pit time loss: ~22.0 seconds. Optimal for track position preservation.
+
+### Two-Stop Strategy
+
+| Phase | Compound | Laps | Expected Pace |
+|-------|----------|------|---------------|
+| Stint 1 | SOFT | 1-18 | 1:33.4 avg |
+| Pit Stop 1 | -- | -- | ~22.0s |
+| Stint 2 | SOFT | 19-38 | 1:33.6 avg |
+| Pit Stop 2 | -- | -- | ~22.0s |
+| Stint 3 | MEDIUM | 39-58 | 1:34.0 avg |
+
+Total pit time loss: ~44.0 seconds. Aggressive pace offset by double pit loss.
+
+## Undercut and Overcut
+
+### Undercut Window
+
+Pitting one lap before the car ahead. Fresh tires produce a lap time delta of approximately 1.5 to 2.0 seconds on out-lap. Effective when the car ahead has degraded tires.
+
+### Overcut Window
+
+Staying out one or two laps longer. Works when tire warm-up takes time and the pitting car loses pace on cold out-lap. Risky in traffic conditions.
+
+## Pit Lane Timing
+
+| Phase | Duration |
+|-------|----------|
+| Pit entry | ~4.0s |
+| Speed limit zone | ~8.0s |
+| Stationary (tire change) | ~2.4s |
+| Speed limit zone exit | ~8.0s |
+| Total pit loss | ~22.4s |
+
+## Weather Contingency
+
+Intermediate and wet compound tires are available in the event of changing conditions. A switch to intermediates adds approximately 3.0 seconds per lap but avoids aquaplaning risk. Full wet tires add approximately 6.0 seconds per lap.

--- a/pit-stop/static/css/style.css
+++ b/pit-stop/static/css/style.css
@@ -1,0 +1,1122 @@
+/* ==========================================================================
+   PIT STOP -- Motorsport Pit Event
+   Dark theme with high-visibility yellow
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   CSS Custom Properties
+   -------------------------------------------------------------------------- */
+
+:root {
+  --bg-primary: #0a0a08;
+  --bg-secondary: #080806;
+  --bg-panel: #141410;
+  --text-primary: #e8e0c0;
+  --text-secondary: #b0a880;
+  --text-muted: #807830;
+  --accent-yellow: #e0c020;
+  --accent-red: #c03030;
+  --accent-white: #e0e0e0;
+  --accent-amber: #d09020;
+  --border-color: #2a2818;
+  --font-display: 'Orbitron', monospace;
+  --font-heading: 'Rajdhani', sans-serif;
+  --font-body: 'IBM Plex Mono', monospace;
+  --font-mono: 'Fira Mono', monospace;
+  --max-width: 1080px;
+}
+
+/* --------------------------------------------------------------------------
+   Reset and Base
+   -------------------------------------------------------------------------- */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  line-height: 1.7;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+}
+
+/* --------------------------------------------------------------------------
+   Layout
+   -------------------------------------------------------------------------- */
+
+.site-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.site-main {
+  min-height: calc(100vh - 200px);
+  padding-bottom: 3rem;
+}
+
+/* --------------------------------------------------------------------------
+   Header
+   -------------------------------------------------------------------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--border-color);
+  margin-bottom: 2.5rem;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+}
+
+.logo-flag {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.08em;
+}
+
+.site-logo:hover .logo-text {
+  color: var(--text-primary);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.25rem 0;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.site-nav a:hover {
+  color: var(--accent-yellow);
+  border-bottom-color: var(--accent-yellow);
+}
+
+.site-nav .nav-cta {
+  color: var(--bg-primary);
+  background-color: var(--accent-yellow);
+  padding: 0.35rem 1rem;
+  border-bottom: none;
+  font-weight: 700;
+}
+
+.site-nav .nav-cta:hover {
+  background-color: var(--text-primary);
+  color: var(--bg-primary);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background-color: var(--accent-yellow);
+}
+
+/* --------------------------------------------------------------------------
+   Footer
+   -------------------------------------------------------------------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  border-top: 2px solid var(--border-color);
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer-logo {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.08em;
+}
+
+.footer-separator {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.footer-tagline {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-timing {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-stripe svg {
+  width: 100%;
+  height: 8px;
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   Typography
+   -------------------------------------------------------------------------- */
+
+h1, h2, h3, h4 {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.6rem;
+  color: var(--accent-yellow);
+}
+
+h3 {
+  font-size: 1.15rem;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
+}
+
+h4 {
+  font-size: 1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.4rem;
+  color: var(--text-muted);
+}
+
+p {
+  margin: 1em 0;
+  color: var(--text-secondary);
+}
+
+a {
+  color: var(--accent-yellow);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+a:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+}
+
+strong {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background-color: var(--bg-panel);
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border-color);
+}
+
+pre {
+  background-color: var(--bg-panel);
+  padding: 1.25rem;
+  overflow-x: auto;
+  border: 1px solid var(--border-color);
+  margin: 1.5rem 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border: none;
+}
+
+/* --------------------------------------------------------------------------
+   Tables
+   -------------------------------------------------------------------------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+}
+
+thead {
+  border-bottom: 2px solid var(--accent-yellow);
+}
+
+th {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-yellow);
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+td {
+  padding: 0.5rem 0.8rem;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+tr:hover td {
+  background-color: var(--bg-panel);
+}
+
+/* --------------------------------------------------------------------------
+   Hero Section
+   -------------------------------------------------------------------------- */
+
+.hero-section {
+  text-align: center;
+  padding: 4rem 0 3rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-inner {
+  position: relative;
+}
+
+.hero-tire-tracks {
+  width: 100%;
+  max-width: 900px;
+  height: auto;
+  margin-bottom: 2rem;
+  opacity: 0.6;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 5rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.12em;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.hero-subtitle {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin: 0.5rem 0;
+}
+
+.hero-tagline {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-top: 0.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   Section Headings
+   -------------------------------------------------------------------------- */
+
+.section-heading {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding-bottom: 0.6rem;
+  border-bottom: 2px solid var(--border-color);
+  margin-bottom: 2rem;
+  margin-top: 3rem;
+}
+
+.section-header {
+  margin-bottom: 2rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid var(--border-color);
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.08em;
+}
+
+/* --------------------------------------------------------------------------
+   Pit Board SVG
+   -------------------------------------------------------------------------- */
+
+.pit-board-section {
+  margin: 3rem 0;
+}
+
+.pit-board-svg {
+  width: 100%;
+  max-width: 800px;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --------------------------------------------------------------------------
+   Position Grid
+   -------------------------------------------------------------------------- */
+
+.positions-section {
+  margin: 3rem 0;
+}
+
+.position-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.position-card {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 1.5rem 1rem;
+  text-align: center;
+  transition: border-color 0.15s;
+}
+
+.position-card:hover {
+  border-color: var(--accent-yellow);
+}
+
+.position-number {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 3.5rem;
+  line-height: 1;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.position-p1 .position-number {
+  color: var(--accent-yellow);
+}
+
+.position-p2 .position-number {
+  color: var(--text-primary);
+}
+
+.position-p3 .position-number {
+  color: var(--accent-amber);
+}
+
+.position-p4 .position-number {
+  color: var(--text-secondary);
+}
+
+.position-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.driver-name {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.gap-time {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.tire-indicator {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-align: center;
+  margin: 0.25rem auto 0;
+  border-width: 2px;
+  border-style: solid;
+}
+
+.tire-soft {
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+.tire-medium {
+  color: var(--accent-amber);
+  border-color: var(--accent-amber);
+}
+
+.tire-hard {
+  color: var(--accent-white);
+  border-color: var(--accent-white);
+}
+
+.position-link {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 2px;
+}
+
+.position-link:hover {
+  color: var(--accent-yellow);
+  border-bottom-color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Checkered Flag
+   -------------------------------------------------------------------------- */
+
+.checkered-section {
+  margin: 3rem 0;
+}
+
+.checkered-flag-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   Tire Compounds
+   -------------------------------------------------------------------------- */
+
+.tire-compound-section {
+  margin: 3rem 0;
+}
+
+.tire-compounds-svg {
+  width: 100%;
+  max-width: 900px;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --------------------------------------------------------------------------
+   CTA Section
+   -------------------------------------------------------------------------- */
+
+.cta-section {
+  margin: 4rem 0 2rem;
+  text-align: center;
+}
+
+.cta-inner {
+  background-color: var(--bg-panel);
+  border: 2px solid var(--accent-yellow);
+  padding: 3rem 2rem;
+}
+
+.cta-heading {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 2.5rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+.cta-text {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.cta-button {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--bg-primary);
+  background-color: var(--accent-yellow);
+  padding: 0.75rem 2.5rem;
+  text-decoration: none;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 2px solid var(--accent-yellow);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.cta-button:hover {
+  background-color: transparent;
+  color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Section List (positions listing)
+   -------------------------------------------------------------------------- */
+
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  transition: border-color 0.15s;
+}
+
+ul.section-list li:hover {
+  border-color: var(--accent-yellow);
+}
+
+ul.section-list li a {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Post / Article
+   -------------------------------------------------------------------------- */
+
+.post-article {
+  max-width: 800px;
+}
+
+.post-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid var(--border-color);
+}
+
+.post-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+}
+
+.post-position-badge {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 2.5rem;
+  color: var(--accent-yellow);
+  border: 3px solid var(--accent-yellow);
+  padding: 0.25rem 1rem;
+  line-height: 1.1;
+  margin-bottom: 0.5rem;
+  margin-right: 1rem;
+  vertical-align: middle;
+}
+
+.post-gap-time {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--text-secondary);
+  vertical-align: middle;
+}
+
+.post-content {
+  margin-bottom: 2rem;
+}
+
+.post-footer {
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.post-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag-link {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  padding: 0.2rem 0.6rem;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tag-link:hover {
+  color: var(--accent-yellow);
+  border-color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Position Detail Card (in post content)
+   -------------------------------------------------------------------------- */
+
+.position-detail-card {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  background-color: var(--bg-panel);
+  border: 2px solid var(--border-color);
+  padding: 1.5rem 2rem;
+  margin-bottom: 2rem;
+}
+
+.position-badge {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 4rem;
+  line-height: 1;
+  letter-spacing: 0.05em;
+}
+
+.position-badge-p1 {
+  color: var(--accent-yellow);
+}
+
+.position-badge-p2 {
+  color: var(--text-primary);
+}
+
+.position-badge-p3 {
+  color: var(--accent-amber);
+}
+
+.position-badge-p4 {
+  color: var(--text-secondary);
+}
+
+.gap-display {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 2.5rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+/* --------------------------------------------------------------------------
+   Strategy Page
+   -------------------------------------------------------------------------- */
+
+.strategy-header,
+.register-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid var(--border-color);
+}
+
+.page-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 2.2rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+}
+
+.page-subtitle {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Registration Form
+   -------------------------------------------------------------------------- */
+
+.register-form {
+  max-width: 540px;
+  margin: 2rem 0;
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-label {
+  display: block;
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+
+.form-input {
+  display: block;
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  padding: 0.65rem 0.8rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.form-input::placeholder {
+  color: var(--text-muted);
+}
+
+.form-input:focus {
+  border-color: var(--accent-yellow);
+}
+
+.form-input option {
+  background-color: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.form-button {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--bg-primary);
+  background-color: var(--accent-yellow);
+  border: 2px solid var(--accent-yellow);
+  padding: 0.65rem 2rem;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.form-button:hover {
+  background-color: transparent;
+  color: var(--accent-yellow);
+}
+
+/* --------------------------------------------------------------------------
+   404 Error Page
+   -------------------------------------------------------------------------- */
+
+.error-page {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.error-code {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 8rem;
+  color: var(--accent-yellow);
+  line-height: 1;
+  letter-spacing: 0.1em;
+  opacity: 0.3;
+}
+
+.error-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 2rem;
+  color: var(--accent-yellow);
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+
+.error-text {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+
+.error-link {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--bg-primary);
+  background-color: var(--accent-yellow);
+  padding: 0.6rem 1.5rem;
+  text-decoration: none;
+  letter-spacing: 0.08em;
+  border: 2px solid var(--accent-yellow);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.error-link:hover {
+  background-color: transparent;
+  color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+/* --------------------------------------------------------------------------
+   Taxonomy
+   -------------------------------------------------------------------------- */
+
+.taxonomy-desc {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   Pagination
+   -------------------------------------------------------------------------- */
+
+nav.pagination {
+  margin: 2rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+nav.pagination a:hover {
+  color: var(--accent-yellow);
+  border-color: var(--accent-yellow);
+  text-decoration: none;
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--accent-yellow);
+  color: var(--accent-yellow);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  opacity: 0.5;
+}
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 3rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1rem;
+    letter-spacing: 0.12em;
+  }
+
+  .position-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .position-number {
+    font-size: 2.5rem;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+  }
+
+  .position-detail-card {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+
+  .gap-display {
+    font-size: 1.8rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .site-nav {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 0;
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.75rem;
+  }
+
+  .site-nav.active {
+    display: flex;
+  }
+
+  .site-nav a {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .site-nav .nav-cta {
+    text-align: center;
+    margin-top: 0.5rem;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+
+  .site-wrapper {
+    padding: 0 1rem;
+  }
+
+  .hero-title {
+    font-size: 2.2rem;
+  }
+
+  .position-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-inner {
+    padding: 2rem 1rem;
+  }
+
+  .cta-heading {
+    font-size: 1.8rem;
+  }
+
+  .post-position-badge {
+    font-size: 1.8rem;
+    display: block;
+    margin-right: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .post-gap-time {
+    font-size: 1.3rem;
+  }
+
+  .error-code {
+    font-size: 5rem;
+  }
+}

--- a/pit-stop/templates/404.html
+++ b/pit-stop/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <div class="error-code">404</div>
+      <h1 class="error-title">OFF TRACK</h1>
+      <p class="error-text">The page you are looking for has gone wide. Return to the racing line.</p>
+      <a href="{{ base_url }}/" class="error-link">RETURN TO PIT LANE</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/pit-stop/templates/footer.html
+++ b/pit-stop/templates/footer.html
@@ -1,0 +1,30 @@
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <span class="footer-logo">PIT STOP</span>
+          <span class="footer-separator">//</span>
+          <span class="footer-tagline">MOTORSPORT EVENT</span>
+        </div>
+        <div class="footer-meta">
+          <span class="footer-timing">Timing by pit wall telemetry</span>
+        </div>
+      </div>
+      <div class="footer-stripe">
+        <svg viewBox="0 0 1200 8" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" preserveAspectRatio="none">
+          <defs>
+            <pattern id="footerCheck" x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
+              <rect x="0" y="0" width="4" height="4" fill="#e0c020"/>
+              <rect x="4" y="0" width="4" height="4" fill="#0a0a08"/>
+              <rect x="0" y="4" width="4" height="4" fill="#0a0a08"/>
+              <rect x="4" y="4" width="4" height="4" fill="#e0c020"/>
+            </pattern>
+          </defs>
+          <rect x="0" y="0" width="1200" height="8" fill="url(#footerCheck)" opacity="0.3"/>
+        </svg>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/pit-stop/templates/header.html
+++ b/pit-stop/templates/header.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">
+        <svg class="logo-flag" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="0" y="0" width="14" height="14" fill="#e0c020"/>
+          <rect x="14" y="0" width="14" height="14" fill="#0a0a08"/>
+          <rect x="0" y="14" width="14" height="14" fill="#0a0a08"/>
+          <rect x="14" y="14" width="14" height="14" fill="#e0c020"/>
+        </svg>
+        <span class="logo-text">PIT STOP</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Pit Lane</a>
+        <a href="{{ base_url }}/positions/">Positions</a>
+        <a href="{{ base_url }}/strategy/">Strategy</a>
+        <a href="{{ base_url }}/register/" class="nav-cta">Pit In</a>
+      </nav>
+      <button class="nav-toggle" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
+    </header>

--- a/pit-stop/templates/page.html
+++ b/pit-stop/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/pit-stop/templates/post.html
+++ b/pit-stop/templates/post.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="post-article">
+      <header class="post-header">
+        <h1 class="post-title">{{ page.title | e }}</h1>
+        {% if page.extra.position is present %}
+        <div class="post-position-badge">{{ page.extra.position }}</div>
+        {% endif %}
+        {% if page.extra.gap is present %}
+        <div class="post-gap-time">{{ page.extra.gap }}</div>
+        {% endif %}
+      </header>
+      <div class="post-content">
+        {{ content }}
+      </div>
+      {% if page.tags is present %}
+      <footer class="post-footer">
+        <div class="post-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag-link">{{ tag }}</a>
+          {% endfor %}
+        </div>
+      </footer>
+      {% endif %}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/pit-stop/templates/section.html
+++ b/pit-stop/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </div>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/pit-stop/templates/taxonomy.html
+++ b/pit-stop/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </div>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/pit-stop/templates/taxonomy_term.html
+++ b/pit-stop/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="section-header">
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </div>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2673,6 +2673,13 @@
     "docs",
     "cicd"
   ],
+  "pit-stop": [
+    "event",
+    "dark",
+    "motorsport",
+    "speed",
+    "frantic"
+  ],
   "pixel": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1648

## Summary
- Add pit-stop example site: motorsport pit event with racing aesthetics
- SVG tire track rubber mark patterns, pit board display panels, checkered flag patterns, tire compound color coding
- Typography: Orbitron/Rajdhani Bold display in high-visibility yellow/black, IBM Plex Mono/Fira Mono Bold body
- Position boards P1/P2/P3 in oversized bold numbers, gap times in +0.000 format

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG illustrations render correctly
- [ ] Confirm yellow-on-black color scheme with no CSS gradients
- [ ] Verify tags.json includes pit-stop with correct tags