### PR TITLE
feat: add starlight portfolio example template

### DIFF
--- a/starlight/config.toml
+++ b/starlight/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Starlight"
+description = "A glowing, elegant, dark-themed portfolio"
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/starlight/content/about.md
+++ b/starlight/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About"
++++
+
+This theme was built as a showcase of what's possible with [Hwaro](https://github.com/hahwul/hwaro), combining a simple directory structure with a beautiful, modern aesthetic.
+
+The design emphasizes:
+
+1. **Dark Mode by Default**: Deep, rich backgrounds.
+2. **Subtle Glow**: Soft shadows and borders that respond to interaction.
+3. **Simplicity**: No unnecessary bloat, just the essentials for a portfolio or blog.
+
+Feel free to explore the [Gallery](/gallery/) to see how content is structured.

--- a/starlight/content/gallery/_index.md
+++ b/starlight/content/gallery/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Gallery"
+template = "section"
+sort_by = "date"
+reverse = true
+paginate = 10
++++
+
+Welcome to the gallery. This section highlights individual pieces of work, each shining with its own unique light.

--- a/starlight/content/gallery/nebula.md
+++ b/starlight/content/gallery/nebula.md
@@ -1,0 +1,16 @@
++++
+title = "Nebula Photography"
+date = "2023-10-15"
+description = "Capturing the vast, colorful clouds of dust and gas."
+tags = ["photography", "space"]
++++
+
+The Orion Nebula is one of the brightest nebulae, and is visible to the naked eye in the night sky. It is located at a distance of 1,344 ± 20 light-years and is the closest region of massive star formation to Earth.
+
+```html
+<div class="nebula-container">
+  <img src="nebula.jpg" alt="Orion Nebula">
+</div>
+```
+
+The M42 nebula is estimated to be 24 light-years across. It has a mass of about 2,000 times that of the Sun.

--- a/starlight/content/gallery/pulsar.md
+++ b/starlight/content/gallery/pulsar.md
@@ -1,0 +1,18 @@
++++
+title = "Pulsar Visualizer"
+date = "2023-11-02"
+description = "A generative art piece based on pulsar radio emissions."
+tags = ["generative", "space", "code"]
++++
+
+A pulsar is a highly magnetized rotating neutron star that emits beams of electromagnetic radiation out of its magnetic poles.
+
+This project attempts to visualize the rhythmic pulses using generative code.
+
+### The Algorithm
+
+The visualization relies on calculating the intersection of the magnetic axis and the rotational axis over time.
+
+- Phase locking
+- Frequency modulation
+- Amplitude scaling

--- a/starlight/content/index.md
+++ b/starlight/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Home"
++++
+
+<div style="text-align: center; margin: 4rem 0;">
+  <h1 style="font-size: 3rem; margin-bottom: 1rem; color: var(--text);">Illuminating <span style="color: var(--primary);">Ideas</span></h1>
+  <p style="font-size: 1.2rem; max-width: 600px; margin: 0 auto 2rem auto;">A minimalist, glowing portfolio theme designed to showcase your creative work with elegance and clarity.</p>
+  <a href="/gallery/" class="btn">Explore Gallery</a>
+</div>
+
+## Features
+
+- **Elegant Typography**: Carefully selected fonts with excellent readability.
+- **Glowing Accents**: Subtle neon touches to guide the eye without overwhelming.
+- **Responsive Design**: Looks stunning on any device.
+- **Performance Focused**: Built with Hwaro for blazing-fast load times.

--- a/starlight/static/css/style.css
+++ b/starlight/static/css/style.css
@@ -1,0 +1,275 @@
+:root {
+  --primary: #cba6f7;
+  --secondary: #89b4fa;
+  --text: #cdd6f4;
+  --text-muted: #a6adc8;
+  --border: #313244;
+  --bg: #11111b;
+  --bg-subtle: #181825;
+  --bg-hover: #1e1e2e;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Layout */
+.site-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 3rem;
+}
+
+.site-logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  text-shadow: 0 0 10px rgba(203, 166, 247, 0.2);
+  transition: text-shadow 0.3s ease, color 0.3s ease;
+}
+
+.site-logo:hover {
+  color: var(--primary);
+  text-shadow: 0 0 20px rgba(203, 166, 247, 0.5);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-header nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+.site-header nav a:hover {
+  color: var(--primary);
+}
+
+.site-main {
+  flex: 1;
+}
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.3;
+  margin-top: 2em;
+  margin-bottom: 0.75em;
+  font-weight: 600;
+  color: var(--text);
+}
+
+h1 {
+  font-size: 2.2rem;
+  margin-top: 0;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  font-size: 1.7rem;
+}
+
+h3 {
+  font-size: 1.3rem;
+}
+
+p {
+  margin: 1.2em 0;
+  color: var(--text-muted);
+}
+
+a {
+  color: var(--secondary);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+a:hover {
+  color: var(--primary);
+}
+
+.site-main a:not([class]) {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-color: rgba(137, 180, 250, 0.3);
+}
+
+.site-main a:not([class]):hover {
+  text-decoration-color: var(--primary);
+}
+
+code {
+  background: var(--bg-subtle);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+  color: var(--primary);
+}
+
+pre {
+  background: var(--bg-subtle);
+  padding: 1.5rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background: var(--border);
+  margin: 3rem 0;
+}
+
+/* Components */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  gap: 1rem;
+}
+
+ul.section-list li {
+  background: var(--bg-subtle);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+ul.section-list li:hover {
+  transform: translateY(-2px);
+  border-color: var(--primary);
+  box-shadow: 0 4px 20px rgba(203, 166, 247, 0.1);
+}
+
+ul.section-list li a {
+  display: block;
+  padding: 1.5rem;
+  font-weight: 500;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+/* Specific elements verified by grep */
+nav.pagination {
+  margin: 2rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+nav.pagination a, .pagination-current span, .pagination-disabled span {
+  display: inline-block;
+  padding: 0.5rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: all 0.3s ease;
+}
+
+nav.pagination a:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+  background: rgba(203, 166, 247, 0.1);
+}
+
+.pagination-current span {
+  border-color: var(--primary);
+  background: rgba(203, 166, 247, 0.15);
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.pagination-disabled span {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Button */
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: rgba(203, 166, 247, 0.1);
+  color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background: var(--primary);
+  color: var(--bg);
+  text-decoration: none !important;
+  box-shadow: 0 0 15px rgba(203, 166, 247, 0.4);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .site-header {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  h1 {
+    font-size: 1.8rem;
+  }
+}

--- a/starlight/templates/404.html
+++ b/starlight/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="site-main error-page">
+    <h1>404</h1>
+    <p>Page not found</p>
+    <a href="{{ base_url }}/" class="btn">Return Home</a>
+  </main>
+{% endblock %}

--- a/starlight/templates/base.html
+++ b/starlight/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page and page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/gallery/">Gallery</a>
+      </nav>
+    </header>
+    {% block content %}{% endblock %}
+    <footer class="site-footer">
+      <p>Powered by Hwaro</p>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/starlight/templates/page.html
+++ b/starlight/templates/page.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="site-main">
+    {{ content | safe }}
+  </main>
+{% endblock %}

--- a/starlight/templates/section.html
+++ b/starlight/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+    <ul class="section-list">
+      {{ section.list | safe }}
+    </ul>
+    {{ pagination | safe }}
+  </main>
+{% endblock %}

--- a/starlight/templates/shortcodes/alert.html
+++ b/starlight/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/starlight/templates/taxonomy.html
+++ b/starlight/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="site-main">
+    <h1>{{ taxonomy_name | capitalize }}</h1>
+    {{ content | safe }}
+  </main>
+{% endblock %}

--- a/starlight/templates/taxonomy_term.html
+++ b/starlight/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <main class="site-main">
+    <h1>{{ taxonomy_name | capitalize }}: {{ taxonomy_term | e }}</h1>
+    {{ content | safe }}
+  </main>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -3311,6 +3311,12 @@
     "acclaim",
     "celebration"
   ],
+  "starlight": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "minimal"
+  ],
   "starting-gun": [
     "event",
     "dark",


### PR DESCRIPTION
Creates a new "starlight" example for the Hwaro framework.

Features:
- Dark theme portfolio design with elegant glowing accents and responsive layout
- Inherited base.html template structure
- Correctly escaped HTML helpers (og_all_tags, pagination, section.list)
- Added to tags.json under "portfolio", "elegant", "minimal", "dark"

---
*PR created automatically by Jules for task [12679046431684332909](https://jules.google.com/task/12679046431684332909) started by @chei-l*