### PR TITLE
Fix 404 error on Diagnostics link in cockpit example

### DIFF
--- a/cockpit/content/diagnostics/index.md
+++ b/cockpit/content/diagnostics/index.md
@@ -1,0 +1,8 @@
++++
+title = "Diagnostics"
+template = "page"
+date = "2025-04-12T23:00:00"
++++
+
+Running system diagnostics...
+All systems operational.


### PR DESCRIPTION
This PR creates the missing diagnostics page in the `cockpit` example to fix a 404 error from the main navigation link.

---
*PR created automatically by Jules for task [15858535102308493295](https://jules.google.com/task/15858535102308493295) started by @chei-l*