### PR TITLE
Add Elysium Portfolio example site

### DIFF
--- a/elysium-portfolio/AGENTS.md
+++ b/elysium-portfolio/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/elysium-portfolio/config.toml
+++ b/elysium-portfolio/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Elysium Portfolio"
+description = "An elegant, dark-themed portfolio"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/elysium-portfolio/content/about.md
+++ b/elysium-portfolio/content/about.md
@@ -1,0 +1,27 @@
++++
+title = "About"
+tags = ["about", "artist"]
++++
+
+# The Artist
+
+I am a digital artist and designer focused on creating elegant, immersive visual experiences. With a background in traditional illustration and a passion for modern technology, my work bridges the gap between the analog and the digital.
+
+> "Art is not what you see, but what you make others see." — Edgar Degas
+
+## My Approach
+
+I believe in the power of minimalism. By stripping away the unnecessary, we can reveal the core essence of a subject. My aesthetic is defined by dark, moody atmospheres, high-contrast lighting, and a meticulous attention to typographic detail.
+
+## Experience & Exhibitions
+
+*   **Lumina Gallery** — Solo Exhibition, "Shadows & Light", 2023
+*   **Nexus Arts Festival** — Featured Artist, 2022
+*   **Creative Director** — Obsidian Design Studio, 2019-Present
+*   **BFA in Digital Arts** — Metropolis Institute of Art, 2018
+
+## Get in Touch
+
+Interested in a collaboration or a commission? Let's create something beautiful together.
+
+[Contact Me (mail@example.com)](#)

--- a/elysium-portfolio/content/index.md
+++ b/elysium-portfolio/content/index.md
@@ -1,0 +1,50 @@
++++
+title = "Home"
++++
+
+<div class="hero">
+  <h1>Visual Narratives &amp; Digital Art</h1>
+  <p>Exploring the intersection of minimalism, technology, and timeless aesthetics.</p>
+  <a href="/projects/" class="button">View Projects</a>
+</div>
+
+<hr>
+
+<h2>Selected Works</h2>
+
+<div class="projects-grid">
+  <a href="#" class="project-card">
+    <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=2564&auto=format&fit=crop" alt="Abstract Art 1">
+    <div class="project-info">
+      <h3 class="project-title">Ethereal Constructs</h3>
+      <p class="project-desc">Digital Painting, 2024</p>
+      <div class="tags"><span class="tag">Abstract</span><span class="tag">Digital</span></div>
+    </div>
+  </a>
+
+  <a href="#" class="project-card">
+    <img src="https://images.unsplash.com/photo-1550684848-fac1c5b4e853?q=80&w=2670&auto=format&fit=crop" alt="Abstract Art 2">
+    <div class="project-info">
+      <h3 class="project-title">Neon Noir</h3>
+      <p class="project-desc">Concept Art, 2023</p>
+      <div class="tags"><span class="tag">Cyberpunk</span><span class="tag">Illustration</span></div>
+    </div>
+  </a>
+
+  <a href="#" class="project-card">
+    <img src="https://images.unsplash.com/photo-1604871000636-074fa5117945?q=80&w=2487&auto=format&fit=crop" alt="Abstract Art 3">
+    <div class="project-info">
+      <h3 class="project-title">Geometric Horizons</h3>
+      <p class="project-desc">3D Render, 2023</p>
+      <div class="tags"><span class="tag">3D</span><span class="tag">Minimal</span></div>
+    </div>
+  </a>
+</div>
+
+<hr>
+
+<h2>Recent Thoughts</h2>
+
+*   **The Evolution of Digital Canvases** — How technology shapes the way we express visual emotion.
+*   **Minimalism in a Noisy World** — Finding focus and clarity through reductive design.
+*   **Color Theory in the Dark** — Exploring the psychological impact of high-contrast palettes.

--- a/elysium-portfolio/content/projects/_index.md
+++ b/elysium-portfolio/content/projects/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Projects"
+template = "section"
+transparent = true
++++
+
+Here is a selection of my featured works and ongoing experiments.

--- a/elysium-portfolio/templates/404.html
+++ b/elysium-portfolio/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero" style="padding: 8rem 0;">
+  <h1 style="font-size: 6rem; margin-bottom: 0;">404</h1>
+  <h2>Lost in the Void</h2>
+  <p>The masterpiece you are searching for does not exist or has been moved.</p>
+  <a href="{{ base_url }}/" class="button" style="margin-top: 2rem;">Return Home</a>
+</div>
+{% endblock %}

--- a/elysium-portfolio/templates/base.html
+++ b/elysium-portfolio/templates/base.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    /* Elegant Dark Theme for Portfolio */
+    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap');
+
+    :root {
+      --primary: #d4af37; /* Gold */
+      --primary-hover: #f1cf5b;
+      --text: #e0e0e0;
+      --text-muted: #9e9e9e;
+      --border: #333333;
+      --bg: #0f0f11;
+      --bg-subtle: #1a1a1d;
+
+      --font-serif: 'Playfair Display', serif;
+      --font-sans: 'Inter', -apple-system, sans-serif;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-sans);
+      line-height: 1.7;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    ::selection {
+      background: rgba(212, 175, 55, 0.3);
+      color: #fff;
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 900px; margin: 0 auto; padding: 0 2rem; display: flex; flex-direction: column; min-height: 100vh; }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 2.5rem 0;
+      margin-bottom: 3rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .site-logo {
+      font-family: var(--font-serif);
+      font-weight: 600;
+      font-size: 1.8rem;
+      color: #fff;
+      text-decoration: none;
+      letter-spacing: 0.5px;
+      transition: color 0.3s ease;
+    }
+
+    .site-logo:hover { color: var(--primary); }
+
+    .site-header nav { display: flex; gap: 2rem; }
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-weight: 500;
+      transition: color 0.3s ease;
+    }
+    .site-header nav a:hover,
+    .site-header nav a.active { color: var(--primary); }
+
+    .site-main { flex: 1; }
+
+    .site-footer {
+      margin-top: 5rem;
+      padding: 2rem 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+      letter-spacing: 0.5px;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-serif);
+      line-height: 1.3;
+      margin-top: 1.5em;
+      margin-bottom: 0.75em;
+      font-weight: 400;
+      color: #fff;
+    }
+
+    h1 { font-size: 3.5rem; margin-top: 0; line-height: 1.1; letter-spacing: -0.5px; }
+    h2 { font-size: 2.2rem; }
+    h3 { font-size: 1.5rem; }
+
+    p { margin: 1.2em 0; color: #b3b3b3; font-size: 1.05rem; }
+
+    a { color: var(--primary); text-decoration: none; transition: color 0.2s ease; }
+    a:hover { color: var(--primary-hover); }
+
+    blockquote {
+      margin: 2rem 0;
+      padding: 1.5rem 2rem;
+      border-left: 3px solid var(--primary);
+      background: var(--bg-subtle);
+      font-style: italic;
+      color: #d1d1d1;
+    }
+
+    code {
+      background: var(--bg-subtle);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      color: #e6e6e6;
+    }
+
+    pre {
+      background: var(--bg-subtle);
+      padding: 1.5rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    }
+    pre code { background: none; padding: 0; color: inherit; }
+
+    hr {
+      border: 0;
+      height: 1px;
+      background: var(--border);
+      margin: 3rem 0;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+      display: block;
+      margin: 2rem auto;
+    }
+
+    /* Components */
+    .hero {
+      padding: 4rem 0;
+      text-align: center;
+    }
+    .hero h1 { margin-bottom: 1rem; }
+    .hero p {
+      font-size: 1.2rem;
+      max-width: 600px;
+      margin: 0 auto 2rem;
+      color: var(--text-muted);
+    }
+
+    .button {
+      display: inline-block;
+      padding: 0.8rem 2rem;
+      background: transparent;
+      color: var(--primary);
+      border: 1px solid var(--primary);
+      border-radius: 30px;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: all 0.3s ease;
+    }
+    .button:hover {
+      background: var(--primary);
+      color: var(--bg);
+      text-decoration: none;
+    }
+
+    /* Projects Grid */
+    .projects-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 2.5rem;
+      margin: 3rem 0;
+    }
+
+    .project-card {
+      background: var(--bg-subtle);
+      border-radius: 12px;
+      overflow: hidden;
+      border: 1px solid rgba(255,255,255,0.03);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      display: block;
+    }
+
+    .project-card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 15px 30px rgba(0,0,0,0.4);
+      text-decoration: none;
+      border-color: rgba(212, 175, 55, 0.2);
+    }
+
+    .project-card img {
+      margin: 0;
+      border-radius: 0;
+      box-shadow: none;
+      width: 100%;
+      aspect-ratio: 4/3;
+      object-fit: cover;
+      transition: transform 0.5s ease;
+    }
+
+    .project-card:hover img {
+      transform: scale(1.05);
+    }
+
+    .project-info {
+      padding: 1.5rem;
+    }
+
+    .project-title {
+      font-family: var(--font-serif);
+      font-size: 1.4rem;
+      color: #fff;
+      margin: 0 0 0.5rem;
+    }
+
+    .project-desc {
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      margin: 0;
+    }
+
+    /* Section Lists (Default Hwaro overrides) */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem;
+      padding: 1.5rem;
+      background: var(--bg-subtle);
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.03);
+      transition: all 0.3s ease;
+    }
+    ul.section-list li:hover {
+      border-color: rgba(212, 175, 55, 0.3);
+      transform: translateX(5px);
+    }
+    ul.section-list li a {
+      font-family: var(--font-serif);
+      font-size: 1.3rem;
+      color: #fff;
+      display: block;
+      margin-bottom: 0.5rem;
+    }
+    ul.section-list li a:hover {
+      color: var(--primary);
+    }
+
+    /* Taxonomies & Pagination */
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 2rem; font-style: italic; }
+
+    nav.pagination { margin: 3rem 0; }
+    nav.pagination .pagination-list {
+      list-style: none; padding: 0; margin: 0;
+      display: flex; gap: 0.5rem; flex-wrap: wrap; justify-content: center;
+    }
+    nav.pagination a, nav.pagination span {
+      display: flex; align-items: center; justify-content: center;
+      min-width: 40px; height: 40px; padding: 0 0.5rem;
+      border-radius: 50%; border: 1px solid var(--border);
+      color: var(--text-muted); text-decoration: none;
+      font-family: var(--font-serif); font-size: 1.1rem;
+      transition: all 0.3s ease;
+    }
+    nav.pagination a:hover { color: var(--primary); border-color: var(--primary); }
+
+    .pagination-current span {
+      border-color: var(--primary);
+      background: var(--primary);
+      color: var(--bg);
+    }
+    .pagination-disabled span { opacity: 0.3; }
+
+    /* Tags styling */
+    .tags { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem; }
+    .tag {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      padding: 0.3rem 0.8rem;
+      border-radius: 20px;
+      background: rgba(255,255,255,0.05);
+      color: var(--text-muted);
+      border: 1px solid rgba(255,255,255,0.1);
+      transition: all 0.3s ease;
+    }
+    .tag:hover {
+      background: rgba(212, 175, 55, 0.1);
+      color: var(--primary);
+      border-color: rgba(212, 175, 55, 0.3);
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .site-header { flex-direction: column; gap: 1.5rem; padding: 2rem 0; }
+      h1 { font-size: 2.5rem; }
+      .projects-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/projects/">Work</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} {{ site.title }}. All rights reserved. <br> Powered by <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/elysium-portfolio/templates/page.html
+++ b/elysium-portfolio/templates/page.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+    {{ content | safe }}
+{% endblock %}

--- a/elysium-portfolio/templates/section.html
+++ b/elysium-portfolio/templates/section.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ section.title | default("Section") | e }}</h1>
+    {{ content | safe }}
+    <ul class="section-list">
+      {{ section.list | safe }}
+    </ul>
+    {{ pagination | safe }}
+{% endblock %}

--- a/elysium-portfolio/templates/shortcodes/alert.html
+++ b/elysium-portfolio/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/elysium-portfolio/templates/taxonomy.html
+++ b/elysium-portfolio/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ taxonomy_name | default("Taxonomy") | capitalize | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content | safe }}
+{% endblock %}

--- a/elysium-portfolio/templates/taxonomy_term.html
+++ b/elysium-portfolio/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ taxonomy_term | default("Term") | capitalize | e }}</h1>
+    <p class="taxonomy-desc">Content tagged with <strong>{{ taxonomy_term | e }}</strong>:</p>
+    {{ content | safe }}
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1104,6 +1104,11 @@
     "minimal",
     "dark"
   ],
+  "elysium-portfolio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
   "embargo-lift": [
     "event",
     "dark",


### PR DESCRIPTION
This PR introduces a new example site named `elysium-portfolio` to the repository. It showcases how to build a sophisticated, dark-themed portfolio website using Hwaro. 

Key additions:
- Configured a new Hwaro project with the `title` "Elysium Portfolio".
- Implemented template inheritance (`base.html` and extending templates like `page.html`, `section.html`, `404.html`, etc.).
- Designed an elegant custom CSS theme within `base.html` featuring Playfair Display typography, responsive grids, and subtle hover interactions.
- Added sample markdown content (`index.md`, `about.md`, `projects/_index.md`) to reflect a typical creative portfolio structure.
- Updated the root `tags.json` to register `elysium-portfolio` under tags `dark`, `portfolio`, and `minimal`.

All files have been verified to build correctly with the current version of Hwaro.

---
*PR created automatically by Jules for task [4917372836620000598](https://jules.google.com/task/4917372836620000598) started by @chei-l*