### PR TITLE
Fix 404s in thesis theme Recent Papers section

### DIFF
--- a/thesis/content/index.md
+++ b/thesis/content/index.md
@@ -7,21 +7,3 @@ description = "An academic journal theme for Hwaro. Clean typography, structured
   <div class="article-abstract-label">About This Theme</div>
   <p>Thesis is a Hwaro theme designed for academic writing and research publications. It features serif typography, a table of contents sidebar, footnotes, references, and structured metadata -- everything needed to present scholarly work on the web.</p>
 </div>
-
-## Recent Papers
-
-<ul class="paper-list">
-{% for p in site.pages %}
-{% if p.section == "papers" %}
-  <li class="paper-list-item">
-    <div class="paper-list-title"><a href="{{ p.url }}">{{ p.title }}</a></div>
-    <div class="paper-list-meta">
-      {% if p.extra.authors %}{{ p.extra.authors }} &middot; {% endif %}{{ p.date | date("%B %d, %Y") }}
-    </div>
-    {% if p.description %}
-    <div class="paper-list-excerpt">{{ p.description | truncate_words(30) }}</div>
-    {% endif %}
-  </li>
-{% endif %}
-{% endfor %}
-</ul>

--- a/thesis/templates/home.html
+++ b/thesis/templates/home.html
@@ -3,6 +3,22 @@
   <main class="layout layout--single">
     <div class="content-area">
       {{ content | safe }}
+      <h2 id="recent-papers">Recent Papers</h2>
+      <ul class="paper-list">
+      {% for p in site.pages %}
+      {% if p.section == "papers" %}
+        <li class="paper-list-item">
+          <div class="paper-list-title"><a href="{{ p.url }}">{{ p.title }}</a></div>
+          <div class="paper-list-meta">
+            {% if p.extra.authors %}{{ p.extra.authors }} &middot; {% endif %}{{ p.date | date("%B %d, %Y") }}
+          </div>
+          {% if p.description %}
+          <div class="paper-list-excerpt">{{ p.description | truncate_words(30) }}</div>
+          {% endif %}
+        </li>
+      {% endif %}
+      {% endfor %}
+      </ul>
     </div>
   </main>
 


### PR DESCRIPTION
This commit resolves a 404 issue on the `thesis` theme's homepage where the `Recent Papers` links were literal strings (`{{ p.url }}`) instead of actual paths.

The templating engine logic (`{% for p in site.pages %}`) does not execute within the Hwaro markdown body context. The loop and HTML list elements were correctly moved from `thesis/content/index.md` to `thesis/templates/home.html` immediately after `{{ content | safe }}` to restore functionality without altering the site's design or layout.

---
*PR created automatically by Jules for task [16476160283685037490](https://jules.google.com/task/16476160283685037490) started by @chei-l*