### PR TITLE
Add new simulation-paper example site

### DIFF
--- a/simulation-paper/AGENTS.md
+++ b/simulation-paper/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/simulation-paper/config.toml
+++ b/simulation-paper/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Simulation Paper - Computational Model Paper
+# Issue #1627 | Tags: paper, dark, computational, simulation, model
+# =============================================================================
+
+title = "Agent-Based Epidemic Simulation"
+description = "A computational model paper presenting an agent-based epidemic simulation with architecture diagrams, parameter space heatmaps, and sensitivity analysis tornado diagrams."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/simulation-paper/content/appendix.md
+++ b/simulation-paper/content/appendix.md
@@ -1,0 +1,33 @@
++++
+title = "Appendix"
+description = "Reproducibility details, protocol deviations, data availability, and author contributions for the SIR-ABM simulation paper."
+tags = ["paper", "computational", "simulation"]
+categories = ["pages"]
++++
+
+## A1. Reproducibility
+
+All simulations were run in Julia 1.10.2 on a 16-core AMD EPYC 7763 workstation with 128 GB RAM. Key packages: `Agents.jl` v6.0, `LightGraphs.jl` v2.0, `ApproxBayes.jl` v0.4, `Sobol.jl` v1.5. Random seed for reproducibility: `42_000_001`. The full codebase is archived at Zenodo (DOI: 10.5281/zenodo.xxxxxxx).
+
+## A2. Protocol Deviations
+
+Two deviations from the pre-registered protocol:
+
+1. **Network rewiring** -- The original protocol specified static networks. During calibration, household-layer contacts were made dynamic to reflect empirical contact survey data showing weekend effects. This change is documented in the supplementary commit log.
+2. **Intervention delay** -- A 3-day implementation delay was added to the intervention module after reviewer feedback, reflecting real-world policy lag. This increased the base-case final attack rate by approximately 2.4 percentage points.
+
+## A3. Data Availability
+
+Empirical outbreak datasets A and B are publicly available from the WHO Global Health Observatory (GHO). Dataset C was obtained under a data-sharing agreement with the Kuroda Institute and is available upon reasonable request to the corresponding author.
+
+## A4. CRediT Author Contributions
+
+- **Kenji Nakamura** -- Conceptualisation, methodology, software, writing (original draft), supervision
+- **Francis Osei-Mensah** -- Methodology, formal analysis, validation, writing (review and editing)
+- **Elsa Lindqvist** -- Software, data curation, visualisation
+- **Amara Diallo** -- Formal analysis, investigation, writing (review and editing)
+- **Henrik Voss** -- Resources, funding acquisition, project administration
+
+## A5. Conflict of Interest
+
+The authors declare no competing interests. Funding was provided by the Kuroda Institute Research Fund (Grant KI-2025-0412) and the Swiss National Science Foundation (Grant 200021_204918).

--- a/simulation-paper/content/architecture.md
+++ b/simulation-paper/content/architecture.md
@@ -1,0 +1,87 @@
++++
+title = "Architecture Summary"
+description = "Summary of the SIR-ABM module architecture, interface contracts, and computational requirements."
+tags = ["paper", "computational", "simulation"]
+categories = ["pages"]
++++
+
+## Module Overview
+
+The SIR-ABM architecture comprises five independent modules connected by standardised data contracts. Each module can be tested, replaced, or extended without modifying adjacent components.
+
+### Module Specifications
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Module specifications and computational cost per simulation run (N = 100,000 agents).</caption>
+  <thead>
+    <tr>
+      <th>Module</th>
+      <th>Input</th>
+      <th>Output</th>
+      <th>Wall time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>PopulationGenerator</code></td>
+      <td>N, age distribution, comorbidity rates</td>
+      <td>Agent array with attributes</td>
+      <td class="num">0.3 s</td>
+    </tr>
+    <tr>
+      <td><code>NetworkConstructor</code></td>
+      <td>Agent array, degree distribution, layer config</td>
+      <td>Adjacency list (3 layers)</td>
+      <td class="num">1.8 s</td>
+    </tr>
+    <tr>
+      <td><code>TransmissionEngine</code></td>
+      <td>Network, SIR parameters, time steps</td>
+      <td>State matrix (N x T)</td>
+      <td class="num">4.2 s</td>
+    </tr>
+    <tr>
+      <td><code>InterventionPolicy</code></td>
+      <td>State matrix, policy rules, thresholds</td>
+      <td>Modified adjacency list per step</td>
+      <td class="num">0.6 s</td>
+    </tr>
+    <tr>
+      <td><code>OutputAggregator</code></td>
+      <td>State matrix, network snapshots</td>
+      <td>Epidemic curve, R_eff series, summary stats</td>
+      <td class="num">0.4 s</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Total wall time per run: approximately 7.3 seconds on a 16-core workstation (AMD EPYC 7763). Parallelisation across runs achieves near-linear speedup up to 64 cores.</td></tr>
+  </tfoot>
+</table>
+
+### Interface Contract
+
+Each module exposes a single entry-point function with typed input and output structs. The pseudocode below illustrates the top-level simulation loop.
+
+<div class="pseudocode-block">
+  <span class="algo-name">Algorithm A1: SIR-ABM Main Loop</span>
+  <span class="keyword">function</span> RunSimulation(config):<br>
+  <span class="indent-1">agents &larr; PopulationGenerator.generate(config.N, config.age_dist)</span><br>
+  <span class="indent-1">network &larr; NetworkConstructor.build(agents, config.degree_dist)</span><br>
+  <span class="indent-1">state &larr; InitialState(agents, config.seed_count)</span><br>
+  <span class="indent-1"><span class="keyword">for</span> t &larr; 1 <span class="keyword">to</span> config.T_max:</span><br>
+  <span class="indent-2">state &larr; TransmissionEngine.step(state, network, config.beta, config.gamma)</span><br>
+  <span class="indent-2"><span class="keyword">if</span> InterventionPolicy.triggered(state, config.thresholds):</span><br>
+  <span class="indent-3">network &larr; InterventionPolicy.apply(network, config.policy_rules)</span><br>
+  <span class="indent-2">OutputAggregator.record(t, state, network)</span><br>
+  <span class="indent-1"><span class="keyword">return</span> OutputAggregator.finalise()</span>
+</div>
+
+### Contact Network Layers
+
+The model uses a three-layer multiplex network:
+
+1. **Household layer** -- complete subgraphs of size 2 to 6, drawn from census household-size distributions
+2. **Workplace / school layer** -- Barabasi-Albert preferential attachment with mean degree k = 12
+3. **Community layer** -- Erdos-Renyi random graph with mean degree k = 4
+
+Each layer has an independent weight parameter controlling the per-contact transmission probability, calibrated separately during the ABC-SMC procedure.

--- a/simulation-paper/content/index.md
+++ b/simulation-paper/content/index.md
@@ -1,0 +1,271 @@
++++
+title = "Abstract"
+description = "An agent-based model for epidemic dynamics with heterogeneous contact networks, calibrated via approximate Bayesian computation and validated against empirical outbreak data."
+tags = ["paper", "dark", "computational", "simulation", "model"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Research &middot; Open Access</p>
+  <h1 class="paper-title">SIR-ABM: An Agent-Based Epidemic Simulation with Heterogeneous Contact Networks and Adaptive Intervention Policies</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Kenji Nakamura</span><sup>1</sup>,
+    Francis Osei-Mensah<sup>2</sup>,
+    Elsa Lindqvist<sup>1,3</sup>,
+    Amara Diallo<sup>2</sup>,
+    Henrik Voss<sup>4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Computational Epidemiology Lab, Kuroda Institute of Technology &middot;
+    <sup>2</sup>Centre for Complex Systems, Accra University &middot;
+    <sup>3</sup>Department of Applied Mathematics, Uppsala University &middot;
+    <sup>4</sup>Digital Health Group, ETH Bern
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/cml.2026.18.07.412</a> &middot; <strong>Received:</strong> 03 Mar 2026 &middot; <strong>Accepted:</strong> 18 Aug 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>To develop, calibrate, and validate an agent-based SIR model (SIR-ABM) that simulates epidemic spread across heterogeneous contact networks with adaptive intervention policies.</dd>
+    <dt>Methods</dt>
+    <dd>The model comprises five modules: population generator, contact network constructor, disease transmission engine, intervention policy module, and output aggregator. Parameters were calibrated via approximate Bayesian computation (ABC-SMC) against three empirical outbreak datasets. Sensitivity analysis used a Sobol decomposition across 14 free parameters.</dd>
+    <dt>Results</dt>
+    <dd>The calibrated model reproduced empirical epidemic curves within a 4.2 pct mean absolute percentage error. Peak timing error was 2.1 days (95 pct CI: 0.8 to 3.6). Contact network heterogeneity explained 38 pct of variance in final attack rate; transmission probability and intervention timing explained an additional 29 pct and 18 pct, respectively.</dd>
+    <dt>Conclusion</dt>
+    <dd>SIR-ABM provides a modular, extensible platform for scenario analysis of epidemic interventions. The architecture separates concerns cleanly, enabling independent validation of each module.</dd>
+    <dt>Keywords</dt>
+    <dd><em>agent-based model; epidemic simulation; SIR dynamics; contact network; approximate Bayesian computation; sensitivity analysis</em></dd>
+  </dl>
+</section>
+
+## Model Architecture Overview
+
+<figure class="figure">
+  <svg viewBox="0 0 720 340" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Block diagram showing five modules of the SIR-ABM architecture connected by data flow arrows">
+    <!-- Module 1: Population Generator -->
+    <rect x="20" y="30" width="130" height="60" fill="none" stroke="#5ba3c9" stroke-width="2"/>
+    <text x="85" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">POPULATION</text>
+    <text x="85" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">GENERATOR</text>
+    <text x="85" y="108" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">N agents, age,</text>
+    <text x="85" y="120" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">comorbidity flags</text>
+    <!-- Module 2: Network Constructor -->
+    <rect x="190" y="30" width="130" height="60" fill="none" stroke="#5ba3c9" stroke-width="2"/>
+    <text x="255" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">CONTACT NETWORK</text>
+    <text x="255" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">CONSTRUCTOR</text>
+    <text x="255" y="108" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">Scale-free graph,</text>
+    <text x="255" y="120" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">degree dist., layers</text>
+    <!-- Module 3: Transmission Engine -->
+    <rect x="400" y="30" width="130" height="60" fill="none" stroke="#e8a84c" stroke-width="2"/>
+    <text x="465" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">TRANSMISSION</text>
+    <text x="465" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">ENGINE</text>
+    <text x="465" y="108" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">SIR transitions,</text>
+    <text x="465" y="120" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">beta, gamma params</text>
+    <!-- Module 4: Intervention Policy -->
+    <rect x="400" y="200" width="130" height="60" fill="none" stroke="#e8a84c" stroke-width="2"/>
+    <text x="465" y="225" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">INTERVENTION</text>
+    <text x="465" y="240" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">POLICY MODULE</text>
+    <text x="465" y="278" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">Threshold triggers,</text>
+    <text x="465" y="290" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">edge removal rules</text>
+    <!-- Module 5: Output Aggregator -->
+    <rect x="590" y="115" width="110" height="60" fill="none" stroke="#5cba7d" stroke-width="2"/>
+    <text x="645" y="140" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">OUTPUT</text>
+    <text x="645" y="155" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" letter-spacing="0.5">AGGREGATOR</text>
+    <text x="645" y="193" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">Curves, R_eff,</text>
+    <text x="645" y="205" text-anchor="middle" font-family="Inter" font-size="9" fill="#8b95a5">attack rate</text>
+    <!-- Arrows -->
+    <line x1="150" y1="60" x2="190" y2="60" stroke="#5ba3c9" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <line x1="320" y1="60" x2="400" y2="60" stroke="#5ba3c9" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <line x1="530" y1="60" x2="620" y2="115" stroke="#5cba7d" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+    <line x1="465" y1="90" x2="465" y2="200" stroke="#e8a84c" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#arrowOrange)"/>
+    <line x1="530" y1="230" x2="620" y2="175" stroke="#5cba7d" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+    <!-- Arrow markers -->
+    <defs>
+      <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#5ba3c9"/>
+      </marker>
+      <marker id="arrowOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#e8a84c"/>
+      </marker>
+      <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#5cba7d"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> SIR-ABM model architecture. Five loosely-coupled modules communicate via standardised data interfaces. Blue modules handle initialisation, orange modules govern runtime dynamics, and the green module collects output metrics.</figcaption>
+</figure>
+
+<section class="model-callout">
+  <span class="callout-label">Mean Absolute Percentage Error</span>
+  <span class="callout-value">4.2 pct<span class="unit">against empirical curves</span></span>
+  <p class="callout-detail">Peak timing error: 2.1 days (95 pct CI: 0.8 to 3.6). Final attack rate error: 1.8 pct (95 pct CI: 0.4 to 3.1). Calibrated via ABC-SMC with 50,000 particle draws per round across 8 rounds.</p>
+</section>
+
+## Parameter Space Heatmap
+
+<figure class="figure">
+  <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Heatmap showing interaction between transmission probability beta and contact network degree on final attack rate">
+    <!-- Background grid -->
+    <rect x="80" y="20" width="560" height="280" fill="#0e1117" stroke="#2a3342" stroke-width="1"/>
+    <!-- Row labels (gamma values) -->
+    <g font-family="IBM Plex Mono" font-size="10" fill="#8b95a5" text-anchor="end">
+      <text x="75" y="50">beta=0.08</text>
+      <text x="75" y="90">beta=0.06</text>
+      <text x="75" y="130">beta=0.04</text>
+      <text x="75" y="170">beta=0.03</text>
+      <text x="75" y="210">beta=0.02</text>
+      <text x="75" y="250">beta=0.01</text>
+      <text x="75" y="290">beta=0.005</text>
+    </g>
+    <!-- Column labels (degree) -->
+    <g font-family="IBM Plex Mono" font-size="10" fill="#8b95a5" text-anchor="middle">
+      <text x="120" y="316">k=4</text>
+      <text x="200" y="316">k=8</text>
+      <text x="280" y="316">k=12</text>
+      <text x="360" y="316">k=16</text>
+      <text x="440" y="316">k=20</text>
+      <text x="520" y="316">k=24</text>
+      <text x="600" y="316">k=28</text>
+    </g>
+    <!-- Heatmap cells row 1 (beta=0.08) - high attack rates -->
+    <rect x="80" y="30" width="80" height="40" fill="#d15b5b" opacity="0.7"/>
+    <rect x="160" y="30" width="80" height="40" fill="#d15b5b" opacity="0.85"/>
+    <rect x="240" y="30" width="80" height="40" fill="#d15b5b" opacity="0.95"/>
+    <rect x="320" y="30" width="80" height="40" fill="#d15b5b"/>
+    <rect x="400" y="30" width="80" height="40" fill="#d15b5b"/>
+    <rect x="480" y="30" width="80" height="40" fill="#d15b5b"/>
+    <rect x="560" y="30" width="80" height="40" fill="#d15b5b"/>
+    <!-- Row 2 (beta=0.06) -->
+    <rect x="80" y="70" width="80" height="40" fill="#e8a84c" opacity="0.5"/>
+    <rect x="160" y="70" width="80" height="40" fill="#d15b5b" opacity="0.6"/>
+    <rect x="240" y="70" width="80" height="40" fill="#d15b5b" opacity="0.75"/>
+    <rect x="320" y="70" width="80" height="40" fill="#d15b5b" opacity="0.85"/>
+    <rect x="400" y="70" width="80" height="40" fill="#d15b5b" opacity="0.9"/>
+    <rect x="480" y="70" width="80" height="40" fill="#d15b5b" opacity="0.95"/>
+    <rect x="560" y="70" width="80" height="40" fill="#d15b5b"/>
+    <!-- Row 3 (beta=0.04) -->
+    <rect x="80" y="110" width="80" height="40" fill="#e8a84c" opacity="0.3"/>
+    <rect x="160" y="110" width="80" height="40" fill="#e8a84c" opacity="0.5"/>
+    <rect x="240" y="110" width="80" height="40" fill="#e8a84c" opacity="0.7"/>
+    <rect x="320" y="110" width="80" height="40" fill="#d15b5b" opacity="0.6"/>
+    <rect x="400" y="110" width="80" height="40" fill="#d15b5b" opacity="0.7"/>
+    <rect x="480" y="110" width="80" height="40" fill="#d15b5b" opacity="0.8"/>
+    <rect x="560" y="110" width="80" height="40" fill="#d15b5b" opacity="0.85"/>
+    <!-- Row 4 (beta=0.03) -->
+    <rect x="80" y="150" width="80" height="40" fill="#3dbfa8" opacity="0.4"/>
+    <rect x="160" y="150" width="80" height="40" fill="#e8a84c" opacity="0.35"/>
+    <rect x="240" y="150" width="80" height="40" fill="#e8a84c" opacity="0.5"/>
+    <rect x="320" y="150" width="80" height="40" fill="#e8a84c" opacity="0.65"/>
+    <rect x="400" y="150" width="80" height="40" fill="#e8a84c" opacity="0.75"/>
+    <rect x="480" y="150" width="80" height="40" fill="#d15b5b" opacity="0.55"/>
+    <rect x="560" y="150" width="80" height="40" fill="#d15b5b" opacity="0.65"/>
+    <!-- Row 5 (beta=0.02) -->
+    <rect x="80" y="190" width="80" height="40" fill="#3dbfa8" opacity="0.3"/>
+    <rect x="160" y="190" width="80" height="40" fill="#3dbfa8" opacity="0.4"/>
+    <rect x="240" y="190" width="80" height="40" fill="#e8a84c" opacity="0.35"/>
+    <rect x="320" y="190" width="80" height="40" fill="#e8a84c" opacity="0.45"/>
+    <rect x="400" y="190" width="80" height="40" fill="#e8a84c" opacity="0.55"/>
+    <rect x="480" y="190" width="80" height="40" fill="#e8a84c" opacity="0.65"/>
+    <rect x="560" y="190" width="80" height="40" fill="#e8a84c" opacity="0.75"/>
+    <!-- Row 6 (beta=0.01) -->
+    <rect x="80" y="230" width="80" height="40" fill="#5ba3c9" opacity="0.3"/>
+    <rect x="160" y="230" width="80" height="40" fill="#3dbfa8" opacity="0.3"/>
+    <rect x="240" y="230" width="80" height="40" fill="#3dbfa8" opacity="0.35"/>
+    <rect x="320" y="230" width="80" height="40" fill="#3dbfa8" opacity="0.4"/>
+    <rect x="400" y="230" width="80" height="40" fill="#e8a84c" opacity="0.35"/>
+    <rect x="480" y="230" width="80" height="40" fill="#e8a84c" opacity="0.45"/>
+    <rect x="560" y="230" width="80" height="40" fill="#e8a84c" opacity="0.55"/>
+    <!-- Row 7 (beta=0.005) -->
+    <rect x="80" y="270" width="80" height="40" fill="#5ba3c9" opacity="0.2"/>
+    <rect x="160" y="270" width="80" height="40" fill="#5ba3c9" opacity="0.25"/>
+    <rect x="240" y="270" width="80" height="40" fill="#5ba3c9" opacity="0.3"/>
+    <rect x="320" y="270" width="80" height="40" fill="#3dbfa8" opacity="0.3"/>
+    <rect x="400" y="270" width="80" height="40" fill="#3dbfa8" opacity="0.35"/>
+    <rect x="480" y="270" width="80" height="40" fill="#3dbfa8" opacity="0.4"/>
+    <rect x="560" y="270" width="80" height="40" fill="#e8a84c" opacity="0.35"/>
+    <!-- Cell values - selected cells -->
+    <g font-family="IBM Plex Mono" font-size="9" fill="#e2e8f0" text-anchor="middle" font-weight="500">
+      <text x="120" y="55">0.62</text>
+      <text x="360" y="55">0.94</text>
+      <text x="600" y="55">0.98</text>
+      <text x="120" y="135">0.18</text>
+      <text x="360" y="135">0.54</text>
+      <text x="600" y="135">0.82</text>
+      <text x="120" y="215">0.04</text>
+      <text x="360" y="215">0.22</text>
+      <text x="600" y="215">0.48</text>
+      <text x="120" y="295">0.01</text>
+      <text x="360" y="295">0.08</text>
+      <text x="600" y="295">0.19</text>
+    </g>
+    <!-- Legend -->
+    <text x="360" y="350" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#8b95a5" letter-spacing="1">MEAN CONTACT DEGREE (k)</text>
+    <text x="28" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#8b95a5" letter-spacing="1" transform="rotate(-90 28 170)">TRANSMISSION PROBABILITY</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Parameter space heatmap: final attack rate as a function of transmission probability (beta) and mean contact degree (k). Red indicates high attack rates (above 0.60); amber indicates moderate (0.20 to 0.60); teal and blue indicate low (below 0.20). Each cell represents the mean of 500 simulation runs.</figcaption>
+</figure>
+
+## Key Metrics
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Calibration and validation results against three empirical outbreak datasets.</caption>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Dataset A</th>
+      <th>Dataset B</th>
+      <th>Dataset C</th>
+      <th>Pooled</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Mean absolute percentage error</td>
+      <td class="num">3.8 pct</td>
+      <td class="num">4.1 pct</td>
+      <td class="num">4.7 pct</td>
+      <td class="num">4.2 pct</td>
+    </tr>
+    <tr>
+      <td>Peak timing error (days)</td>
+      <td class="num">1.4</td>
+      <td class="num">2.6</td>
+      <td class="num">2.3</td>
+      <td class="num">2.1</td>
+    </tr>
+    <tr>
+      <td>Final attack rate error</td>
+      <td class="num">1.2 pct</td>
+      <td class="num">2.1 pct</td>
+      <td class="num">2.0 pct</td>
+      <td class="num">1.8 pct</td>
+    </tr>
+    <tr>
+      <td>R-effective at peak</td>
+      <td class="num">2.14</td>
+      <td class="num">1.87</td>
+      <td class="num">2.41</td>
+      <td class="num">2.14</td>
+    </tr>
+    <tr>
+      <td>ABC-SMC acceptance rate (round 8)</td>
+      <td class="num">0.032</td>
+      <td class="num">0.028</td>
+      <td class="num">0.024</td>
+      <td class="num">0.028</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">All values are point estimates from the posterior median. Credible intervals are reported in Section 3.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the section index. The full manuscript contains the following numbered sections.
+
+1. **Section 1. Model Design** -- architecture, module interfaces, and design rationale
+2. **Section 2. Calibration** -- ABC-SMC procedure, prior specifications, and convergence
+3. **Section 3. Validation** -- out-of-sample tests and goodness-of-fit metrics
+4. **Section 4. Sensitivity Analysis** -- Sobol decomposition and tornado diagrams
+5. **Section 5. Discussion** -- interpretation, limitations, and future extensions

--- a/simulation-paper/content/parameters.md
+++ b/simulation-paper/content/parameters.md
@@ -1,0 +1,145 @@
++++
+title = "Parameter Reference"
+description = "Complete parameter table for the SIR-ABM model, with base-case values, ranges, prior distributions, and data sources."
+tags = ["paper", "computational", "simulation"]
+categories = ["pages"]
++++
+
+## Parameter Table
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table P1.</span> Model parameters with base-case values, calibration priors, and sources.</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Symbol</th>
+      <th>Base case</th>
+      <th>Range</th>
+      <th>Prior</th>
+      <th>Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Transmission probability</td>
+      <td class="num">beta</td>
+      <td class="num">0.034</td>
+      <td class="num">0.01 -- 0.08</td>
+      <td>Uniform</td>
+      <td>[1]</td>
+    </tr>
+    <tr>
+      <td>Recovery rate</td>
+      <td class="num">gamma</td>
+      <td class="num">0.10</td>
+      <td class="num">0.06 -- 0.14</td>
+      <td>Uniform</td>
+      <td>[2]</td>
+    </tr>
+    <tr>
+      <td>Household contact weight</td>
+      <td class="num">w_h</td>
+      <td class="num">1.00</td>
+      <td class="num">0.60 -- 1.00</td>
+      <td>Beta(5,2)</td>
+      <td>[3]</td>
+    </tr>
+    <tr>
+      <td>Workplace contact weight</td>
+      <td class="num">w_w</td>
+      <td class="num">0.42</td>
+      <td class="num">0.10 -- 0.80</td>
+      <td>Beta(3,4)</td>
+      <td>[3]</td>
+    </tr>
+    <tr>
+      <td>Community contact weight</td>
+      <td class="num">w_c</td>
+      <td class="num">0.18</td>
+      <td class="num">0.05 -- 0.50</td>
+      <td>Beta(2,8)</td>
+      <td>[3]</td>
+    </tr>
+    <tr>
+      <td>Mean workplace degree</td>
+      <td class="num">k_w</td>
+      <td class="num">12</td>
+      <td class="num">6 -- 24</td>
+      <td>DiscreteUnif</td>
+      <td>[4]</td>
+    </tr>
+    <tr>
+      <td>Mean community degree</td>
+      <td class="num">k_c</td>
+      <td class="num">4</td>
+      <td class="num">2 -- 10</td>
+      <td>DiscreteUnif</td>
+      <td>[4]</td>
+    </tr>
+    <tr>
+      <td>Initial seed count</td>
+      <td class="num">I_0</td>
+      <td class="num">10</td>
+      <td class="num">1 -- 50</td>
+      <td>LogNormal</td>
+      <td>Assumed</td>
+    </tr>
+    <tr>
+      <td>Intervention threshold (pct infected)</td>
+      <td class="num">theta</td>
+      <td class="num">0.05</td>
+      <td class="num">0.01 -- 0.15</td>
+      <td>Uniform</td>
+      <td>[5]</td>
+    </tr>
+    <tr>
+      <td>Intervention edge removal rate</td>
+      <td class="num">rho</td>
+      <td class="num">0.40</td>
+      <td class="num">0.10 -- 0.80</td>
+      <td>Uniform</td>
+      <td>[5]</td>
+    </tr>
+    <tr>
+      <td>Age-dependent susceptibility scalar (65+)</td>
+      <td class="num">s_65</td>
+      <td class="num">1.45</td>
+      <td class="num">1.00 -- 2.00</td>
+      <td>Normal(1.4,0.2)</td>
+      <td>[6]</td>
+    </tr>
+    <tr>
+      <td>Comorbidity susceptibility scalar</td>
+      <td class="num">s_cm</td>
+      <td class="num">1.30</td>
+      <td class="num">1.00 -- 1.80</td>
+      <td>Normal(1.3,0.15)</td>
+      <td>[6]</td>
+    </tr>
+    <tr>
+      <td>Simulation time horizon (days)</td>
+      <td class="num">T_max</td>
+      <td class="num">365</td>
+      <td class="num">180 -- 730</td>
+      <td>Fixed</td>
+      <td>Protocol</td>
+    </tr>
+    <tr>
+      <td>Population size</td>
+      <td class="num">N</td>
+      <td class="num">100,000</td>
+      <td class="num">10,000 -- 500,000</td>
+      <td>Fixed</td>
+      <td>Protocol</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">Base-case values are posterior medians from ABC-SMC calibration. All priors are specified over the stated range. Sources: [1] Nakamura 2024; [2] WHO 2023 technical report; [3] Mossong et al. 2008; [4] Barabasi-Albert defaults; [5] Policy review panel; [6] Meta-analysis by Osei-Mensah 2025.</td></tr>
+  </tfoot>
+</table>
+
+## Calibration Summary
+
+The ABC-SMC procedure ran 8 sequential rounds with 50,000 particles per round. The acceptance threshold decreased from epsilon = 0.20 (round 1) to epsilon = 0.045 (round 8). Convergence was assessed by monitoring the effective sample size (ESS), which stabilised above 2,000 from round 5 onwards.
+
+The posterior distributions are approximately unimodal for all parameters except the community contact weight (w_c), which exhibits mild bimodality reflecting a structural identifiability issue between w_c and k_c. This is addressed in Section 5 (Discussion).

--- a/simulation-paper/content/sections/1-model-design.md
+++ b/simulation-paper/content/sections/1-model-design.md
@@ -1,0 +1,59 @@
++++
+title = "1. Model Design"
+description = "Architecture of the SIR-ABM agent-based model, module decomposition, and design rationale for separating population, network, transmission, intervention, and output concerns."
+weight = 1
+template = "post"
+tags = ["paper", "computational", "simulation"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Design rationale
+
+Agent-based models of epidemic dynamics face a tension between realism and tractability. Equation-based compartmental models (e.g. classical SIR ODEs) are fast and analytically tractable but assume homogeneous mixing. Fully individual-based microsimulations can capture heterogeneity but become computationally expensive and difficult to calibrate.
+
+SIR-ABM addresses this tension through a modular architecture that separates five concerns: agent generation, network construction, disease transmission, intervention policy, and output aggregation. Each module exposes a typed interface, enabling independent testing and replacement.
+
+## 1.2 Population generator
+
+The population generator creates N agents with the following attributes:
+
+- **Age** -- drawn from a user-specified age distribution (default: 2020 UN World Population Prospects, medium variant)
+- **Household ID** -- agents are grouped into households of size 2 to 6 following national census distributions
+- **Comorbidity flag** -- binary indicator drawn with age-dependent probability from epidemiological survey data
+
+## 1.3 Contact network constructor
+
+The three-layer multiplex network is constructed as follows:
+
+<div class="pseudocode-block">
+  <span class="algo-name">Algorithm 1: Network Construction</span>
+  <span class="keyword">function</span> BuildNetwork(agents, config):<br>
+  <span class="indent-1"><span class="comment">// Layer 1: Household (complete subgraphs)</span></span><br>
+  <span class="indent-1"><span class="keyword">for each</span> household h <span class="keyword">in</span> agents:</span><br>
+  <span class="indent-2">AddCompleteSubgraph(G_household, h.members)</span><br>
+  <span class="indent-1"><span class="comment">// Layer 2: Workplace (Barabasi-Albert)</span></span><br>
+  <span class="indent-1">G_work &larr; BarabasiAlbert(N, m = config.k_w / 2)</span><br>
+  <span class="indent-1"><span class="comment">// Layer 3: Community (Erdos-Renyi)</span></span><br>
+  <span class="indent-1">G_comm &larr; ErdosRenyi(N, p = config.k_c / (N - 1))</span><br>
+  <span class="indent-1"><span class="keyword">return</span> MultiplexNetwork(G_household, G_work, G_comm)</span>
+</div>
+
+## 1.4 Transmission engine
+
+At each discrete time step (1 day), the transmission engine iterates over all infected agents. For each infected agent, each contact in all three network layers is evaluated independently:
+
+- Contact occurs with layer-specific weight w_l
+- Transmission occurs with probability beta x w_l x s_age x s_cm
+- Recovery occurs with probability gamma per day
+
+The engine maintains a state vector of length N with values S (susceptible), I (infectious), or R (recovered).
+
+## 1.5 Intervention policy module
+
+The intervention module monitors the prevalence (proportion of agents in state I) at each time step. When prevalence exceeds the threshold theta, the module removes a fraction rho of edges from the workplace and community layers, simulating social distancing or workplace closures. Household contacts are never removed, reflecting the assumption that household mixing continues during interventions.
+
+## 1.6 Output aggregator
+
+The output aggregator records the epidemic curve (S, I, R counts per time step), the effective reproduction number R_eff per time step, and summary statistics including final attack rate, peak prevalence, peak timing, and total person-days of infection.

--- a/simulation-paper/content/sections/2-calibration.md
+++ b/simulation-paper/content/sections/2-calibration.md
@@ -1,0 +1,80 @@
++++
+title = "2. Calibration"
+description = "Approximate Bayesian computation (ABC-SMC) calibration procedure, prior specifications, and convergence diagnostics for the SIR-ABM model."
+weight = 2
+template = "post"
+tags = ["paper", "computational", "simulation"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Calibration approach
+
+We calibrate 12 free parameters (Table P1) using approximate Bayesian computation with sequential Monte Carlo sampling (ABC-SMC). ABC-SMC is chosen because the likelihood function of the agent-based model is intractable; instead, we compare simulated summary statistics against empirical values using a distance metric.
+
+## 2.2 Summary statistics
+
+Five summary statistics form the distance vector:
+
+1. Final attack rate (proportion of agents reaching state R)
+2. Peak prevalence (maximum proportion in state I)
+3. Peak timing (day of peak prevalence)
+4. Epidemic duration (days from first case to last recovery)
+5. Effective reproduction number at day 14 (R_eff_14)
+
+The distance metric is the Euclidean norm of the normalised differences between simulated and empirical summary statistics.
+
+## 2.3 ABC-SMC procedure
+
+<div class="pseudocode-block">
+  <span class="algo-name">Algorithm 2: ABC-SMC Calibration</span>
+  <span class="keyword">function</span> CalibrateABCSMC(data, priors, rounds=8, particles=50000):<br>
+  <span class="indent-1">epsilon &larr; [0.20, 0.15, 0.12, 0.09, 0.07, 0.06, 0.05, 0.045]</span><br>
+  <span class="indent-1"><span class="keyword">for</span> r &larr; 1 <span class="keyword">to</span> rounds:</span><br>
+  <span class="indent-2">accepted &larr; empty list</span><br>
+  <span class="indent-2"><span class="keyword">while</span> |accepted| &lt; particles:</span><br>
+  <span class="indent-3"><span class="keyword">if</span> r == 1:</span><br>
+  <span class="indent-3">&nbsp;&nbsp;theta_star &larr; SampleFromPriors(priors)</span><br>
+  <span class="indent-3"><span class="keyword">else</span>:</span><br>
+  <span class="indent-3">&nbsp;&nbsp;theta_star &larr; PerturbFromPrevious(accepted[r-1], kernel)</span><br>
+  <span class="indent-3">sim_stats &larr; RunSimulation(theta_star).summary()</span><br>
+  <span class="indent-3"><span class="keyword">if</span> Distance(sim_stats, data.summary()) &lt; epsilon[r]:</span><br>
+  <span class="indent-3">&nbsp;&nbsp;accepted.append(theta_star)</span><br>
+  <span class="indent-2">weights &larr; ComputeImportanceWeights(accepted, priors, kernel)</span><br>
+  <span class="indent-1"><span class="keyword">return</span> WeightedPosterior(accepted, weights)</span>
+</div>
+
+## 2.4 Convergence diagnostics
+
+Convergence was assessed using three criteria:
+
+- **Effective sample size (ESS):** stabilised above 2,000 from round 5 onwards (minimum ESS = 2,142 at round 8)
+- **Acceptance rate:** decreased from 18.4 pct (round 1) to 2.8 pct (round 8), consistent with tightening tolerance
+- **Posterior stability:** Kolmogorov-Smirnov distance between rounds 7 and 8 posteriors was below 0.03 for all parameters
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> ABC-SMC convergence metrics by round.</caption>
+  <thead>
+    <tr>
+      <th>Round</th>
+      <th>Epsilon</th>
+      <th>Acceptance rate</th>
+      <th>ESS</th>
+      <th>Wall time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td class="num">1</td><td class="num">0.200</td><td class="num">18.4 pct</td><td class="num">50,000</td><td class="num">2.1 h</td></tr>
+    <tr><td class="num">2</td><td class="num">0.150</td><td class="num">12.6 pct</td><td class="num">14,820</td><td class="num">3.4 h</td></tr>
+    <tr><td class="num">3</td><td class="num">0.120</td><td class="num">8.9 pct</td><td class="num">8,240</td><td class="num">4.8 h</td></tr>
+    <tr><td class="num">4</td><td class="num">0.090</td><td class="num">6.2 pct</td><td class="num">4,610</td><td class="num">6.1 h</td></tr>
+    <tr><td class="num">5</td><td class="num">0.070</td><td class="num">4.8 pct</td><td class="num">3,180</td><td class="num">7.2 h</td></tr>
+    <tr><td class="num">6</td><td class="num">0.060</td><td class="num">3.9 pct</td><td class="num">2,840</td><td class="num">8.4 h</td></tr>
+    <tr><td class="num">7</td><td class="num">0.050</td><td class="num">3.2 pct</td><td class="num">2,410</td><td class="num">9.6 h</td></tr>
+    <tr><td class="num">8</td><td class="num">0.045</td><td class="num">2.8 pct</td><td class="num">2,142</td><td class="num">10.2 h</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Total calibration wall time: approximately 52 hours across 8 rounds. Parallelised across 16 cores.</td></tr>
+  </tfoot>
+</table>

--- a/simulation-paper/content/sections/3-validation.md
+++ b/simulation-paper/content/sections/3-validation.md
@@ -1,0 +1,79 @@
++++
+title = "3. Validation"
+description = "Out-of-sample validation of the calibrated SIR-ABM model against held-out epidemic data, including goodness-of-fit metrics and epidemic curve comparisons."
+weight = 3
+template = "post"
+tags = ["paper", "computational", "simulation"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Validation strategy
+
+The calibrated model was validated against three empirical outbreak datasets:
+
+- **Dataset A** -- a well-documented urban outbreak (N = 82,000; 2019)
+- **Dataset B** -- a regional outbreak with partial intervention data (N = 145,000; 2021)
+- **Dataset C** -- a rural outbreak with detailed contact-tracing data (N = 34,000; 2023)
+
+For each dataset, 1,000 simulations were run from the posterior parameter distribution. The simulated epidemic curves were compared to empirical daily incidence using four metrics.
+
+## 3.2 Goodness-of-fit results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Validation metrics. Values are posterior median (95 pct credible interval).</caption>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Dataset A</th>
+      <th>Dataset B</th>
+      <th>Dataset C</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MAPE (pct)</td>
+      <td class="num">3.8 (2.1--5.9)</td>
+      <td class="num">4.1 (2.6--6.4)</td>
+      <td class="num">4.7 (3.0--7.2)</td>
+    </tr>
+    <tr>
+      <td>Peak timing error (days)</td>
+      <td class="num">1.4 (0.2--3.1)</td>
+      <td class="num">2.6 (0.8--4.8)</td>
+      <td class="num">2.3 (0.6--4.4)</td>
+    </tr>
+    <tr>
+      <td>Attack rate error (pct)</td>
+      <td class="num">1.2 (0.3--2.8)</td>
+      <td class="num">2.1 (0.6--4.1)</td>
+      <td class="num">2.0 (0.5--3.9)</td>
+    </tr>
+    <tr>
+      <td>R_eff at peak (simulated)</td>
+      <td class="num">2.14 (1.82--2.48)</td>
+      <td class="num">1.87 (1.54--2.22)</td>
+      <td class="num">2.41 (2.04--2.80)</td>
+    </tr>
+    <tr>
+      <td>R_eff at peak (empirical)</td>
+      <td class="num">2.08</td>
+      <td class="num">1.92</td>
+      <td class="num">2.35</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">MAPE = mean absolute percentage error. CIs computed from the 2.5th and 97.5th percentiles of 1,000 posterior simulation runs.</td></tr>
+  </tfoot>
+</table>
+
+## 3.3 Epidemic curve comparison
+
+The simulated epidemic curves (posterior median and 95 pct credible band) closely tracked the empirical daily incidence across all three datasets. The model captured the exponential growth phase, peak, and post-peak decline with acceptable fidelity.
+
+Dataset C showed the largest peak timing error (2.3 days), likely attributable to an early localised cluster in the empirical data that is not well captured by the random seeding assumption.
+
+## 3.4 Network structure validation
+
+In addition to epidemic outcome metrics, we validated the simulated contact network structure against the empirical contact matrix from Dataset C (which included contact-tracing data). The simulated degree distribution matched the empirical distribution with a Kolmogorov-Smirnov statistic of 0.048 (p = 0.31), failing to reject the null hypothesis of distributional equivalence.

--- a/simulation-paper/content/sections/4-sensitivity.md
+++ b/simulation-paper/content/sections/4-sensitivity.md
@@ -1,0 +1,155 @@
++++
+title = "4. Sensitivity Analysis"
+description = "Sobol variance decomposition and tornado diagrams quantifying the contribution of each parameter to uncertainty in the SIR-ABM model outputs."
+weight = 4
+template = "post"
+tags = ["paper", "computational", "simulation"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Sobol decomposition
+
+A Sobol variance-based sensitivity analysis was conducted using a Saltelli sampling design with 16,384 base samples, yielding a total of 16,384 x (2 x 14 + 2) = 491,520 model evaluations. First-order (S1) and total-order (ST) sensitivity indices were computed for the final attack rate as the primary outcome.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> Sobol sensitivity indices for final attack rate. Top 7 parameters shown.</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>S1 (first-order)</th>
+      <th>ST (total-order)</th>
+      <th>S1 rank</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>beta</code> (transmission prob.)</td>
+      <td class="num">0.284</td>
+      <td class="num">0.362</td>
+      <td class="num">1</td>
+    </tr>
+    <tr>
+      <td><code>k_w</code> (workplace degree)</td>
+      <td class="num">0.198</td>
+      <td class="num">0.274</td>
+      <td class="num">2</td>
+    </tr>
+    <tr>
+      <td><code>w_h</code> (household weight)</td>
+      <td class="num">0.142</td>
+      <td class="num">0.198</td>
+      <td class="num">3</td>
+    </tr>
+    <tr>
+      <td><code>theta</code> (intervention threshold)</td>
+      <td class="num">0.118</td>
+      <td class="num">0.176</td>
+      <td class="num">4</td>
+    </tr>
+    <tr>
+      <td><code>rho</code> (edge removal rate)</td>
+      <td class="num">0.086</td>
+      <td class="num">0.138</td>
+      <td class="num">5</td>
+    </tr>
+    <tr>
+      <td><code>gamma</code> (recovery rate)</td>
+      <td class="num">0.062</td>
+      <td class="num">0.094</td>
+      <td class="num">6</td>
+    </tr>
+    <tr>
+      <td><code>w_w</code> (workplace weight)</td>
+      <td class="num">0.048</td>
+      <td class="num">0.082</td>
+      <td class="num">7</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Sum of S1 = 0.938 (remainder from 7 minor parameters). Difference between ST and S1 indicates interaction effects.</td></tr>
+  </tfoot>
+</table>
+
+## 4.2 Tornado diagram
+
+<figure class="figure">
+  <svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tornado diagram showing sensitivity of final attack rate to individual parameter perturbations">
+    <!-- Title -->
+    <text x="360" y="20" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#e2e8f0" letter-spacing="1">DETERMINISTIC SENSITIVITY: FINAL ATTACK RATE</text>
+    <!-- Centre line (base case = 0.42) -->
+    <line x1="360" y1="35" x2="360" y2="355" stroke="#5ba3c9" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="360" y="370" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#5ba3c9">BASE CASE = 0.42</text>
+    <!-- Parameter labels -->
+    <g font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#e2e8f0" text-anchor="end">
+      <text x="140" y="64">beta</text>
+      <text x="140" y="107">k_w</text>
+      <text x="140" y="150">w_h</text>
+      <text x="140" y="193">theta</text>
+      <text x="140" y="236">rho</text>
+      <text x="140" y="279">gamma</text>
+      <text x="140" y="322">w_w</text>
+    </g>
+    <!-- Low-end bars (left of centre = lower attack rate) -->
+    <g fill="#3dbfa8">
+      <rect x="190" y="48" width="170" height="24" rx="1"/>
+      <rect x="218" y="91" width="142" height="24" rx="1"/>
+      <rect x="248" y="134" width="112" height="24" rx="1"/>
+      <rect x="262" y="177" width="98" height="24" rx="1"/>
+      <rect x="284" y="220" width="76" height="24" rx="1"/>
+      <rect x="304" y="263" width="56" height="24" rx="1"/>
+      <rect x="316" y="306" width="44" height="24" rx="1"/>
+    </g>
+    <!-- High-end bars (right of centre = higher attack rate) -->
+    <g fill="#d15b5b">
+      <rect x="360" y="48" width="180" height="24" rx="1"/>
+      <rect x="360" y="91" width="148" height="24" rx="1"/>
+      <rect x="360" y="134" width="118" height="24" rx="1"/>
+      <rect x="360" y="177" width="104" height="24" rx="1"/>
+      <rect x="360" y="220" width="82" height="24" rx="1"/>
+      <rect x="360" y="263" width="60" height="24" rx="1"/>
+      <rect x="360" y="306" width="48" height="24" rx="1"/>
+    </g>
+    <!-- Low-end value labels -->
+    <g font-family="IBM Plex Mono" font-size="9" fill="#e2e8f0" text-anchor="end">
+      <text x="186" y="64">0.18</text>
+      <text x="214" y="107">0.22</text>
+      <text x="244" y="150">0.26</text>
+      <text x="258" y="193">0.28</text>
+      <text x="280" y="236">0.31</text>
+      <text x="300" y="279">0.34</text>
+      <text x="312" y="322">0.36</text>
+    </g>
+    <!-- High-end value labels -->
+    <g font-family="IBM Plex Mono" font-size="9" fill="#e2e8f0">
+      <text x="544" y="64">0.72</text>
+      <text x="512" y="107">0.64</text>
+      <text x="482" y="150">0.58</text>
+      <text x="468" y="193">0.55</text>
+      <text x="446" y="236">0.52</text>
+      <text x="424" y="279">0.49</text>
+      <text x="412" y="322">0.47</text>
+    </g>
+    <!-- Legend -->
+    <rect x="560" y="345" width="12" height="12" fill="#3dbfa8"/>
+    <text x="576" y="356" font-family="Inter" font-size="10" fill="#8b95a5">Low bound</text>
+    <rect x="640" y="345" width="12" height="12" fill="#d15b5b"/>
+    <text x="656" y="356" font-family="Inter" font-size="10" fill="#8b95a5">High bound</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 3.</span> Tornado diagram for final attack rate. Each bar shows the range of the output when the named parameter is varied from its low to high bound (Table P1) while all other parameters are held at base case. Transmission probability (beta) and workplace degree (k_w) are the dominant drivers.</figcaption>
+</figure>
+
+## 4.3 Interaction effects
+
+The gap between total-order and first-order indices indicates the presence of interaction effects. The largest interaction is between beta and k_w (joint interaction contributing approximately 7.8 pct of total variance), consistent with the mechanistic expectation that transmission probability and contact frequency are multiplicatively linked in determining the force of infection.
+
+## 4.4 Scenario analyses
+
+Three supplementary scenario analyses were conducted:
+
+1. **No intervention** -- removing the intervention module entirely increases the base-case attack rate from 0.42 to 0.71 (69 pct relative increase)
+2. **Early intervention** (theta = 0.02) -- reduces the attack rate to 0.28 (33 pct relative decrease)
+3. **Aggressive intervention** (rho = 0.70) -- reduces the attack rate to 0.31 (26 pct relative decrease from base case)
+
+These results suggest that intervention timing (theta) has a larger impact than intervention intensity (rho) in this model configuration.

--- a/simulation-paper/content/sections/5-discussion.md
+++ b/simulation-paper/content/sections/5-discussion.md
@@ -1,0 +1,54 @@
++++
+title = "5. Discussion"
+description = "Interpretation of SIR-ABM results, comparison to prior models, methodological limitations, and directions for future work."
+weight = 5
+template = "post"
+tags = ["paper", "computational", "simulation"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Principal findings
+
+The SIR-ABM model reproduces empirical epidemic dynamics with a mean absolute percentage error of 4.2 pct across three diverse outbreak datasets. The modular architecture enables independent validation of each component, and the ABC-SMC calibration produces well-characterised posterior distributions for all 14 free parameters.
+
+The sensitivity analysis identifies transmission probability (beta) and workplace contact degree (k_w) as the dominant drivers of uncertainty in the final attack rate, collectively accounting for 48 pct of first-order variance. Intervention timing (theta) is the third most influential parameter, underscoring the importance of early detection and rapid policy response.
+
+## 5.2 Comparison to prior models
+
+Our MAPE of 4.2 pct compares favourably to published agent-based epidemic models. Ferguson et al. (2020) reported a MAPE of 6.8 pct for a comparable model with homogeneous mixing within workplaces. Kucharski et al. (2021) achieved 3.1 pct MAPE but on a single dataset with extensive calibration data.
+
+The modular architecture is a methodological contribution. Existing frameworks (e.g., EMOD, OpenABM-Covid19) tend toward monolithic designs that make independent module validation difficult. SIR-ABM's separated interfaces reduce the risk of compensatory errors between modules.
+
+## 5.3 Limitations
+
+Four limitations warrant discussion:
+
+1. **Static demographics** -- the model does not account for births, deaths from non-epidemic causes, or migration during the simulation period. For outbreaks shorter than one year, this is a minor concern; for endemic modelling, demographic turnover would need to be incorporated.
+2. **Binary intervention** -- the intervention module implements a single step-change in contact rates. Real-world interventions are graduated, partial, and heterogeneous across subpopulations. Future versions should support multi-level policy schedules.
+3. **Structural identifiability** -- the mild bimodality in the posterior of the community contact weight (w_c) suggests a structural identifiability issue between w_c and k_c. Additional data sources (e.g., mobility data) would help resolve this.
+4. **Computational cost** -- at approximately 52 hours for a full calibration run on 16 cores, the ABC-SMC procedure is expensive. Surrogate-based approaches (e.g., neural network emulators) could reduce this by an order of magnitude.
+
+## 5.4 Future work
+
+Three directions are planned:
+
+1. **Vaccination module** -- adding a fourth state (V) and vaccination scheduling to the transmission engine
+2. **Spatial structure** -- extending the community layer to a geographically-weighted network
+3. **Real-time calibration** -- developing an online ABC-SMC variant that assimilates new surveillance data as it arrives
+
+## References
+
+<ol class="references-list">
+  <li>Nakamura K. Heterogeneous contact networks in epidemic simulation. <em>J Comput Biol.</em> 2024;31(4):201-218.</li>
+  <li>World Health Organization. Technical report on respiratory pathogen parameters. WHO/2023/TR-042. 2023.</li>
+  <li>Mossong J, Hens N, Breban R, et al. Social contacts and mixing patterns relevant to the spread of infectious diseases. <em>PLoS Med.</em> 2008;5(3):e74.</li>
+  <li>Barabasi A-L, Albert R. Emergence of scaling in random networks. <em>Science.</em> 1999;286(5439):509-512.</li>
+  <li>Policy Review Panel. Intervention timing recommendations for epidemic preparedness. National Health Board Technical Note 2025-08. 2025.</li>
+  <li>Osei-Mensah F, Diallo A. Age-dependent susceptibility in respiratory epidemics: a meta-analysis. <em>Epidemiol Infect.</em> 2025;153:e28.</li>
+  <li>Ferguson NM, Laydon D, Nedjati-Gilani G, et al. Impact of non-pharmaceutical interventions to reduce COVID-19 mortality. Imperial College London Report 9. 2020.</li>
+  <li>Kucharski AJ, Russell TW, Diamond C, et al. Early dynamics of transmission and control of COVID-19: a mathematical modelling study. <em>Lancet Infect Dis.</em> 2020;20(5):553-558.</li>
+  <li>Toni T, Welch D, Strelkowa N, et al. Approximate Bayesian computation scheme for parameter inference and model selection. <em>J R Soc Interface.</em> 2009;6(31):187-202.</li>
+  <li>Saltelli A, Annoni P, Azzini I, et al. Variance based sensitivity analysis of model output. <em>Comput Phys Commun.</em> 2010;181(2):259-270.</li>
+</ol>

--- a/simulation-paper/content/sections/_index.md
+++ b/simulation-paper/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The manuscript is organised into five numbered sections. Each section addresses a distinct phase of the modelling workflow, from architecture design through to interpretation of results.

--- a/simulation-paper/static/css/style.css
+++ b/simulation-paper/static/css/style.css
@@ -1,0 +1,627 @@
+/* ============================================================================
+   Agent-Based Epidemic Simulation - Computational Model Paper
+   Dark background, monospace model names, sans body, block diagrams.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0e1117;
+  --bg-2: #161b22;
+  --bg-3: #1c2230;
+  --rule: #2a3342;
+  --ink: #e2e8f0;
+  --ink-2: #c8d1dc;
+  --ink-3: #8b95a5;
+  --ink-4: #5c6575;
+  --accent: #5ba3c9;
+  --accent-2: #3d8ab5;
+  --warn: #e8a84c;
+  --success: #5cba7d;
+  --chart-blue: #5ba3c9;
+  --chart-teal: #3dbfa8;
+  --chart-orange: #e8a84c;
+  --chart-red: #d15b5b;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Inter", "Source Sans 3", -apple-system, sans-serif;
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Inter", sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding {
+  font-weight: 600;
+}
+
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Inter", sans-serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--warn);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--bg-3);
+  border: 1px solid var(--rule);
+  padding: 1.2rem 1.4rem;
+  overflow-x: auto;
+  border-radius: 2px;
+  margin: 1.5rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Inter", sans-serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Pseudocode blocks ---------------- */
+
+.pseudocode-block {
+  background: var(--bg-3);
+  border: 2px solid var(--rule);
+  padding: 1.4rem 1.6rem;
+  margin: 2rem 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  color: var(--ink);
+  overflow-x: auto;
+}
+
+.pseudocode-block .algo-name {
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.pseudocode-block .keyword { color: var(--accent); font-weight: 700; }
+.pseudocode-block .comment { color: var(--ink-4); font-style: italic; }
+.pseudocode-block .indent-1 { padding-left: 1.6rem; }
+.pseudocode-block .indent-2 { padding-left: 3.2rem; }
+.pseudocode-block .indent-3 { padding-left: 4.8rem; }
+
+/* ---------------- Model callout ---------------- */
+
+.model-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.model-callout .callout-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.model-callout .callout-value {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.model-callout .callout-value .unit {
+  font-family: "Inter", sans-serif;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.model-callout .callout-detail {
+  font-family: "Inter", sans-serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.92rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Inter", sans-serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Inter", sans-serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Inter", sans-serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Inter", sans-serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 500;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+  counter-reset: ref;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .model-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .pseudocode-block { padding: 1rem; }
+}

--- a/simulation-paper/templates/404.html
+++ b/simulation-paper/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 &mdash; Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/simulation-paper/templates/footer.html
+++ b/simulation-paper/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#3a4a5c" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#3a4a5c" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura K, Osei-Mensah F, Lindqvist E. Agent-Based Epidemic Simulation: Architecture, Calibration, and Sensitivity. <em>Comput. Model. Lett.</em> 2026;18(7):412-438. doi:10.48127/cml.2026.18.07.412</p>
+        <p class="footer-note">ISSN 2814-0362 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/simulation-paper/templates/header.html
+++ b/simulation-paper/templates/header.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700&family=Source+Sans+3:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="4" y="4" width="56" height="32" fill="none" stroke="#8fc8e8" stroke-width="1.5"/>
+          <rect x="12" y="10" width="16" height="10" fill="none" stroke="#8fc8e8" stroke-width="1"/>
+          <rect x="36" y="10" width="16" height="10" fill="none" stroke="#5ba3c9" stroke-width="1"/>
+          <line x1="20" y1="20" x2="36" y2="15" stroke="#e8a84c" stroke-width="1.2"/>
+          <line x1="20" y1="20" x2="28" y2="30" stroke="#e8a84c" stroke-width="1.2" stroke-dasharray="3 2"/>
+          <line x1="44" y1="20" x2="52" y2="30" stroke="#e8a84c" stroke-width="1.2" stroke-dasharray="3 2"/>
+          <circle cx="28" cy="30" r="2" fill="#5ba3c9"/>
+          <circle cx="52" cy="30" r="2" fill="#5ba3c9"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Computational Modelling Letters</span>
+          <span class="journal-sub">Vol. 18 &middot; Issue 07 &middot; Oct 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/architecture/">ARCHITECTURE</a>
+        <a href="{{ base_url }}/parameters/">PARAMETERS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/simulation-paper/templates/page.html
+++ b/simulation-paper/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/simulation-paper/templates/post.html
+++ b/simulation-paper/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/simulation-paper/templates/section.html
+++ b/simulation-paper/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/simulation-paper/templates/shortcodes/alert.html
+++ b/simulation-paper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("Note") | upper }}:</strong> {{ body }}
+</div>

--- a/simulation-paper/templates/taxonomy.html
+++ b/simulation-paper/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/simulation-paper/templates/taxonomy_term.html
+++ b/simulation-paper/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3223,6 +3223,13 @@
     "silk",
     "cultural"
   ],
+  "simulation-paper": [
+    "paper",
+    "dark",
+    "computational",
+    "simulation",
+    "model"
+  ],
   "sketch": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Adds `simulation-paper` example site: a computational model paper presenting an agent-based epidemic simulation (SIR-ABM)
- Features SVG model architecture block diagrams, parameter space heatmaps, sensitivity analysis tornado diagrams
- Algorithm pseudocode displayed in bordered monospace blocks
- Dark theme with IBM Plex Mono Bold for model names, Inter/Source Sans Pro for body text
- Tags: paper, dark, computational, simulation, model

Closes #1627

## Test plan
- [ ] Verify `hwaro build` succeeds in the simulation-paper directory
- [ ] Check all SVG diagrams render correctly (architecture, heatmap, tornado)
- [ ] Confirm pseudocode blocks display with proper formatting
- [ ] Validate tags.json contains the new entry
- [ ] Test navigation between sections and summary pages