### PR TITLE
Add position-paper example site

### DIFF
--- a/position-paper/AGENTS.md
+++ b/position-paper/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/position-paper/config.toml
+++ b/position-paper/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Position Paper - Stance Declaration Paper
+# Issue #1632 | Tags: paper, dark, position, argumentative, bold
+# =============================================================================
+
+title = "The Case for Algorithmic Transparency"
+description = "A stance declaration paper arguing for mandatory algorithmic transparency in public-sector decision systems, structured as a formal position paper with claim-warrant-evidence architecture."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/position-paper/content/appendix.md
+++ b/position-paper/content/appendix.md
@@ -1,0 +1,32 @@
++++
+title = "Appendix"
+description = "Evidence hierarchy, case audit methodology, and supplementary materials for the position paper."
+tags = ["paper", "position", "appendix"]
++++
+
+## Appendix A: Evidence Hierarchy
+
+The strength ratings used in this paper follow an adapted Oxford-style evidence hierarchy for policy argumentation:
+
+- **Very strong**: Systematic review of empirical cases with consistent directional findings across multiple jurisdictions and domains
+- **Strong**: Multiple independent legal or empirical analyses reaching convergent conclusions
+- **Moderate**: Single-jurisdiction analysis or legal scholarship with limited empirical corroboration
+- **Weak**: Theoretical argument without empirical or comparative legal support
+
+## Appendix B: Case Audit Methodology
+
+The 47-case audit referenced in Argument 3 was compiled through systematic search of legal databases (Westlaw, LexisNexis), investigative journalism archives (ProPublica, The Markup), government audit reports (GAO, state-level auditors), and academic case studies published between 2015 and 2025. Cases were included if they documented: (a) an algorithmic system used in public-sector decision-making, (b) evidence of opacity in the system's operation, and (c) documented harm or adverse outcome linked to the opacity.
+
+## Appendix C: Acknowledgements
+
+We thank Prof. Ava Thornton (Georgetown) for comments on the constitutional analysis, Dr. Kofi Mensah (Leiden) for review of the EU comparative law sections, and three anonymous reviewers for their critical engagement with the manuscript.
+
+## CRediT Author Contributions
+
+- **Mariana Vasquez**: Conceptualization, writing (original draft), formal analysis, project administration
+- **Emeka Okwu**: Legal analysis (due process), writing (review and editing), methodology
+- **Signe Lindqvist**: Empirical case audit, data curation, writing (review and editing)
+
+## Correspondence
+
+Mariana Vasquez, Center for Technology Policy, Hargrove University, 400 Elm Street, Cambridge, MA 02139. Email: vasquez@techpolicy.hargrove.edu

--- a/position-paper/content/implications.md
+++ b/position-paper/content/implications.md
@@ -1,0 +1,33 @@
++++
+title = "Implications"
+description = "Policy recommendations and institutional design proposals for implementing mandatory algorithmic transparency in public-sector contexts."
+tags = ["paper", "position", "implications"]
++++
+
+## Policy Implications
+
+The argument developed in this paper leads to five concrete policy recommendations, ordered by implementation priority.
+
+### Recommendation 1: Establish a Public Algorithm Registry
+
+All public-sector algorithmic decision systems should be entered into a mandatory registry maintained by a designated oversight body. The registry should include the system's purpose, deploying agency, affected population, decision domain, and deployment date. Registries of this kind already operate successfully in the Netherlands and the City of Amsterdam.
+
+### Recommendation 2: Mandate Pre-Deployment Impact Assessments
+
+Before any algorithmic system is deployed in a decision-affecting capacity, the deploying agency must complete a standardized Algorithmic Impact Assessment (AIA). This assessment should evaluate accuracy, fairness across protected classes, and proportionality. Canada's Directive on Automated Decision-Making provides a working model for AIA frameworks.
+
+### Recommendation 3: Create an Independent Audit Authority
+
+An independent body -- modeled on existing inspectors general or data protection authorities -- should have standing authority to audit any registered algorithmic system. The body should possess subpoena power over technical documentation and the authority to mandate remediation or suspension of systems found to violate transparency or fairness standards.
+
+### Recommendation 4: Codify Layered Explanation Rights
+
+Affected individuals should have a statutory right to receive: (a) a plain-language notice that an algorithmic system influenced the decision; (b) an explanation of the primary factors considered; (c) access to a meaningful appeal process that includes human review. This three-tier right builds on GDPR Article 22 while going further in specifying the form and substance of required explanations.
+
+### Recommendation 5: Impose Procurement Transparency Conditions
+
+Government procurement contracts for algorithmic systems must include transparency clauses requiring vendors to provide full documentation to the audit authority. Contracts should specify that trade-secret claims cannot override audit access. This approach has been successfully implemented in New York City's Local Law 144 for automated employment screening.
+
+## Implementation Timeline
+
+We propose a phased rollout over 36 months: registry establishment (months 1-6), impact assessment framework development (months 6-12), pilot audits of existing systems (months 12-24), and full enforcement (months 24-36). This timeline draws on implementation experience from the EU AI Act and Canada's AIA directive.

--- a/position-paper/content/index.md
+++ b/position-paper/content/index.md
@@ -1,0 +1,217 @@
++++
+title = "Thesis"
+description = "A position paper arguing that public-sector algorithmic decision systems must be subject to mandatory transparency requirements, grounded in democratic accountability, due process, and empirical evidence of opaque-system harm."
+tags = ["paper", "dark", "position", "argumentative", "bold"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Position Paper &middot; Open Access</p>
+  <h1 class="paper-title">The Case for Mandatory Algorithmic Transparency in Public-Sector Decision Systems</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Mariana Vasquez</span><sup>1</sup>,
+    Emeka Okwu<sup>2</sup>,
+    Signe Lindqvist<sup>1,3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Center for Technology Policy, Hargrove University &middot;
+    <sup>2</sup>Institute of Democratic Governance, Blackwell College &middot;
+    <sup>3</sup>Nordic AI Ethics Lab, Uppsala
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.47922/jppa.2026.17.04.301</a> &middot; <strong>Received:</strong> 08 Jan 2026 &middot; <strong>Accepted:</strong> 18 Mar 2026</p>
+</header>
+
+<div class="thesis-box">
+  <p class="thesis-statement">All algorithmic systems used in public-sector decisions affecting individual rights must be subject to mandatory, enforceable transparency obligations.</p>
+  <p class="thesis-sub">This paper advances a three-part argument grounded in democratic accountability, procedural due process, and empirical evidence of harm from opaque automated decision systems in welfare, criminal justice, and public health domains.</p>
+</div>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Position</dt>
+    <dd>We argue that algorithmic systems deployed by or on behalf of government agencies to make, inform, or substantially influence decisions affecting individual rights, benefits, or liberties must be subject to mandatory transparency requirements enforced through independent audit and public disclosure.</dd>
+    <dt>Grounds</dt>
+    <dd>The argument proceeds in three stages: (1) democratic accountability requires that citizens can scrutinize the basis of state decisions; (2) procedural due process demands that affected persons can understand and contest adverse determinations; (3) empirical analysis of 47 documented cases demonstrates that opacity correlates with disproportionate harm to marginalized populations.</dd>
+    <dt>Scope</dt>
+    <dd>This position addresses decision-support and decision-making systems in public-sector contexts. It does not extend to private-sector commercial algorithms except where they operate under government contract or delegation.</dd>
+    <dt>Keywords</dt>
+    <dd><em>algorithmic transparency; public accountability; automated decision systems; due process; audit requirements; democratic governance</em></dd>
+  </dl>
+</section>
+
+## Argument Architecture
+
+<figure class="figure">
+  <svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Argument architecture diagram showing claim, warrant, and evidence structure">
+    <!-- background -->
+    <rect x="0" y="0" width="720" height="380" fill="#0e0f14"/>
+    <!-- main claim box -->
+    <rect x="180" y="10" width="360" height="56" fill="none" stroke="#d4a03c" stroke-width="2.5"/>
+    <text x="360" y="30" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="10" fill="#d4a03c" letter-spacing="2">CENTRAL CLAIM</text>
+    <text x="360" y="50" text-anchor="middle" font-family="Playfair Display" font-weight="700" font-size="13" fill="#e8e2d6">Mandatory transparency for public-sector algorithms</text>
+    <!-- three warrant branches -->
+    <line x1="260" y1="66" x2="130" y2="110" stroke="#5a9bd5" stroke-width="1.5"/>
+    <line x1="360" y1="66" x2="360" y2="110" stroke="#5a9bd5" stroke-width="1.5"/>
+    <line x1="460" y1="66" x2="590" y2="110" stroke="#5a9bd5" stroke-width="1.5"/>
+    <!-- Warrant 1: Democratic Accountability -->
+    <rect x="30" y="110" width="200" height="48" fill="none" stroke="#5a9bd5" stroke-width="1.5"/>
+    <text x="130" y="130" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#5a9bd5" letter-spacing="1.5">WARRANT 1</text>
+    <text x="130" y="146" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Democratic accountability</text>
+    <!-- Warrant 2: Due Process -->
+    <rect x="260" y="110" width="200" height="48" fill="none" stroke="#5a9bd5" stroke-width="1.5"/>
+    <text x="360" y="130" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#5a9bd5" letter-spacing="1.5">WARRANT 2</text>
+    <text x="360" y="146" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Procedural due process</text>
+    <!-- Warrant 3: Empirical Harm -->
+    <rect x="490" y="110" width="200" height="48" fill="none" stroke="#5a9bd5" stroke-width="1.5"/>
+    <text x="590" y="130" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#5a9bd5" letter-spacing="1.5">WARRANT 3</text>
+    <text x="590" y="146" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Empirical evidence of harm</text>
+    <!-- Evidence lines from Warrant 1 -->
+    <line x1="80" y1="158" x2="60" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="130" y1="158" x2="130" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="180" y1="158" x2="200" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <!-- Evidence boxes row 1 -->
+    <rect x="10" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="60" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="60" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Constitutional law</text>
+    <rect x="80" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="130" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="130" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">FOIA jurisprudence</text>
+    <rect x="150" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="200" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="200" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">EU AI Act Art 13</text>
+    <!-- Evidence lines from Warrant 2 -->
+    <line x1="310" y1="158" x2="290" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="360" y1="158" x2="360" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="410" y1="158" x2="430" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <rect x="240" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="290" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="290" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Mathews v Eldridge</text>
+    <rect x="310" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="360" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="360" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">GDPR Art 22</text>
+    <rect x="380" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="430" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="430" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Admin law review</text>
+    <!-- Evidence lines from Warrant 3 -->
+    <line x1="540" y1="158" x2="520" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="590" y1="158" x2="590" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <line x1="640" y1="158" x2="660" y2="196" stroke="#6bbf6b" stroke-width="1"/>
+    <rect x="470" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="520" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="520" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">47-case audit</text>
+    <rect x="540" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="590" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="590" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Welfare algorithms</text>
+    <rect x="610" y="196" width="100" height="40" fill="none" stroke="#6bbf6b" stroke-width="1"/>
+    <text x="660" y="212" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#6bbf6b" letter-spacing="1">EVIDENCE</text>
+    <text x="660" y="226" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Recidivism scores</text>
+    <!-- Rebuttal arrows -->
+    <line x1="130" y1="260" x2="130" y2="290" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <rect x="30" y="290" width="200" height="36" fill="none" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="130" y="306" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R1</text>
+    <text x="130" y="320" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Trade secret / IP protection</text>
+    <line x1="360" y1="260" x2="360" y2="290" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <rect x="260" y="290" width="200" height="36" fill="none" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="360" y="306" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R2</text>
+    <text x="360" y="320" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Gaming / adversarial risk</text>
+    <line x1="590" y1="260" x2="590" y2="290" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <rect x="490" y="290" width="200" height="36" fill="none" stroke="#d45a5a" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="590" y="306" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="8" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R3</text>
+    <text x="590" y="320" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Technical complexity</text>
+    <!-- Legend -->
+    <rect x="180" y="348" width="12" height="8" fill="#d4a03c"/>
+    <text x="198" y="356" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">Claim</text>
+    <rect x="260" y="348" width="12" height="8" fill="#5a9bd5"/>
+    <text x="278" y="356" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">Warrant</text>
+    <rect x="340" y="348" width="12" height="8" fill="#6bbf6b"/>
+    <text x="358" y="356" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">Evidence</text>
+    <rect x="420" y="348" width="12" height="8" fill="#d45a5a"/>
+    <text x="438" y="356" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">Rebuttal</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Argument architecture of the position paper. The central claim is supported by three warrants (democratic accountability, due process, empirical harm), each grounded in specific evidence. Anticipated rebuttals (dashed red) are addressed in Section 4.</div>
+</figure>
+
+## Position Spectrum
+
+<div class="position-spectrum">
+  <svg viewBox="0 0 720 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Position spectrum from no regulation to full ban, with this paper's position marked">
+    <!-- axis -->
+    <line x1="40" y1="60" x2="680" y2="60" stroke="#2e3245" stroke-width="2"/>
+    <!-- tick marks -->
+    <line x1="40" y1="52" x2="40" y2="68" stroke="#5e5b52" stroke-width="1.5"/>
+    <line x1="200" y1="52" x2="200" y2="68" stroke="#5e5b52" stroke-width="1.5"/>
+    <line x1="360" y1="52" x2="360" y2="68" stroke="#5e5b52" stroke-width="1.5"/>
+    <line x1="520" y1="52" x2="520" y2="68" stroke="#5e5b52" stroke-width="1.5"/>
+    <line x1="680" y1="52" x2="680" y2="68" stroke="#5e5b52" stroke-width="1.5"/>
+    <!-- labels -->
+    <text x="40" y="88" text-anchor="middle" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">NO REGULATION</text>
+    <text x="200" y="88" text-anchor="middle" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">VOLUNTARY</text>
+    <text x="360" y="88" text-anchor="middle" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">SECTOR CODES</text>
+    <text x="520" y="88" text-anchor="middle" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">MANDATORY</text>
+    <text x="680" y="88" text-anchor="middle" font-family="Archivo" font-size="9" fill="#8e8a7e" letter-spacing="0.5">FULL BAN</text>
+    <!-- position markers for other authors -->
+    <circle cx="160" cy="60" r="6" fill="none" stroke="#5e5b52" stroke-width="1.5"/>
+    <text x="160" y="38" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#5e5b52">Sunstein 2022</text>
+    <circle cx="310" cy="60" r="6" fill="none" stroke="#5e5b52" stroke-width="1.5"/>
+    <text x="310" y="38" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#5e5b52">IEEE P7001</text>
+    <circle cx="440" cy="60" r="6" fill="none" stroke="#5e5b52" stroke-width="1.5"/>
+    <text x="440" y="38" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#5e5b52">EU AI Act</text>
+    <!-- this paper's position (highlighted) -->
+    <circle cx="520" cy="60" r="10" fill="#d4a03c" stroke="#e8e2d6" stroke-width="2"/>
+    <text x="520" y="108" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="10" fill="#d4a03c" letter-spacing="1">THIS PAPER</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Position spectrum showing the regulatory stance adopted by this paper relative to existing frameworks. Our position aligns with mandatory enforceable obligations (rightward of the EU AI Act), stopping short of blanket prohibition.</div>
+</div>
+
+## Key Claims
+
+<div class="cwe-callout">
+  <p class="cwe-label claim">Central Claim</p>
+  <p class="cwe-text">Public-sector algorithmic systems that affect individual rights require mandatory, auditable transparency -- not voluntary guidelines.</p>
+  <p class="cwe-detail">Grounded in democratic accountability (Warrant 1), procedural due process (Warrant 2), and a systematic review of 47 documented opacity harms (Warrant 3).</p>
+</div>
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary of evidence across the three warrant categories.</caption>
+  <thead>
+    <tr>
+      <th>Warrant</th>
+      <th>Evidence type</th>
+      <th>Sources</th>
+      <th>Strength</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>W1: Democratic accountability</td>
+      <td>Constitutional / statutory analysis</td>
+      <td class="num">14</td>
+      <td>Strong</td>
+    </tr>
+    <tr>
+      <td>W2: Due process</td>
+      <td>Case law / comparative legal analysis</td>
+      <td class="num">19</td>
+      <td>Strong</td>
+    </tr>
+    <tr>
+      <td>W3: Empirical harm</td>
+      <td>Case audits / quantitative analysis</td>
+      <td class="num">47</td>
+      <td>Very strong</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Strength ratings follow the Oxford-style evidence hierarchy adapted for policy argumentation (see Appendix A).</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the argument index. The full manuscript contains the following numbered sections.
+
+1. **Argument 1. Democratic Accountability** -- constitutional and statutory foundations for transparency
+2. **Argument 2. Procedural Due Process** -- legal requirements for contestability of automated decisions
+3. **Argument 3. Empirical Evidence of Harm** -- systematic review of 47 documented cases of opacity-related harm
+4. **Argument 4. Rebuttals and Counterarguments** -- addressing trade secret, gaming, and complexity objections
+5. **Argument 5. Policy Implications** -- concrete legislative and institutional recommendations

--- a/position-paper/content/rebuttals.md
+++ b/position-paper/content/rebuttals.md
@@ -1,0 +1,77 @@
++++
+title = "Rebuttals"
+description = "Anticipated counterarguments and our responses, addressing trade-secret protections, adversarial gaming risks, and technical complexity barriers."
+tags = ["paper", "position", "rebuttals"]
++++
+
+## Anticipated Counterarguments
+
+This section examines the three strongest counterarguments to mandatory algorithmic transparency and demonstrates why each is insufficient to override the case for enforceable disclosure.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Rebuttal flow diagram showing counterarguments and responses">
+    <rect x="0" y="0" width="720" height="320" fill="#0e0f14"/>
+    <!-- Rebuttal 1 -->
+    <rect x="20" y="20" width="200" height="50" fill="none" stroke="#d45a5a" stroke-width="1.5"/>
+    <text x="120" y="40" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R1</text>
+    <text x="120" y="58" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Trade secret protection</text>
+    <line x1="220" y1="45" x2="280" y2="45" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="280" y="20" width="200" height="50" fill="none" stroke="#6bbf6b" stroke-width="1.5"/>
+    <text x="380" y="40" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#6bbf6b" letter-spacing="1.5">RESPONSE</text>
+    <text x="380" y="58" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Tiered disclosure model</text>
+    <line x1="480" y1="45" x2="540" y2="45" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="540" y="20" width="160" height="50" fill="none" stroke="#d4a03c" stroke-width="1.5"/>
+    <text x="620" y="40" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1.5">OUTCOME</text>
+    <text x="620" y="58" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">IP preserved + auditable</text>
+    <!-- Rebuttal 2 -->
+    <rect x="20" y="120" width="200" height="50" fill="none" stroke="#d45a5a" stroke-width="1.5"/>
+    <text x="120" y="140" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R2</text>
+    <text x="120" y="158" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Adversarial gaming risk</text>
+    <line x1="220" y1="145" x2="280" y2="145" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="280" y="120" width="200" height="50" fill="none" stroke="#6bbf6b" stroke-width="1.5"/>
+    <text x="380" y="140" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#6bbf6b" letter-spacing="1.5">RESPONSE</text>
+    <text x="380" y="158" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Delayed-release audits</text>
+    <line x1="480" y1="145" x2="540" y2="145" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="540" y="120" width="160" height="50" fill="none" stroke="#d4a03c" stroke-width="1.5"/>
+    <text x="620" y="140" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1.5">OUTCOME</text>
+    <text x="620" y="158" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Security + accountability</text>
+    <!-- Rebuttal 3 -->
+    <rect x="20" y="220" width="200" height="50" fill="none" stroke="#d45a5a" stroke-width="1.5"/>
+    <text x="120" y="240" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d45a5a" letter-spacing="1.5">REBUTTAL R3</text>
+    <text x="120" y="258" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Technical complexity</text>
+    <line x1="220" y1="245" x2="280" y2="245" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="280" y="220" width="200" height="50" fill="none" stroke="#6bbf6b" stroke-width="1.5"/>
+    <text x="380" y="240" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#6bbf6b" letter-spacing="1.5">RESPONSE</text>
+    <text x="380" y="258" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Layered explanation duty</text>
+    <line x1="480" y1="245" x2="540" y2="245" stroke="#8e8a7e" stroke-width="1" marker-end="url(#arrowR)"/>
+    <rect x="540" y="220" width="160" height="50" fill="none" stroke="#d4a03c" stroke-width="1.5"/>
+    <text x="620" y="240" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1.5">OUTCOME</text>
+    <text x="620" y="258" text-anchor="middle" font-family="Work Sans" font-size="11" fill="#e8e2d6">Accessible + rigorous</text>
+    <!-- arrow marker -->
+    <defs>
+      <marker id="arrowR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#8e8a7e"/>
+      </marker>
+    </defs>
+    <!-- legend -->
+    <rect x="200" y="292" width="10" height="8" fill="#d45a5a"/>
+    <text x="216" y="300" font-family="Archivo" font-size="9" fill="#8e8a7e">Counterargument</text>
+    <rect x="320" y="292" width="10" height="8" fill="#6bbf6b"/>
+    <text x="336" y="300" font-family="Archivo" font-size="9" fill="#8e8a7e">Response</text>
+    <rect x="420" y="292" width="10" height="8" fill="#d4a03c"/>
+    <text x="436" y="300" font-family="Archivo" font-size="9" fill="#8e8a7e">Resolution</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 3.</span> Rebuttal flow diagram. Each counterargument (red) is met with a structured response (green) that yields a resolution (gold) preserving both the objection's legitimate concern and the transparency mandate.</div>
+</figure>
+
+### R1: Trade Secret Protection
+
+The most common objection holds that algorithmic transparency would require disclosure of proprietary methods, undermining intellectual property rights and vendor willingness to contract with government agencies. We respond with a tiered disclosure model: full technical specifications are shared only with a certified independent auditor under NDA, while the public receives a plain-language impact assessment. This structure preserves commercial confidentiality while enabling meaningful external scrutiny.
+
+### R2: Adversarial Gaming
+
+Critics argue that revealing decision logic allows subjects to game the system. We note that this concern conflates transparency with real-time disclosure. Our framework mandates retrospective audit access with a 90-day delayed publication window, during which the algorithm can be updated. Empirical evidence from credit scoring regulation (ECOA, Regulation B) demonstrates that explanation requirements did not produce measurable increases in gaming behavior over a 15-year observation period.
+
+### R3: Technical Complexity
+
+The argument that machine learning models are inherently too complex for meaningful explanation conflates technical precision with communicative adequacy. We propose a layered explanation duty: (1) a non-technical summary of the system's purpose and decision factors; (2) a statistical performance report including accuracy, false-positive rates, and disparate impact metrics; (3) full model documentation available to qualified auditors. Existing FDA device approval processes already require analogous layered disclosures for similarly complex systems.

--- a/position-paper/content/sections/1-democratic-accountability.md
+++ b/position-paper/content/sections/1-democratic-accountability.md
@@ -1,0 +1,38 @@
++++
+title = "Democratic Accountability"
+description = "Constitutional and statutory foundations for algorithmic transparency as a requirement of democratic governance."
+weight = 1
+template = "post"
+[extra]
+section_number = "1"
++++
+
+## The Accountability Premise
+
+Democratic governance rests on the principle that citizens can scrutinize the basis on which the state makes decisions affecting their lives. When those decisions are delegated to algorithmic systems that operate as black boxes, this foundational accountability mechanism breaks down.
+
+<div class="cwe-callout">
+  <p class="cwe-label claim">Claim 1.1</p>
+  <p class="cwe-text">Algorithmic opacity in public-sector decisions is structurally incompatible with democratic accountability.</p>
+  <p class="cwe-detail">If the state cannot explain the basis of a decision because the algorithm's logic is opaque even to its operators, then the decision is effectively unreviewable by democratic institutions.</p>
+</div>
+
+### Constitutional Foundations
+
+The constitutional case proceeds from two lines of argument. First, freedom of information statutes (FOIA and state-level equivalents) establish a presumption that government records and decision rationales are public. Algorithmic decision logic constitutes a "government record" within the meaning of these statutes, as several recent court decisions have begun to recognize.
+
+Second, the non-delegation doctrine -- while weakened in modern administrative law -- retains normative force: Congress may delegate decision-making authority to agencies, but the exercise of that authority must remain within reviewable bounds. When an agency deploys an opaque algorithm, it effectively sub-delegates to a system that neither the agency nor the public can meaningfully review.
+
+### Comparative Legal Analysis
+
+The EU AI Act (Article 13) requires that high-risk AI systems be designed to allow human oversight and provide sufficient transparency for deployers and users. Canada's Directive on Automated Decision-Making mandates impact assessments and explanations proportionate to the system's decision impact level. In contrast, the United States currently lacks a federal statutory framework, relying instead on a patchwork of executive orders, agency guidance, and local ordinances.
+
+<div class="cwe-callout">
+  <p class="cwe-label warrant">Warrant 1.1</p>
+  <p class="cwe-text">Democratic accountability requires that citizens can understand and scrutinize the logic by which the state reaches decisions affecting them.</p>
+  <p class="cwe-detail">This principle is embedded in FOIA, the Administrative Procedure Act's requirement for reasoned decision-making, and the constitutional structure of separated powers with judicial review.</p>
+</div>
+
+### Evidence: FOIA Jurisprudence
+
+In at least five documented cases between 2018 and 2025, FOIA requests for algorithmic decision logic were denied on grounds of trade-secret exemptions (Exemption 4) or technical infeasibility. These denials create a structural gap: the government uses an algorithm to make a decision, but claims it cannot disclose the algorithm's logic because it belongs to a private vendor. The result is a decision that is simultaneously governmental (and thus subject to accountability norms) and private (and thus shielded from disclosure). This contradiction must be resolved in favor of accountability.

--- a/position-paper/content/sections/2-due-process.md
+++ b/position-paper/content/sections/2-due-process.md
@@ -1,0 +1,36 @@
++++
+title = "Procedural Due Process"
+description = "Legal requirements for contestability and explanation when automated systems affect individual rights."
+weight = 2
+template = "post"
+[extra]
+section_number = "2"
++++
+
+## The Contestability Requirement
+
+Procedural due process requires that before the government deprives an individual of a protected interest (liberty, property, or a statutory entitlement), the individual must receive notice, an explanation of the basis for the action, and an opportunity to contest the determination. When the "basis for the action" is an opaque algorithmic output, the explanation requirement cannot be satisfied.
+
+<div class="cwe-callout">
+  <p class="cwe-label claim">Claim 2.1</p>
+  <p class="cwe-text">Opaque algorithmic decisions that affect protected interests violate the procedural due process guarantee of a meaningful opportunity to be heard.</p>
+  <p class="cwe-detail">Under the Mathews v. Eldridge framework, the risk of erroneous deprivation increases when neither the decision-maker nor the affected person can explain why the algorithm reached a particular output.</p>
+</div>
+
+### The Mathews Framework Applied
+
+The Supreme Court's three-factor balancing test in Mathews v. Eldridge (1976) weighs: (1) the private interest at stake; (2) the risk of erroneous deprivation under current procedures and the probable value of additional safeguards; (3) the government's interest in administrative efficiency. When algorithmic systems are used in welfare eligibility, parole scoring, or benefit calculations, the private interest is typically substantial. The risk of erroneous deprivation is heightened by opacity: if the system produces an incorrect output, neither the applicant nor the caseworker can identify the error without access to the decision logic. Additional transparency safeguards have high probable value at relatively low cost.
+
+### Comparative Due Process Standards
+
+GDPR Article 22 establishes a right not to be subject to solely automated decisions with legal or similarly significant effects, together with a right to obtain meaningful information about the logic involved. While US constitutional law does not yet recognize an equivalent right, the due process clause provides an analogous foundation. The gap between European statutory protections and American constitutional silence is a policy failure that this paper seeks to address.
+
+<div class="cwe-callout">
+  <p class="cwe-label evidence">Evidence 2.1</p>
+  <p class="cwe-text">In documented welfare-algorithm cases, error rates exceeded 25 pct in three states where beneficiaries had no mechanism to identify or contest algorithmic determinations.</p>
+  <p class="cwe-detail">Indiana (2008-2012), Arkansas (2016), and Idaho (2011) each deployed automated eligibility systems that produced high error rates. In all three cases, affected individuals were unable to understand or effectively challenge adverse determinations because the algorithm's decision logic was not disclosed.</p>
+</div>
+
+### The Explanation Duty
+
+We argue for a structured explanation duty that requires three elements: (1) notice that an algorithmic system played a role in the decision; (2) identification of the principal factors the system considered; (3) a description sufficient for the affected person to identify potential errors in the input data or the system's application of decision criteria to their case. This duty is proportionate, technically feasible, and consistent with existing administrative law obligations for reasoned decision-making.

--- a/position-paper/content/sections/3-empirical-harm.md
+++ b/position-paper/content/sections/3-empirical-harm.md
@@ -1,0 +1,89 @@
++++
+title = "Empirical Evidence of Harm"
+description = "Systematic review of 47 documented cases demonstrating that algorithmic opacity produces disproportionate harm to marginalized populations."
+weight = 3
+template = "post"
+[extra]
+section_number = "3"
++++
+
+## Systematic Case Review
+
+We conducted a systematic review of documented cases in which opaque algorithmic systems deployed by public-sector agencies produced measurable harm. The review identified 47 cases meeting our inclusion criteria (see Appendix B for methodology), spanning welfare, criminal justice, education, child services, and public health domains.
+
+<div class="cwe-callout">
+  <p class="cwe-label claim">Claim 3.1</p>
+  <p class="cwe-text">Algorithmic opacity in public-sector systems correlates with disproportionate adverse outcomes for low-income and minority populations.</p>
+  <p class="cwe-detail">In 38 of 47 cases (81 pct), the primary affected population was disproportionately low-income, non-white, or both. In 29 cases (62 pct), the harm was not discovered until external investigators -- journalists, academics, or auditors -- obtained access to system documentation.</p>
+</div>
+
+### Case Distribution by Domain
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Distribution of 47 documented opacity-harm cases by policy domain and harm type.</caption>
+  <thead>
+    <tr>
+      <th>Domain</th>
+      <th>Cases</th>
+      <th>Disparate impact</th>
+      <th>Error rate</th>
+      <th>Discovery method</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Welfare / benefits</td>
+      <td class="num">14</td>
+      <td class="num">12 (86 pct)</td>
+      <td class="num">18-42 pct</td>
+      <td>External audit</td>
+    </tr>
+    <tr>
+      <td>Criminal justice</td>
+      <td class="num">11</td>
+      <td class="num">9 (82 pct)</td>
+      <td class="num">23-35 pct</td>
+      <td>Investigative journalism</td>
+    </tr>
+    <tr>
+      <td>Child services</td>
+      <td class="num">8</td>
+      <td class="num">7 (88 pct)</td>
+      <td class="num">15-30 pct</td>
+      <td>Litigation discovery</td>
+    </tr>
+    <tr>
+      <td>Education</td>
+      <td class="num">7</td>
+      <td class="num">5 (71 pct)</td>
+      <td class="num">12-25 pct</td>
+      <td>Academic research</td>
+    </tr>
+    <tr>
+      <td>Public health</td>
+      <td class="num">7</td>
+      <td class="num">5 (71 pct)</td>
+      <td class="num">8-20 pct</td>
+      <td>Government audit</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Disparate impact = documented disproportionate effect on protected classes. Error rate ranges reflect minimum-maximum across cases within domain.</td></tr>
+  </tfoot>
+</table>
+
+### Illustrative Cases
+
+**Welfare benefit automation (Indiana, 2008-2012).** The state contracted with a private vendor to automate eligibility determinations for Medicaid, food stamps, and cash assistance. The system denied benefits at a rate more than three times the pre-automation baseline. Over one million benefit applications were affected. The algorithm's decision logic was protected as a trade secret, and neither caseworkers nor applicants could identify the source of errors. A subsequent state audit found that the system had been incorrectly weighing documentation requirements, but this was not discoverable until the contract was terminated and internal records were released.
+
+**Recidivism risk scoring (multiple states).** The COMPAS risk assessment tool, used in pretrial and sentencing decisions, was found by ProPublica's 2016 analysis to produce significantly higher false-positive rates for Black defendants compared to white defendants. The tool's proprietary scoring methodology was not disclosed to defendants or their attorneys, preventing meaningful challenge at sentencing. Subsequent academic analyses confirmed the disparity pattern across multiple jurisdictions.
+
+<div class="cwe-callout">
+  <p class="cwe-label evidence">Evidence 3.1</p>
+  <p class="cwe-text">In 62 pct of the 47 cases, the harm was discovered only when external parties gained access to system documentation through litigation, journalism, or audit.</p>
+  <p class="cwe-detail">Internal agency review processes failed to identify the harm in these cases. This finding supports the argument that mandatory external transparency mechanisms -- not voluntary internal review -- are necessary to detect and correct algorithmic harm.</p>
+</div>
+
+### The Opacity-Harm Mechanism
+
+The causal pathway from opacity to harm operates through three mechanisms: (1) error concealment -- opaque systems hide systematic errors that would be caught by human review; (2) accountability diffusion -- when no person can explain a decision, no person is responsible for correcting it; (3) power asymmetry -- affected individuals lack the information needed to identify and challenge erroneous determinations.

--- a/position-paper/content/sections/4-rebuttals-detail.md
+++ b/position-paper/content/sections/4-rebuttals-detail.md
@@ -1,0 +1,30 @@
++++
+title = "Counterarguments and Responses"
+description = "Detailed treatment of trade-secret, gaming, and complexity objections with structured refutations."
+weight = 4
+template = "post"
+[extra]
+section_number = "4"
++++
+
+## Engaging the Opposition
+
+A position paper that does not engage seriously with counterarguments fails as argumentation. In this section we address the three strongest objections to our thesis, each taken at its most charitable formulation.
+
+### Counterargument 1: Intellectual Property and Trade Secrets
+
+**The objection.** Requiring disclosure of algorithmic decision logic would violate the intellectual property rights of private vendors who develop these systems. If transparency mandates make government contracts commercially unattractive, fewer vendors will participate, reducing competition and potentially degrading system quality.
+
+**Our response.** This objection conflates public transparency with full source-code disclosure. Our framework does not require public release of proprietary code. Instead, we propose tiered disclosure: (a) full technical documentation is provided to an independent audit body under confidentiality protections equivalent to those governing classified information; (b) the public receives a plain-language impact assessment describing the system's purpose, inputs, decision factors, and performance metrics. This structure has been implemented in pharmaceutical regulation (where proprietary drug formulations are reviewed by the FDA but not publicly disclosed) and financial regulation (where proprietary trading algorithms are subject to SEC oversight without public disclosure).
+
+### Counterargument 2: Adversarial Gaming
+
+**The objection.** If decision criteria are disclosed, affected individuals will manipulate their inputs to achieve favorable outcomes, undermining system accuracy and fairness.
+
+**Our response.** The gaming objection has three weaknesses. First, it proves too much: the same argument could be deployed against any disclosure requirement, including the right to know the charges against you in a criminal proceeding. Second, empirical evidence does not support the predicted effect. The Equal Credit Opportunity Act has required creditors to disclose the reasons for adverse credit decisions since 1974; studies over the subsequent fifty years have not found that this disclosure produced measurable increases in application fraud. Third, our framework includes a 90-day delayed-release mechanism for audit reports, allowing agencies to update systems before detailed findings become public.
+
+### Counterargument 3: Technical Complexity
+
+**The objection.** Modern machine learning models are too complex for meaningful explanation. Requiring explanations that are technically accurate would be incomprehensible to non-specialists; requiring explanations that are comprehensible would be technically misleading.
+
+**Our response.** This objection presents a false dilemma. Explanation adequacy is context-dependent. A patient does not need to understand the biochemistry of a drug to receive a meaningful explanation of its effects and risks; the FDA-mandated package insert demonstrates that layered explanation is both feasible and effective. We propose an analogous layered duty: (1) a non-technical summary accessible to the affected individual; (2) a statistical performance report for policymakers and oversight bodies; (3) full technical documentation for qualified auditors. Each layer serves a different accountability function, and together they satisfy the transparency requirement without demanding impossible simplicity.

--- a/position-paper/content/sections/5-policy-framework.md
+++ b/position-paper/content/sections/5-policy-framework.md
@@ -1,0 +1,85 @@
++++
+title = "Proposed Policy Framework"
+description = "A concrete legislative and institutional blueprint for implementing mandatory algorithmic transparency."
+weight = 5
+template = "post"
+[extra]
+section_number = "5"
++++
+
+## From Argument to Action
+
+The preceding arguments establish the normative case for mandatory algorithmic transparency. This section translates that case into a concrete policy framework.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Policy framework implementation flowchart">
+    <rect x="0" y="0" width="720" height="260" fill="#0e0f14"/>
+    <!-- Phase 1 -->
+    <rect x="20" y="30" width="130" height="60" fill="none" stroke="#d4a03c" stroke-width="2"/>
+    <text x="85" y="52" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1">PHASE 1</text>
+    <text x="85" y="68" text-anchor="middle" font-family="Work Sans" font-size="10" fill="#e8e2d6">Registry</text>
+    <text x="85" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#8e8a7e">Months 1-6</text>
+    <!-- Phase 2 -->
+    <rect x="170" y="30" width="130" height="60" fill="none" stroke="#d4a03c" stroke-width="2"/>
+    <text x="235" y="52" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1">PHASE 2</text>
+    <text x="235" y="68" text-anchor="middle" font-family="Work Sans" font-size="10" fill="#e8e2d6">Impact assessments</text>
+    <text x="235" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#8e8a7e">Months 6-12</text>
+    <!-- Phase 3 -->
+    <rect x="320" y="30" width="130" height="60" fill="none" stroke="#d4a03c" stroke-width="2"/>
+    <text x="385" y="52" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1">PHASE 3</text>
+    <text x="385" y="68" text-anchor="middle" font-family="Work Sans" font-size="10" fill="#e8e2d6">Pilot audits</text>
+    <text x="385" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#8e8a7e">Months 12-24</text>
+    <!-- Phase 4 -->
+    <rect x="470" y="30" width="130" height="60" fill="none" stroke="#d4a03c" stroke-width="2"/>
+    <text x="535" y="52" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#d4a03c" letter-spacing="1">PHASE 4</text>
+    <text x="535" y="68" text-anchor="middle" font-family="Work Sans" font-size="10" fill="#e8e2d6">Full enforcement</text>
+    <text x="535" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#8e8a7e">Months 24-36</text>
+    <!-- arrows -->
+    <line x1="150" y1="60" x2="170" y2="60" stroke="#8e8a7e" stroke-width="1.5" marker-end="url(#arrowP)"/>
+    <line x1="300" y1="60" x2="320" y2="60" stroke="#8e8a7e" stroke-width="1.5" marker-end="url(#arrowP)"/>
+    <line x1="450" y1="60" x2="470" y2="60" stroke="#8e8a7e" stroke-width="1.5" marker-end="url(#arrowP)"/>
+    <!-- deliverables -->
+    <line x1="85" y1="90" x2="85" y2="120" stroke="#2e3245" stroke-width="1"/>
+    <text x="85" y="136" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Public algorithm</text>
+    <text x="85" y="148" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">database</text>
+    <line x1="235" y1="90" x2="235" y2="120" stroke="#2e3245" stroke-width="1"/>
+    <text x="235" y="136" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">AIA templates</text>
+    <text x="235" y="148" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">and standards</text>
+    <line x1="385" y1="90" x2="385" y2="120" stroke="#2e3245" stroke-width="1"/>
+    <text x="385" y="136" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">12 agency audits</text>
+    <text x="385" y="148" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">completed</text>
+    <line x1="535" y1="90" x2="535" y2="120" stroke="#2e3245" stroke-width="1"/>
+    <text x="535" y="136" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">Penalties and</text>
+    <text x="535" y="148" text-anchor="middle" font-family="Work Sans" font-size="9" fill="#c8c2b4">remediation powers</text>
+    <!-- Feedback loop -->
+    <rect x="610" y="30" width="90" height="60" fill="none" stroke="#5a9bd5" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="655" y="52" text-anchor="middle" font-family="Archivo" font-weight="700" font-size="9" fill="#5a9bd5" letter-spacing="1">REVIEW</text>
+    <text x="655" y="68" text-anchor="middle" font-family="Work Sans" font-size="10" fill="#e8e2d6">Annual cycle</text>
+    <text x="655" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#8e8a7e">Ongoing</text>
+    <line x1="600" y1="60" x2="610" y2="60" stroke="#8e8a7e" stroke-width="1.5" marker-end="url(#arrowP)"/>
+    <!-- feedback arrow back -->
+    <path d="M 655 90 L 655 210 L 85 210 L 85 190" fill="none" stroke="#5a9bd5" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrowB)"/>
+    <text x="370" y="226" text-anchor="middle" font-family="Archivo" font-size="9" fill="#5a9bd5" letter-spacing="0.5">Annual review feeds back to registry updates and standards refinement</text>
+    <defs>
+      <marker id="arrowP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#8e8a7e"/>
+      </marker>
+      <marker id="arrowB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#5a9bd5"/>
+      </marker>
+    </defs>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 4.</span> Proposed 36-month implementation timeline with four phases and an annual review feedback loop. Each phase builds on the institutional capacity developed in the previous stage.</div>
+</figure>
+
+### Legislative Design
+
+The framework requires a statutory foundation. We recommend a standalone Algorithmic Transparency Act rather than amendments to existing statutes, for three reasons: (1) a dedicated statute signals legislative commitment and creates a clear enforcement mandate; (2) it avoids the interpretive complications of grafting algorithmic provisions onto statutes designed for other purposes; (3) it provides a single, identifiable legal authority that agencies, courts, and the public can reference.
+
+### Institutional Design
+
+The audit authority should be structured as an independent agency within the executive branch, modeled on the Government Accountability Office's relationship to Congress. Key design features include: fixed-term appointments for the director and board members; a dedicated technical staff with expertise in machine learning, statistics, and administrative law; subpoena power over agency records and vendor documentation; authority to recommend suspension of systems found to violate transparency standards; and annual public reporting on the state of algorithmic governance.
+
+### Enforcement Mechanisms
+
+The framework includes three enforcement tiers: (1) administrative penalties for failure to register systems or complete impact assessments; (2) mandatory remediation orders for systems found to produce unjustified disparate impact; (3) injunctive authority to suspend systems that pose imminent risk of serious harm. Private right of action should be available to individuals who suffer adverse decisions from unregistered or non-compliant systems.

--- a/position-paper/content/sections/_index.md
+++ b/position-paper/content/sections/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Argument Index"
+description = "The five numbered arguments of the position paper."
+sort_by = "weight"
+tags = ["paper", "position", "argumentative"]
++++
+
+The position paper is organized into five numbered arguments. Each builds on the preceding section and includes supporting evidence, structured claims, and -- where applicable -- responses to counterarguments.

--- a/position-paper/static/css/style.css
+++ b/position-paper/static/css/style.css
@@ -1,0 +1,649 @@
+/* ============================================================================
+   Position Paper - Stance Declaration Paper
+   Dark background, bold argumentative typography, Playfair Display/Abril
+   Fatface display, Archivo/Work Sans body. No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0e0f14;
+  --bg-2: #161821;
+  --bg-3: #1c1f2b;
+  --rule: #2e3245;
+  --ink: #e8e2d6;
+  --ink-2: #c8c2b4;
+  --ink-3: #8e8a7e;
+  --ink-4: #5e5b52;
+  --accent: #d4a03c;
+  --accent-2: #b8882e;
+  --claim: #d4a03c;
+  --warrant: #5a9bd5;
+  --evidence: #6bbf6b;
+  --rebuttal: #d45a5a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Work Sans", "Archivo", sans-serif;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Archivo", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Work Sans", sans-serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding {
+  font-weight: 600;
+}
+
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Work Sans", sans-serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Thesis declaration box ---------------- */
+
+.thesis-box {
+  border: 3px solid var(--accent);
+  padding: 2rem 2.2rem;
+  margin: 2.5rem 0;
+  background: var(--bg-2);
+  position: relative;
+}
+
+.thesis-box::before {
+  content: "THESIS";
+  position: absolute;
+  top: -0.7em;
+  left: 1.5rem;
+  background: var(--bg-2);
+  padding: 0 0.8rem;
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.thesis-box .thesis-statement {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: 3.06rem;
+  line-height: 1.18;
+  color: var(--ink);
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+
+.thesis-box .thesis-sub {
+  font-family: "Work Sans", sans-serif;
+  font-size: 1rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Work Sans", sans-serif;
+}
+
+/* ---------------- Claim-Warrant-Evidence callout ---------------- */
+
+.cwe-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--rule);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.cwe-callout .cwe-label {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin: 0 0 0.4rem;
+}
+
+.cwe-callout .cwe-label.claim { color: var(--claim); }
+.cwe-callout .cwe-label.warrant { color: var(--warrant); }
+.cwe-callout .cwe-label.evidence { color: var(--evidence); }
+.cwe-callout .cwe-label.rebuttal { color: var(--rebuttal); }
+
+.cwe-callout .cwe-text {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: 1.3rem;
+  line-height: 1.4;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+}
+
+.cwe-callout .cwe-detail {
+  font-family: "Work Sans", sans-serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.95rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Position spectrum ---------------- */
+
+.position-spectrum {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.2rem;
+  margin: 2.2rem 0;
+}
+
+.position-spectrum svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.position-spectrum .caption {
+  font-family: "Work Sans", sans-serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.position-spectrum .caption .fig-num {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Playfair Display", serif;
+  font-weight: 800;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Work Sans", sans-serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-article blockquote,
+.paper-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  font-style: italic;
+  color: var(--ink-2);
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Work Sans", sans-serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Work Sans", sans-serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Archivo", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Work Sans", sans-serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Archivo", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Work Sans", sans-serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Work Sans", sans-serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Archivo", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Archivo", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+  counter-reset: ref;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-family: "Work Sans", sans-serif;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Work Sans", sans-serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .thesis-box .thesis-statement { font-size: 2rem; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/position-paper/templates/404.html
+++ b/position-paper/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / PAGE NOT FOUND</p>
+      <h1 class="paper-section-title">Argument not found</h1>
+      <p>The reference you followed does not resolve to a section in this paper. Return to the thesis to navigate the argument.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to the thesis</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/position-paper/templates/footer.html
+++ b/position-paper/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#e8e2d6" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#e8e2d6" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Vasquez M, Okwu E, Lindqvist S. The Case for Algorithmic Transparency in Public-Sector Decision Systems. <em>J Public Policy Argum.</em> 2026;17(4):301-338. doi:10.47922/jppa.2026.17.04.301</p>
+        <p class="footer-note">ISSN 2891-0334 &middot; Copyright &copy; 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/position-paper/templates/header.html
+++ b/position-paper/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;800;900&family=Abril+Fatface&family=Archivo:wght@500;600;700&family=Work+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#e8e2d6" stroke-width="1.5"/>
+          <line x1="12" y1="20" x2="52" y2="20" stroke="#e8e2d6" stroke-width="2"/>
+          <polygon points="32,6 42,16 22,16" fill="none" stroke="#d4a03c" stroke-width="1.5"/>
+          <line x1="32" y1="16" x2="32" y2="34" stroke="#d4a03c" stroke-width="1.5"/>
+          <circle cx="20" cy="30" r="3" fill="none" stroke="#e8e2d6" stroke-width="1"/>
+          <circle cx="44" cy="30" r="3" fill="none" stroke="#e8e2d6" stroke-width="1"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Public Policy Argumentation</span>
+          <span class="journal-sub">Vol. 17 &middot; Issue 04 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">THESIS</a>
+        <a href="{{ base_url }}/sections/">ARGUMENTS</a>
+        <a href="{{ base_url }}/rebuttals/">REBUTTALS</a>
+        <a href="{{ base_url }}/implications/">IMPLICATIONS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/position-paper/templates/page.html
+++ b/position-paper/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/position-paper/templates/post.html
+++ b/position-paper/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Argument {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to argument index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/position-paper/templates/section.html
+++ b/position-paper/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">ARGUMENT INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/position-paper/templates/shortcodes/alert.html
+++ b/position-paper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/position-paper/templates/taxonomy.html
+++ b/position-paper/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Every keyword, subject index, and bibliographic tag in this paper.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/position-paper/templates/taxonomy_term.html
+++ b/position-paper/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">SUBJECT INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Sections cross-referenced to this subject keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3930,5 +3930,12 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds new position-paper example site for Issue #1632
- Stance Declaration Paper with dark theme featuring SVG argument architecture diagrams (claim > warrant > evidence), position spectrum displays, and rebuttal flow diagrams
- Uses Playfair Display Black/Abril Fatface for display typography and Archivo SemiBold/Work Sans Medium for body text
- Thesis statement rendered at 3x body size in bordered declaration box
- Updates tags.json with new entry: paper, dark, position, argumentative, bold

## Test plan
- [ ] Verify `hwaro build` completes successfully in the position-paper directory
- [ ] Verify site renders correctly with `hwaro serve`
- [ ] Check all SVG diagrams render properly (argument architecture, position spectrum, rebuttal flow, policy framework)
- [ ] Confirm dark theme colors and typography hierarchy
- [ ] Verify tags.json is valid JSON with no missing entries