### PR TITLE
Add new mixed-methods example site

### DIFF
--- a/mixed-methods/AGENTS.md
+++ b/mixed-methods/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/mixed-methods/config.toml
+++ b/mixed-methods/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Mixed-Methods - Convergent Design Paper
+# Issue #1628 | Tags: paper, light, mixed-methods, convergent, dual
+# =============================================================================
+
+title = "Convergent Mixed-Methods Design"
+description = "A convergent design paper merging quantitative and qualitative strands, with joint display matrices, integration wheel diagrams, and dual-font typography for QUANT and QUAL elements."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/mixed-methods/content/appendix.md
+++ b/mixed-methods/content/appendix.md
@@ -1,0 +1,36 @@
++++
+title = "Appendix"
+description = "Supplementary materials including the legitimation framework, reflexivity statement, and data availability for the convergent mixed-methods study."
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["pages"]
++++
+
+## A1. Legitimation Framework
+
+The quality of the mixed-methods inferences was assessed using Onwuegbuzie and Johnson's (2006) legitimation typology:
+
+| Legitimation type | Assessment | Rating |
+| --- | --- | --- |
+| Sample integration | QUANT participants were a superset of QUAL participants (n=28 drawn from N=342) | Adequate |
+| Inside-outside | Emic (QUAL) and etic (QUANT) perspectives both represented | Strong |
+| Weakness minimisation | QUANT compensates for QUAL generalisability; QUAL compensates for QUANT depth | Strong |
+| Conversion | Not applicable (no data conversion between strands) | N/A |
+| Paradigmatic mixing | Pragmatist stance explicitly adopted | Adequate |
+| Commensurability | Research questions were designed to enable convergence across strands | Strong |
+| Multiple validities | QUANT: internal validity (pre-post control). QUAL: credibility (member checking) | Adequate |
+
+## A2. Reflexivity Statement
+
+The research team included members with quantitative expertise (Alvarez, Chen) and qualitative expertise (Okafor, Eriksson). Al-Rashid served as a methodological bridge, having training in both traditions. The team met weekly during the analysis phase to discuss emerging findings and negotiate interpretations. Potential biases were discussed openly: Alvarez had prior involvement in designing the intervention, which was acknowledged as a potential threat to insider-outsider legitimation.
+
+## A3. Data Availability
+
+Quantitative survey data (de-identified) are available at the Seville Metropolitan University data repository (accession: SMU-2026-0318). Qualitative interview transcripts are not publicly available due to participant confidentiality but may be made available upon reasonable request to the corresponding author with appropriate ethics approval.
+
+## A4. CRediT Author Contributions
+
+- **Maria Alvarez** -- Conceptualisation, funding acquisition, QUANT analysis, supervision, writing (original draft)
+- **Wei Chen** -- QUANT data collection, QUANT analysis, writing (review and editing)
+- **Nkechi Okafor** -- QUAL data collection, QUAL analysis, writing (review and editing)
+- **Jonas Eriksson** -- QUAL analysis, integration, writing (review and editing)
+- **Fatima Al-Rashid** -- Methodology (mixed-methods design), integration, legitimation assessment

--- a/mixed-methods/content/index.md
+++ b/mixed-methods/content/index.md
@@ -1,0 +1,154 @@
++++
+title = "Abstract"
+description = "A convergent mixed-methods evaluation of digital health literacy interventions, merging survey data with interview narratives through joint display matrices and integration wheels."
+tags = ["paper", "light", "mixed-methods", "convergent", "dual"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Convergent Design &middot; Open Access</p>
+  <h1 class="paper-title">A Convergent Mixed-Methods Evaluation of Digital Health Literacy Interventions in Community Health Centres</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Maria Alvarez</span><sup>1</sup>,
+    Wei Chen<sup>2</sup>,
+    Nkechi Okafor<sup>1,3</sup>,
+    Jonas Eriksson<sup>4</sup>,
+    Fatima Al-Rashid<sup>2</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Public Health, Seville Metropolitan University &middot;
+    <sup>2</sup>Institute for Digital Health, Hangzhou Medical College &middot;
+    <sup>3</sup>Community Health Research Unit, Lagos University &middot;
+    <sup>4</sup>School of Education, Gothenburg University
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.41927/jmmr.2026.20.04.318</a> &middot; <strong>Received:</strong> 08 Jan 2026 &middot; <strong>Accepted:</strong> 14 Sep 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Purpose</dt>
+    <dd>To evaluate the effectiveness and lived experience of a digital health literacy intervention in community health centres using a convergent mixed-methods design that merges quantitative survey outcomes with qualitative interview narratives.</dd>
+    <dt>Methods</dt>
+    <dd><span class="strand-quant">QUANT:</span> Pre-post quasi-experimental design (N = 342) measuring eHealth Literacy Scale (eHEALS) scores and portal usage rates. <span class="strand-qual">QUAL:</span> Semi-structured interviews (n = 28) analysed via reflexive thematic analysis. Integration through joint display matrices and pillar integration process.</dd>
+    <dt>Results</dt>
+    <dd><span class="strand-quant">QUANT:</span> Mean eHEALS score increased from 26.4 to 31.8 (p &lt; 0.001, d = 0.62). Portal login frequency increased 2.4-fold. <span class="strand-qual">QUAL:</span> Three themes emerged: navigating digital barriers, building confidence through practice, and redefining the patient role. <span class="strand-meta">META-INFERENCE:</span> Quantitative gains converged with qualitative accounts of growing confidence, but diverged on the question of sustained engagement after programme end.</dd>
+    <dt>Keywords</dt>
+    <dd><em>mixed methods; convergent design; digital health literacy; eHEALS; joint display; community health</em></dd>
+  </dl>
+</section>
+
+## Convergent Design Flow
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Convergent design flow diagram showing parallel QUANT and QUAL strands merging at an integration point">
+    <!-- QUANT strand -->
+    <rect x="30" y="40" width="140" height="50" fill="none" stroke="#2b6ca3" stroke-width="2"/>
+    <text x="100" y="60" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#2b6ca3" letter-spacing="1">QUANT STRAND</text>
+    <text x="100" y="78" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5e6878">Survey (N=342)</text>
+    <rect x="210" y="40" width="140" height="50" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <text x="280" y="60" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2b6ca3">DATA COLLECTION</text>
+    <text x="280" y="78" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5e6878">Pre-post eHEALS</text>
+    <rect x="390" y="40" width="140" height="50" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <text x="460" y="60" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2b6ca3">ANALYSIS</text>
+    <text x="460" y="78" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5e6878">Paired t-test, d</text>
+    <!-- QUANT arrows -->
+    <line x1="170" y1="65" x2="210" y2="65" stroke="#2b6ca3" stroke-width="1.5" marker-end="url(#arrowQ)"/>
+    <line x1="350" y1="65" x2="390" y2="65" stroke="#2b6ca3" stroke-width="1.5" marker-end="url(#arrowQ)"/>
+    <!-- QUAL strand -->
+    <rect x="30" y="200" width="140" height="50" fill="none" stroke="#8b4a6b" stroke-width="2"/>
+    <text x="100" y="220" text-anchor="middle" font-family="Cormorant" font-weight="700" font-size="12" fill="#8b4a6b">QUAL Strand</text>
+    <text x="100" y="238" text-anchor="middle" font-family="Cormorant" font-size="10" fill="#5e6878">Interviews (n=28)</text>
+    <rect x="210" y="200" width="140" height="50" fill="none" stroke="#8b4a6b" stroke-width="1.5"/>
+    <text x="280" y="220" text-anchor="middle" font-family="Cormorant" font-weight="700" font-size="11" fill="#8b4a6b">Data Collection</text>
+    <text x="280" y="238" text-anchor="middle" font-family="Cormorant" font-size="10" fill="#5e6878">Semi-structured</text>
+    <rect x="390" y="200" width="140" height="50" fill="none" stroke="#8b4a6b" stroke-width="1.5"/>
+    <text x="460" y="220" text-anchor="middle" font-family="Cormorant" font-weight="700" font-size="11" fill="#8b4a6b">Analysis</text>
+    <text x="460" y="238" text-anchor="middle" font-family="Cormorant" font-size="10" fill="#5e6878">Reflexive thematic</text>
+    <!-- QUAL arrows -->
+    <line x1="170" y1="225" x2="210" y2="225" stroke="#8b4a6b" stroke-width="1.5" marker-end="url(#arrowL)"/>
+    <line x1="350" y1="225" x2="390" y2="225" stroke="#8b4a6b" stroke-width="1.5" marker-end="url(#arrowL)"/>
+    <!-- Integration point -->
+    <rect x="570" y="110" width="130" height="70" fill="none" stroke="#3a7a5c" stroke-width="2.5"/>
+    <text x="635" y="138" text-anchor="middle" font-family="Inter" font-weight="700" font-size="11" fill="#3a7a5c" letter-spacing="0.5">INTEGRATION</text>
+    <text x="635" y="155" text-anchor="middle" font-family="Inter" font-size="9" fill="#5e6878">Joint display</text>
+    <text x="635" y="168" text-anchor="middle" font-family="Inter" font-size="9" fill="#5e6878">Meta-inference</text>
+    <!-- Convergence arrows -->
+    <line x1="530" y1="65" x2="570" y2="130" stroke="#3a7a5c" stroke-width="1.5" marker-end="url(#arrowM)"/>
+    <line x1="530" y1="225" x2="570" y2="160" stroke="#3a7a5c" stroke-width="1.5" marker-end="url(#arrowM)"/>
+    <!-- Arrow markers -->
+    <defs>
+      <marker id="arrowQ" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#2b6ca3"/>
+      </marker>
+      <marker id="arrowL" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b4a6b"/>
+      </marker>
+      <marker id="arrowM" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#3a7a5c"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Convergent design flow. The <span class="strand-quant">QUANT</span> strand (top, blue) and <span class="strand-qual">QUAL</span> strand (bottom, purple) proceed in parallel through data collection and analysis, converging at the integration point (green) where findings are merged via joint display matrices and meta-inference.</figcaption>
+</figure>
+
+<section class="meta-callout">
+  <span class="callout-label">Meta-Inference</span>
+  <p>Quantitative gains in eHEALS scores <strong>converge</strong> with qualitative reports of growing confidence in navigating health portals. However, the strands <strong>diverge</strong> on sustained engagement: portal usage data show a 34 pct decline at 6-month follow-up, while interview participants described lasting changes in health information-seeking behaviour. This divergence suggests that self-reported confidence may not fully translate to continued portal use without ongoing structural support.</p>
+</section>
+
+## Joint Display Matrix (Summary)
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Joint display matrix summarising convergence and divergence across key findings.</caption>
+  <thead>
+    <tr>
+      <th>Domain</th>
+      <th>QUANT finding</th>
+      <th>QUAL finding</th>
+      <th>Integration</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Skill acquisition</td>
+      <td class="quant-cell">eHEALS +5.4 points (d=0.62)</td>
+      <td class="qual-cell">Theme: building confidence through practice</td>
+      <td class="meta-cell">Convergent</td>
+    </tr>
+    <tr>
+      <td>Portal uptake</td>
+      <td class="quant-cell">Login frequency +2.4x</td>
+      <td class="qual-cell">Participants described initial hesitation giving way to routine use</td>
+      <td class="meta-cell">Convergent</td>
+    </tr>
+    <tr>
+      <td>Sustained engagement</td>
+      <td class="quant-cell">34 pct decline at 6 months</td>
+      <td class="qual-cell">Participants reported lasting changes in information-seeking</td>
+      <td class="meta-cell">Divergent</td>
+    </tr>
+    <tr>
+      <td>Barrier perception</td>
+      <td class="quant-cell">Low baseline eHEALS subscale (14.2/24)</td>
+      <td class="qual-cell">Theme: navigating digital barriers (technical + emotional)</td>
+      <td class="meta-cell">Expansion (QUAL elaborates)</td>
+    </tr>
+    <tr>
+      <td>Role transformation</td>
+      <td class="quant-cell">Not measured</td>
+      <td class="qual-cell">Theme: redefining the patient role as active participant</td>
+      <td class="meta-cell">Expansion (QUAL only)</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Integration categories follow Creswell and Plano Clark (2018): convergent = findings agree; divergent = findings disagree; expansion = one strand elaborates on the other.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+1. **Section 1. Introduction** -- rationale, research questions, and design justification
+2. **Section 2. QUANT Strand** -- survey design, sample, measures, and statistical results
+3. **Section 3. QUAL Strand** -- interview protocol, sampling, coding, and thematic findings
+4. **Section 4. Integration** -- joint display, integration wheel, and meta-inferences
+5. **Section 5. Discussion** -- interpretation, legitimation, limitations, and implications

--- a/mixed-methods/content/instruments.md
+++ b/mixed-methods/content/instruments.md
@@ -1,0 +1,45 @@
++++
+title = "Instruments"
+description = "Measurement instruments and data collection tools used in both the QUANT and QUAL strands of the convergent design."
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["pages"]
++++
+
+## QUANT Instrument: eHealth Literacy Scale (eHEALS)
+
+The eHEALS (Norman and Skinner, 2006) is an 8-item self-report measure of perceived eHealth literacy. Each item is scored on a 5-point Likert scale (1 = strongly disagree to 5 = strongly agree), yielding a total score range of 8 to 40.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table I1.</span> eHEALS items and pre/post descriptive statistics (N = 342).</caption>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>Statement</th>
+      <th>Pre M (SD)</th>
+      <th>Post M (SD)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td class="num">1</td><td>I know what health resources are available on the Internet</td><td class="num">3.2 (1.1)</td><td class="num">3.9 (0.9)</td></tr>
+    <tr><td class="num">2</td><td>I know where to find helpful health resources on the Internet</td><td class="num">3.1 (1.2)</td><td class="num">3.8 (0.9)</td></tr>
+    <tr><td class="num">3</td><td>I know how to find helpful health resources on the Internet</td><td class="num">3.3 (1.0)</td><td class="num">4.0 (0.8)</td></tr>
+    <tr><td class="num">4</td><td>I know how to use the Internet to answer my health questions</td><td class="num">3.4 (1.1)</td><td class="num">4.1 (0.8)</td></tr>
+    <tr><td class="num">5</td><td>I know how to use the health information I find to help me</td><td class="num">3.5 (1.0)</td><td class="num">4.0 (0.9)</td></tr>
+    <tr><td class="num">6</td><td>I have the skills to evaluate health resources on the Internet</td><td class="num">3.0 (1.2)</td><td class="num">3.7 (1.0)</td></tr>
+    <tr><td class="num">7</td><td>I can tell high quality from low quality health resources</td><td class="num">3.1 (1.1)</td><td class="num">3.8 (0.9)</td></tr>
+    <tr><td class="num">8</td><td>I feel confident in using information from the Internet to make health decisions</td><td class="num">3.2 (1.1)</td><td class="num">4.0 (0.9)</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">M = mean; SD = standard deviation. All items showed statistically significant improvement (p &lt; 0.01, Bonferroni-corrected).</td></tr>
+  </tfoot>
+</table>
+
+## QUAL Instrument: Interview Protocol
+
+Semi-structured interviews lasted 35 to 55 minutes and followed a protocol with three guiding domains:
+
+1. **Experience with the intervention** -- What was it like participating in the programme? What activities were most helpful or least helpful?
+2. **Changes in health information behaviour** -- How has the way you look for health information changed, if at all? Can you describe a specific example?
+3. **Barriers and facilitators** -- What made it easier or harder to use digital health tools? What would you change about the programme?
+
+Probes were used to deepen responses and seek concrete examples. All interviews were audio-recorded and transcribed verbatim. Member checking was conducted with 8 of the 28 participants.

--- a/mixed-methods/content/integration.md
+++ b/mixed-methods/content/integration.md
@@ -1,0 +1,64 @@
++++
+title = "Integration Summary"
+description = "Overview of the integration procedure, joint display construction, and the pillar integration process used to merge QUANT and QUAL findings."
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["pages"]
++++
+
+## Integration Wheel
+
+<figure class="figure">
+  <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Integration wheel diagram showing five domains with convergence and divergence indicators">
+    <!-- Centre circle -->
+    <circle cx="360" cy="210" r="50" fill="none" stroke="#3a7a5c" stroke-width="2"/>
+    <text x="360" y="205" text-anchor="middle" font-family="Inter" font-weight="700" font-size="11" fill="#3a7a5c">META-</text>
+    <text x="360" y="220" text-anchor="middle" font-family="Inter" font-weight="700" font-size="11" fill="#3a7a5c">INFERENCE</text>
+    <!-- Domain 1: Skill acquisition (top) -->
+    <circle cx="360" cy="60" r="40" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <circle cx="360" cy="60" r="40" fill="none" stroke="#8b4a6b" stroke-width="1.5" stroke-dasharray="6 6" stroke-dashoffset="3"/>
+    <text x="360" y="55" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">SKILL</text>
+    <text x="360" y="68" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">ACQUISITION</text>
+    <line x1="360" y1="100" x2="360" y2="160" stroke="#3a7a5c" stroke-width="1.5"/>
+    <text x="380" y="135" font-family="Inter" font-weight="700" font-size="9" fill="#3a7a5c">CONVERGE</text>
+    <!-- Domain 2: Portal uptake (top-right) -->
+    <circle cx="560" cy="120" r="40" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <circle cx="560" cy="120" r="40" fill="none" stroke="#8b4a6b" stroke-width="1.5" stroke-dasharray="6 6" stroke-dashoffset="3"/>
+    <text x="560" y="115" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">PORTAL</text>
+    <text x="560" y="128" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">UPTAKE</text>
+    <line x1="522" y1="140" x2="406" y2="192" stroke="#3a7a5c" stroke-width="1.5"/>
+    <text x="480" y="158" font-family="Inter" font-weight="700" font-size="9" fill="#3a7a5c">CONVERGE</text>
+    <!-- Domain 3: Sustained engagement (bottom-right) -->
+    <circle cx="500" cy="320" r="40" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <circle cx="500" cy="320" r="40" fill="none" stroke="#8b4a6b" stroke-width="1.5" stroke-dasharray="6 6" stroke-dashoffset="3"/>
+    <text x="500" y="315" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">SUSTAINED</text>
+    <text x="500" y="328" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">ENGAGEMENT</text>
+    <line x1="468" y1="296" x2="394" y2="248" stroke="#c44a3a" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="448" y="280" font-family="Inter" font-weight="700" font-size="9" fill="#c44a3a">DIVERGE</text>
+    <!-- Domain 4: Barrier perception (bottom-left) -->
+    <circle cx="220" cy="320" r="40" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+    <circle cx="220" cy="320" r="40" fill="none" stroke="#8b4a6b" stroke-width="1.5" stroke-dasharray="6 6" stroke-dashoffset="3"/>
+    <text x="220" y="315" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">BARRIER</text>
+    <text x="220" y="328" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#1a2030">PERCEPTION</text>
+    <line x1="252" y1="296" x2="326" y2="248" stroke="#e8a84c" stroke-width="1.5"/>
+    <text x="266" y="280" font-family="Inter" font-weight="700" font-size="9" fill="#e8a84c">EXPAND</text>
+    <!-- Domain 5: Role transformation (top-left) -->
+    <circle cx="160" cy="120" r="40" fill="none" stroke="#8b4a6b" stroke-width="1.5"/>
+    <text x="160" y="115" text-anchor="middle" font-family="Cormorant" font-weight="700" font-size="10" fill="#1a2030">ROLE</text>
+    <text x="160" y="128" text-anchor="middle" font-family="Cormorant" font-weight="700" font-size="10" fill="#1a2030">TRANSFORM</text>
+    <line x1="198" y1="140" x2="314" y2="192" stroke="#e8a84c" stroke-width="1.5"/>
+    <text x="238" y="158" font-family="Inter" font-weight="700" font-size="9" fill="#e8a84c">EXPAND</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Integration wheel. Five domains connect to the central meta-inference node. Solid green lines indicate convergence; dashed red lines indicate divergence; solid amber lines indicate expansion (one strand elaborates). Domain 5 (Role Transformation) has a purple-only border, indicating a QUAL-only finding.</figcaption>
+</figure>
+
+## Pillar Integration Process
+
+The integration followed the pillar integration process (Johnson et al. 2019):
+
+1. **Listing** -- QUANT results and QUAL themes were listed side-by-side in a joint display matrix
+2. **Matching** -- Each QUANT finding was matched to the most relevant QUAL theme
+3. **Checking** -- Each matched pair was classified as convergent, divergent, or expansion
+4. **Pillar construction** -- Matched pairs were grouped into five conceptual pillars (domains)
+5. **Meta-inference** -- An overarching inference was drawn for each pillar and for the study as a whole
+
+The meta-inference was conducted collaboratively by all five authors, with attention to reflexive positioning: the QUANT analysts (Alvarez, Chen) and QUAL analysts (Okafor, Eriksson) independently drafted domain-level inferences before meeting to negotiate the final meta-inference statement.

--- a/mixed-methods/content/sections/1-introduction.md
+++ b/mixed-methods/content/sections/1-introduction.md
@@ -1,0 +1,30 @@
++++
+title = "1. Introduction"
+description = "Rationale for a convergent mixed-methods evaluation, research questions, and justification of the design choice."
+weight = 1
+template = "post"
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Background
+
+Digital health literacy -- the ability to seek, find, understand, and appraise health information from digital sources -- has become a prerequisite for effective engagement with modern healthcare systems. Patient portals, telehealth platforms, and online health resources assume a level of digital fluency that many community health centre populations do not possess.
+
+Previous research has evaluated digital health literacy interventions primarily through quantitative pre-post designs, capturing changes in standardised scores but missing the lived experience of participants. Qualitative studies have provided rich accounts of barriers and facilitators but cannot establish the magnitude or generalisability of intervention effects.
+
+## 1.2 Research questions
+
+This study addresses three research questions using a convergent mixed-methods design:
+
+1. <span class="strand-quant">QUANT:</span> To what extent does a digital health literacy intervention improve eHEALS scores and patient portal usage among community health centre patients?
+2. <span class="strand-qual">QUAL:</span> How do participants experience the intervention, and what barriers and facilitators shape their engagement with digital health tools?
+3. <span class="strand-meta">META-INFERENCE:</span> In what ways do quantitative outcomes and qualitative experiences converge, diverge, or expand upon each other?
+
+## 1.3 Design justification
+
+A convergent design was selected because the research questions require both breadth (generalisable effect estimates) and depth (contextualised understanding) to fully address the evaluation aims. The two strands are given approximately equal priority and are collected concurrently, meeting the criteria for a parallel convergent design as described by Creswell and Plano Clark (2018).
+
+The integration point occurs after independent analysis of each strand, using joint display matrices and the pillar integration process (Johnson et al. 2019) to systematically compare, contrast, and synthesise findings.

--- a/mixed-methods/content/sections/2-quant-strand.md
+++ b/mixed-methods/content/sections/2-quant-strand.md
@@ -1,0 +1,46 @@
++++
+title = "2. QUANT Strand"
+description = "Quantitative survey design, sample characteristics, measures, and statistical results for the digital health literacy intervention evaluation."
+weight = 2
+template = "post"
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Design and sample
+
+A quasi-experimental pre-post design was used. Participants (N = 342) were recruited from four community health centres in Seville over a 6-month period (January to June 2026). Inclusion criteria: adults aged 18 and over, registered at a participating centre, with no prior participation in a digital health literacy programme.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Sample demographics (N = 342).</caption>
+  <thead>
+    <tr>
+      <th>Characteristic</th>
+      <th>n</th>
+      <th>pct</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Female</td><td class="num">198</td><td class="num">57.9</td></tr>
+    <tr><td>Male</td><td class="num">138</td><td class="num">40.4</td></tr>
+    <tr><td>Non-binary / prefer not to say</td><td class="num">6</td><td class="num">1.8</td></tr>
+    <tr><td>Age 18-34</td><td class="num">82</td><td class="num">24.0</td></tr>
+    <tr><td>Age 35-54</td><td class="num">144</td><td class="num">42.1</td></tr>
+    <tr><td>Age 55+</td><td class="num">116</td><td class="num">33.9</td></tr>
+    <tr><td>Primary education only</td><td class="num">96</td><td class="num">28.1</td></tr>
+    <tr><td>Secondary education</td><td class="num">148</td><td class="num">43.3</td></tr>
+    <tr><td>Tertiary education</td><td class="num">98</td><td class="num">28.7</td></tr>
+  </tbody>
+</table>
+
+## 2.2 Measures
+
+The primary outcome was the eHealth Literacy Scale (eHEALS; Norman and Skinner, 2006), administered at baseline and 8 weeks post-intervention. The secondary outcome was patient portal login frequency, extracted from portal analytics for the 8-week intervention period and the 6-month follow-up period.
+
+## 2.3 Results
+
+Mean eHEALS scores increased from 26.4 (SD = 6.8) at baseline to 31.8 (SD = 5.2) at post-test (paired t = 12.84, df = 341, p < 0.001, Cohen d = 0.62). The effect was consistent across age groups (interaction p = 0.41) and education levels (interaction p = 0.28).
+
+Portal login frequency increased from a mean of 1.2 logins per month at baseline to 2.9 logins per month during the intervention period (a 2.4-fold increase). At the 6-month follow-up, portal login frequency had declined to 1.9 logins per month, representing a 34 pct decline from the intervention period peak but still 58 pct above baseline.

--- a/mixed-methods/content/sections/3-qual-strand.md
+++ b/mixed-methods/content/sections/3-qual-strand.md
@@ -1,0 +1,42 @@
++++
+title = "3. QUAL Strand"
+description = "Qualitative interview strand: sampling strategy, coding process, and three emergent themes from reflexive thematic analysis."
+weight = 3
+template = "post"
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Sampling and data collection
+
+Purposive sampling was used to select 28 interview participants from the survey sample (N = 342), stratified by age group, gender, and baseline eHEALS score to ensure maximum variation. Interviews were conducted in the final two weeks of the 8-week intervention period.
+
+All interviews were audio-recorded and transcribed verbatim. Field notes were taken during and immediately after each interview. Member checking was conducted with 8 participants (29 pct) to verify accuracy of preliminary themes.
+
+## 3.2 Analysis approach
+
+Reflexive thematic analysis (Braun and Clarke, 2022) was conducted by two analysts (Okafor, Eriksson) working independently before comparing codes and negotiating themes. The analysis followed six phases: familiarisation, coding, initial theme generation, theme development, refinement, and writing.
+
+A total of 412 initial codes were generated, consolidated into 14 candidate themes, and refined into three final themes.
+
+## 3.3 Theme 1: Navigating digital barriers
+
+Participants described multiple layers of barriers to engaging with digital health tools. Technical barriers included unreliable internet access, unfamiliarity with device interfaces, and password management difficulties. Emotional barriers included fear of making mistakes, anxiety about privacy, and a sense of being left behind.
+
+> "I kept thinking I would break something. My daughter showed me how to log in, but when I was alone I could not remember the steps. It was not just the technology -- it was the feeling that this was not meant for someone like me." (P14, female, age 62)
+
+## 3.4 Theme 2: Building confidence through practice
+
+Participants who attended multiple intervention sessions described a gradual process of building confidence through repeated practice in a supportive environment. The presence of facilitators and peer learners was described as essential.
+
+> "The third session was when it clicked. I could find my test results without asking anyone. That was the moment I thought: I can do this by myself." (P07, male, age 48)
+
+## 3.5 Theme 3: Redefining the patient role
+
+Several participants described a shift in how they saw their role in the healthcare encounter. Prior to the intervention, health information was something received passively from clinicians. After the intervention, participants described themselves as active seekers of health information who could prepare for appointments and ask informed questions.
+
+> "Before, I would go to the doctor and just listen. Now I look things up first. I come with questions. The doctor said she noticed I was more engaged." (P22, female, age 55)
+
+This theme was identified exclusively in the QUAL strand; no corresponding quantitative measure was included in the survey design.

--- a/mixed-methods/content/sections/4-integration.md
+++ b/mixed-methods/content/sections/4-integration.md
@@ -1,0 +1,38 @@
++++
+title = "4. Integration"
+description = "Systematic comparison and synthesis of QUANT and QUAL findings through joint display matrices, the integration wheel, and meta-inference."
+weight = 4
+template = "post"
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Joint display construction
+
+The joint display matrix was constructed by first listing all QUANT results (effect sizes, significance tests, and descriptive statistics) and all QUAL themes alongside each other. Each row represents a substantive domain derived from the research questions. The integration column classifies the relationship as convergent, divergent, or expansion.
+
+The full joint display matrix is presented in Table 1 on the Abstract page. Here we elaborate on the three most significant integration findings.
+
+## 4.2 Convergence: Skill acquisition
+
+The QUANT finding of a statistically significant and practically meaningful improvement in eHEALS scores (d = 0.62) converges with the QUAL theme of building confidence through practice. Both strands indicate that the intervention successfully improved participants' perceived ability to engage with digital health information. The qualitative data add nuance by specifying the mechanism (repeated practice in a supportive environment) and the tipping point (typically around the third session).
+
+## 4.3 Divergence: Sustained engagement
+
+The most important divergence concerns sustained engagement. The QUANT data show a 34 pct decline in portal login frequency at 6-month follow-up, suggesting that behavioural gains are partially lost without continued support. However, QUAL participants (interviewed at 8 weeks) described lasting changes in their orientation toward health information, including new habits of looking things up before appointments.
+
+This divergence can be interpreted in several ways:
+
+1. **Temporal discrepancy** -- interviews captured intentions and early habits; portal data captured actual behaviour over a longer period
+2. **Measurement gap** -- the portal login metric captures only one form of health information-seeking; participants may have shifted to other digital sources not tracked by the portal
+3. **Desirability bias** -- interview responses may reflect socially desirable accounts of lasting change
+
+## 4.4 Expansion: Role transformation
+
+The QUAL theme of redefining the patient role had no quantitative counterpart, representing a pure expansion. This finding suggests that future evaluations should include a measure of patient activation (e.g., the Patient Activation Measure) to capture this dimension quantitatively.
+
+## 4.5 Meta-inference
+
+The overarching meta-inference is: the digital health literacy intervention produces measurable and experienced gains in skill and confidence, but the translation of these gains into sustained behavioural change requires ongoing structural support. The convergence on skill acquisition validates the intervention mechanism; the divergence on sustained engagement identifies a critical gap for future programme design.

--- a/mixed-methods/content/sections/5-discussion.md
+++ b/mixed-methods/content/sections/5-discussion.md
@@ -1,0 +1,43 @@
++++
+title = "5. Discussion"
+description = "Interpretation of integrated findings, legitimation assessment, study limitations, and implications for practice and future mixed-methods research."
+weight = 5
+template = "post"
+tags = ["paper", "mixed-methods", "convergent"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of integrated findings
+
+This convergent mixed-methods study demonstrates that a digital health literacy intervention in community health centres produces statistically significant improvements in eHEALS scores (d = 0.62) that converge with qualitative accounts of growing confidence and new health information-seeking habits. The study also identifies a critical divergence: quantitative portal usage data suggest declining engagement after programme completion, while qualitative participants report lasting attitudinal changes. This divergence underscores the importance of mixed-methods designs for capturing the full complexity of intervention effects.
+
+## 5.2 Comparison to prior work
+
+Our eHEALS effect size (d = 0.62) is comparable to the meta-analytic estimate of d = 0.58 reported by Xie et al. (2024) across 18 digital health literacy interventions. The qualitative finding of role transformation aligns with Nutbeam's (2000) conceptualisation of critical health literacy as a pathway to empowerment, extending beyond functional skill acquisition.
+
+## 5.3 Limitations
+
+Four limitations should be noted:
+
+1. **Quasi-experimental design** -- the absence of a control group limits causal inference in the QUANT strand. Regression to the mean cannot be ruled out.
+2. **Selection bias in QUAL sampling** -- despite purposive stratification, interview participants may be more engaged or reflective than the broader sample.
+3. **Temporal mismatch** -- interviews were conducted at 8 weeks; the portal usage follow-up extended to 6 months. A second round of interviews at follow-up would have strengthened the integration.
+4. **Single-site context** -- all four health centres are in Seville; generalisability to other contexts is uncertain.
+
+## 5.4 Implications
+
+For practice: digital health literacy interventions should incorporate post-programme support mechanisms (e.g., monthly refresher sessions, peer-support networks) to address the engagement decline identified in this study. For research: the QUAL-only theme of role transformation suggests that future evaluations should include a patient activation measure to enable quantitative capture of this dimension.
+
+## References
+
+<ol class="references-list">
+  <li>Braun V, Clarke V. Thematic analysis: a practical guide. London: Sage; 2022.</li>
+  <li>Creswell JW, Plano Clark VL. Designing and conducting mixed methods research. 3rd ed. Thousand Oaks: Sage; 2018.</li>
+  <li>Johnson RB, de Waal C, Stefurak T, Hildebrand DL. Understanding the philosophical positions of classical and neopragmatists for mixed methods research. <em>Kolner Z Soz Sozpsychol.</em> 2019;69(S2):63-86.</li>
+  <li>Norman CD, Skinner HA. eHEALS: the eHealth Literacy Scale. <em>J Med Internet Res.</em> 2006;8(4):e27.</li>
+  <li>Nutbeam D. Health literacy as a public health goal: a challenge for contemporary health education and communication strategies into the 21st century. <em>Health Promot Int.</em> 2000;15(3):259-267.</li>
+  <li>Onwuegbuzie AJ, Johnson RB. The validity issue in mixed research. <em>Res Sch.</em> 2006;13(1):48-63.</li>
+  <li>Xie L, Zhang Y, Huang K, et al. Digital health literacy interventions: a systematic review and meta-analysis. <em>J Health Commun.</em> 2024;29(8):512-528.</li>
+</ol>

--- a/mixed-methods/content/sections/_index.md
+++ b/mixed-methods/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The paper is organised into five sections, following the structure recommended by Creswell and Plano Clark (2018) for convergent mixed-methods reports.

--- a/mixed-methods/static/css/style.css
+++ b/mixed-methods/static/css/style.css
@@ -1,0 +1,567 @@
+/* ============================================================================
+   Mixed-Methods - Convergent Design Paper
+   Light background, dual-font QUANT/QUAL typography, joint display matrices,
+   integration wheel diagrams. No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #fafaf7;
+  --paper-2: #f0ede6;
+  --rule: #d4cfc2;
+  --ink: #1a2030;
+  --ink-2: #2e3848;
+  --ink-3: #5e6878;
+  --ink-4: #8a92a0;
+  --quant: #2b6ca3;
+  --quant-2: #1e5280;
+  --qual: #8b4a6b;
+  --qual-2: #6e3854;
+  --meta: #3a7a5c;
+  --meta-2: #2c5e46;
+  --accent: #2b6ca3;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.02rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--quant);
+  border-bottom-color: var(--quant);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--meta);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.7rem, 3.4vw, 2.4rem);
+  line-height: 1.18;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", serif;
+  font-size: 1.08rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--quant); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.92rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--quant); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--meta);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--meta);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", serif;
+}
+
+/* ---------------- QUANT / QUAL strand labels ---------------- */
+
+.strand-quant {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--quant);
+  letter-spacing: 0.08em;
+}
+
+.strand-qual {
+  font-family: "Cormorant", Georgia, serif;
+  font-weight: 700;
+  color: var(--qual);
+}
+
+.strand-meta {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--meta);
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.08rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--quant);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--quant-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--meta);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.12rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Meta-inference callout ---------------- */
+
+.meta-callout {
+  background: var(--paper-2);
+  border: 2px solid var(--meta);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.meta-callout .callout-label {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--meta);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.6rem;
+}
+
+.meta-callout p {
+  margin: 0.4rem 0;
+  font-family: "Crimson Pro", serif;
+  color: var(--ink-2);
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--meta);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--meta);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table td.quant-cell { border-left: 3px solid var(--quant); }
+.paper-table td.qual-cell { border-left: 3px solid var(--qual); }
+.paper-table td.meta-cell { border-left: 3px solid var(--meta); }
+
+.paper-table tfoot td {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Crimson Pro", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Inter", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--quant); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--quant);
+  text-decoration: none;
+  border-bottom: 1px solid var(--quant);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--quant-2); border-bottom-color: var(--quant-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .meta-callout { padding: 1rem; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/mixed-methods/templates/404.html
+++ b/mixed-methods/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/mixed-methods/templates/footer.html
+++ b/mixed-methods/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c8c0b4" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c8c0b4" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Alvarez M, Chen W, Okafor N. Convergent mixed-methods evaluation of digital health literacy interventions. <em>J Mixed Methods Res.</em> 2026;20(4):318-342. doi:10.41927/jmmr.2026.20.04.318</p>
+        <p class="footer-note">ISSN 1558-6898 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/mixed-methods/templates/header.html
+++ b/mixed-methods/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Cormorant:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Two overlapping circles representing convergence -->
+          <circle cx="24" cy="20" r="14" fill="none" stroke="#2b6ca3" stroke-width="1.5"/>
+          <circle cx="40" cy="20" r="14" fill="none" stroke="#8b4a6b" stroke-width="1.5"/>
+          <line x1="32" y1="8" x2="32" y2="32" stroke="#3a7a5c" stroke-width="1" stroke-dasharray="3 2"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Mixed Methods Research</span>
+          <span class="journal-sub">Vol. 20 &middot; Issue 04 &middot; Dec 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/integration/">INTEGRATION</a>
+        <a href="{{ base_url }}/instruments/">INSTRUMENTS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/mixed-methods/templates/page.html
+++ b/mixed-methods/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/mixed-methods/templates/post.html
+++ b/mixed-methods/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/mixed-methods/templates/section.html
+++ b/mixed-methods/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/mixed-methods/templates/shortcodes/alert.html
+++ b/mixed-methods/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("Note") | upper }}:</strong> {{ body }}
+</div>

--- a/mixed-methods/templates/taxonomy.html
+++ b/mixed-methods/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/mixed-methods/templates/taxonomy_term.html
+++ b/mixed-methods/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2218,6 +2218,13 @@
     "desert",
     "distortion"
   ],
+  "mixed-methods": [
+    "paper",
+    "light",
+    "mixed-methods",
+    "convergent",
+    "dual"
+  ],
   "modern-blog": [
     "dark",
     "blog",
@@ -2807,6 +2814,13 @@
     "light",
     "blog",
     "academic"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
   ],
   "postcard": [
     "light",
@@ -3937,12 +3951,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "position-paper": [
-    "paper",
-    "dark",
-    "position",
-    "argumentative",
-    "bold"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `mixed-methods` example site: a convergent design paper merging QUANT and QUAL strands
- Features SVG convergent design flow diagrams, joint display matrices, integration wheel diagrams
- Dual typography: IBM Plex Sans Bold for QUANT labels, Cormorant Bold for QUAL labels, Inter Bold for meta-inference
- Light theme with color-coded strand markers (blue=QUANT, purple=QUAL, green=META)
- Tags: paper, light, mixed-methods, convergent, dual

Closes #1628

## Test plan
- [ ] Verify `hwaro build` succeeds in the mixed-methods directory
- [ ] Check convergent design flow SVG renders correctly
- [ ] Check integration wheel SVG renders correctly
- [ ] Confirm dual-font strand labels display properly
- [ ] Validate tags.json contains the new entry