### PR TITLE
Add technical-report example site

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -3951,5 +3951,12 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
   ]
 }

--- a/technical-report/AGENTS.md
+++ b/technical-report/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/technical-report/config.toml
+++ b/technical-report/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Technical Report - Institutional TR Paper
+# Issue #1633 | Tags: paper, light, institutional, technical-report, formal
+# =============================================================================
+
+title = "Infrastructure Resilience Assessment"
+description = "An institutional technical report assessing seismic resilience of critical bridge infrastructure, formatted in the house style of a government research laboratory with classification headers and distribution statements."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/technical-report/content/appendix.md
+++ b/technical-report/content/appendix.md
@@ -1,0 +1,28 @@
++++
+title = "Appendix"
+description = "Supporting materials including data sources, model validation results, and distribution information."
+tags = ["paper", "technical-report", "appendix"]
++++
+
+## Appendix A: Data Sources
+
+- **Bridge inventory**: National Bridge Inventory (NBI) 2025 extract, supplemented by state DOT structural inspection records for Oregon, Washington, and Northern California
+- **Seismic hazard**: USGS 2023 National Seismic Hazard Model, Cascadia Subduction Zone rupture scenarios from Goldfinger et al. (2017)
+- **Geotechnical**: Vs30 site classifications from USGS Vs30 map server, supplemented by borehole data from state geological surveys
+- **Traffic demand**: FHWA Highway Performance Monitoring System (HPMS) 2024 data, regional travel demand models from state MPOs
+
+## Appendix B: Model Validation Summary
+
+Finite-element models were validated against three independent datasets: (1) NIRL shake-table test results for five representative bridge types (correlation coefficient R = 0.91-0.96); (2) recorded ground motion and damage observations from the 2001 Mw 6.8 Nisqually earthquake (12 bridges with documented damage, correct damage state prediction in 10 of 12 cases); (3) cross-comparison with HAZUS-MH fragility curves (mean absolute error in damage state probability < 0.08 across all bridge types).
+
+## Appendix C: Distribution and Reproduction
+
+This report may be reproduced in whole or in part for any purpose of the United States Government. Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not constitute or imply its endorsement by the National Infrastructure Research Laboratory.
+
+## Appendix D: Acknowledgements
+
+This work was supported by NIRL Contract NIRL-CE-2024-0089. The authors thank the Oregon, Washington, and California Departments of Transportation for providing bridge inspection records and structural drawings. Dr. Lin Chen (USGS) provided technical review of the seismic hazard characterization. Laboratory computational resources were provided by the NIRL High-Performance Computing Center.
+
+## Point of Contact
+
+Dr. Catherine R. Halloran, Principal Investigator, Structural Systems Division, National Infrastructure Research Laboratory. Email: halloran@nirl.gov. Phone: (503) 555-0142.

--- a/technical-report/content/findings.md
+++ b/technical-report/content/findings.md
@@ -1,0 +1,23 @@
++++
+title = "Key Findings"
+description = "Summary of principal findings from the seismic resilience assessment, including damage distributions, network impacts, and economic loss estimates."
+tags = ["paper", "technical-report", "findings"]
++++
+
+## Principal Findings
+
+### Finding 1: Corridor Vulnerability Concentration
+
+Vulnerability is not uniformly distributed across the corridor. Twelve bridges -- representing 8 pct of the inventory -- account for 67 pct of the total network connectivity loss under the CSZ Mw 9.0 scenario. These bottleneck bridges are concentrated at river crossings where alternative routes are unavailable within 50 km.
+
+### Finding 2: Subduction Zone vs. Crustal Events
+
+The CSZ Mw 9.0 scenario produces qualitatively different damage patterns than crustal events of comparable local intensity. The extended duration of subduction zone ground motions (120-180 seconds vs. 15-40 seconds for crustal events) amplifies cumulative damage in concrete bridge columns, increasing the Extensive-or-worse damage fraction by 40 pct relative to crustal events with similar peak ground acceleration.
+
+### Finding 3: Restoration Timeline
+
+Under the baseline repair scenario (current workforce and material supply assumptions), the corridor network connectivity index requires 180 days to recover from 0.38 to 0.75 following the CSZ Mw 9.0 event. Under an accelerated repair scenario (federal emergency mobilization), this timeline reduces to 90 days. Full restoration to pre-event connectivity (index = 1.0) requires 540-720 days under baseline assumptions.
+
+### Finding 4: Retrofit Cost-Benefit
+
+The 12 bottleneck bridges can be retrofitted at an estimated cost of $340M (2026 USD). Without retrofit, the CSZ scenario produces estimated direct and indirect economic losses of $4.2B in the first year, yielding a benefit-cost ratio of 12.4:1 for the retrofit program.

--- a/technical-report/content/index.md
+++ b/technical-report/content/index.md
@@ -1,0 +1,158 @@
++++
+title = "Cover Page"
+description = "Technical Report TR-2026-0471: Seismic Resilience Assessment of Critical Bridge Infrastructure in the Pacific Northwest Corridor."
+tags = ["paper", "light", "institutional", "technical-report", "formal"]
++++
+
+<header class="paper-header">
+  <div class="report-badge">TR-2026-0471</div>
+  <p class="paper-eyebrow">Technical Report &middot; Final</p>
+  <h1 class="paper-title">Seismic Resilience Assessment of Critical Bridge Infrastructure in the Pacific Northwest Corridor</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Dr. Catherine R. Halloran</span><sup>1</sup>,
+    James K. Whitfield<sup>1</sup>,
+    Dr. Yuki Tanaka-Morrison<sup>2</sup>,
+    David O. Ramirez<sup>1</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>National Infrastructure Research Laboratory, Structural Systems Division &middot;
+    <sup>2</sup>Pacific Seismic Hazards Consortium, University of Oregon
+  </p>
+  <p class="paper-doi"><strong>Report No:</strong> TR-2026-0471 &middot; <strong>Date:</strong> April 2026 &middot; <strong>Contract:</strong> NIRL-CE-2024-0089</p>
+</header>
+
+<div class="distribution-statement">
+  <p class="dist-label">Distribution Statement A</p>
+  <p>Approved for public release; distribution is unlimited. This document has been cleared by the National Infrastructure Research Laboratory Public Affairs Office. NIRL-PA-2026-0234.</p>
+</div>
+
+<figure class="figure">
+  <svg viewBox="0 0 720 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Report classification header banner">
+    <rect x="0" y="0" width="720" height="60" fill="#f8f7f3"/>
+    <rect x="0" y="0" width="720" height="4" fill="#2a6b3f"/>
+    <rect x="0" y="56" width="720" height="4" fill="#2a6b3f"/>
+    <text x="20" y="36" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="2">NATIONAL INFRASTRUCTURE RESEARCH LABORATORY</text>
+    <text x="700" y="36" text-anchor="end" font-family="JetBrains Mono, monospace" font-weight="700" font-size="11" fill="#2a6b3f" letter-spacing="1.5">TR-2026-0471</text>
+  </svg>
+</figure>
+
+<div class="approval-block">
+  <div class="approval-entry">
+    <p class="approval-role">Prepared by</p>
+    <p class="approval-name">Dr. Catherine R. Halloran</p>
+    <p class="approval-title">Principal Investigator, Structural Systems Division</p>
+    <p class="approval-date">2026-04-08</p>
+  </div>
+  <div class="approval-entry">
+    <p class="approval-role">Reviewed by</p>
+    <p class="approval-name">Dr. Marcus T. Webb</p>
+    <p class="approval-title">Division Chief, Structural Systems Division</p>
+    <p class="approval-date">2026-04-10</p>
+  </div>
+  <div class="approval-entry">
+    <p class="approval-role">Approved by</p>
+    <p class="approval-name">Dr. Sandra Reyes-Nakamura</p>
+    <p class="approval-title">Director, National Infrastructure Research Laboratory</p>
+    <p class="approval-date">2026-04-12</p>
+  </div>
+  <div class="approval-entry">
+    <p class="approval-role">Released by</p>
+    <p class="approval-name">Lt. Col. Daniel P. Forsythe (Ret.)</p>
+    <p class="approval-title">Chief, Public Affairs Office</p>
+    <p class="approval-date">2026-04-14</p>
+  </div>
+</div>
+
+<section class="abstract-box">
+  <h2>Executive Summary</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>Assess the seismic resilience of 142 critical bridge structures in the Pacific Northwest transportation corridor under scenario-based and probabilistic seismic hazard conditions.</dd>
+    <dt>Methods</dt>
+    <dd>Nonlinear dynamic analysis using calibrated finite-element models subjected to 7 scenario earthquakes (Mw 6.5-9.1) and a 2,500-year return-period probabilistic hazard suite. Resilience metrics include structural damage state probabilities, restoration time estimates, and network-level connectivity indices.</dd>
+    <dt>Results</dt>
+    <dd>Under the Cascadia Subduction Zone (CSZ) Mw 9.0 scenario, 34 bridges (24 pct) exceed the Extensive damage state, with an estimated 180-day median restoration time for the corridor. The network connectivity index drops to 0.38 immediately post-event, recovering to 0.75 within 90 days under accelerated repair assumptions.</dd>
+    <dt>Recommendations</dt>
+    <dd>Prioritize seismic retrofit of 12 bridges identified as critical network bottlenecks. Estimated retrofit cost: $340M. Without retrofit, estimated economic losses under CSZ scenario: $4.2B over the first year.</dd>
+    <dt>Keywords</dt>
+    <dd><em>seismic resilience; bridge infrastructure; Cascadia Subduction Zone; nonlinear dynamic analysis; restoration modeling; network connectivity</em></dd>
+  </dl>
+</section>
+
+## Report Number Reference
+
+<figure class="figure">
+  <svg viewBox="0 0 720 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Report numbering badge showing TR-2026-0471 breakdown">
+    <rect x="0" y="0" width="720" height="100" fill="#f8f7f3"/>
+    <!-- Badge boxes -->
+    <rect x="100" y="20" width="80" height="60" fill="#1a2337"/>
+    <text x="140" y="48" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="16" fill="#f8f7f3">TR</text>
+    <text x="140" y="66" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#8a8e9a" letter-spacing="1">TYPE</text>
+    <rect x="190" y="20" width="4" height="60" fill="#2a6b3f"/>
+    <rect x="204" y="20" width="100" height="60" fill="#1a2337"/>
+    <text x="254" y="48" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="16" fill="#f8f7f3">2026</text>
+    <text x="254" y="66" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#8a8e9a" letter-spacing="1">FISCAL YEAR</text>
+    <rect x="314" y="20" width="4" height="60" fill="#2a6b3f"/>
+    <rect x="328" y="20" width="100" height="60" fill="#1a2337"/>
+    <text x="378" y="48" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="16" fill="#f8f7f3">0471</text>
+    <text x="378" y="66" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#8a8e9a" letter-spacing="1">SEQUENCE</text>
+    <!-- Explanation labels -->
+    <text x="490" y="40" font-family="Source Sans 3" font-weight="600" font-size="11" fill="#1a2337">Technical Report</text>
+    <text x="490" y="56" font-family="Source Sans 3" font-size="11" fill="#5b6272">Fiscal Year 2026, Report #471</text>
+    <text x="490" y="72" font-family="Source Sans 3" font-size="11" fill="#5b6272">Structural Systems Division</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Report numbering convention. TR = Technical Report; four-digit year identifies fiscal year; four-digit sequence number is assigned by the laboratory records office upon acceptance.</div>
+</figure>
+
+## Key Findings
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary of seismic performance under the CSZ Mw 9.0 scenario for the 142-bridge inventory.</caption>
+  <thead>
+    <tr>
+      <th>Damage state</th>
+      <th>Bridges</th>
+      <th>Pct of inventory</th>
+      <th>Median restoration (days)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>None / Slight</td>
+      <td class="num">52</td>
+      <td class="num">37 pct</td>
+      <td class="num">0-7</td>
+    </tr>
+    <tr>
+      <td>Moderate</td>
+      <td class="num">56</td>
+      <td class="num">39 pct</td>
+      <td class="num">30-90</td>
+    </tr>
+    <tr>
+      <td>Extensive</td>
+      <td class="num">26</td>
+      <td class="num">18 pct</td>
+      <td class="num">120-240</td>
+    </tr>
+    <tr>
+      <td>Complete</td>
+      <td class="num">8</td>
+      <td class="num">6 pct</td>
+      <td class="num">360-720</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Damage states follow HAZUS-MH classification. Restoration times are median estimates from the laboratory's bridge repair model (NIRL-BRM v3.2).</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Report
+
+This report is organized into the following numbered sections per NIRL Technical Report Format Guide (NIRL-TRF-2023-Rev3).
+
+1. **Section 1. Introduction** -- study objectives, scope, and background on the Pacific Northwest corridor
+2. **Section 2. Seismic Hazard Characterization** -- scenario earthquakes and probabilistic hazard analysis
+3. **Section 3. Structural Modeling and Analysis** -- finite-element model development and validation
+4. **Section 4. Resilience Assessment** -- damage probabilities, restoration modeling, and network connectivity analysis
+5. **Section 5. Recommendations** -- retrofit priorities, cost estimates, and implementation timeline

--- a/technical-report/content/methodology.md
+++ b/technical-report/content/methodology.md
@@ -1,0 +1,21 @@
++++
+title = "Methodology"
+description = "Overview of the analytical framework, modeling approach, and validation procedures used in this technical report."
+tags = ["paper", "technical-report", "methodology"]
++++
+
+## Analytical Framework
+
+This report employs a three-stage analytical framework: (1) seismic hazard characterization, (2) structural demand analysis, and (3) resilience quantification. Each stage uses validated models and established engineering practice standards as specified in AASHTO Guide Specifications for LRFD Seismic Bridge Design and NIRL Standard Practice for Infrastructure Resilience Assessment (NIRL-SP-2024-001).
+
+### Seismic Hazard Inputs
+
+Seven scenario earthquakes were selected to span the range of plausible seismic hazards in the Pacific Northwest corridor, from a moderate crustal event (Mw 6.5 on the Portland Hills Fault) to the full-rupture Cascadia Subduction Zone event (Mw 9.0-9.1). Ground motion time histories were generated using the USGS ShakeMap framework with site-specific amplification factors derived from Vs30 measurements at each bridge location.
+
+### Structural Modeling
+
+All 142 bridges were modeled using three-dimensional nonlinear finite-element representations in OpenSees. Models were calibrated against available experimental data from NIRL shake-table tests and field measurements from the 2001 Nisqually earthquake. Key modeling parameters include: concrete constitutive relationships (modified Kent-Park), steel reinforcement behavior (Menegotto-Pinto), soil-structure interaction (p-y curves from API RP2A), and bearing pad response (bilinear hysteretic models).
+
+### Resilience Metrics
+
+Resilience is quantified through three complementary metrics: (a) structural damage state probabilities for individual bridges, derived from fragility curves specific to each bridge type; (b) restoration time estimates using the NIRL Bridge Repair Model (BRM v3.2); (c) network connectivity indices measuring the fraction of origin-destination pairs that remain connected as bridges are sequentially removed from and restored to the network.

--- a/technical-report/content/sections/1-introduction.md
+++ b/technical-report/content/sections/1-introduction.md
@@ -1,0 +1,35 @@
++++
+title = "Introduction"
+description = "Study objectives, scope, and background on the seismic hazard environment of the Pacific Northwest transportation corridor."
+weight = 1
+template = "post"
+[extra]
+section_number = "1"
++++
+
+## 1.1 Background
+
+The Pacific Northwest corridor contains 142 bridges classified as critical transportation infrastructure under the National Highway System designation. These structures carry an aggregate annual average daily traffic (AADT) of 2.4 million vehicles and serve as essential links for freight movement, emergency evacuation, and economic connectivity between major population centers in Oregon, Washington, and Northern California.
+
+The region faces significant seismic hazard from three source types: (1) the Cascadia Subduction Zone (CSZ), capable of producing Mw 8.0-9.1 megathrust earthquakes with return periods of 200-600 years; (2) deep intraslab events within the subducting Juan de Fuca plate (Mw 6.0-7.5); and (3) shallow crustal faults including the Portland Hills, Seattle, and South Whidbey Island faults (Mw 6.0-7.0).
+
+## 1.2 Study Objectives
+
+This technical report has three objectives:
+
+1. Characterize the seismic demand on the 142-bridge inventory under seven scenario earthquakes and a 2,500-year return-period probabilistic hazard suite
+2. Estimate structural damage state probabilities, restoration timelines, and network-level connectivity impacts for each scenario
+3. Identify priority bridges for seismic retrofit based on network criticality and cost-benefit analysis
+
+## 1.3 Scope and Limitations
+
+The study is limited to highway bridges on the National Highway System within the three-state corridor. Railroad bridges, pedestrian structures, and locally maintained bridges are excluded. Tsunami-induced scour effects are not modeled in this report but are addressed separately in NIRL Technical Memorandum TM-2026-0089. Soil liquefaction effects are included for sites with estimated liquefaction susceptibility of Moderate or higher per the USGS liquefaction hazard maps.
+
+## 1.4 Applicable Standards
+
+Analysis procedures conform to the following standards and specifications:
+
+- AASHTO Guide Specifications for LRFD Seismic Bridge Design, 3rd Edition (2023)
+- FEMA HAZUS-MH 6.0 Earthquake Model Technical Manual
+- NIRL Standard Practice for Infrastructure Resilience Assessment (NIRL-SP-2024-001)
+- Caltrans Seismic Design Criteria, Version 2.0 (2019)

--- a/technical-report/content/sections/2-seismic-hazard.md
+++ b/technical-report/content/sections/2-seismic-hazard.md
@@ -1,0 +1,87 @@
++++
+title = "Seismic Hazard Characterization"
+description = "Scenario earthquake selection, ground motion generation, and site-specific amplification for the bridge inventory."
+weight = 2
+template = "post"
+[extra]
+section_number = "2"
++++
+
+## 2.1 Scenario Earthquakes
+
+Seven scenario earthquakes were selected to represent the range of plausible seismic hazards. Scenarios are identified by alphanumeric codes per NIRL convention.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Scenario earthquake parameters.</caption>
+  <thead>
+    <tr>
+      <th>Scenario</th>
+      <th>Source</th>
+      <th>Mw</th>
+      <th>Depth (km)</th>
+      <th>Duration (s)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>S1-PHF</td>
+      <td>Portland Hills Fault</td>
+      <td class="num">6.5</td>
+      <td class="num">8</td>
+      <td class="num">15-25</td>
+    </tr>
+    <tr>
+      <td>S2-SEA</td>
+      <td>Seattle Fault</td>
+      <td class="num">7.0</td>
+      <td class="num">10</td>
+      <td class="num">20-35</td>
+    </tr>
+    <tr>
+      <td>S3-SWI</td>
+      <td>South Whidbey Island Fault</td>
+      <td class="num">6.8</td>
+      <td class="num">12</td>
+      <td class="num">18-30</td>
+    </tr>
+    <tr>
+      <td>S4-INT</td>
+      <td>Intraslab (Nisqually-type)</td>
+      <td class="num">6.8</td>
+      <td class="num">52</td>
+      <td class="num">25-40</td>
+    </tr>
+    <tr>
+      <td>S5-CSZ-P</td>
+      <td>CSZ Partial Rupture (Southern)</td>
+      <td class="num">8.2</td>
+      <td class="num">15-25</td>
+      <td class="num">60-90</td>
+    </tr>
+    <tr>
+      <td>S6-CSZ-F</td>
+      <td>CSZ Full Rupture</td>
+      <td class="num">9.0</td>
+      <td class="num">10-30</td>
+      <td class="num">120-180</td>
+    </tr>
+    <tr>
+      <td>S7-CSZ-M</td>
+      <td>CSZ Maximum Considered</td>
+      <td class="num">9.1</td>
+      <td class="num">10-30</td>
+      <td class="num">140-200</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Mw = moment magnitude. Duration = significant duration (5-95 pct Arias intensity). CSZ scenarios based on Goldfinger et al. (2017) rupture models.</td></tr>
+  </tfoot>
+</table>
+
+## 2.2 Ground Motion Generation
+
+Site-specific ground motion time histories were generated using the USGS ShakeMap framework (v4.1) with the following ground motion prediction equations (GMPEs): Abrahamson, Silva, and Kamai (2014) for crustal sources; Zhao et al. (2006) for intraslab sources; and Atkinson and Macias (2009) for the Cascadia subduction interface. For each scenario, 30 ground motion realizations were generated per bridge site to capture epistemic uncertainty in the GMPEs.
+
+## 2.3 Site Amplification
+
+Site-specific amplification factors were derived from measured and inferred Vs30 values using the NEHRP site classification system. Of the 142 bridge sites: 18 are classified as Site Class B (rock), 64 as Site Class C (very dense soil/soft rock), 48 as Site Class D (stiff soil), and 12 as Site Class E (soft soil). Site Class E locations are concentrated in river valley alluvial deposits and are associated with the highest amplification factors and liquefaction susceptibility.

--- a/technical-report/content/sections/3-structural-modeling.md
+++ b/technical-report/content/sections/3-structural-modeling.md
@@ -1,0 +1,89 @@
++++
+title = "Structural Modeling and Analysis"
+description = "Finite-element model development, calibration, and nonlinear dynamic analysis procedures."
+weight = 3
+template = "post"
+[extra]
+section_number = "3"
++++
+
+## 3.1 Model Development
+
+Three-dimensional nonlinear finite-element models were developed for all 142 bridges using the OpenSees computational framework (v3.6.0). Bridge types in the inventory include: multi-span continuous concrete girder (52), multi-span simply-supported steel girder (34), multi-span continuous steel girder (28), single-span concrete slab (16), and other types (12).
+
+<figure class="figure">
+  <svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Schematic of finite-element bridge model showing key components">
+    <rect x="0" y="0" width="720" height="280" fill="#f8f7f3"/>
+    <!-- Ground line -->
+    <line x1="40" y1="220" x2="680" y2="220" stroke="#1a2337" stroke-width="1"/>
+    <!-- Hatch marks for ground -->
+    <g stroke="#5b6272" stroke-width="0.8">
+      <line x1="40" y1="220" x2="30" y2="230"/>
+      <line x1="80" y1="220" x2="70" y2="230"/>
+      <line x1="120" y1="220" x2="110" y2="230"/>
+      <line x1="160" y1="220" x2="150" y2="230"/>
+      <line x1="200" y1="220" x2="190" y2="230"/>
+      <line x1="520" y1="220" x2="510" y2="230"/>
+      <line x1="560" y1="220" x2="550" y2="230"/>
+      <line x1="600" y1="220" x2="590" y2="230"/>
+      <line x1="640" y1="220" x2="630" y2="230"/>
+      <line x1="680" y1="220" x2="670" y2="230"/>
+    </g>
+    <!-- Left abutment -->
+    <rect x="80" y="140" width="30" height="80" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="95" y="260" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#5b6272">Abutment 1</text>
+    <!-- Pier 1 -->
+    <rect x="230" y="100" width="20" height="120" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="240" y="260" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#5b6272">Pier 1</text>
+    <!-- Pier 2 -->
+    <rect x="390" y="100" width="20" height="120" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="400" y="260" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#5b6272">Pier 2</text>
+    <!-- Pier 3 -->
+    <rect x="530" y="100" width="20" height="120" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="540" y="260" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#5b6272">Pier 3</text>
+    <!-- Right abutment -->
+    <rect x="610" y="140" width="30" height="80" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="625" y="260" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#5b6272">Abutment 2</text>
+    <!-- Deck -->
+    <rect x="80" y="130" width="560" height="14" fill="none" stroke="#1a2337" stroke-width="2"/>
+    <!-- Bearing symbols -->
+    <polygon points="96,140 88,152 104,152" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <polygon points="236,100 228,112 244,112" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <polygon points="396,100 388,112 404,112" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <polygon points="536,100 528,112 544,112" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <polygon points="626,140 618,152 634,152" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <!-- Soil springs -->
+    <g stroke="#b8372a" stroke-width="1" fill="none">
+      <path d="M 95 220 L 95 224 L 85 228 L 105 232 L 85 236 L 105 240 L 95 244"/>
+      <path d="M 240 220 L 240 224 L 230 228 L 250 232 L 230 236 L 250 240 L 240 244"/>
+      <path d="M 400 220 L 400 224 L 390 228 L 410 232 L 390 236 L 410 240 L 400 244"/>
+      <path d="M 540 220 L 540 224 L 530 228 L 550 232 L 530 236 L 550 240 L 540 244"/>
+      <path d="M 625 220 L 625 224 L 615 228 L 635 232 L 615 236 L 635 240 L 625 244"/>
+    </g>
+    <!-- Labels -->
+    <text x="360" y="124" text-anchor="middle" font-family="Source Sans 3" font-weight="700" font-size="10" fill="#1a2337" letter-spacing="1">SUPERSTRUCTURE (beam-column elements)</text>
+    <text x="360" y="62" text-anchor="middle" font-family="Source Sans 3" font-size="9" fill="#2a6b3f">Bearing pads (bilinear hysteretic)</text>
+    <line x1="360" y1="66" x2="360" y2="100" stroke="#2a6b3f" stroke-width="0.8" stroke-dasharray="3 3"/>
+    <text x="640" y="186" font-family="Source Sans 3" font-size="9" fill="#b8372a">p-y soil springs</text>
+    <!-- Legend -->
+    <rect x="40" y="20" width="10" height="8" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+    <text x="56" y="28" font-family="Source Sans 3" font-size="9" fill="#5b6272">Structural element</text>
+    <polygon points="140,16 134,28 146,28" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+    <text x="152" y="28" font-family="Source Sans 3" font-size="9" fill="#5b6272">Bearing</text>
+    <line x1="210" y1="24" x2="230" y2="24" stroke="#b8372a" stroke-width="1"/>
+    <text x="236" y="28" font-family="Source Sans 3" font-size="9" fill="#5b6272">Soil spring</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Schematic of a representative multi-span bridge finite-element model showing superstructure beam-column elements, bearing pad connections (triangles), pier columns, abutments, and p-y soil springs (zigzag lines).</div>
+</figure>
+
+## 3.2 Material Constitutive Models
+
+Concrete behavior is represented using the modified Kent-Park model with confinement effects per Mander et al. (1988). Reinforcing steel follows the Menegotto-Pinto model with isotropic strain hardening. These constitutive models have been validated against over 200 cyclic column tests in the NIRL structural testing database.
+
+## 3.3 Nonlinear Dynamic Analysis
+
+Each bridge model was subjected to the 30 ground motion realizations per scenario (7 scenarios x 30 realizations = 210 analyses per bridge). Analysis was performed using the Newmark-beta time integration method with adaptive time stepping. Engineering demand parameters (EDPs) recorded include: maximum column drift ratio, maximum bearing displacement, peak foundation rotation, and residual displacement.
+
+## 3.4 Damage State Classification
+
+Structural damage states were assigned based on EDP thresholds calibrated to observed bridge performance in past earthquakes. The four damage states follow the HAZUS-MH classification: Slight (minor cracking, no structural concern), Moderate (significant cracking, limited spalling), Extensive (major structural damage, possible partial collapse), Complete (structural failure, bridge impassable).

--- a/technical-report/content/sections/4-resilience-assessment.md
+++ b/technical-report/content/sections/4-resilience-assessment.md
@@ -1,0 +1,80 @@
++++
+title = "Resilience Assessment"
+description = "Damage state probabilities, restoration modeling, and network-level connectivity analysis results."
+weight = 4
+template = "post"
+[extra]
+section_number = "4"
++++
+
+## 4.1 Damage State Probabilities
+
+Under the CSZ Mw 9.0 full-rupture scenario (S6-CSZ-F), the inventory damage distribution is: 37 pct None/Slight, 39 pct Moderate, 18 pct Extensive, 6 pct Complete. The spatial distribution of damage is not uniform; bridges in the coastal zone and Willamette Valley alluvial deposits experience systematically higher damage due to site amplification and liquefaction effects.
+
+## 4.2 Restoration Modeling
+
+Restoration timelines were estimated using the NIRL Bridge Repair Model (BRM v3.2), which accounts for: damage state-dependent repair activities, resource mobilization delays, construction sequencing constraints, and workforce availability. Two scenarios were modeled:
+
+- **Baseline**: Normal resource mobilization with current contractor capacity. Median corridor restoration to 75 pct connectivity: 180 days.
+- **Accelerated**: Federal emergency declaration enabling rapid resource deployment. Median corridor restoration to 75 pct connectivity: 90 days.
+
+## 4.3 Network Connectivity Analysis
+
+Network connectivity was assessed using a graph-theoretic model of the Pacific Northwest highway network with 142 bridge nodes and 318 road-segment edges. The connectivity index measures the fraction of origin-destination pairs (drawn from the 20 largest population centers in the corridor) that remain connected through the highway network.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Network connectivity recovery curve showing baseline and accelerated repair scenarios">
+    <rect x="0" y="0" width="720" height="300" fill="#f8f7f3"/>
+    <!-- Grid -->
+    <g stroke="#c8c4b8" stroke-width="0.5">
+      <line x1="80" y1="30" x2="680" y2="30"/>
+      <line x1="80" y1="84" x2="680" y2="84"/>
+      <line x1="80" y1="138" x2="680" y2="138"/>
+      <line x1="80" y1="192" x2="680" y2="192"/>
+      <line x1="80" y1="246" x2="680" y2="246"/>
+    </g>
+    <!-- Axes -->
+    <line x1="80" y1="30" x2="80" y2="250" stroke="#1a2337" stroke-width="1.5"/>
+    <line x1="80" y1="250" x2="680" y2="250" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- Y-axis labels -->
+    <text x="72" y="34" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5b6272">1.0</text>
+    <text x="72" y="88" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0.8</text>
+    <text x="72" y="142" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0.6</text>
+    <text x="72" y="196" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0.4</text>
+    <text x="72" y="250" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0.2</text>
+    <!-- X-axis labels -->
+    <text x="80" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0</text>
+    <text x="200" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">90</text>
+    <text x="320" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">180</text>
+    <text x="440" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">360</text>
+    <text x="560" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">540</text>
+    <text x="680" y="270" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5b6272">720</text>
+    <!-- Axis titles -->
+    <text x="380" y="292" text-anchor="middle" font-family="Source Sans 3" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="1">DAYS POST-EVENT</text>
+    <text x="28" y="140" text-anchor="middle" font-family="Source Sans 3" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="1" transform="rotate(-90,28,140)">CONNECTIVITY INDEX</text>
+    <!-- Pre-event level -->
+    <line x1="80" y1="30" x2="100" y2="30" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- Drop to 0.38 -->
+    <line x1="100" y1="30" x2="100" y2="186" stroke="#1a2337" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <!-- Baseline recovery curve -->
+    <polyline points="100,186 140,178 180,166 220,148 260,134 300,118 340,104 380,92 420,78 460,68 500,56 540,48 580,42 620,36 660,33 680,31" fill="none" stroke="#1a2337" stroke-width="2"/>
+    <!-- Accelerated recovery curve -->
+    <polyline points="100,186 140,164 180,138 220,108 260,86 300,68 340,54 380,44 420,38 460,34 500,32 540,31 580,30 620,30 660,30 680,30" fill="none" stroke="#2a6b3f" stroke-width="2"/>
+    <!-- 0.75 threshold line -->
+    <line x1="80" y1="84" x2="680" y2="84" stroke="#b8372a" stroke-width="1" stroke-dasharray="6 4"/>
+    <text x="685" y="88" font-family="Source Sans 3" font-weight="700" font-size="9" fill="#b8372a">0.75 target</text>
+    <!-- 0.38 annotation -->
+    <circle cx="100" cy="186" r="4" fill="#b8372a" stroke="#1a2337" stroke-width="1"/>
+    <text x="114" y="190" font-family="JetBrains Mono" font-size="9" fill="#b8372a">CI = 0.38</text>
+    <!-- Legend -->
+    <line x1="200" y1="16" x2="230" y2="16" stroke="#1a2337" stroke-width="2"/>
+    <text x="236" y="20" font-family="Source Sans 3" font-size="9" fill="#5b6272">Baseline repair</text>
+    <line x1="340" y1="16" x2="370" y2="16" stroke="#2a6b3f" stroke-width="2"/>
+    <text x="376" y="20" font-family="Source Sans 3" font-size="9" fill="#5b6272">Accelerated repair</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 3.</span> Network connectivity recovery curves for the CSZ Mw 9.0 scenario. The connectivity index drops to 0.38 immediately post-event. Under baseline repair assumptions (black), the 0.75 target is reached at approximately 180 days; under accelerated repair (green), at approximately 90 days.</div>
+</figure>
+
+## 4.4 Bottleneck Identification
+
+The 12 bottleneck bridges were identified through sequential bridge-removal analysis. Removing any one of these 12 bridges from the post-event network reduces the connectivity index by at least 0.05 -- more than four times the average per-bridge impact. These bridges are concentrated at major river crossings on Interstate 5 and Interstate 84 where no alternative crossing exists within 50 km.

--- a/technical-report/content/sections/5-recommendations.md
+++ b/technical-report/content/sections/5-recommendations.md
@@ -1,0 +1,86 @@
++++
+title = "Recommendations"
+description = "Retrofit prioritization, cost-benefit analysis, and implementation timeline for the seismic resilience program."
+weight = 5
+template = "post"
+[extra]
+section_number = "5"
++++
+
+## 5.1 Retrofit Prioritization
+
+Based on the bottleneck analysis in Section 4.4, the following 12 bridges are recommended for priority seismic retrofit. Bridges are ranked by their network criticality score (NCS), defined as the reduction in corridor connectivity index caused by the bridge's removal from the post-event network.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Priority bridges for seismic retrofit, ranked by network criticality score.</caption>
+  <thead>
+    <tr>
+      <th>Rank</th>
+      <th>Bridge ID</th>
+      <th>Location</th>
+      <th>NCS</th>
+      <th>Est. cost ($M)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="num">1</td>
+      <td>OR-I5-0472</td>
+      <td>Willamette River, Salem</td>
+      <td class="num">0.12</td>
+      <td class="num">48.2</td>
+    </tr>
+    <tr>
+      <td class="num">2</td>
+      <td>WA-I5-1183</td>
+      <td>Columbia River, Vancouver</td>
+      <td class="num">0.11</td>
+      <td class="num">62.4</td>
+    </tr>
+    <tr>
+      <td class="num">3</td>
+      <td>OR-I84-0091</td>
+      <td>Columbia Gorge, Cascade Locks</td>
+      <td class="num">0.09</td>
+      <td class="num">35.8</td>
+    </tr>
+    <tr>
+      <td class="num">4</td>
+      <td>OR-I5-0388</td>
+      <td>Umpqua River, Roseburg</td>
+      <td class="num">0.08</td>
+      <td class="num">22.6</td>
+    </tr>
+    <tr>
+      <td class="num">5</td>
+      <td>WA-I5-0924</td>
+      <td>Skagit River, Burlington</td>
+      <td class="num">0.07</td>
+      <td class="num">28.4</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">NCS = Network Criticality Score. Estimated costs in 2026 USD, include design, construction, and traffic management. Full table of 12 bridges in Appendix E.</td></tr>
+  </tfoot>
+</table>
+
+## 5.2 Cost-Benefit Analysis
+
+The estimated total cost of retrofitting all 12 priority bridges is $340M (2026 USD). Under the CSZ Mw 9.0 scenario, the retrofitted network maintains a post-event connectivity index of 0.62 (vs. 0.38 without retrofit), reducing first-year economic losses from an estimated $4.2B to $1.1B. The resulting benefit-cost ratio is 12.4:1, using a 50-year analysis period and 3 pct real discount rate.
+
+## 5.3 Implementation Timeline
+
+The laboratory recommends a phased implementation over 8 years:
+
+- **Phase 1 (Years 1-3)**: Retrofit the top 4 bridges (highest NCS), estimated cost $169M
+- **Phase 2 (Years 3-5)**: Retrofit bridges ranked 5-8, estimated cost $98M
+- **Phase 3 (Years 5-8)**: Retrofit bridges ranked 9-12, estimated cost $73M
+
+This phased approach maximizes early network resilience improvement: completing Phase 1 alone raises the post-event connectivity index from 0.38 to 0.52, capturing 62 pct of the total retrofit benefit.
+
+## 5.4 Recommendations for Further Study
+
+1. Extend the analysis to include tsunami-induced scour effects for coastal bridges (see companion report TM-2026-0089)
+2. Develop detailed retrofit designs for the top 4 priority bridges to refine cost estimates
+3. Conduct a parallel assessment of the railroad bridge network to support multimodal resilience planning
+4. Update the analysis when the next revision of the USGS National Seismic Hazard Model is released (expected 2028)

--- a/technical-report/content/sections/_index.md
+++ b/technical-report/content/sections/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Section Index"
+description = "The five numbered sections of Technical Report TR-2026-0471."
+sort_by = "weight"
+tags = ["paper", "technical-report", "formal"]
++++
+
+This report follows the NIRL Technical Report Format Guide (NIRL-TRF-2023-Rev3). Sections are numbered sequentially and may be read independently or in order.

--- a/technical-report/static/css/style.css
+++ b/technical-report/static/css/style.css
@@ -1,0 +1,585 @@
+/* ============================================================================
+   Technical Report - Institutional TR Paper
+   Light background, government/lab report aesthetics. Source Sans Pro Bold /
+   IBM Plex Sans Bold display, Noto Serif / Crimson Pro body. No gradients.
+   ============================================================================ */
+
+:root {
+  --paper: #f8f7f3;
+  --paper-2: #efeee8;
+  --rule: #c8c4b8;
+  --ink: #1a2337;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #2a6b3f;
+  --accent-2: #1e5230;
+  --alert: #b8372a;
+  --badge-bg: #1a2337;
+  --badge-text: #f8f7f3;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Noto Serif", "Crimson Pro", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.classification-banner { width: 100%; }
+.classification-banner .banner-svg { width: 100%; height: 28px; display: block; }
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 48px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.agency-name {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.report-id {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+/* ---------------- Report number badge ---------------- */
+
+.report-badge {
+  display: inline-block;
+  background: var(--badge-bg);
+  color: var(--badge-text);
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.88rem;
+  letter-spacing: 0.12em;
+  padding: 0.4rem 1.2rem;
+  margin-bottom: 1.2rem;
+}
+
+.paper-title {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Distribution statement ---------------- */
+
+.distribution-statement {
+  border: 2px solid var(--accent);
+  padding: 1rem 1.4rem;
+  margin: 1.5rem 0;
+  background: var(--paper-2);
+}
+
+.distribution-statement .dist-label {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.3rem;
+}
+
+.distribution-statement p {
+  font-family: "Noto Serif", serif;
+  font-size: 0.92rem;
+  margin: 0;
+  color: var(--ink-2);
+}
+
+/* ---------------- Approval signature block ---------------- */
+
+.approval-block {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.approval-block .approval-entry {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1rem;
+}
+
+.approval-block .approval-role {
+  font-family: "Source Sans 3", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.3rem;
+}
+
+.approval-block .approval-name {
+  font-family: "Noto Serif", serif;
+  font-size: 1rem;
+  color: var(--ink);
+  margin: 0;
+}
+
+.approval-block .approval-title {
+  font-family: "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.88rem;
+  color: var(--ink-3);
+  margin: 0.1rem 0 0;
+}
+
+.approval-block .approval-date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: var(--ink-4);
+  margin: 0.2rem 0 0;
+}
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Noto Serif", "Crimson Pro", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Noto Serif", "Crimson Pro", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Source Sans 3", "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .approval-block { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/technical-report/templates/404.html
+++ b/technical-report/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / PAGE NOT FOUND</p>
+      <h1 class="paper-section-title">Section not found</h1>
+      <p>The reference you followed does not resolve to a section in this report. Return to the cover page to navigate the document.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to cover page</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/technical-report/templates/footer.html
+++ b/technical-report/templates/footer.html
@@ -1,0 +1,23 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2337" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2337" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">National Infrastructure Research Laboratory. <em>Seismic Resilience Assessment of Critical Bridge Infrastructure in the Pacific Northwest Corridor.</em> Technical Report TR-2026-0471. April 2026.</p>
+        <p class="footer-note">Distribution Statement A: Approved for public release; distribution is unlimited. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  <div class="classification-banner bottom" aria-label="Classification marking">
+    <svg viewBox="0 0 1000 28" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" class="banner-svg">
+      <rect x="0" y="0" width="1000" height="28" fill="#2a6b3f"/>
+      <text x="500" y="18" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="12" fill="#ffffff" letter-spacing="4">UNCLASSIFIED // FOR PUBLIC RELEASE</text>
+    </svg>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/technical-report/templates/header.html
+++ b/technical-report/templates/header.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&family=IBM+Plex+Sans:wght@500;600;700&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="classification-banner top" aria-label="Classification marking">
+    <svg viewBox="0 0 1000 28" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" class="banner-svg">
+      <rect x="0" y="0" width="1000" height="28" fill="#2a6b3f"/>
+      <text x="500" y="18" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-weight="700" font-size="12" fill="#ffffff" letter-spacing="4">UNCLASSIFIED // FOR PUBLIC RELEASE</text>
+    </svg>
+  </div>
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Report home">
+        <svg viewBox="0 0 64 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="44" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+          <line x1="10" y1="12" x2="54" y2="12" stroke="#1a2337" stroke-width="1"/>
+          <line x1="10" y1="20" x2="40" y2="20" stroke="#1a2337" stroke-width="0.8"/>
+          <line x1="10" y1="26" x2="44" y2="26" stroke="#1a2337" stroke-width="0.8"/>
+          <line x1="10" y1="32" x2="38" y2="32" stroke="#1a2337" stroke-width="0.8"/>
+          <rect x="44" y="30" width="12" height="12" fill="none" stroke="#2a6b3f" stroke-width="1.5"/>
+          <line x1="47" y1="34" x2="53" y2="34" stroke="#2a6b3f" stroke-width="0.8"/>
+          <line x1="47" y1="38" x2="53" y2="38" stroke="#2a6b3f" stroke-width="0.8"/>
+        </svg>
+        <span class="logo-text">
+          <span class="agency-name">National Infrastructure Research Laboratory</span>
+          <span class="report-id">TR-2026-0471 &middot; April 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">COVER</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/methodology/">METHODOLOGY</a>
+        <a href="{{ base_url }}/findings/">FINDINGS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/technical-report/templates/page.html
+++ b/technical-report/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/technical-report/templates/post.html
+++ b/technical-report/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/technical-report/templates/section.html
+++ b/technical-report/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/technical-report/templates/shortcodes/alert.html
+++ b/technical-report/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/technical-report/templates/taxonomy.html
+++ b/technical-report/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Subject index and keyword cross-references for this technical report.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/technical-report/templates/taxonomy_term.html
+++ b/technical-report/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">SUBJECT INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Sections cross-referenced to this subject keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Adds new technical-report example site for Issue #1633
- Institutional TR Paper with light theme featuring government/lab report aesthetics
- SVG classification headers (UNCLASSIFIED // FOR PUBLIC RELEASE banners), distribution statement banners, report numbering badges (TR-2026-0471), and approval signature blocks
- Uses Source Sans Pro Bold/IBM Plex Sans Bold for display and Noto Serif/Crimson Pro for body
- Updates tags.json with new entry: paper, light, institutional, technical-report, formal

## Test plan
- [ ] Verify `hwaro build` completes successfully in the technical-report directory
- [ ] Verify site renders correctly with `hwaro serve`
- [ ] Check SVG classification banners render at top and bottom of page
- [ ] Confirm report numbering badge and approval signature block layout
- [ ] Verify tags.json is valid JSON with no missing entries