### PR TITLE
Add new scoping-review example site

### DIFF
--- a/scoping-review/AGENTS.md
+++ b/scoping-review/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/scoping-review/config.toml
+++ b/scoping-review/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Scoping Review - Literature Mapping Paper
+# Issue #1629 | Tags: paper, light, scoping, mapping, landscape
+# =============================================================================
+
+title = "Scoping Review of Adaptive Learning Systems"
+description = "A literature mapping paper presenting a scoping review of adaptive learning systems in higher education, with evidence gap maps, bubble chart diagrams, and temporal accumulation charts."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/scoping-review/content/appendix.md
+++ b/scoping-review/content/appendix.md
@@ -1,0 +1,34 @@
++++
+title = "Appendix"
+description = "Search strategy, PRISMA-ScR checklist, and supplementary materials for the scoping review of adaptive learning systems."
+tags = ["paper", "scoping", "mapping"]
+categories = ["pages"]
++++
+
+## A1. Search Strategy
+
+The following databases were searched on 15 March 2026:
+
+1. **Scopus** -- 1,142 records
+2. **Web of Science** -- 986 records
+3. **ERIC** -- 648 records
+4. **IEEE Xplore** -- 312 records
+5. **PsycINFO** -- 130 records
+
+Search string (adapted per database): ("adaptive learning" OR "personalised learning" OR "intelligent tutoring") AND ("higher education" OR "university" OR "college") AND ("outcomes" OR "achievement" OR "engagement" OR "retention" OR "equity")
+
+## A2. PRISMA-ScR Checklist
+
+This review follows the Preferred Reporting Items for Systematic Reviews and Meta-Analyses extension for Scoping Reviews (PRISMA-ScR; Tricco et al. 2018). The completed checklist is available in the supplementary data repository.
+
+## A3. Data Availability
+
+The full charting dataset (142 studies with all extracted fields) is available at the University of Helsinki Open Data Repository (accession: UH-2026-ALSREV). The review protocol was pre-registered at OSF (registration: osf.io/xxxxx).
+
+## A4. CRediT Author Contributions
+
+- **Ivan Petrov** -- Conceptualisation, methodology, screening, charting, writing (original draft), supervision
+- **Sara Nakamura-Williams** -- Screening, charting, gap analysis, writing (review and editing)
+- **Tunde Adeyemi** -- Search strategy, database management, writing (review and editing)
+- **Linnea Borg** -- Charting, visualisation, data curation
+- **Rajesh Patel** -- Methodology, gap analysis, writing (review and editing)

--- a/scoping-review/content/charting.md
+++ b/scoping-review/content/charting.md
@@ -1,0 +1,94 @@
++++
+title = "Data Charting"
+description = "Summary of the data charting process, extraction framework, and descriptive overview of the 142 included studies."
+tags = ["paper", "scoping", "mapping"]
+categories = ["pages"]
++++
+
+## Charting Framework
+
+Data were extracted into a standardised charting form with the following fields:
+
+| Field | Description | Categories |
+| --- | --- | --- |
+| Author(s) | First author and year | Free text |
+| Country | Country of study | 28 countries |
+| Discipline | Academic discipline | STEM, Social Sciences, Humanities, Health, Other |
+| Intervention type | ALS mechanism | Content sequencing, Difficulty adjustment, Feedback personalisation, Hybrid |
+| Outcome category | Primary outcome measured | Achievement, Engagement, Retention, Satisfaction, Equity |
+| Study design | Methodological approach | RCT, Quasi-experimental, Pre-post, Observational, Case study |
+| Sample size | Number of participants | Numeric |
+| Duration | Intervention length | Weeks |
+
+## Temporal Accumulation
+
+<figure class="figure">
+  <svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Temporal accumulation chart showing cumulative study count from 2014 to 2026">
+    <!-- Axes -->
+    <line x1="60" y1="260" x2="700" y2="260" stroke="#1a1e28" stroke-width="1.5"/>
+    <line x1="60" y1="20" x2="60" y2="260" stroke="#1a1e28" stroke-width="1.5"/>
+    <!-- Gridlines -->
+    <g stroke="#d4cfc0" stroke-width="0.5">
+      <line x1="60" y1="200" x2="700" y2="200"/>
+      <line x1="60" y1="140" x2="700" y2="140"/>
+      <line x1="60" y1="80" x2="700" y2="80"/>
+    </g>
+    <!-- Y-axis labels -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5a6270" text-anchor="end">
+      <text x="54" y="264">0</text>
+      <text x="54" y="204">40</text>
+      <text x="54" y="144">80</text>
+      <text x="54" y="84">120</text>
+      <text x="54" y="28">160</text>
+    </g>
+    <!-- X-axis labels -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5a6270" text-anchor="middle">
+      <text x="110" y="278">2014</text>
+      <text x="160" y="278">2015</text>
+      <text x="210" y="278">2016</text>
+      <text x="260" y="278">2017</text>
+      <text x="310" y="278">2018</text>
+      <text x="360" y="278">2019</text>
+      <text x="410" y="278">2020</text>
+      <text x="460" y="278">2021</text>
+      <text x="510" y="278">2022</text>
+      <text x="560" y="278">2023</text>
+      <text x="610" y="278">2024</text>
+      <text x="660" y="278">2025</text>
+      <text x="695" y="278">26</text>
+    </g>
+    <!-- Cumulative line -->
+    <polyline fill="none" stroke="#2a5a3c" stroke-width="2.5"
+      points="110,254 160,250 210,244 260,236 310,224 360,210 410,194 460,172 510,144 560,112 610,72 660,38 695,24"/>
+    <!-- Year points -->
+    <g fill="#2a5a3c">
+      <circle cx="110" cy="254" r="3"/>
+      <circle cx="160" cy="250" r="3"/>
+      <circle cx="210" cy="244" r="3"/>
+      <circle cx="260" cy="236" r="3"/>
+      <circle cx="310" cy="224" r="3"/>
+      <circle cx="360" cy="210" r="3"/>
+      <circle cx="410" cy="194" r="3"/>
+      <circle cx="460" cy="172" r="3"/>
+      <circle cx="510" cy="144" r="3"/>
+      <circle cx="560" cy="112" r="3"/>
+      <circle cx="610" cy="72" r="3"/>
+      <circle cx="660" cy="38" r="3"/>
+      <circle cx="695" cy="24" r="3"/>
+    </g>
+    <!-- Annotation: acceleration point -->
+    <line x1="460" y1="172" x2="500" y2="130" stroke="#1a1e28" stroke-width="0.8"/>
+    <text x="504" y="126" font-family="EB Garamond" font-weight="700" font-size="10" fill="#1a1e28">Acceleration post-2021</text>
+    <text x="504" y="140" font-family="Crimson Pro" font-size="9" fill="#5a6270">67 pct of studies from 2021-2026</text>
+    <!-- Axis titles -->
+    <text x="380" y="296" text-anchor="middle" font-family="EB Garamond" font-weight="700" font-size="11" fill="#1a1e28" letter-spacing="0.5">PUBLICATION YEAR</text>
+    <text x="18" y="140" text-anchor="middle" font-family="EB Garamond" font-weight="700" font-size="11" fill="#1a1e28" letter-spacing="0.5" transform="rotate(-90 18 140)">CUMULATIVE STUDIES</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Temporal accumulation chart showing the cumulative count of included studies from 2014 to 2026. The field has accelerated markedly since 2021, with 67 pct of all included studies published in the final 6 years of the review period.</figcaption>
+</figure>
+
+## Discipline Distribution
+
+Of the 142 included studies, 91 (64 pct) were conducted in STEM disciplines (mathematics, computer science, engineering, natural sciences). Social sciences accounted for 24 (17 pct), health sciences for 14 (10 pct), and humanities for only 8 (6 pct). Five studies (4 pct) were cross-disciplinary.
+
+The concentration in STEM is consistent with the historical development of ALS, which originated in intelligent tutoring systems for well-structured domains with clear right/wrong answers.

--- a/scoping-review/content/gaps.md
+++ b/scoping-review/content/gaps.md
@@ -1,0 +1,43 @@
++++
+title = "Research Gaps"
+description = "Detailed analysis of four identified evidence gaps with prioritised recommendations for future research on adaptive learning systems."
+tags = ["paper", "scoping", "mapping"]
+categories = ["pages"]
++++
+
+## Identified Evidence Gaps
+
+The evidence gap map (Figure 1) reveals four zero-cell gaps and several near-empty cells. Below we describe each major gap with research recommendations.
+
+<section class="gap-callout">
+  <span class="gap-label">Gap 1: Feedback Personalisation x Retention</span>
+  <p><strong>Zero studies examined the effect of personalised feedback on long-term retention outcomes.</strong> While 12 studies evaluated feedback personalisation for immediate achievement gains, none tracked whether these gains persisted beyond the intervention period. This gap is critical because the sustainability of learning gains is a key concern for higher education institutions investing in ALS infrastructure.</p>
+  <p><strong>Recommendation:</strong> Conduct longitudinal studies (6 to 12 months post-intervention) comparing personalised and generic feedback on delayed retention tests.</p>
+</section>
+
+<section class="gap-callout">
+  <span class="gap-label">Gap 2: Difficulty Adjustment x Equity</span>
+  <p><strong>No studies examined whether difficulty-adjustment algorithms produce equitable outcomes across demographic groups.</strong> Difficulty-adjustment is one of the most widely deployed ALS mechanisms (19 studies on achievement), yet no study has investigated whether the algorithms differentially benefit or disadvantage students by race/ethnicity, socioeconomic status, or disability status.</p>
+  <p><strong>Recommendation:</strong> Disaggregate outcomes by demographic characteristics in future difficulty-adjustment studies; audit algorithm fairness using counterfactual analysis.</p>
+</section>
+
+<section class="gap-callout">
+  <span class="gap-label">Gap 3: Hybrid Interventions x Equity</span>
+  <p><strong>Multi-component ALS interventions have never been evaluated for equity outcomes.</strong> Hybrid interventions combining multiple ALS mechanisms are the most complex and the most difficult to audit for fairness. The absence of equity analysis in this category is a significant blind spot.</p>
+  <p><strong>Recommendation:</strong> Mandate equity reporting in future evaluations of hybrid ALS platforms; adopt intersectional analysis frameworks.</p>
+</section>
+
+<section class="gap-callout">
+  <span class="gap-label">Gap 4: Humanities Disciplines</span>
+  <p><strong>Only 8 of 142 studies (6 pct) were conducted in humanities disciplines.</strong> Adaptive learning in less-structured domains such as writing, history, and philosophy presents unique design challenges (e.g., open-ended assessment, interpretive reasoning). The near-absence of humanities research limits the generalisability of current ALS evidence.</p>
+  <p><strong>Recommendation:</strong> Fund dedicated ALS research programmes in humanities departments; develop assessment rubrics compatible with adaptive sequencing for open-ended tasks.</p>
+</section>
+
+## Priority Matrix
+
+| Gap | Severity | Feasibility | Priority |
+| --- | --- | --- | --- |
+| Feedback x Retention | High (sustainability unknown) | Moderate (requires longitudinal design) | 1 |
+| Difficulty x Equity | Critical (fairness concern) | High (existing data can be disaggregated) | 1 |
+| Hybrid x Equity | Critical (complexity + fairness) | Moderate (requires new study designs) | 2 |
+| Humanities | High (generalisability) | Low (requires domain-specific ALS) | 3 |

--- a/scoping-review/content/index.md
+++ b/scoping-review/content/index.md
@@ -1,0 +1,171 @@
++++
+title = "Abstract"
+description = "A scoping review mapping the landscape of adaptive learning systems in higher education, identifying evidence gaps and research trajectories across 142 included studies."
+tags = ["paper", "light", "scoping", "mapping", "landscape"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Scoping Review &middot; Open Access</p>
+  <h1 class="paper-title">Adaptive Learning Systems in Higher Education: A Scoping Review and Evidence Gap Map (2014--2026)</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Ivan Petrov</span><sup>1</sup>,
+    Sara Nakamura-Williams<sup>2</sup>,
+    Tunde Adeyemi<sup>3</sup>,
+    Linnea Borg<sup>1</sup>,
+    Rajesh Patel<sup>2,4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Centre for Learning Analytics, University of Helsinki &middot;
+    <sup>2</sup>School of Education, Stanford University &middot;
+    <sup>3</sup>Department of Computer Science, University of Lagos &middot;
+    <sup>4</sup>AI in Education Lab, Indian Institute of Technology Delhi
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.39210/ret.2026.34.02.088</a> &middot; <strong>Received:</strong> 20 Apr 2026 &middot; <strong>Accepted:</strong> 06 Oct 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Adaptive learning systems (ALS) that personalise instruction based on learner performance have proliferated in higher education, yet the research landscape remains fragmented across education, computer science, and learning analytics literatures.</dd>
+    <dt>Objective</dt>
+    <dd>To map the scope and nature of evidence on ALS in higher education, identify research gaps, and chart the trajectory of the field from 2014 to 2026.</dd>
+    <dt>Methods</dt>
+    <dd>A scoping review following the Arksey and O'Malley framework (updated by Levac et al. 2010). Five databases were searched. Two reviewers independently screened 3,218 records, yielding 142 included studies. Data were charted across six dimensions: population, intervention, comparison, outcomes, study design, and discipline.</dd>
+    <dt>Results</dt>
+    <dd>Included studies spanned 28 countries, with 64 pct conducted in STEM disciplines. Randomised controlled trials accounted for only 18 pct; most studies (52 pct) used quasi-experimental designs. The evidence gap map reveals substantial gaps in humanities disciplines, long-term retention outcomes, and equity-focused analyses.</dd>
+    <dt>Keywords</dt>
+    <dd><em>scoping review; adaptive learning; personalised learning; evidence gap map; higher education; learning analytics</em></dd>
+  </dl>
+</section>
+
+## Evidence Gap Map
+
+<figure class="figure">
+  <svg viewBox="0 0 720 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Evidence gap map showing research density across intervention types and outcome categories">
+    <!-- Background grid -->
+    <rect x="120" y="40" width="580" height="300" fill="#faf9f5" stroke="#d4cfc0" stroke-width="1"/>
+    <!-- Grid lines -->
+    <g stroke="#d4cfc0" stroke-width="0.5">
+      <line x1="120" y1="100" x2="700" y2="100"/>
+      <line x1="120" y1="160" x2="700" y2="160"/>
+      <line x1="120" y1="220" x2="700" y2="220"/>
+      <line x1="120" y1="280" x2="700" y2="280"/>
+      <line x1="265" y1="40" x2="265" y2="340"/>
+      <line x1="410" y1="40" x2="410" y2="340"/>
+      <line x1="555" y1="40" x2="555" y2="340"/>
+    </g>
+    <!-- Column headers (intervention types) -->
+    <g font-family="EB Garamond" font-weight="700" font-size="10" fill="#1a1e28" text-anchor="middle">
+      <text x="192" y="32">Content</text>
+      <text x="192" y="18">Sequencing</text>
+      <text x="338" y="32">Difficulty</text>
+      <text x="338" y="18">Adjustment</text>
+      <text x="482" y="32">Feedback</text>
+      <text x="482" y="18">Personalisation</text>
+      <text x="628" y="32">Hybrid /</text>
+      <text x="628" y="18">Multi-component</text>
+    </g>
+    <!-- Row headers (outcomes) -->
+    <g font-family="EB Garamond" font-weight="700" font-size="10" fill="#1a1e28" text-anchor="end">
+      <text x="115" y="74">Achievement</text>
+      <text x="115" y="134">Engagement</text>
+      <text x="115" y="194">Retention</text>
+      <text x="115" y="254">Satisfaction</text>
+      <text x="115" y="314">Equity</text>
+    </g>
+    <!-- Bubbles (size = number of studies; colour = evidence density) -->
+    <!-- Row 1: Achievement -->
+    <circle cx="192" cy="70" r="22" fill="#2a5a3c" opacity="0.5"/>
+    <text x="192" y="74" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">28</text>
+    <circle cx="338" cy="70" r="18" fill="#2a5a3c" opacity="0.45"/>
+    <text x="338" y="74" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">19</text>
+    <circle cx="482" cy="70" r="14" fill="#4a8a6c" opacity="0.45"/>
+    <text x="482" y="74" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">12</text>
+    <circle cx="628" cy="70" r="16" fill="#4a8a6c" opacity="0.4"/>
+    <text x="628" y="74" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">15</text>
+    <!-- Row 2: Engagement -->
+    <circle cx="192" cy="130" r="14" fill="#4a8a6c" opacity="0.4"/>
+    <text x="192" y="134" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">11</text>
+    <circle cx="338" cy="130" r="10" fill="#c47a32" opacity="0.5"/>
+    <text x="338" y="134" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">6</text>
+    <circle cx="482" cy="130" r="12" fill="#4a8a6c" opacity="0.4"/>
+    <text x="482" y="134" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">9</text>
+    <circle cx="628" cy="130" r="11" fill="#c47a32" opacity="0.45"/>
+    <text x="628" y="134" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">7</text>
+    <!-- Row 3: Retention (sparse) -->
+    <circle cx="192" cy="190" r="7" fill="#8b4513" opacity="0.5"/>
+    <text x="192" y="194" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#1a1e28" font-weight="700">3</text>
+    <circle cx="338" cy="190" r="5" fill="#8b4513" opacity="0.6"/>
+    <text x="338" y="194" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#1a1e28" font-weight="700">2</text>
+    <circle cx="628" cy="190" r="6" fill="#8b4513" opacity="0.55"/>
+    <text x="628" y="194" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#1a1e28" font-weight="700">2</text>
+    <!-- Gap marker for Feedback x Retention -->
+    <rect x="462" y="178" width="40" height="24" fill="none" stroke="#8b4513" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="482" y="194" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8b4513" font-weight="700">0</text>
+    <!-- Row 4: Satisfaction -->
+    <circle cx="192" cy="250" r="10" fill="#c47a32" opacity="0.45"/>
+    <text x="192" y="254" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">6</text>
+    <circle cx="338" cy="250" r="9" fill="#c47a32" opacity="0.45"/>
+    <text x="338" y="254" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">5</text>
+    <circle cx="482" cy="250" r="8" fill="#c47a32" opacity="0.45"/>
+    <text x="482" y="254" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">4</text>
+    <circle cx="628" cy="250" r="9" fill="#c47a32" opacity="0.4"/>
+    <text x="628" y="254" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a1e28" font-weight="700">5</text>
+    <!-- Row 5: Equity (very sparse) -->
+    <circle cx="192" cy="310" r="5" fill="#8b4513" opacity="0.6"/>
+    <text x="192" y="314" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#1a1e28" font-weight="700">2</text>
+    <rect x="318" y="298" width="40" height="24" fill="none" stroke="#8b4513" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="338" y="314" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8b4513" font-weight="700">0</text>
+    <circle cx="482" cy="310" r="4" fill="#8b4513" opacity="0.6"/>
+    <text x="482" y="314" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#1a1e28" font-weight="700">1</text>
+    <rect x="608" y="298" width="40" height="24" fill="none" stroke="#8b4513" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="628" y="314" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8b4513" font-weight="700">0</text>
+    <!-- Legend -->
+    <g transform="translate(120, 360)">
+      <circle cx="10" cy="8" r="8" fill="#2a5a3c" opacity="0.5"/>
+      <text x="24" y="12" font-family="Crimson Pro" font-size="10" fill="#5a6270">Dense evidence (15+)</text>
+      <circle cx="170" cy="8" r="6" fill="#c47a32" opacity="0.5"/>
+      <text x="182" y="12" font-family="Crimson Pro" font-size="10" fill="#5a6270">Moderate (4-14)</text>
+      <circle cx="300" cy="8" r="4" fill="#8b4513" opacity="0.55"/>
+      <text x="310" y="12" font-family="Crimson Pro" font-size="10" fill="#5a6270">Sparse (1-3)</text>
+      <rect x="390" y="0" width="16" height="16" fill="none" stroke="#8b4513" stroke-width="2" stroke-dasharray="4 3"/>
+      <text x="412" y="12" font-family="Crimson Pro" font-size="10" fill="#8b4513">Evidence gap (0)</text>
+    </g>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Evidence gap map. Bubble size and opacity represent the number of studies in each cell. Dashed outlines indicate cells with zero studies (evidence gaps). Retention outcomes and equity-focused analyses are the most under-researched areas.</figcaption>
+</figure>
+
+<section class="gap-callout">
+  <span class="gap-label">Research Gap Identified</span>
+  <p><strong>Equity-focused analyses are nearly absent.</strong> Only 3 of 142 studies (2.1 pct) examined differential effects of adaptive learning systems by student demographic characteristics (race/ethnicity, socioeconomic status, disability). No studies examined equity outcomes for feedback personalisation or hybrid interventions. This represents a critical gap given the growing adoption of ALS in institutions serving diverse student populations.</p>
+</section>
+
+## Key Metrics
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Scoping review summary statistics.</caption>
+  <thead>
+    <tr><th>Dimension</th><th>Value</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Databases searched</td><td class="num">5</td></tr>
+    <tr><td>Records identified</td><td class="num">3,218</td></tr>
+    <tr><td>Duplicates removed</td><td class="num">842</td></tr>
+    <tr><td>Full-text screened</td><td class="num">384</td></tr>
+    <tr><td>Studies included</td><td class="num">142</td></tr>
+    <tr><td>Countries represented</td><td class="num">28</td></tr>
+    <tr><td>Date range</td><td>2014 -- 2026</td></tr>
+    <tr><td>STEM studies</td><td class="num">91 (64 pct)</td></tr>
+    <tr><td>RCTs</td><td class="num">26 (18 pct)</td></tr>
+    <tr><td>Evidence gaps identified</td><td class="num">4 cells (of 20)</td></tr>
+  </tbody>
+</table>
+
+## Structure of the Paper
+
+1. **Section 1. Introduction** -- rationale, research questions, and framework
+2. **Section 2. Methods** -- search strategy, screening, and charting procedures
+3. **Section 3. Results** -- descriptive findings, evidence gap map, and bubble chart
+4. **Section 4. Gaps and Future Directions** -- identified gaps with recommendations
+5. **Section 5. Discussion** -- limitations, implications, and conclusions

--- a/scoping-review/content/sections/1-introduction.md
+++ b/scoping-review/content/sections/1-introduction.md
@@ -1,0 +1,30 @@
++++
+title = "1. Introduction"
+description = "Rationale for mapping the adaptive learning systems literature, research questions, and the scoping review framework."
+weight = 1
+template = "post"
+tags = ["paper", "scoping", "mapping"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Background
+
+Adaptive learning systems (ALS) adjust the content, difficulty, sequencing, or feedback of instructional materials in response to individual learner performance. In higher education, ALS have been deployed across disciplines ranging from introductory mathematics to medical education, with commercial platforms (e.g., ALEKS, Knewton, Smart Sparrow) and open-source frameworks gaining significant institutional adoption since 2015.
+
+Despite this growth, the research landscape remains fragmented. Studies are published across education, computer science, learning analytics, and discipline-specific journals, making it difficult for stakeholders to assess the overall state of evidence.
+
+## 1.2 Rationale for a scoping review
+
+A scoping review is appropriate because the objective is to map the breadth of evidence rather than to synthesise effect sizes (which would require a systematic review or meta-analysis). The scoping approach enables identification of evidence gaps and research trajectories, which are the primary contributions of this paper.
+
+## 1.3 Research questions
+
+1. What is the scope and nature of existing evidence on ALS in higher education?
+2. How is the evidence distributed across intervention types, outcome categories, disciplines, and study designs?
+3. Where are the most significant evidence gaps, and what research priorities do they suggest?
+
+## 1.4 Framework
+
+We follow the Arksey and O'Malley (2005) five-stage framework, updated by Levac et al. (2010): (1) identifying the research question, (2) identifying relevant studies, (3) study selection, (4) charting the data, and (5) collating, summarising, and reporting results. An optional sixth stage (consultation with stakeholders) was conducted with five ALS researchers and three university administrators.

--- a/scoping-review/content/sections/2-methods.md
+++ b/scoping-review/content/sections/2-methods.md
@@ -1,0 +1,28 @@
++++
+title = "2. Methods"
+description = "Search strategy, screening process, inclusion and exclusion criteria, and data charting procedures for the scoping review."
+weight = 2
+template = "post"
+tags = ["paper", "scoping", "mapping"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Search strategy
+
+Five electronic databases were searched on 15 March 2026 using a pre-defined search string combining ALS terminology, higher education context, and outcome terms (see Appendix A1 for the full search string). No date restrictions were applied, though all included studies fell within the 2014 to 2026 range. Grey literature was not systematically searched, but reference lists of included studies were scanned for additional records.
+
+## 2.2 Screening
+
+Records were uploaded to the Rayyan systematic review tool for de-duplication and screening. Title-abstract screening was conducted independently by two reviewers (Petrov, Nakamura-Williams) with a pilot round of 200 records to calibrate inclusion criteria (inter-rater agreement: kappa = 0.84). Disagreements were resolved by discussion; a third reviewer (Patel) adjudicated when consensus could not be reached.
+
+Full-text screening applied the following criteria:
+
+**Inclusion:** (a) Empirical study; (b) ALS intervention in higher education; (c) Reported at least one learning-related outcome; (d) Published in English in a peer-reviewed journal or conference proceeding.
+
+**Exclusion:** (a) K-12 settings only; (b) Purely descriptive or conceptual papers; (c) Conference abstracts without full text; (d) Studies of non-digital adaptive instruction.
+
+## 2.3 Data charting
+
+A standardised charting form was developed iteratively by the research team and piloted on 15 studies. The form captured eight dimensions (see the Charting page for the full framework). Two reviewers independently charted each study; discrepancies were resolved by discussion.

--- a/scoping-review/content/sections/3-results.md
+++ b/scoping-review/content/sections/3-results.md
@@ -1,0 +1,45 @@
++++
+title = "3. Results"
+description = "Descriptive findings from the 142 included studies, including distribution by intervention type, outcome, discipline, and study design."
+weight = 3
+template = "post"
+tags = ["paper", "scoping", "mapping"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Study selection
+
+Of 3,218 records identified, 842 were duplicates. Title-abstract screening of the remaining 2,376 records excluded 1,992, leaving 384 for full-text screening. Of these, 242 were excluded (124 wrong population, 62 wrong intervention, 34 no outcome data, 22 not empirical), yielding 142 included studies.
+
+## 3.2 Distribution by study design
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Included studies by study design.</caption>
+  <thead>
+    <tr><th>Design</th><th>n</th><th>pct</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Quasi-experimental</td><td class="num">74</td><td class="num">52.1</td></tr>
+    <tr><td>RCT</td><td class="num">26</td><td class="num">18.3</td></tr>
+    <tr><td>Pre-post (no control)</td><td class="num">22</td><td class="num">15.5</td></tr>
+    <tr><td>Observational / correlational</td><td class="num">12</td><td class="num">8.5</td></tr>
+    <tr><td>Case study / mixed methods</td><td class="num">8</td><td class="num">5.6</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="3">Percentages may not sum to 100 due to rounding.</td></tr>
+  </tfoot>
+</table>
+
+## 3.3 Distribution by intervention type
+
+Content sequencing was the most studied ALS mechanism (52 studies, 37 pct), followed by difficulty adjustment (32, 23 pct), hybrid/multi-component (29, 20 pct), and feedback personalisation (29, 20 pct).
+
+## 3.4 Geographic distribution
+
+The 142 studies spanned 28 countries. The United States contributed the largest share (42 studies, 30 pct), followed by China (18, 13 pct), the United Kingdom (12, 8 pct), and Australia (9, 6 pct). Studies from Sub-Saharan Africa (4, 3 pct) and South America (3, 2 pct) were notably under-represented.
+
+## 3.5 Sample size distribution
+
+Median sample size was 186 participants (IQR: 82 to 412). The smallest study enrolled 24 participants; the largest enrolled 12,480 participants using institutional learning analytics data.

--- a/scoping-review/content/sections/4-gaps.md
+++ b/scoping-review/content/sections/4-gaps.md
@@ -1,0 +1,32 @@
++++
+title = "4. Gaps and Future Directions"
+description = "Detailed analysis of the four primary evidence gaps identified in the scoping review, with prioritised research recommendations."
+weight = 4
+template = "post"
+tags = ["paper", "scoping", "mapping"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Overview of gaps
+
+The evidence gap map (Figure 1, Abstract page) identifies four zero-cell gaps where no studies exist: (1) feedback personalisation and retention, (2) difficulty adjustment and equity, (3) hybrid interventions and equity, and (4) any intervention type and equity in hybrid contexts. Additionally, the entire equity row contains only 3 studies across all intervention types, making it the most under-researched outcome category.
+
+## 4.2 Gap analysis: Retention outcomes
+
+Retention outcomes (long-term knowledge persistence beyond the intervention period) are under-studied across all intervention types. Only 7 of 142 studies (4.9 pct) measured retention at any follow-up interval. The median follow-up was 4 weeks; no study tracked retention beyond 6 months. This gap is particularly concerning because adaptive learning proponents claim durable learning gains as a key benefit of personalisation.
+
+## 4.3 Gap analysis: Equity
+
+The near-absence of equity-focused analysis (3 studies, 2.1 pct) is the most critical gap identified in this review. As ALS are adopted at scale by institutions serving diverse student populations, the potential for algorithmic bias to amplify existing educational inequities is a serious concern.
+
+The three equity studies identified all examined content sequencing interventions: two found no significant differential effects by gender, and one found a small advantage for students with lower prior achievement. No studies examined race/ethnicity, socioeconomic status, or disability as moderating variables for any ALS mechanism.
+
+## 4.4 Gap analysis: Humanities
+
+The concentration of ALS research in STEM disciplines (64 pct) reflects the origins of intelligent tutoring systems in well-structured domains. Humanities disciplines, which require assessment of open-ended, interpretive, and creative work, present fundamentally different design challenges. The 8 humanities studies identified in this review were concentrated in language learning; no studies addressed history, philosophy, or literary studies.
+
+## 4.5 Stakeholder consultation
+
+Five ALS researchers and three university administrators were consulted on the gap analysis. All agreed that equity should be the top priority for future research. Administrators additionally emphasised the need for cost-effectiveness evidence, which was outside the scope of this review.

--- a/scoping-review/content/sections/5-discussion.md
+++ b/scoping-review/content/sections/5-discussion.md
@@ -1,0 +1,48 @@
++++
+title = "5. Discussion"
+description = "Limitations of the scoping review, implications for ALS research and practice, and concluding remarks."
+weight = 5
+template = "post"
+tags = ["paper", "scoping", "mapping"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary
+
+This scoping review mapped 142 studies of adaptive learning systems in higher education published between 2014 and 2026. The field has grown rapidly (67 pct of studies from 2021 onward), is dominated by STEM disciplines (64 pct), and relies heavily on quasi-experimental designs (52 pct). Achievement is the most commonly measured outcome (74 studies), while equity is virtually absent (3 studies). Four zero-cell evidence gaps were identified.
+
+## 5.2 Limitations
+
+Four limitations should be acknowledged:
+
+1. **English-language bias** -- the restriction to English-language publications may have excluded relevant studies from non-Anglophone contexts, particularly in Asia and Latin America
+2. **Grey literature** -- conference abstracts and institutional reports were excluded, potentially missing implementation evidence
+3. **Scoping (not systematic)** -- no quality appraisal or effect-size synthesis was conducted, which limits the ability to draw conclusions about effectiveness
+4. **Dynamic field** -- given the rapid growth of the field, the evidence landscape may have changed between the search date (March 2026) and publication
+
+## 5.3 Implications for research
+
+The evidence gap map provides a concrete roadmap for future research. The highest-priority recommendations are:
+
+1. Disaggregate ALS outcomes by demographic characteristics in all future studies
+2. Conduct longitudinal follow-up studies to assess retention beyond the intervention period
+3. Develop and evaluate ALS for humanities disciplines, beginning with writing and language studies
+4. Increase the proportion of RCTs to strengthen causal inference
+
+## 5.4 Implications for practice
+
+For university administrators considering ALS adoption: the strongest evidence supports content sequencing and difficulty adjustment for achievement gains in STEM courses. Evidence for engagement and retention outcomes is weaker, and equity evidence is effectively absent. Institutions should request equity audits from ALS vendors before deployment.
+
+## References
+
+<ol class="references-list">
+  <li>Arksey H, O'Malley L. Scoping studies: towards a methodological framework. <em>Int J Soc Res Methodol.</em> 2005;8(1):19-32.</li>
+  <li>Levac D, Colquhoun H, O'Brien KK. Scoping studies: advancing the methodology. <em>Implement Sci.</em> 2010;5:69.</li>
+  <li>Tricco AC, Lillie E, Zarin W, et al. PRISMA extension for scoping reviews (PRISMA-ScR). <em>Ann Intern Med.</em> 2018;169(7):467-473.</li>
+  <li>Aleven V, McLaughlin EA, Glenn RA, Koedinger KR. Instruction based on adaptive learning technologies. In: <em>Handbook of Research on Learning and Instruction.</em> 2nd ed. Routledge; 2016.</li>
+  <li>Kerr P. Adaptive learning. <em>ELT J.</em> 2016;70(1):88-93.</li>
+  <li>Xie H, Chu HC, Hwang GJ, Wang CC. Trends and development in technology-enhanced adaptive/personalised learning: a systematic review. <em>Comput Educ.</em> 2019;140:103599.</li>
+  <li>Baker RS. Stupid tutoring systems, intelligent humans. <em>Int J Artif Intell Educ.</em> 2016;26(2):600-614.</li>
+</ol>

--- a/scoping-review/content/sections/_index.md
+++ b/scoping-review/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The review follows the five-stage Arksey and O'Malley framework for scoping reviews, updated by Levac et al. (2010). Each section addresses one stage of the review process.

--- a/scoping-review/static/css/style.css
+++ b/scoping-review/static/css/style.css
@@ -1,0 +1,528 @@
+/* ============================================================================
+   Scoping Review - Literature Mapping Paper
+   Light background, serif display, evidence gap maps, bubble charts.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #faf9f5;
+  --paper-2: #f0ede4;
+  --rule: #d4cfc0;
+  --ink: #1a1e28;
+  --ink-2: #2e3442;
+  --ink-3: #5a6270;
+  --ink-4: #8a92a0;
+  --accent: #2a5a3c;
+  --accent-2: #1e4230;
+  --gap: #8b4513;
+  --gap-2: #6e3610;
+  --chart-1: #2a5a3c;
+  --chart-2: #4a8a6c;
+  --chart-3: #8b4513;
+  --chart-4: #c47a32;
+  --chart-5: #2b6ca3;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.68;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Playfair Display", "EB Garamond", Georgia, serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "EB Garamond", serif;
+  font-weight: 600;
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Playfair Display", Georgia, serif;
+  font-weight: 800;
+  font-size: clamp(1.7rem, 3.4vw, 2.5rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", serif;
+  font-size: 1.08rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.92rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 0.88rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2, .paper-content h2 {
+  font-family: "Playfair Display", Georgia, serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3, .paper-content h3 {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.12rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+}
+
+.paper-article h4, .paper-content h4 {
+  font-family: "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p, .paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a, .paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover, .paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li, .paper-content li { margin: 0.3rem 0; }
+
+.paper-article code, .paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong, .paper-content strong { color: var(--ink); font-weight: 700; }
+.paper-article em, .paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Playfair Display", Georgia, serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.12rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Research gap callout ---------------- */
+
+.gap-callout {
+  background: var(--paper);
+  border: 2px solid var(--gap);
+  padding: 1.2rem 1.6rem;
+  margin: 2rem 0;
+}
+
+.gap-callout .gap-label {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  color: var(--gap);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.6rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.gap-callout p {
+  margin: 0.4rem 0;
+  font-family: "Crimson Pro", serif;
+  color: var(--ink-2);
+}
+
+.gap-callout strong {
+  color: var(--gap);
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption, .figure .caption {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "EB Garamond", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th, .paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  font-family: "EB Garamond", serif;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "EB Garamond", serif;
+  font-size: 0.98rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "EB Garamond", serif;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .gap-callout { padding: 1rem; }
+}

--- a/scoping-review/templates/404.html
+++ b/scoping-review/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/scoping-review/templates/footer.html
+++ b/scoping-review/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c8c0b0" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c8c0b0" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Petrov I, Nakamura-Williams S, Adeyemi T. Adaptive learning systems in higher education: a scoping review and evidence gap map. <em>Rev. Educ. Technol.</em> 2026;34(2):88-124. doi:10.39210/ret.2026.34.02.088</p>
+        <p class="footer-note">ISSN 2044-8260 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/scoping-review/templates/header.html
+++ b/scoping-review/templates/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Grid pattern representing evidence map -->
+          <rect x="4" y="4" width="56" height="32" fill="none" stroke="#2a5a3c" stroke-width="1.5"/>
+          <line x1="4" y1="16" x2="60" y2="16" stroke="#2a5a3c" stroke-width="0.8"/>
+          <line x1="4" y1="28" x2="60" y2="28" stroke="#2a5a3c" stroke-width="0.8"/>
+          <line x1="22" y1="4" x2="22" y2="36" stroke="#2a5a3c" stroke-width="0.8"/>
+          <line x1="42" y1="4" x2="42" y2="36" stroke="#2a5a3c" stroke-width="0.8"/>
+          <circle cx="13" cy="10" r="3" fill="#2a5a3c" opacity="0.6"/>
+          <circle cx="32" cy="10" r="5" fill="#2a5a3c" opacity="0.4"/>
+          <circle cx="51" cy="22" r="4" fill="#8b4513" opacity="0.5"/>
+          <circle cx="32" cy="32" r="2" fill="#8b4513" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Review of Educational Technology</span>
+          <span class="journal-sub">Vol. 34 &middot; Issue 02 &middot; Nov 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/charting/">CHARTING</a>
+        <a href="{{ base_url }}/gaps/">GAPS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/scoping-review/templates/page.html
+++ b/scoping-review/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/scoping-review/templates/post.html
+++ b/scoping-review/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/scoping-review/templates/section.html
+++ b/scoping-review/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/scoping-review/templates/shortcodes/alert.html
+++ b/scoping-review/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default("info") }}">
+  <strong>{{ type | default("Note") | upper }}:</strong> {{ body }}
+</div>

--- a/scoping-review/templates/taxonomy.html
+++ b/scoping-review/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/scoping-review/templates/taxonomy_term.html
+++ b/scoping-review/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3180,6 +3180,13 @@
     "scientific",
     "academic"
   ],
+  "scoping-review": [
+    "paper",
+    "light",
+    "scoping",
+    "mapping",
+    "landscape"
+  ],
   "scrimshaw": [
     "bold",
     "elegant",
@@ -3498,6 +3505,13 @@
     "blog",
     "tech",
     "card"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
   ],
   "tectonic": [
     "dark",
@@ -3951,12 +3965,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "technical-report": [
-    "paper",
-    "light",
-    "institutional",
-    "technical-report",
-    "formal"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `scoping-review` example site: a literature mapping paper on adaptive learning systems
- Features SVG evidence gap map diagrams, bubble chart diagrams, temporal accumulation charts
- Display in Playfair Display/EB Garamond, body in Crimson Pro/STIX Two
- Research gap sections in bold bordered callout boxes
- Tags: paper, light, scoping, mapping, landscape

Closes #1629

## Test plan
- [ ] Verify `hwaro build` succeeds in the scoping-review directory
- [ ] Check evidence gap map SVG renders correctly with bubble sizes
- [ ] Confirm temporal accumulation chart displays properly
- [ ] Validate gap callout boxes have correct border styling
- [ ] Validate tags.json contains the new entry