### PR TITLE
Add dose-response example site

### DIFF
--- a/dose-response/AGENTS.md
+++ b/dose-response/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/dose-response/config.toml
+++ b/dose-response/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Dose-Response - Pharmacological Curve Paper
+# Issue #1634 | Tags: paper, light, pharmacological, dose-response, clinical
+# =============================================================================
+
+title = "Dose-Response Analysis of Compound MRX-7721"
+description = "A pharmacological paper presenting dose-response characterization of a novel kinase inhibitor, including sigmoid EC50 curves, therapeutic window analysis, drug interaction combination indices, and ADME profiling."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/dose-response/content/appendix.md
+++ b/dose-response/content/appendix.md
@@ -1,0 +1,28 @@
++++
+title = "Appendix"
+description = "Supplementary methods, statistical analysis details, and author information."
+tags = ["paper", "dose-response", "appendix"]
++++
+
+## Appendix A: Cell Line and Assay Conditions
+
+All dose-response experiments were conducted in HEL 92.1.7 erythroleukemia cells (ATCC TIB-180) maintained in RPMI-1640 supplemented with 10 pct FBS. Cells were seeded at 5,000 cells per well in 384-well plates and treated for 4 hours. JAK2 phosphorylation was quantified by AlphaLISA SureFire assay (PerkinElmer). Each concentration was tested in triplicate across three independent experiments.
+
+## Appendix B: Curve Fitting Methods
+
+Dose-response curves were fitted using a four-parameter logistic model (Hill equation): E = Bottom + (Top - Bottom) / (1 + (EC50/C)^n), where E is effect, C is concentration, and n is the Hill coefficient. Fitting was performed in R (v4.3.2) using the drc package (v3.0-1). Confidence intervals were derived from 1,000 bootstrap resamples with bias-corrected and accelerated (BCa) percentile method.
+
+## Appendix C: Combination Index Calculation
+
+The Chou-Talalay combination index was calculated using CompuSyn software (v1.0.1). The median-effect equation (fa/fu = (D/Dm)^m) was used to derive parameters for each drug individually and in combination. CI values were calculated at fa = 0.1, 0.3, 0.5, 0.7, and 0.9 using the formula for mutually exclusive mechanisms of action.
+
+## CRediT Author Contributions
+
+- **Kenji Nakamura**: Conceptualization, methodology, formal analysis, writing (original draft)
+- **Luciana Ferreira**: Investigation, data curation, writing (review and editing)
+- **Anders Strand**: ADME profiling, pharmacokinetic modeling, writing (review and editing)
+- **Nkechi Okafor**: Combination index analysis, visualization, writing (review and editing)
+
+## Correspondence
+
+Kenji Nakamura, Department of Clinical Pharmacology, Kinase Therapeutics Institute, 200 Discovery Drive, San Diego, CA 92121. Email: nakamura@kti-pharma.org

--- a/dose-response/content/index.md
+++ b/dose-response/content/index.md
@@ -1,0 +1,181 @@
++++
+title = "Abstract"
+description = "Dose-response characterization of MRX-7721, a selective JAK2 inhibitor, including EC50 determination, therapeutic window analysis, and combination interaction profiling."
+tags = ["paper", "light", "pharmacological", "dose-response", "clinical"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Research &middot; Open Access</p>
+  <h1 class="paper-title">Dose-Response Characterization of <span class="drug-name">MRX-7721</span>, a Selective JAK2 Inhibitor: EC50 Determination, Therapeutic Window, and Combination Interaction Profiling</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Kenji Nakamura</span><sup>1</sup>,
+    Luciana Ferreira<sup>2</sup>,
+    Anders Strand<sup>1,3</sup>,
+    Nkechi Okafor<sup>2</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Clinical Pharmacology, Kinase Therapeutics Institute &middot;
+    <sup>2</sup>Division of Quantitative Pharmacology, Meridian Biomedical Center &middot;
+    <sup>3</sup>Nordic DMPK Consortium, Karolinska Institute
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.41093/jqp.2026.34.02.088</a> &middot; <strong>Received:</strong> 12 Jan 2026 &middot; <strong>Accepted:</strong> 28 Mar 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd><span class="drug-name">MRX-7721</span> is a novel selective inhibitor of Janus kinase 2 (JAK2) under investigation for myeloproliferative neoplasms. Comprehensive dose-response characterization is needed to define the therapeutic window and guide Phase II dose selection.</dd>
+    <dt>Methods</dt>
+    <dd>Sigmoid Emax models were fitted to concentration-response data from cell-based JAK2 phosphorylation assays (n = 8 concentrations, triplicate). Therapeutic window boundaries were defined by EC90 (efficacy) and IC20 for off-target kinases (selectivity). Drug interactions with ruxolitinib were characterized using the Chou-Talalay combination index method.</dd>
+    <dt>Results</dt>
+    <dd>The EC50 for JAK2 inhibition was <strong>42.3 nM</strong> (95 pct CI: 36.1-49.5 nM) with a Hill coefficient of 1.38. The therapeutic window spans 28-310 nM (EC20 to IC20 for FLT3). The combination index with ruxolitinib was 0.61 at the EC50 isobole, indicating synergism.</dd>
+    <dt>Conclusion</dt>
+    <dd>MRX-7721 demonstrates potent, selective JAK2 inhibition with a favorable therapeutic window. Synergistic interaction with ruxolitinib supports combination dosing strategies for treatment-resistant myelofibrosis.</dd>
+    <dt>Keywords</dt>
+    <dd><em>dose-response; JAK2 inhibitor; EC50; therapeutic window; combination index; Chou-Talalay; sigmoid Emax; myeloproliferative neoplasm</em></dd>
+  </dl>
+</section>
+
+## Dose-Response Curve
+
+<figure class="figure">
+  <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Sigmoid dose-response curve for MRX-7721 showing EC50 annotation at 42.3 nM">
+    <!-- background -->
+    <rect x="0" y="0" width="720" height="420" fill="#faf9f5"/>
+    <!-- grid -->
+    <g stroke="#ccc8ba" stroke-width="0.5">
+      <line x1="80" y1="40" x2="680" y2="40"/>
+      <line x1="80" y1="100" x2="680" y2="100"/>
+      <line x1="80" y1="160" x2="680" y2="160"/>
+      <line x1="80" y1="220" x2="680" y2="220"/>
+      <line x1="80" y1="280" x2="680" y2="280"/>
+      <line x1="80" y1="340" x2="680" y2="340"/>
+    </g>
+    <!-- axes -->
+    <line x1="80" y1="40" x2="80" y2="350" stroke="#1a2337" stroke-width="1.5"/>
+    <line x1="80" y1="350" x2="680" y2="350" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- Y-axis labels (pct inhibition) -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="end">
+      <text x="72" y="44">100</text>
+      <text x="72" y="104">80</text>
+      <text x="72" y="164">60</text>
+      <text x="72" y="224">40</text>
+      <text x="72" y="284">20</text>
+      <text x="72" y="344">0</text>
+    </g>
+    <!-- X-axis labels (log concentration nM) -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="middle">
+      <text x="130" y="368">1</text>
+      <text x="230" y="368">3</text>
+      <text x="330" y="368">10</text>
+      <text x="430" y="368">30</text>
+      <text x="530" y="368">100</text>
+      <text x="630" y="368">300</text>
+    </g>
+    <!-- Axis titles -->
+    <text x="380" y="398" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="12" fill="#1a2337" letter-spacing="0.5">Concentration (nM, log scale)</text>
+    <text x="28" y="200" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="12" fill="#1a2337" letter-spacing="0.5" transform="rotate(-90,28,200)">pct JAK2 Inhibition</text>
+    <!-- Sigmoid curve -->
+    <path d="M 100 338 Q 140 336 180 332 Q 220 326 260 316 Q 300 298 340 264 Q 370 232 400 190 Q 430 150 460 112 Q 490 84 520 68 Q 560 54 600 48 Q 640 44 660 42" fill="none" stroke="#2a6894" stroke-width="2.5"/>
+    <!-- Data points with error bars -->
+    <g fill="#2a6894" stroke="#1a2337" stroke-width="0.8">
+      <circle cx="130" cy="336" r="4"/>
+      <line x1="130" y1="330" x2="130" y2="342" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="230" cy="328" r="4"/>
+      <line x1="230" y1="320" x2="230" y2="336" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="330" cy="302" r="4"/>
+      <line x1="330" y1="290" x2="330" y2="314" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="380" cy="248" r="4"/>
+      <line x1="380" y1="232" x2="380" y2="264" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="430" cy="186" r="4"/>
+      <line x1="430" y1="170" x2="430" y2="202" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="480" cy="108" r="4"/>
+      <line x1="480" y1="96" x2="480" y2="120" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="530" cy="68" r="4"/>
+      <line x1="530" y1="58" x2="530" y2="78" stroke="#2a6894" stroke-width="1.5"/>
+      <circle cx="630" cy="44" r="4"/>
+      <line x1="630" y1="38" x2="630" y2="50" stroke="#2a6894" stroke-width="1.5"/>
+    </g>
+    <!-- EC50 annotation -->
+    <line x1="420" y1="195" x2="420" y2="350" stroke="#c44a2b" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <line x1="80" y1="195" x2="420" y2="195" stroke="#c44a2b" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <circle cx="420" cy="195" r="6" fill="#c44a2b" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- EC50 label -->
+    <rect x="440" y="170" width="140" height="40" fill="#faf9f5" stroke="#c44a2b" stroke-width="1"/>
+    <text x="510" y="186" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#c44a2b" letter-spacing="1">EC50</text>
+    <text x="510" y="202" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="12" fill="#1a2337">42.3 nM</text>
+    <!-- Hill coefficient -->
+    <text x="580" y="260" font-family="STIX Two Text" font-style="italic" font-size="11" fill="#5b6272">n<tspan font-size="8" dy="3">H</tspan><tspan dy="-3"> = 1.38</tspan></text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Sigmoid dose-response curve for MRX-7721 inhibition of JAK2 phosphorylation. Data points represent mean of triplicate measurements; error bars show SEM. The fitted four-parameter logistic model yields EC50 = 42.3 nM (95 pct CI: 36.1-49.5 nM, Hill coefficient n<sub>H</sub> = 1.38).</div>
+</figure>
+
+<div class="ec50-callout">
+  <span class="ec50-label">EC50 (JAK2)</span>
+  <span class="ec50-value">42.3 nM<span class="unit">95 pct CI: 36.1-49.5</span></span>
+  <p class="ec50-detail">Determined from 8-point concentration-response curve (1-300 nM) in HEL 92.1.7 erythroleukemia cells. Fitted by four-parameter logistic regression. Hill coefficient = 1.38; R-squared = 0.997; bottom asymptote = 2.1 pct; top asymptote = 98.4 pct.</p>
+</div>
+
+## Key Pharmacological Parameters
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary of dose-response and selectivity parameters for MRX-7721.</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Target</th>
+      <th>Value</th>
+      <th>95 pct CI</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>EC50</td>
+      <td>JAK2</td>
+      <td class="num">42.3 nM</td>
+      <td class="num">36.1-49.5</td>
+    </tr>
+    <tr>
+      <td>EC20</td>
+      <td>JAK2</td>
+      <td class="num">18.4 nM</td>
+      <td class="num">14.2-22.8</td>
+    </tr>
+    <tr>
+      <td>EC90</td>
+      <td>JAK2</td>
+      <td class="num">148.2 nM</td>
+      <td class="num">128.0-171.5</td>
+    </tr>
+    <tr>
+      <td>IC50</td>
+      <td>JAK1 (off-target)</td>
+      <td class="num">1,240 nM</td>
+      <td class="num">980-1,560</td>
+    </tr>
+    <tr>
+      <td>IC20</td>
+      <td>FLT3 (off-target)</td>
+      <td class="num">310 nM</td>
+      <td class="num">260-370</td>
+    </tr>
+    <tr>
+      <td>Selectivity ratio</td>
+      <td>JAK2 / JAK1</td>
+      <td class="num">29.3x</td>
+      <td class="num">22.1-39.4</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">EC = effective concentration for target inhibition; IC = inhibitory concentration for off-target kinases. CI = confidence interval from bootstrap resampling (n = 1,000).</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+1. **Section 1. Dose-Response Modeling** -- sigmoid Emax fitting, parameter estimation, and model diagnostics
+2. **Section 2. Therapeutic Window** -- efficacy and selectivity boundaries, safety margin analysis
+3. **Section 3. Drug Interactions** -- Chou-Talalay combination index with ruxolitinib
+4. **Section 4. ADME Profiling** -- absorption, distribution, metabolism, and excretion characterization
+5. **Section 5. Discussion** -- clinical implications and Phase II dose selection rationale

--- a/dose-response/content/interactions.md
+++ b/dose-response/content/interactions.md
@@ -1,0 +1,75 @@
++++
+title = "Drug Interactions"
+description = "Combination interaction profiling of MRX-7721 with ruxolitinib using the Chou-Talalay combination index method."
+tags = ["paper", "dose-response", "drug-interaction"]
++++
+
+## Combination Index Analysis
+
+The interaction between MRX-7721 and ruxolitinib was characterized using the Chou-Talalay median-effect principle. Cells were treated with each drug alone and in combination at fixed molar ratios (MRX-7721 : ruxolitinib = 1:5, based on the ratio of their respective EC50 values).
+
+<figure class="figure">
+  <svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Combination index diagram showing synergism between MRX-7721 and ruxolitinib">
+    <rect x="0" y="0" width="720" height="380" fill="#faf9f5"/>
+    <!-- Grid -->
+    <g stroke="#ccc8ba" stroke-width="0.5">
+      <line x1="100" y1="40" x2="660" y2="40"/>
+      <line x1="100" y1="110" x2="660" y2="110"/>
+      <line x1="100" y1="180" x2="660" y2="180"/>
+      <line x1="100" y1="250" x2="660" y2="250"/>
+      <line x1="100" y1="320" x2="660" y2="320"/>
+    </g>
+    <!-- Axes -->
+    <line x1="100" y1="40" x2="100" y2="330" stroke="#1a2337" stroke-width="1.5"/>
+    <line x1="100" y1="330" x2="660" y2="330" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- Y-axis (CI value) -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="end">
+      <text x="92" y="44">2.0</text>
+      <text x="92" y="114">1.5</text>
+      <text x="92" y="184">1.0</text>
+      <text x="92" y="254">0.5</text>
+      <text x="92" y="324">0.0</text>
+    </g>
+    <!-- X-axis (Fraction affected) -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="middle">
+      <text x="156" y="348">0.1</text>
+      <text x="268" y="348">0.3</text>
+      <text x="380" y="348">0.5</text>
+      <text x="492" y="348">0.7</text>
+      <text x="604" y="348">0.9</text>
+    </g>
+    <!-- Axis labels -->
+    <text x="380" y="372" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="0.5">Fraction Affected (fa)</text>
+    <text x="40" y="185" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="0.5" transform="rotate(-90,40,185)">Combination Index (CI)</text>
+    <!-- CI = 1 reference line (additivity) -->
+    <line x1="100" y1="180" x2="660" y2="180" stroke="#1a2337" stroke-width="1" stroke-dasharray="6 4"/>
+    <!-- Zone labels -->
+    <text x="670" y="100" font-family="IBM Plex Sans" font-size="9" fill="#b8372a" letter-spacing="0.5">ANTAGONISM</text>
+    <text x="670" y="200" font-family="IBM Plex Sans" font-size="9" fill="#5b6272" letter-spacing="0.5">ADDITIVITY</text>
+    <text x="670" y="280" font-family="IBM Plex Sans" font-size="9" fill="#2a8a5a" letter-spacing="0.5">SYNERGISM</text>
+    <!-- CI curve -->
+    <polyline points="156,216 212,222 268,232 324,240 380,246 436,252 492,260 548,268 604,278" fill="none" stroke="#2a6894" stroke-width="2.5"/>
+    <!-- Data points -->
+    <g fill="#2a6894" stroke="#1a2337" stroke-width="0.8">
+      <circle cx="156" cy="216" r="5"/>
+      <circle cx="268" cy="232" r="5"/>
+      <circle cx="380" cy="246" r="5"/>
+      <circle cx="492" cy="260" r="5"/>
+      <circle cx="604" cy="278" r="5"/>
+    </g>
+    <!-- EC50 annotation -->
+    <circle cx="380" cy="246" r="8" fill="none" stroke="#c44a2b" stroke-width="2"/>
+    <line x1="380" y1="246" x2="440" y2="210" stroke="#1a2337" stroke-width="0.8"/>
+    <text x="446" y="206" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#1a2337">CI at EC50 = 0.61</text>
+    <text x="446" y="220" font-family="STIX Two Text" font-style="italic" font-size="10" fill="#2a8a5a">Synergism</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 4.</span> Combination index (CI) plot for MRX-7721 + ruxolitinib across the effect range. CI values below 1.0 (dashed line) indicate synergism; above 1.0 indicates antagonism. The CI at the EC50 isobole is 0.61, indicating moderate synergism across the clinically relevant effect range.</div>
+</figure>
+
+### Interpretation
+
+The combination index values range from 0.72 (at fa = 0.1) to 0.46 (at fa = 0.9), indicating synergism across the entire effect range. The strongest synergism is observed at higher effect levels (fa > 0.7), suggesting that the combination is particularly advantageous when high levels of JAK2 inhibition are required. This finding supports the clinical rationale for combination therapy in patients with inadequate response to ruxolitinib monotherapy.
+
+### Dose Reduction Index
+
+At the EC50 isobole, the dose reduction index (DRI) for MRX-7721 is 2.1 and for ruxolitinib is 1.8. This means that in combination, each drug can be administered at approximately half of its single-agent dose to achieve the same effect, potentially reducing dose-dependent toxicities while maintaining efficacy.

--- a/dose-response/content/pharmacokinetics.md
+++ b/dose-response/content/pharmacokinetics.md
@@ -1,0 +1,65 @@
++++
+title = "ADME Profile"
+description = "Absorption, distribution, metabolism, and excretion characterization of MRX-7721."
+tags = ["paper", "dose-response", "ADME"]
++++
+
+## ADME Summary
+
+<figure class="figure">
+  <svg viewBox="0 0 720 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="ADME flow diagram showing absorption, distribution, metabolism, and excretion stages">
+    <rect x="0" y="0" width="720" height="200" fill="#faf9f5"/>
+    <!-- A box -->
+    <rect x="20" y="50" width="140" height="100" fill="none" stroke="#2a6894" stroke-width="2"/>
+    <text x="90" y="76" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a6894" letter-spacing="1.5">ABSORPTION</text>
+    <text x="90" y="96" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">F = 72 pct</text>
+    <text x="90" y="112" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">T<tspan font-size="7" dy="3">max</tspan><tspan dy="-3"> = 1.8 h</tspan></text>
+    <text x="90" y="128" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#5b6272">Oral, food effect minimal</text>
+    <!-- D box -->
+    <rect x="200" y="50" width="140" height="100" fill="none" stroke="#2a6894" stroke-width="2"/>
+    <text x="270" y="76" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a6894" letter-spacing="1.5">DISTRIBUTION</text>
+    <text x="270" y="96" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">V<tspan font-size="7" dy="3">d</tspan><tspan dy="-3"> = 48 L</tspan></text>
+    <text x="270" y="112" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">PPB = 94 pct</text>
+    <text x="270" y="128" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#5b6272">CNS penetration low</text>
+    <!-- M box -->
+    <rect x="380" y="50" width="140" height="100" fill="none" stroke="#2a6894" stroke-width="2"/>
+    <text x="450" y="76" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a6894" letter-spacing="1.5">METABOLISM</text>
+    <text x="450" y="96" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">CYP3A4 (major)</text>
+    <text x="450" y="112" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">CYP2D6 (minor)</text>
+    <text x="450" y="128" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#5b6272">Active metabolite M3</text>
+    <!-- E box -->
+    <rect x="560" y="50" width="140" height="100" fill="none" stroke="#2a6894" stroke-width="2"/>
+    <text x="630" y="76" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a6894" letter-spacing="1.5">EXCRETION</text>
+    <text x="630" y="96" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">t<tspan font-size="7" dy="3">1/2</tspan><tspan dy="-3"> = 8.4 h</tspan></text>
+    <text x="630" y="112" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#1a2337">CL = 5.7 L/h</text>
+    <text x="630" y="128" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#5b6272">Renal 34 pct / fecal 58 pct</text>
+    <!-- Arrows -->
+    <defs>
+      <marker id="arrowADME" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#5b6272"/>
+      </marker>
+    </defs>
+    <line x1="160" y1="100" x2="200" y2="100" stroke="#5b6272" stroke-width="1.5" marker-end="url(#arrowADME)"/>
+    <line x1="340" y1="100" x2="380" y2="100" stroke="#5b6272" stroke-width="1.5" marker-end="url(#arrowADME)"/>
+    <line x1="520" y1="100" x2="560" y2="100" stroke="#5b6272" stroke-width="1.5" marker-end="url(#arrowADME)"/>
+    <!-- Title -->
+    <text x="360" y="28" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="12" fill="#1a2337" letter-spacing="1">ADME PROFILE: MRX-7721</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 5.</span> ADME flow diagram for MRX-7721. Key pharmacokinetic parameters are shown for each disposition stage. Bioavailability = 72 pct; terminal half-life = 8.4 hours, supporting twice-daily oral dosing.</div>
+</figure>
+
+### Absorption
+
+MRX-7721 is rapidly absorbed after oral administration, with a median time to peak plasma concentration (T<sub>max</sub>) of 1.8 hours. Absolute oral bioavailability is 72 pct based on comparison of AUC values after intravenous and oral dosing in the Phase I study (n = 24). Co-administration with a high-fat meal increased C<sub>max</sub> by 12 pct and AUC by 8 pct, neither of which is considered clinically relevant; the drug may be administered without regard to food.
+
+### Distribution
+
+The apparent volume of distribution at steady state (V<sub>d,ss</sub>) is 48 L, indicating moderate extravascular distribution. Plasma protein binding is 94 pct, primarily to albumin (89 pct) with minor binding to alpha-1-acid glycoprotein. CNS penetration is low (CSF-to-plasma ratio < 0.05), consistent with the intended peripheral target.
+
+### Metabolism
+
+MRX-7721 is metabolized primarily by CYP3A4 (contributing approximately 74 pct of total clearance) with a minor contribution from CYP2D6 (approximately 18 pct). The primary metabolite M3 (N-desmethyl MRX-7721) retains approximately 40 pct of the parent compound's JAK2 inhibitory activity and circulates at approximately 25 pct of parent AUC at steady state.
+
+### Excretion
+
+The terminal elimination half-life is 8.4 hours, supporting twice-daily dosing. Total plasma clearance is 5.7 L/h. After a single radiolabeled dose, 34 pct of radioactivity was recovered in urine and 58 pct in feces over 168 hours, with the remainder unrecovered. Less than 5 pct of the administered dose is excreted unchanged in urine.

--- a/dose-response/content/sections/1-dose-response-modeling.md
+++ b/dose-response/content/sections/1-dose-response-modeling.md
@@ -1,0 +1,74 @@
++++
+title = "Dose-Response Modeling"
+description = "Sigmoid Emax model fitting, parameter estimation, and model diagnostics for MRX-7721 concentration-response data."
+weight = 1
+template = "post"
+[extra]
+section_number = "1"
++++
+
+## Model Selection
+
+The concentration-response relationship for MRX-7721 was characterized using the four-parameter logistic (4PL) model, also known as the sigmoid Emax model. This model was selected over the three-parameter logistic model (fixed Hill coefficient = 1) based on Akaike Information Criterion comparison (AIC_4PL = -42.3 vs. AIC_3PL = -36.8).
+
+### Parameter Estimates
+
+The fitted model parameters are:
+
+- **Bottom (E<sub>0</sub>)**: 2.1 pct (95 pct CI: 0.4-3.8 pct) -- residual JAK2 phosphorylation at saturating drug concentrations
+- **Top (E<sub>max</sub>)**: 98.4 pct (95 pct CI: 96.2-100.0 pct) -- baseline phosphorylation in vehicle-treated cells
+- **EC50**: 42.3 nM (95 pct CI: 36.1-49.5 nM) -- concentration producing 50 pct inhibition
+- **Hill coefficient (n<sub>H</sub>)**: 1.38 (95 pct CI: 1.12-1.64) -- steepness of the concentration-response curve
+
+The Hill coefficient of 1.38, slightly above unity, suggests modest positive cooperativity in JAK2 binding. This is consistent with the reported binding mode of MRX-7721, which occupies both the ATP-binding pocket and an adjacent allosteric site.
+
+### Model Diagnostics
+
+Goodness of fit was assessed by three criteria: (1) coefficient of determination R-squared = 0.997; (2) residual standard error = 3.2 pct of response range; (3) runs test for systematic deviation from the fitted curve (p = 0.68, no evidence of systematic misfit). Visual inspection of residual plots confirmed homoscedastic, normally distributed residuals with no evidence of concentration-dependent bias.
+
+## Potency Comparison
+
+To contextualize MRX-7721 potency, we compared its EC50 against published values for approved JAK2 inhibitors:
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Potency comparison of JAK2 inhibitors in cell-based phosphorylation assays.</caption>
+  <thead>
+    <tr>
+      <th>Compound</th>
+      <th>EC50 (nM)</th>
+      <th>Hill coefficient</th>
+      <th>JAK2/JAK1 selectivity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>MRX-7721</strong></td>
+      <td class="num">42.3</td>
+      <td class="num">1.38</td>
+      <td class="num">29.3x</td>
+    </tr>
+    <tr>
+      <td>Ruxolitinib</td>
+      <td class="num">210</td>
+      <td class="num">1.05</td>
+      <td class="num">3.3x</td>
+    </tr>
+    <tr>
+      <td>Fedratinib</td>
+      <td class="num">320</td>
+      <td class="num">1.12</td>
+      <td class="num">35x</td>
+    </tr>
+    <tr>
+      <td>Pacritinib</td>
+      <td class="num">180</td>
+      <td class="num">0.98</td>
+      <td class="num">5.2x</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">EC50 values from cell-based assays in HEL 92.1.7 cells (this study) or published literature. Selectivity ratios based on cell-based IC50 comparisons.</td></tr>
+  </tfoot>
+</table>
+
+MRX-7721 is approximately 5-fold more potent than ruxolitinib and demonstrates the highest JAK2/JAK1 selectivity among the JAK2 inhibitors tested, with the exception of fedratinib.

--- a/dose-response/content/sections/2-therapeutic-window.md
+++ b/dose-response/content/sections/2-therapeutic-window.md
@@ -1,0 +1,70 @@
++++
+title = "Therapeutic Window"
+description = "Definition of the therapeutic window boundaries based on efficacy and off-target selectivity thresholds."
+weight = 2
+template = "post"
+[extra]
+section_number = "2"
++++
+
+## Window Definition
+
+The therapeutic window for MRX-7721 is defined by two boundaries:
+
+- **Lower bound (efficacy threshold)**: EC20 for JAK2 inhibition = 18.4 nM. Below this concentration, JAK2 inhibition is insufficient for clinical benefit.
+- **Upper bound (selectivity limit)**: IC20 for FLT3 inhibition = 310 nM. Above this concentration, off-target kinase inhibition begins to contribute adverse effects (cytopenia risk).
+
+The resulting therapeutic window spans **18.4-310 nM**, representing a 16.8-fold range. This compares favorably to ruxolitinib (therapeutic index approximately 5-fold) and suggests a wider margin for dose optimization.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Therapeutic window diagram showing efficacy and toxicity boundaries for MRX-7721">
+    <rect x="0" y="0" width="720" height="240" fill="#faf9f5"/>
+    <!-- Concentration axis -->
+    <line x1="60" y1="140" x2="680" y2="140" stroke="#1a2337" stroke-width="1.5"/>
+    <!-- Tick marks -->
+    <g stroke="#1a2337" stroke-width="1">
+      <line x1="120" y1="135" x2="120" y2="145"/>
+      <line x1="230" y1="135" x2="230" y2="145"/>
+      <line x1="340" y1="135" x2="340" y2="145"/>
+      <line x1="450" y1="135" x2="450" y2="145"/>
+      <line x1="560" y1="135" x2="560" y2="145"/>
+      <line x1="660" y1="135" x2="660" y2="145"/>
+    </g>
+    <!-- Concentration labels -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="middle">
+      <text x="120" y="162">1 nM</text>
+      <text x="230" y="162">10 nM</text>
+      <text x="340" y="162">42 nM</text>
+      <text x="450" y="162">100 nM</text>
+      <text x="560" y="162">310 nM</text>
+      <text x="660" y="162">1000 nM</text>
+    </g>
+    <text x="370" y="186" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2337" letter-spacing="0.5">Concentration (nM, log scale)</text>
+    <!-- Sub-therapeutic zone -->
+    <rect x="60" y="80" width="170" height="50" fill="#ccc8ba" opacity="0.3"/>
+    <text x="145" y="72" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#5b6272" letter-spacing="0.5">SUB-THERAPEUTIC</text>
+    <!-- Therapeutic window (green zone) -->
+    <rect x="230" y="80" width="330" height="50" fill="#2a8a5a" opacity="0.15"/>
+    <rect x="230" y="80" width="330" height="50" fill="none" stroke="#2a8a5a" stroke-width="2"/>
+    <text x="395" y="100" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="12" fill="#2a8a5a" letter-spacing="1">THERAPEUTIC WINDOW</text>
+    <text x="395" y="118" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#2a8a5a">18.4 - 310 nM (16.8x range)</text>
+    <!-- Toxic zone -->
+    <rect x="560" y="80" width="120" height="50" fill="#b8372a" opacity="0.1"/>
+    <text x="620" y="72" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#b8372a" letter-spacing="0.5">OFF-TARGET RISK</text>
+    <!-- EC50 marker -->
+    <line x1="340" y1="80" x2="340" y2="130" stroke="#c44a2b" stroke-width="2"/>
+    <circle cx="340" cy="140" r="4" fill="#c44a2b"/>
+    <text x="340" y="210" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#c44a2b">EC50 = 42.3 nM</text>
+    <!-- EC20 marker -->
+    <line x1="230" y1="130" x2="230" y2="140" stroke="#2a8a5a" stroke-width="2"/>
+    <text x="230" y="210" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#2a8a5a">EC20</text>
+    <!-- IC20 FLT3 marker -->
+    <line x1="560" y1="130" x2="560" y2="140" stroke="#b8372a" stroke-width="2"/>
+    <text x="560" y="210" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#b8372a">IC20 FLT3</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Therapeutic window diagram for MRX-7721. The green zone indicates the concentration range between the efficacy threshold (EC20 for JAK2, 18.4 nM) and the selectivity limit (IC20 for FLT3, 310 nM). The EC50 (42.3 nM) falls well within the therapeutic window.</div>
+</figure>
+
+### Clinical Dose Implications
+
+Based on the therapeutic window boundaries and the pharmacokinetic profile (oral bioavailability 72 pct, half-life 8.4 hours), population PK modeling predicts that a dose of 25 mg twice daily will maintain plasma trough concentrations above the EC20 (18.4 nM) and peak concentrations below the IC20 for FLT3 (310 nM) in greater than 90 pct of patients. This dose is recommended for Phase II evaluation.

--- a/dose-response/content/sections/3-drug-interactions.md
+++ b/dose-response/content/sections/3-drug-interactions.md
@@ -1,0 +1,22 @@
++++
+title = "Drug Interaction Analysis"
+description = "Chou-Talalay combination index analysis for MRX-7721 in combination with ruxolitinib."
+weight = 3
+template = "post"
+[extra]
+section_number = "3"
++++
+
+## Combination Rationale
+
+Ruxolitinib is the current standard of care for myelofibrosis, but approximately 50 pct of patients lose response within 3 years. Combination therapy with MRX-7721 may overcome acquired resistance by simultaneously targeting the ATP-binding pocket (ruxolitinib) and the allosteric site (MRX-7721), reducing the probability of single-mechanism escape mutations.
+
+## Combination Index Results
+
+The combination was tested at five effect levels (fa = 0.1, 0.3, 0.5, 0.7, 0.9) using a constant molar ratio of MRX-7721 : ruxolitinib = 1:5. All combination index values fell below 1.0, indicating synergism at every tested effect level.
+
+The dose reduction index (DRI) at the EC50 isobole was 2.1 for MRX-7721 and 1.8 for ruxolitinib. In clinical terms, this means that the combination can achieve the same level of JAK2 inhibition as either drug alone, but at approximately half the dose of each component -- a meaningful advantage for reducing dose-dependent hematological toxicity.
+
+## Mechanistic Interpretation
+
+The observed synergism is consistent with the complementary binding modes of the two drugs. MRX-7721 binds to the allosteric pocket adjacent to the ATP-binding site, and ruxolitinib occupies the ATP-binding site itself. Simultaneous occupancy of both sites produces cooperative inhibition that exceeds the sum of individual effects, as predicted by the Bliss independence model and confirmed by the Chou-Talalay analysis.

--- a/dose-response/content/sections/4-adme-profiling.md
+++ b/dose-response/content/sections/4-adme-profiling.md
@@ -1,0 +1,69 @@
++++
+title = "ADME Profiling"
+description = "Absorption, distribution, metabolism, and excretion characterization supporting dose selection."
+weight = 4
+template = "post"
+[extra]
+section_number = "4"
++++
+
+## Pharmacokinetic Summary
+
+MRX-7721 displays favorable oral pharmacokinetic properties for a twice-daily dosing regimen. The key parameters -- 72 pct bioavailability, 8.4-hour half-life, and predominantly hepatic clearance -- are consistent with the target product profile for a chronic oral kinase inhibitor.
+
+### Key PK Parameters
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Summary pharmacokinetic parameters for MRX-7721 (25 mg oral dose, n = 24).</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+      <th>CV pct</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>C<sub>max</sub></td>
+      <td class="num">186 nM</td>
+      <td class="num">28</td>
+    </tr>
+    <tr>
+      <td>T<sub>max</sub></td>
+      <td class="num">1.8 h</td>
+      <td class="num">32</td>
+    </tr>
+    <tr>
+      <td>AUC<sub>0-12h</sub></td>
+      <td class="num">1,024 nM*h</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>t<sub>1/2</sub></td>
+      <td class="num">8.4 h</td>
+      <td class="num">18</td>
+    </tr>
+    <tr>
+      <td>CL/F</td>
+      <td class="num">5.7 L/h</td>
+      <td class="num">22</td>
+    </tr>
+    <tr>
+      <td>V<sub>d</sub>/F</td>
+      <td class="num">48 L</td>
+      <td class="num">26</td>
+    </tr>
+    <tr>
+      <td>F (absolute)</td>
+      <td class="num">72 pct</td>
+      <td class="num">15</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="3">CV = coefficient of variation. Parameters from Phase I single-dose study in healthy volunteers.</td></tr>
+  </tfoot>
+</table>
+
+### Drug-Drug Interaction Risk
+
+As a CYP3A4 substrate, MRX-7721 is expected to interact with strong CYP3A4 inhibitors (e.g., ketoconazole, clarithromycin) and inducers (e.g., rifampin, carbamazepine). In vitro studies indicate a 3.2-fold increase in MRX-7721 AUC when co-administered with ketoconazole and a 68 pct decrease with rifampin. Dose adjustments will be specified in the Phase II protocol for patients receiving strong CYP3A4 modulators. MRX-7721 does not inhibit or induce CYP enzymes at clinically relevant concentrations, minimizing the risk of perpetrating interactions with co-medications.

--- a/dose-response/content/sections/5-discussion.md
+++ b/dose-response/content/sections/5-discussion.md
@@ -1,0 +1,26 @@
++++
+title = "Discussion"
+description = "Clinical implications, Phase II dose selection rationale, and limitations of the dose-response analysis."
+weight = 5
+template = "post"
+[extra]
+section_number = "5"
++++
+
+## Clinical Implications
+
+The dose-response data presented in this paper support advancing MRX-7721 into Phase II clinical trials for myeloproliferative neoplasms. Three findings are particularly relevant to clinical development:
+
+First, the EC50 of 42.3 nM places MRX-7721 among the most potent JAK2 inhibitors in development, approximately 5-fold more potent than ruxolitinib in the same cell-based assay. This potency advantage may translate to lower required doses and reduced off-target toxicity.
+
+Second, the 16.8-fold therapeutic window (EC20 to IC20 for FLT3) is substantially wider than the estimated therapeutic indices for currently approved JAK2 inhibitors. This wider window provides greater flexibility in dose optimization and may reduce the incidence of dose-limiting toxicities, particularly cytopenias.
+
+Third, the synergistic interaction with ruxolitinib (CI = 0.61 at the EC50 isobole) provides a pharmacological rationale for combination therapy in patients who have lost response to ruxolitinib monotherapy. The dose reduction indices suggest that both drugs can be administered at approximately half of their respective monotherapy doses while maintaining equivalent efficacy.
+
+## Phase II Dose Selection
+
+Based on the integrated dose-response and pharmacokinetic data, we recommend a starting dose of 25 mg twice daily for Phase II. This dose is predicted to maintain plasma concentrations within the therapeutic window (trough > EC20, peak < IC20 for FLT3) in greater than 90 pct of patients.
+
+## Limitations
+
+Several limitations should be acknowledged. First, all dose-response data were generated in HEL 92.1.7 cells; the EC50 in primary patient-derived cells may differ. Second, the combination index analysis was conducted at a single fixed molar ratio; a more comprehensive isobologram analysis across multiple ratios is warranted. Third, in vivo pharmacodynamic confirmation of the in vitro therapeutic window is needed from the ongoing Phase I expansion cohort.

--- a/dose-response/content/sections/_index.md
+++ b/dose-response/content/sections/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Section Index"
+description = "The five numbered sections of the dose-response manuscript."
+sort_by = "weight"
+tags = ["paper", "dose-response", "clinical"]
++++
+
+The manuscript is organized into five numbered sections covering dose-response modeling, therapeutic window analysis, drug interaction profiling, ADME characterization, and clinical discussion.

--- a/dose-response/static/css/style.css
+++ b/dose-response/static/css/style.css
@@ -1,0 +1,553 @@
+/* ============================================================================
+   Dose-Response - Pharmacological Curve Paper
+   Light background, clinical pharmacology aesthetics. IBM Plex Sans Bold /
+   Roboto Bold display, STIX Two / Noto Serif body. No gradients.
+   ============================================================================ */
+
+:root {
+  --paper: #faf9f5;
+  --paper-2: #f0efe8;
+  --rule: #ccc8ba;
+  --ink: #1a2337;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #2a6894;
+  --accent-2: #1e4f72;
+  --ec50: #c44a2b;
+  --therapeutic: #2a8a5a;
+  --toxic: #b8372a;
+  --drug-a: #2a6894;
+  --drug-b: #8a5a9a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "STIX Two Text", "Noto Serif", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Drug name styling ---------------- */
+
+.drug-name {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* ---------------- EC50 callout ---------------- */
+
+.ec50-callout {
+  background: var(--paper);
+  border: 2px solid var(--ec50);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.ec50-callout .ec50-label {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--ec50);
+  text-transform: uppercase;
+}
+
+.ec50-callout .ec50-value {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.ec50-callout .ec50-value .unit {
+  font-family: "STIX Two Text", serif;
+  font-size: 1rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.ec50-callout .ec50-detail {
+  font-family: "STIX Two Text", serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.95rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "STIX Two Text", "Noto Serif", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "STIX Two Text", "Noto Serif", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "STIX Two Text", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .ec50-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/dose-response/templates/404.html
+++ b/dose-response/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / PAGE NOT FOUND</p>
+      <h1 class="paper-section-title">Compound not found</h1>
+      <p>The reference you followed does not resolve to a section in this paper. Return to the abstract to navigate the manuscript.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to the abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/dose-response/templates/footer.html
+++ b/dose-response/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2337" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2337" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura K, Ferreira L, Strand A, Okafor N. Dose-Response Characterization of MRX-7721, a Selective JAK2 Inhibitor. <em>J Quant Pharmacol.</em> 2026;34(2):88-114. doi:10.41093/jqp.2026.34.02.088</p>
+        <p class="footer-note">ISSN 2891-4402 &middot; Copyright &copy; 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/dose-response/templates/header.html
+++ b/dose-response/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@500;600;700&family=Roboto:wght@500;700&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#1a2337" stroke-width="1.5"/>
+          <path d="M 8 34 Q 20 34 26 24 Q 32 14 38 10 Q 44 6 56 6" fill="none" stroke="#2a6894" stroke-width="2"/>
+          <line x1="32" y1="6" x2="32" y2="34" stroke="#c44a2b" stroke-width="1" stroke-dasharray="3 2"/>
+          <circle cx="32" cy="17" r="3" fill="#c44a2b"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Quantitative Pharmacology</span>
+          <span class="journal-sub">Vol. 34 &middot; Issue 02 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/pharmacokinetics/">ADME</a>
+        <a href="{{ base_url }}/interactions/">INTERACTIONS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/dose-response/templates/page.html
+++ b/dose-response/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/dose-response/templates/post.html
+++ b/dose-response/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/dose-response/templates/section.html
+++ b/dose-response/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/dose-response/templates/shortcodes/alert.html
+++ b/dose-response/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/dose-response/templates/taxonomy.html
+++ b/dose-response/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Subject index and keyword cross-references for this pharmacological paper.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/dose-response/templates/taxonomy_term.html
+++ b/dose-response/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">SUBJECT INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Sections cross-referenced to this subject keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3965,5 +3965,12 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "dose-response": [
+    "paper",
+    "light",
+    "pharmacological",
+    "dose-response",
+    "clinical"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds new dose-response example site for Issue #1634
- Pharmacological Curve Paper with light theme featuring SVG sigmoid dose-response curves with EC50 annotations, therapeutic window diagrams, drug interaction combination index diagrams, and ADME flow diagrams
- Uses IBM Plex Sans Bold/Roboto Bold for display and STIX Two/Noto Serif for body
- Updates tags.json with new entry: paper, light, pharmacological, dose-response, clinical

## Test plan
- [ ] Verify `hwaro build` completes successfully in the dose-response directory
- [ ] Verify site renders correctly with `hwaro serve`
- [ ] Check all SVG diagrams render properly (dose-response curve, therapeutic window, combination index, ADME flow)
- [ ] Confirm light theme colors and drug name typography
- [ ] Verify tags.json is valid JSON with no missing entries