### PR TITLE
Add network-meta example site

### DIFF
--- a/network-meta/AGENTS.md
+++ b/network-meta/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/network-meta/config.toml
+++ b/network-meta/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Network Meta-Analysis - Network Comparison Paper
+# Issue #1635 | Tags: paper, dark, network, meta-analysis, comparative
+# =============================================================================
+
+title = "Network Meta-Analysis of Biologic Therapies"
+description = "A network meta-analysis comparing biologic therapies for moderate-to-severe rheumatoid arthritis, with network geometry diagrams, rankograms, league tables, and comparison-adjusted funnel plots."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/network-meta/content/appendix.md
+++ b/network-meta/content/appendix.md
@@ -1,0 +1,132 @@
++++
+title = "Appendix"
+description = "Supplementary methodology, model convergence diagnostics, sensitivity analyses, and author contributions for the network meta-analysis."
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Supplementary Material</p>
+  <h1 class="paper-title">Appendix</h1>
+</header>
+
+## Appendix A: Search Strategy
+
+The systematic search was conducted across the following databases through September 30, 2025:
+
+- **MEDLINE** (via PubMed): 1966 to September 2025
+- **Embase** (via Ovid): 1974 to September 2025
+- **Cochrane Central Register of Controlled Trials (CENTRAL)**: Issue 9, 2025
+- **ClinicalTrials.gov** and **WHO ICTRP**: searched October 1, 2025
+
+Search terms combined MeSH headings and free-text terms for the population (rheumatoid arthritis), interventions (adalimumab, etanercept, infliximab, tocilizumab, tofacitinib, and their brand names), and study design (randomized controlled trial). No language restrictions were applied. Reference lists of included studies and relevant systematic reviews were hand-searched.
+
+## Appendix B: Model Specification
+
+The network meta-analysis was implemented in a Bayesian framework using Markov chain Monte Carlo (MCMC) sampling via JAGS 4.3.1 called from R 4.3.2. The model specification followed the NICE Decision Support Unit Technical Support Document 2.
+
+### Likelihood and Link Function
+
+A binomial likelihood with logit link was used:
+
+- r<sub>ik</sub> ~ Bin(p<sub>ik</sub>, n<sub>ik</sub>)
+- logit(p<sub>ik</sub>) = mu<sub>i</sub> + delta<sub>ik</sub>
+
+where r<sub>ik</sub> is the number of ACR50 responders in arm k of trial i, n<sub>ik</sub> is the total number randomized, mu<sub>i</sub> is the trial-specific baseline effect, and delta<sub>ik</sub> is the trial-specific treatment effect relative to the baseline treatment.
+
+### Prior Distributions
+
+- Treatment effects d<sub>1k</sub>: N(0, 10000)
+- Between-study SD (tau): Uniform(0, 2)
+- Baseline effects mu<sub>i</sub>: N(0, 10000)
+
+## Appendix C: Convergence Diagnostics
+
+<div class="diagnostic-box">
+  <p class="diag-label">MCMC Convergence Summary</p>
+  Chains: 4<br>
+  Burn-in: 50,000 iterations<br>
+  Sampling: 100,000 iterations (thinned by 10)<br>
+  Effective samples per parameter: 10,000<br>
+  <br>
+  Gelman-Rubin R-hat (all parameters): max 1.003<br>
+  Geweke z-scores: all |z| &lt; 1.96<br>
+  Heidelberger-Welch stationarity: all passed<br>
+  Brooks-Gelman-Rubin multivariate PSRF: 1.001
+</div>
+
+Trace plots and density plots for all treatment effect parameters showed satisfactory mixing and convergence. Autocorrelation was negligible after thinning by a factor of 10. The effective sample size exceeded 10,000 for all monitored parameters.
+
+### Model Fit
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Model comparison: fixed-effects vs random-effects.</caption>
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>Residual deviance</th>
+      <th>pD</th>
+      <th>DIC</th>
+      <th>tau (95% CrI)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Fixed-effects</td>
+      <td class="num">102.8</td>
+      <td class="num">46</td>
+      <td class="num">420.3</td>
+      <td class="num">&mdash;</td>
+    </tr>
+    <tr>
+      <td>Random-effects</td>
+      <td class="num">86.4</td>
+      <td class="num">52.3</td>
+      <td class="num">412.7</td>
+      <td class="num">0.18 (0.08, 0.34)</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">pD = effective number of parameters. DIC = deviance information criterion. Lower DIC indicates better model fit. The random-effects model was selected based on lower DIC and improved residual deviance.</td></tr>
+  </tfoot>
+</table>
+
+## Appendix D: Sensitivity Analyses
+
+Three pre-specified sensitivity analyses were performed:
+
+1. **Excluding studies with high risk of bias**: Removal of 7 studies rated as high risk of bias on the Cochrane Risk of Bias 2.0 tool did not materially alter the treatment rankings (SUCRA values changed by less than 4 percentage points for all treatments).
+
+2. **Informative prior for heterogeneity**: Using a log-normal prior for the between-study variance (informed by the Turner et al. predictive distributions for pharmacological interventions on semi-objective outcomes) yielded a posterior median tau of 0.16 (95% CrI 0.06 to 0.31), with no change in the direction or significance of any pairwise comparison.
+
+3. **Fixed-effects model**: The fixed-effects analysis produced similar point estimates but narrower credible intervals. The ranking order was unchanged (tocilizumab first, tofacitinib second).
+
+## Appendix E: Inconsistency Assessment
+
+Consistency between direct and indirect evidence was evaluated using three approaches:
+
+- **Node-splitting**: None of the 10 comparisons with both direct and indirect evidence showed statistically significant inconsistency (all p > 0.10).
+- **Global Wald test**: chi-squared = 6.42 on 6 df, p = 0.38.
+- **Design-by-treatment interaction model**: No significant inconsistency detected (p = 0.44).
+
+## CRediT Author Contributions
+
+- **Jisoo Park**: Conceptualization, methodology, formal analysis, software, writing (original draft), project administration
+- **Folake Adeyemi**: Data curation, investigation, writing (review and editing), validation
+- **Marek Kowalski**: Methodology, formal analysis, writing (review and editing), visualization
+- **Wei Chen**: Conceptualization, supervision, funding acquisition, writing (review and editing)
+
+## Funding
+
+This work was supported by the National Research Foundation (Grant NRF-2025-EBM-04182). The funder had no role in study design, data collection, analysis, or manuscript preparation.
+
+## Conflicts of Interest
+
+JP has received consulting fees from Roche unrelated to this work. FA, MK, and WC declare no competing interests.
+
+## Data Availability
+
+The extracted dataset and JAGS model code are available at https://doi.org/10.5281/zenodo.XXXXXXX. Individual patient data are not available due to the aggregate nature of the included studies.
+
+## Correspondence
+
+Jisoo Park, Department of Biostatistics, Langford School of Public Health, 200 University Drive, Langford, MA 02140. Email: j.park@langford.edu

--- a/network-meta/content/index.md
+++ b/network-meta/content/index.md
@@ -1,0 +1,199 @@
++++
+title = "Abstract"
+description = "Comparative efficacy of biologic therapies for moderate-to-severe rheumatoid arthritis: a Bayesian network meta-analysis of randomized controlled trials."
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Network Meta-Analysis &middot; Open Access</p>
+  <h1 class="paper-title">Comparative Efficacy of Biologic Therapies for Moderate-to-Severe Rheumatoid Arthritis: A Bayesian Network Meta-Analysis</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Jisoo Park</span><sup>1,*</sup>,
+    Folake Adeyemi<sup>2</sup>,
+    Marek Kowalski<sup>3</sup>,
+    Wei Chen<sup>1,4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Biostatistics, Langford School of Public Health &middot;
+    <sup>2</sup>Centre for Rheumatology Research, University of Lagos Teaching Hospital &middot;
+    <sup>3</sup>Division of Evidence Synthesis, Jagiellonian University Medical College &middot;
+    <sup>4</sup>Collaborative Centre for Health Technology Assessment, Singapore
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.52104/esm.2026.11.01.022</a> &middot; <strong>Received:</strong> 14 Oct 2025 &middot; <strong>Accepted:</strong> 22 Feb 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Multiple biologic disease-modifying antirheumatic drugs (bDMARDs) and targeted synthetic DMARDs (tsDMARDs) are approved for moderate-to-severe rheumatoid arthritis, yet head-to-head trials comparing all available agents remain scarce. Network meta-analysis enables indirect comparisons across a connected evidence network.</dd>
+    <dt>Methods</dt>
+    <dd>We searched MEDLINE, Embase, CENTRAL, and clinical trial registries through September 2025 for randomized controlled trials of at least 24 weeks duration comparing adalimumab, etanercept, infliximab, tocilizumab, or tofacitinib against placebo or each other in adults with moderate-to-severe RA despite conventional DMARD therapy. The primary outcome was ACR50 response at 24 weeks. A Bayesian random-effects network meta-analysis was fitted using a binomial likelihood with a logit link. Ranking probabilities were estimated via the surface under the cumulative ranking curve (SUCRA).</dd>
+    <dt>Results</dt>
+    <dd>Forty-two RCTs (n = 15,843 patients) formed a connected network of six treatments and ten direct comparisons. All five active treatments were superior to placebo for ACR50 response. Tocilizumab ranked first (SUCRA 87.2%), followed by tofacitinib (78.4%), etanercept (65.1%), adalimumab (58.3%), and infliximab (49.8%). The league table showed that tocilizumab was statistically superior to infliximab (OR 1.42, 95% CrI 1.04 to 1.94) but not to the other active agents. No significant inconsistency was detected (global Wald test p = 0.38).</dd>
+    <dt>Conclusion</dt>
+    <dd>All five biologic and targeted synthetic DMARDs demonstrated clinically meaningful efficacy over placebo. Tocilizumab showed the highest probability of being the most efficacious treatment for ACR50 response, though differences among the active agents were generally modest. These findings support individualized treatment selection based on patient-specific factors alongside relative efficacy data.</dd>
+    <dt>Keywords</dt>
+    <dd><em>network meta-analysis; rheumatoid arthritis; biologic therapy; adalimumab; etanercept; infliximab; tocilizumab; tofacitinib; SUCRA; league table</em></dd>
+  </dl>
+</section>
+
+## Network Geometry
+
+<figure class="figure">
+  <svg viewBox="0 0 720 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Network geometry diagram showing six treatment nodes and their connecting edges weighted by number of trials">
+    <!-- background -->
+    <rect x="0" y="0" width="720" height="480" fill="#0c0f16"/>
+    <!-- edges (drawn first, behind nodes) -->
+    <!-- Placebo--Adalimumab: 8 trials -->
+    <line x1="360" y1="80" x2="160" y2="200" stroke="#4a5568" stroke-width="6" opacity="0.7"/>
+    <!-- Placebo--Etanercept: 7 trials -->
+    <line x1="360" y1="80" x2="560" y2="200" stroke="#4a5568" stroke-width="5.5" opacity="0.7"/>
+    <!-- Placebo--Infliximab: 6 trials -->
+    <line x1="360" y1="80" x2="160" y2="380" stroke="#4a5568" stroke-width="5" opacity="0.7"/>
+    <!-- Placebo--Tocilizumab: 7 trials -->
+    <line x1="360" y1="80" x2="560" y2="380" stroke="#4a5568" stroke-width="5.5" opacity="0.7"/>
+    <!-- Placebo--Tofacitinib: 5 trials -->
+    <line x1="360" y1="80" x2="360" y2="420" stroke="#4a5568" stroke-width="4" opacity="0.7"/>
+    <!-- Adalimumab--Etanercept: 2 trials -->
+    <line x1="160" y1="200" x2="560" y2="200" stroke="#4a5568" stroke-width="2" opacity="0.7"/>
+    <!-- Adalimumab--Infliximab: 1 trial -->
+    <line x1="160" y1="200" x2="160" y2="380" stroke="#4a5568" stroke-width="1.2" opacity="0.7"/>
+    <!-- Etanercept--Tocilizumab: 2 trials -->
+    <line x1="560" y1="200" x2="560" y2="380" stroke="#4a5568" stroke-width="2" opacity="0.7"/>
+    <!-- Adalimumab--Tofacitinib: 1 trial -->
+    <line x1="160" y1="200" x2="360" y2="420" stroke="#4a5568" stroke-width="1.2" opacity="0.7"/>
+    <!-- Tocilizumab--Tofacitinib: 1 trial -->
+    <line x1="560" y1="380" x2="360" y2="420" stroke="#4a5568" stroke-width="1.2" opacity="0.7"/>
+    <!-- nodes -->
+    <!-- Placebo (n=4210) - largest sample -->
+    <circle cx="360" cy="80" r="28" fill="none" stroke="#8e8a7e" stroke-width="2.5"/>
+    <text x="360" y="75" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#8e8a7e">Placebo</text>
+    <text x="360" y="90" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=4210</text>
+    <!-- Adalimumab (n=3180) -->
+    <circle cx="160" cy="200" r="24" fill="none" stroke="#5a8fba" stroke-width="2.5"/>
+    <text x="160" y="195" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#5a8fba">Adalimumab</text>
+    <text x="160" y="210" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=3180</text>
+    <!-- Etanercept (n=2640) -->
+    <circle cx="560" cy="200" r="22" fill="none" stroke="#6bbf6b" stroke-width="2.5"/>
+    <text x="560" y="195" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#6bbf6b">Etanercept</text>
+    <text x="560" y="210" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=2640</text>
+    <!-- Infliximab (n=2120) -->
+    <circle cx="160" cy="380" r="20" fill="none" stroke="#d4a03c" stroke-width="2.5"/>
+    <text x="160" y="375" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#d4a03c">Infliximab</text>
+    <text x="160" y="390" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=2120</text>
+    <!-- Tocilizumab (n=2480) -->
+    <circle cx="560" cy="380" r="21" fill="none" stroke="#c45a7c" stroke-width="2.5"/>
+    <text x="560" y="375" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#c45a7c">Tocilizumab</text>
+    <text x="560" y="390" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=2480</text>
+    <!-- Tofacitinib (n=1213) -->
+    <circle cx="360" cy="420" r="16" fill="none" stroke="#9b6fd4" stroke-width="2.5"/>
+    <text x="360" y="415" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#9b6fd4">Tofacitinib</text>
+    <text x="360" y="430" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5e5b52">n=1213</text>
+    <!-- edge trial count labels -->
+    <text x="248" y="132" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">8</text>
+    <text x="472" y="132" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">7</text>
+    <text x="244" y="238" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">6</text>
+    <text x="472" y="238" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">7</text>
+    <text x="368" y="256" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">5</text>
+    <text x="360" y="193" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">2</text>
+    <text x="145" y="290" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">1</text>
+    <text x="575" y="290" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">2</text>
+    <text x="248" y="320" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">1</text>
+    <text x="472" y="410" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7e7a6e">1</text>
+    <!-- legend -->
+    <text x="30" y="465" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#7e7a6e" letter-spacing="1">NODE SIZE = SAMPLE SIZE</text>
+    <text x="360" y="465" font-family="IBM Plex Sans" font-weight="600" font-size="9" fill="#7e7a6e" letter-spacing="1">EDGE WIDTH = NUMBER OF TRIALS</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Network geometry for ACR50 response at 24 weeks. Node diameter is proportional to total sample size randomized to each treatment. Edge thickness is proportional to the number of direct comparison trials. Numbers on edges indicate trial counts. The network is fully connected with 6 nodes and 10 edges across 42 RCTs (n = 15,843).</div>
+</figure>
+
+## League Table (Summary)
+
+<div class="table-wrap">
+<table class="league-table">
+  <caption><span class="tab-num">Table 1.</span> League table of pairwise odds ratios (95% CrI) for ACR50 response. Read across rows: OR &gt; 1 favors the row treatment over the column treatment.</caption>
+  <thead>
+    <tr>
+      <th></th>
+      <th>PBO</th>
+      <th>ADA</th>
+      <th>ETN</th>
+      <th>IFX</th>
+      <th>TCZ</th>
+      <th>TOF</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="diagonal">Placebo</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.31 (0.24, 0.40)</td>
+      <td class="num">0.29 (0.22, 0.38)</td>
+      <td class="num">0.34 (0.25, 0.46)</td>
+      <td class="num">0.24 (0.18, 0.33)</td>
+      <td class="num">0.27 (0.19, 0.38)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Adalimumab</td>
+      <td class="num favor-treatment">3.22 (2.51, 4.13)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.93 (0.68, 1.28)</td>
+      <td class="num">1.10 (0.78, 1.56)</td>
+      <td class="num">0.78 (0.55, 1.10)</td>
+      <td class="num">0.87 (0.58, 1.29)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Etanercept</td>
+      <td class="num favor-treatment">3.46 (2.65, 4.52)</td>
+      <td class="num">1.07 (0.78, 1.47)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">1.18 (0.83, 1.69)</td>
+      <td class="num">0.84 (0.59, 1.19)</td>
+      <td class="num">0.93 (0.62, 1.40)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Infliximab</td>
+      <td class="num favor-treatment">2.94 (2.19, 3.94)</td>
+      <td class="num">0.91 (0.64, 1.29)</td>
+      <td class="num">0.85 (0.59, 1.21)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.71 (0.49, 1.02)</td>
+      <td class="num">0.79 (0.52, 1.21)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Tocilizumab</td>
+      <td class="num favor-treatment">4.14 (3.07, 5.59)</td>
+      <td class="num">1.29 (0.91, 1.82)</td>
+      <td class="num">1.20 (0.84, 1.71)</td>
+      <td class="num favor-treatment">1.42 (1.04, 1.94)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">1.12 (0.74, 1.69)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Tofacitinib</td>
+      <td class="num favor-treatment">3.68 (2.62, 5.18)</td>
+      <td class="num">1.14 (0.77, 1.71)</td>
+      <td class="num">1.07 (0.71, 1.60)</td>
+      <td class="num">1.26 (0.83, 1.92)</td>
+      <td class="num">0.89 (0.59, 1.35)</td>
+      <td class="diagonal">&mdash;</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="7">PBO = placebo; ADA = adalimumab; ETN = etanercept; IFX = infliximab; TCZ = tocilizumab; TOF = tofacitinib. Statistically significant results (95% CrI excludes 1) shown in color. OR &gt; 1 favors row treatment.</td></tr>
+  </tfoot>
+</table>
+</div>
+
+## Structure of the Paper
+
+Navigate the full manuscript through the section index. The paper contains the following numbered sections:
+
+<ol class="section-list">
+  <li><a href="{{ base_url }}/sections/1-introduction/">Introduction</a> -- clinical background, review rationale, and objectives</li>
+  <li><a href="{{ base_url }}/sections/2-network-geometry/">Network Geometry</a> -- search strategy, evidence network, and node/edge characteristics</li>
+  <li><a href="{{ base_url }}/sections/3-pairwise-results/">Pairwise Results</a> -- odds ratios, credible intervals, and the full league table</li>
+  <li><a href="{{ base_url }}/sections/4-ranking-analysis/">Ranking Analysis</a> -- SUCRA values, rankograms, and cumulative ranking curves</li>
+  <li><a href="{{ base_url }}/sections/5-discussion/">Discussion</a> -- interpretation, strengths, limitations, and clinical implications</li>
+</ol>

--- a/network-meta/content/league-table.md
+++ b/network-meta/content/league-table.md
@@ -1,0 +1,160 @@
++++
+title = "League Table"
+description = "Full pairwise league table of odds ratios and 95% credible intervals for ACR50 response at 24 weeks across all six treatments."
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Full Results</p>
+  <h1 class="paper-title">League Table: Pairwise Comparisons</h1>
+  <p class="paper-lede">All pairwise odds ratios (95% credible intervals) from the Bayesian random-effects network meta-analysis. The primary outcome is ACR50 response at 24 weeks.</p>
+</header>
+
+## Reading the League Table
+
+Each cell contains the odds ratio (OR) and 95% credible interval (CrI) for the comparison between the row treatment and the column treatment. An OR greater than 1 indicates that the row treatment is favored over the column treatment. Cells where the 95% CrI excludes 1 represent statistically significant differences.
+
+<div class="table-wrap">
+<table class="league-table">
+  <caption><span class="tab-num">Table 2.</span> Complete league table for ACR50 response at 24 weeks. Read across: OR &gt; 1 favors row over column.</caption>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Placebo</th>
+      <th>Adalimumab</th>
+      <th>Etanercept</th>
+      <th>Infliximab</th>
+      <th>Tocilizumab</th>
+      <th>Tofacitinib</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="diagonal">Placebo</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.31 (0.24, 0.40)</td>
+      <td class="num">0.29 (0.22, 0.38)</td>
+      <td class="num">0.34 (0.25, 0.46)</td>
+      <td class="num">0.24 (0.18, 0.33)</td>
+      <td class="num">0.27 (0.19, 0.38)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Adalimumab</td>
+      <td class="num favor-treatment">3.22 (2.51, 4.13)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.93 (0.68, 1.28)</td>
+      <td class="num">1.10 (0.78, 1.56)</td>
+      <td class="num">0.78 (0.55, 1.10)</td>
+      <td class="num">0.87 (0.58, 1.29)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Etanercept</td>
+      <td class="num favor-treatment">3.46 (2.65, 4.52)</td>
+      <td class="num">1.07 (0.78, 1.47)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">1.18 (0.83, 1.69)</td>
+      <td class="num">0.84 (0.59, 1.19)</td>
+      <td class="num">0.93 (0.62, 1.40)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Infliximab</td>
+      <td class="num favor-treatment">2.94 (2.19, 3.94)</td>
+      <td class="num">0.91 (0.64, 1.29)</td>
+      <td class="num">0.85 (0.59, 1.21)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">0.71 (0.49, 1.02)</td>
+      <td class="num">0.79 (0.52, 1.21)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Tocilizumab</td>
+      <td class="num favor-treatment">4.14 (3.07, 5.59)</td>
+      <td class="num">1.29 (0.91, 1.82)</td>
+      <td class="num">1.20 (0.84, 1.71)</td>
+      <td class="num favor-treatment">1.42 (1.04, 1.94)</td>
+      <td class="diagonal">&mdash;</td>
+      <td class="num">1.12 (0.74, 1.69)</td>
+    </tr>
+    <tr>
+      <td class="diagonal">Tofacitinib</td>
+      <td class="num favor-treatment">3.68 (2.62, 5.18)</td>
+      <td class="num">1.14 (0.77, 1.71)</td>
+      <td class="num">1.07 (0.71, 1.60)</td>
+      <td class="num">1.26 (0.83, 1.92)</td>
+      <td class="num">0.89 (0.59, 1.35)</td>
+      <td class="diagonal">&mdash;</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="7">Values are odds ratios (95% credible intervals) from the Bayesian random-effects model. Statistically significant comparisons (CrI excludes 1) are highlighted. OR &gt; 1 favors the row treatment over the column treatment.</td></tr>
+  </tfoot>
+</table>
+</div>
+
+## Key Findings from the League Table
+
+### All Actives vs Placebo
+
+All five active treatments demonstrated statistically significant superiority over placebo for ACR50 response at 24 weeks:
+
+- **Tocilizumab vs placebo:** OR 4.14 (95% CrI 3.07 to 5.59)
+- **Tofacitinib vs placebo:** OR 3.68 (95% CrI 2.62 to 5.18)
+- **Etanercept vs placebo:** OR 3.46 (95% CrI 2.65 to 4.52)
+- **Adalimumab vs placebo:** OR 3.22 (95% CrI 2.51 to 4.13)
+- **Infliximab vs placebo:** OR 2.94 (95% CrI 2.19 to 3.94)
+
+### Active vs Active Comparisons
+
+Among the 10 pairwise comparisons of active treatments, only one reached statistical significance:
+
+- **Tocilizumab vs infliximab:** OR 1.42 (95% CrI 1.04 to 1.94), favoring tocilizumab
+
+The remaining nine active-vs-active comparisons yielded credible intervals that crossed 1, indicating no statistically significant difference at the 95% credibility level. Point estimates generally favored tocilizumab and tofacitinib over the other agents, consistent with the SUCRA ranking order.
+
+### Heterogeneity Assessment
+
+The between-study heterogeneity standard deviation was estimated as tau = 0.18 (95% CrI 0.08 to 0.34), indicating low-to-moderate heterogeneity. The predictive intervals for treatment effects were modestly wider than the credible intervals but did not alter the direction of any comparison.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Heterogeneity and model fit statistics.</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Estimate</th>
+      <th>95% CrI</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Between-study SD (tau)</td>
+      <td class="num">0.18</td>
+      <td class="num">0.08, 0.34</td>
+    </tr>
+    <tr>
+      <td>Residual deviance</td>
+      <td class="num">86.4</td>
+      <td class="num">&mdash;</td>
+    </tr>
+    <tr>
+      <td>Total data points</td>
+      <td class="num">88</td>
+      <td class="num">&mdash;</td>
+    </tr>
+    <tr>
+      <td>DIC</td>
+      <td class="num">412.7</td>
+      <td class="num">&mdash;</td>
+    </tr>
+    <tr>
+      <td>Global inconsistency (Wald p)</td>
+      <td class="num">0.38</td>
+      <td class="num">&mdash;</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="3">Residual deviance close to the number of data points indicates adequate model fit. DIC = deviance information criterion.</td></tr>
+  </tfoot>
+</table>
+
+<footer class="paper-section-footer">
+  <a href="{{ base_url }}/rankings/" class="button-link">Ranking analysis &rarr;</a>
+</footer>

--- a/network-meta/content/rankings.md
+++ b/network-meta/content/rankings.md
@@ -1,0 +1,179 @@
++++
+title = "Rankings"
+description = "Treatment ranking probabilities, SUCRA values, and rankograms for ACR50 response at 24 weeks."
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Ranking Analysis</p>
+  <h1 class="paper-title">Treatment Rankings and Rankograms</h1>
+  <p class="paper-lede">Surface under the cumulative ranking curve (SUCRA) values and probability distributions for each treatment's rank across the posterior sample.</p>
+</header>
+
+## SUCRA Summary
+
+The SUCRA statistic represents the probability that a treatment is among the best options, expressed as a percentage. A SUCRA of 100% would indicate a treatment is certainly the best; 0% indicates it is certainly the worst.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> SUCRA values and median ranks for ACR50 response at 24 weeks.</caption>
+  <thead>
+    <tr>
+      <th>Treatment</th>
+      <th>SUCRA (%)</th>
+      <th>Median rank</th>
+      <th>P(Best)</th>
+      <th>P(Worst active)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tocilizumab</td>
+      <td class="num">87.2</td>
+      <td class="num">1</td>
+      <td class="num">0.42</td>
+      <td class="num">0.02</td>
+    </tr>
+    <tr>
+      <td>Tofacitinib</td>
+      <td class="num">78.4</td>
+      <td class="num">2</td>
+      <td class="num">0.28</td>
+      <td class="num">0.05</td>
+    </tr>
+    <tr>
+      <td>Etanercept</td>
+      <td class="num">65.1</td>
+      <td class="num">3</td>
+      <td class="num">0.14</td>
+      <td class="num">0.10</td>
+    </tr>
+    <tr>
+      <td>Adalimumab</td>
+      <td class="num">58.3</td>
+      <td class="num">3</td>
+      <td class="num">0.10</td>
+      <td class="num">0.18</td>
+    </tr>
+    <tr>
+      <td>Infliximab</td>
+      <td class="num">49.8</td>
+      <td class="num">4</td>
+      <td class="num">0.06</td>
+      <td class="num">0.31</td>
+    </tr>
+    <tr>
+      <td>Placebo</td>
+      <td class="num">1.2</td>
+      <td class="num">6</td>
+      <td class="num">0.00</td>
+      <td class="num">&mdash;</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">P(Best) = probability of ranking first among all six treatments. P(Worst active) = probability of ranking last among the five active treatments. Placebo excluded from worst-active calculation.</td></tr>
+  </tfoot>
+</table>
+
+## Rankogram
+
+The rankogram shows the probability of each treatment achieving each rank (1st through 6th) based on the posterior distribution from the Bayesian model.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Rankogram showing probability of each treatment being ranked 1st through 6th for ACR50 response">
+    <rect x="0" y="0" width="720" height="420" fill="#0c0f16"/>
+    <!-- axis labels -->
+    <text x="360" y="405" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="11" fill="#7e7a6e">Rank</text>
+    <text x="18" y="200" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="11" fill="#7e7a6e" transform="rotate(-90 18 200)">Probability</text>
+    <!-- y-axis ticks and grid -->
+    <line x1="60" y1="40" x2="60" y2="370" stroke="#2a2f3e" stroke-width="1"/>
+    <line x1="60" y1="370" x2="700" y2="370" stroke="#2a2f3e" stroke-width="1"/>
+    <!-- y gridlines: 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 -->
+    <line x1="60" y1="370" x2="700" y2="370" stroke="#2a2f3e" stroke-width="0.5"/>
+    <text x="52" y="374" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.0</text>
+    <line x1="60" y1="304" x2="700" y2="304" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <text x="52" y="308" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.1</text>
+    <line x1="60" y1="238" x2="700" y2="238" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <text x="52" y="242" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.2</text>
+    <line x1="60" y1="172" x2="700" y2="172" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <text x="52" y="176" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.3</text>
+    <line x1="60" y1="106" x2="700" y2="106" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <text x="52" y="110" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.4</text>
+    <line x1="60" y1="40" x2="700" y2="40" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <text x="52" y="44" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.5</text>
+    <!-- x-axis rank labels -->
+    <!-- Rank groups at x: 115, 222, 329, 436, 543, 650 -->
+    <text x="115" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">1st</text>
+    <text x="222" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">2nd</text>
+    <text x="329" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">3rd</text>
+    <text x="436" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">4th</text>
+    <text x="543" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">5th</text>
+    <text x="650" y="388" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#7e7a6e">6th</text>
+    <!-- Bar width=14, gap=3 between bars within group, 5 bars per group (excl placebo for ranks 1-5, incl for rank 6) -->
+    <!-- Color key: ADA=#5a8fba ETN=#6bbf6b IFX=#d4a03c TCZ=#c45a7c TOF=#9b6fd4 PBO=#8e8a7e -->
+    <!-- RANK 1 probabilities: TCZ=0.42 TOF=0.28 ETN=0.14 ADA=0.10 IFX=0.06 PBO=0.00 -->
+    <!-- scale: 0.5 = 330px height, so 0.1 = 66px -->
+    <!-- group center=115, bars from x=73 -->
+    <rect x="73" y="304" width="14" height="66" fill="#5a8fba"/>
+    <rect x="90" y="277.6" width="14" height="92.4" fill="#6bbf6b"/>
+    <rect x="107" y="330.4" width="14" height="39.6" fill="#d4a03c"/>
+    <rect x="124" y="92.8" width="14" height="277.2" fill="#c45a7c"/>
+    <rect x="141" y="185.2" width="14" height="184.8" fill="#9b6fd4"/>
+    <!-- RANK 2: TCZ=0.26 TOF=0.30 ETN=0.18 ADA=0.16 IFX=0.10 PBO=0.00 -->
+    <rect x="180" y="264.4" width="14" height="105.6" fill="#5a8fba"/>
+    <rect x="197" y="251.2" width="14" height="118.8" fill="#6bbf6b"/>
+    <rect x="214" y="304" width="14" height="66" fill="#d4a03c"/>
+    <rect x="231" y="198.4" width="14" height="171.6" fill="#c45a7c"/>
+    <rect x="248" y="172" width="14" height="198" fill="#9b6fd4"/>
+    <!-- RANK 3: TCZ=0.16 TOF=0.20 ETN=0.28 ADA=0.22 IFX=0.14 PBO=0.00 -->
+    <rect x="287" y="224.8" width="14" height="145.2" fill="#5a8fba"/>
+    <rect x="304" y="185.2" width="14" height="184.8" fill="#6bbf6b"/>
+    <rect x="321" y="277.6" width="14" height="92.4" fill="#d4a03c"/>
+    <rect x="338" y="264.4" width="14" height="105.6" fill="#c45a7c"/>
+    <rect x="355" y="238" width="14" height="132" fill="#9b6fd4"/>
+    <!-- RANK 4: TCZ=0.10 TOF=0.14 ETN=0.22 ADA=0.26 IFX=0.24 PBO=0.04 -->
+    <rect x="394" y="198.4" width="14" height="171.6" fill="#5a8fba"/>
+    <rect x="411" y="224.8" width="14" height="145.2" fill="#6bbf6b"/>
+    <rect x="428" y="211.6" width="14" height="158.4" fill="#d4a03c"/>
+    <rect x="445" y="304" width="14" height="66" fill="#c45a7c"/>
+    <rect x="462" y="277.6" width="14" height="92.4" fill="#9b6fd4"/>
+    <!-- RANK 5: TCZ=0.04 TOF=0.06 ETN=0.14 ADA=0.22 IFX=0.38 PBO=0.16 -->
+    <rect x="501" y="224.8" width="14" height="145.2" fill="#5a8fba"/>
+    <rect x="518" y="277.6" width="14" height="92.4" fill="#6bbf6b"/>
+    <rect x="535" y="118.8" width="14" height="251.2" fill="#d4a03c"/>
+    <rect x="552" y="343.6" width="14" height="26.4" fill="#c45a7c"/>
+    <rect x="569" y="330.4" width="14" height="39.6" fill="#9b6fd4"/>
+    <!-- RANK 6: TCZ=0.02 TOF=0.02 ETN=0.04 ADA=0.04 IFX=0.08 PBO=0.80 -->
+    <rect x="608" y="343.6" width="14" height="26.4" fill="#5a8fba"/>
+    <rect x="625" y="343.6" width="14" height="26.4" fill="#6bbf6b"/>
+    <rect x="642" y="317.2" width="14" height="52.8" fill="#d4a03c"/>
+    <rect x="659" y="356.8" width="14" height="13.2" fill="#c45a7c"/>
+    <rect x="676" y="356.8" width="14" height="13.2" fill="#9b6fd4"/>
+    <!-- Legend -->
+    <rect x="80" y="18" width="10" height="10" fill="#5a8fba"/>
+    <text x="95" y="27" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">ADA</text>
+    <rect x="140" y="18" width="10" height="10" fill="#6bbf6b"/>
+    <text x="155" y="27" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">ETN</text>
+    <rect x="200" y="18" width="10" height="10" fill="#d4a03c"/>
+    <text x="215" y="27" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">IFX</text>
+    <rect x="260" y="18" width="10" height="10" fill="#c45a7c"/>
+    <text x="275" y="27" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">TCZ</text>
+    <rect x="320" y="18" width="10" height="10" fill="#9b6fd4"/>
+    <text x="335" y="27" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">TOF</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Rankogram showing the posterior probability of each active treatment being ranked 1st through 6th for ACR50 response at 24 weeks. Tocilizumab (TCZ) has the highest probability of being ranked first (42%), followed by tofacitinib (TOF, 28%). Placebo bars omitted from ranks 1-5 for clarity (probability near zero); placebo dominates rank 6 with P = 0.80.</div>
+</figure>
+
+## Interpretation of Rankings
+
+Treatment rankings should be interpreted alongside the league table and credible intervals. While SUCRA provides a useful summary for ordering treatments, small differences in SUCRA do not necessarily reflect clinically meaningful differences in efficacy. The overlap in ranking distributions -- particularly among the middle-ranked treatments (etanercept, adalimumab, and tofacitinib) -- indicates substantial uncertainty in the precise ordering.
+
+<div class="result-box">
+  <p class="result-label">Key Finding</p>
+  <p class="result-text">Tocilizumab had the highest probability of ranking first (42%) and a SUCRA of 87.2%, but was not statistically superior to adalimumab, etanercept, or tofacitinib in pairwise comparisons.</p>
+  <p class="result-detail">Rankings are based on the full posterior distribution of treatment effects and account for both direct and indirect evidence. They should inform but not replace clinical judgment regarding individual patient factors.</p>
+</div>
+
+<footer class="paper-section-footer">
+  <a href="{{ base_url }}/league-table/" class="button-link">&larr; League table</a> &nbsp;&nbsp;
+  <a href="{{ base_url }}/appendix/" class="button-link">Appendix &rarr;</a>
+</footer>

--- a/network-meta/content/sections/1-introduction.md
+++ b/network-meta/content/sections/1-introduction.md
@@ -1,0 +1,54 @@
++++
+title = "Introduction"
+description = "Clinical background of rheumatoid arthritis treatment, rationale for network meta-analysis, and study objectives."
+weight = 1
+template = "post"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
+[extra]
+section_number = "1"
++++
+
+## Clinical Background
+
+Rheumatoid arthritis (RA) is a chronic systemic autoimmune disease affecting approximately 0.5 to 1% of the global adult population. Characterized by persistent synovial inflammation, progressive joint destruction, and functional disability, RA imposes substantial morbidity and economic burden. The past two decades have witnessed a transformation in RA management through the introduction of biologic disease-modifying antirheumatic drugs (bDMARDs) and, more recently, targeted synthetic DMARDs (tsDMARDs).
+
+For patients with moderate-to-severe RA who respond inadequately to conventional synthetic DMARDs (csDMARDs) such as methotrexate, clinical guidelines recommend escalation to biologic or targeted synthetic therapy. The available agents target distinct molecular pathways:
+
+- **Adalimumab** (anti-TNF monoclonal antibody)
+- **Etanercept** (soluble TNF receptor fusion protein)
+- **Infliximab** (chimeric anti-TNF monoclonal antibody)
+- **Tocilizumab** (anti-IL-6 receptor monoclonal antibody)
+- **Tofacitinib** (JAK inhibitor, targeted synthetic DMARD)
+
+### The Evidence Gap
+
+While each of these agents has demonstrated superiority over placebo in pivotal randomized controlled trials, the evidence base for choosing among them is fragmented. Head-to-head trials comparing two active treatments directly are expensive and logistically difficult, resulting in a sparse landscape of direct comparisons. Clinicians and patients face the practical question of which agent to select first, but the available evidence rarely provides direct comparative answers.
+
+## Rationale for Network Meta-Analysis
+
+Network meta-analysis (NMA) addresses this evidence gap by synthesizing direct and indirect evidence within a connected network of randomized comparisons. If treatment A has been compared to placebo and treatment B has also been compared to placebo, NMA allows an indirect comparison of A versus B through the common comparator, while preserving the randomization of the original trials.
+
+The Bayesian framework is particularly well suited to NMA because it naturally incorporates uncertainty in all parameters, provides posterior probability distributions for treatment effects, and enables probabilistic ranking of treatments. The SUCRA (surface under the cumulative ranking curve) statistic summarizes ranking probabilities into a single interpretable value.
+
+<div class="result-box">
+  <p class="result-label">Study Objective</p>
+  <p class="result-text">To compare the relative efficacy of five biologic and targeted synthetic DMARDs for ACR50 response in adults with moderate-to-severe rheumatoid arthritis using Bayesian network meta-analysis.</p>
+  <p class="result-detail">Pre-specified secondary objectives included treatment ranking via SUCRA, assessment of network heterogeneity and inconsistency, and evaluation of small-study effects through comparison-adjusted funnel plots.</p>
+</div>
+
+## Scope and Eligibility
+
+### Inclusion Criteria
+
+- **Population**: Adults (aged 18 years or older) with moderate-to-severe RA as defined by the ACR/EULAR 2010 classification criteria or the ACR 1987 revised criteria, with inadequate response to at least one csDMARD
+- **Interventions**: Adalimumab, etanercept, infliximab, tocilizumab, or tofacitinib at approved doses, alone or in combination with csDMARDs
+- **Comparator**: Placebo (with or without background csDMARD) or any of the listed active interventions
+- **Outcome**: ACR50 response at 24 weeks (primary), ACR20 and ACR70 at 24 weeks (secondary)
+- **Design**: Randomized controlled trials with parallel-group design and at least 24 weeks of follow-up
+
+### Exclusion Criteria
+
+- Trials exclusively enrolling biologic-experienced patients
+- Trials using non-approved doses without an approved-dose arm
+- Crossover designs without adequate washout
+- Trials reporting fewer than 10 patients per arm

--- a/network-meta/content/sections/2-network-geometry.md
+++ b/network-meta/content/sections/2-network-geometry.md
@@ -1,0 +1,160 @@
++++
+title = "Network Geometry"
+description = "Description of the evidence network, search results, study characteristics, and the structure of direct and indirect comparisons."
+weight = 2
+template = "post"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
+[extra]
+section_number = "2"
++++
+
+## Search Results
+
+The systematic search identified 3,842 records after deduplication. After title and abstract screening (performed independently by two reviewers with 94% inter-rater agreement), 187 full-text articles were assessed for eligibility. Of these, 42 RCTs met all inclusion criteria and were included in the network meta-analysis. The 42 trials randomized a total of 15,843 patients across the six treatment nodes.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 5.</span> Summary of included studies by treatment comparison.</caption>
+  <thead>
+    <tr>
+      <th>Comparison</th>
+      <th>No. of trials</th>
+      <th>Total patients</th>
+      <th>Median duration (wk)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Adalimumab vs Placebo</td>
+      <td class="num">8</td>
+      <td class="num">3,648</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Etanercept vs Placebo</td>
+      <td class="num">7</td>
+      <td class="num">2,912</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Infliximab vs Placebo</td>
+      <td class="num">6</td>
+      <td class="num">2,286</td>
+      <td class="num">30</td>
+    </tr>
+    <tr>
+      <td>Tocilizumab vs Placebo</td>
+      <td class="num">7</td>
+      <td class="num">3,104</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Tofacitinib vs Placebo</td>
+      <td class="num">5</td>
+      <td class="num">1,762</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Adalimumab vs Etanercept</td>
+      <td class="num">2</td>
+      <td class="num">684</td>
+      <td class="num">26</td>
+    </tr>
+    <tr>
+      <td>Adalimumab vs Infliximab</td>
+      <td class="num">1</td>
+      <td class="num">312</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Etanercept vs Tocilizumab</td>
+      <td class="num">2</td>
+      <td class="num">628</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Adalimumab vs Tofacitinib</td>
+      <td class="num">1</td>
+      <td class="num">286</td>
+      <td class="num">24</td>
+    </tr>
+    <tr>
+      <td>Tocilizumab vs Tofacitinib</td>
+      <td class="num">1</td>
+      <td class="num">221</td>
+      <td class="num">24</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Two multi-arm trials contribute to more than one comparison. Patient counts sum to more than 15,843 because multi-arm trials share control arms across comparisons.</td></tr>
+  </tfoot>
+</table>
+
+## Network Structure
+
+The evidence network is fully connected, meaning that every treatment node can be reached from every other node through at least one path of direct comparisons. Placebo serves as the central hub, with direct evidence connecting it to all five active treatments. Five additional edges connect pairs of active treatments (adalimumab-etanercept, adalimumab-infliximab, etanercept-tocilizumab, adalimumab-tofacitinib, and tocilizumab-tofacitinib).
+
+### Node Characteristics
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 6.</span> Node characteristics: total patients randomized and number of trial arms per treatment.</caption>
+  <thead>
+    <tr>
+      <th>Treatment</th>
+      <th>Total patients</th>
+      <th>No. of arms</th>
+      <th>Median sample per arm</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Placebo</td>
+      <td class="num">4,210</td>
+      <td class="num">33</td>
+      <td class="num">124</td>
+    </tr>
+    <tr>
+      <td>Adalimumab</td>
+      <td class="num">3,180</td>
+      <td class="num">12</td>
+      <td class="num">248</td>
+    </tr>
+    <tr>
+      <td>Etanercept</td>
+      <td class="num">2,640</td>
+      <td class="num">11</td>
+      <td class="num">228</td>
+    </tr>
+    <tr>
+      <td>Tocilizumab</td>
+      <td class="num">2,480</td>
+      <td class="num">10</td>
+      <td class="num">236</td>
+    </tr>
+    <tr>
+      <td>Infliximab</td>
+      <td class="num">2,120</td>
+      <td class="num">7</td>
+      <td class="num">290</td>
+    </tr>
+    <tr>
+      <td>Tofacitinib</td>
+      <td class="num">1,213</td>
+      <td class="num">7</td>
+      <td class="num">168</td>
+    </tr>
+  </tbody>
+</table>
+
+### Edge Characteristics
+
+The majority of evidence flows through the placebo-controlled comparisons, which collectively account for 33 of the 42 included trials (79%). The five active-vs-active edges are supported by a total of 7 trials, with the adalimumab-etanercept and etanercept-tocilizumab comparisons each informed by 2 trials, and the remaining three active-vs-active comparisons each supported by a single trial.
+
+This distribution of evidence is typical for network meta-analyses in rheumatology, where regulatory requirements mandate placebo-controlled pivotal trials but head-to-head trials are conducted less frequently. The implication is that the majority of active-vs-active comparisons rely substantially on indirect evidence through the placebo node.
+
+## Risk of Bias Assessment
+
+Risk of bias was assessed using the Cochrane Risk of Bias 2.0 tool. Of the 42 included trials, 28 (67%) were rated as low risk of bias, 7 (17%) as having some concerns, and 7 (17%) as high risk of bias. The most common source of concern was deviation from intended interventions due to differential dropout rates between active treatment and placebo arms, which is a recognized challenge in RA trials where patients may withdraw due to lack of efficacy.
+
+## Transitivity Assessment
+
+The transitivity assumption -- that indirect comparisons are valid because trials share similar characteristics apart from the treatments compared -- was assessed by examining the distribution of potential effect modifiers across comparisons. The following variables were examined: mean age, proportion female, mean disease duration, mean baseline DAS28, proportion receiving concomitant methotrexate, and geographic region of enrollment. No systematic differences in these modifiers were observed across the network edges, supporting the transitivity assumption.

--- a/network-meta/content/sections/3-pairwise-results.md
+++ b/network-meta/content/sections/3-pairwise-results.md
@@ -1,0 +1,241 @@
++++
+title = "Pairwise Results"
+description = "Network meta-analysis results including odds ratios, credible intervals, and the full league table for ACR50 response."
+weight = 3
+template = "post"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
+[extra]
+section_number = "3"
++++
+
+## Primary Outcome: ACR50 at 24 Weeks
+
+The primary analysis included all 42 trials reporting ACR50 response at 24 weeks. The random-effects model was selected over the fixed-effects model based on lower DIC (412.7 vs 420.3) and adequate residual deviance (86.4 versus 88 data points).
+
+### Active Treatments vs Placebo
+
+All five active treatments were significantly superior to placebo for ACR50 response:
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 7.</span> Active treatments versus placebo for ACR50 at 24 weeks.</caption>
+  <thead>
+    <tr>
+      <th>Treatment</th>
+      <th>OR vs placebo</th>
+      <th>95% CrI</th>
+      <th>Direct evidence</th>
+      <th>NNT</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tocilizumab</td>
+      <td class="num">4.14</td>
+      <td class="num">3.07, 5.59</td>
+      <td class="num">7 trials</td>
+      <td class="num">3.8</td>
+    </tr>
+    <tr>
+      <td>Tofacitinib</td>
+      <td class="num">3.68</td>
+      <td class="num">2.62, 5.18</td>
+      <td class="num">5 trials</td>
+      <td class="num">4.1</td>
+    </tr>
+    <tr>
+      <td>Etanercept</td>
+      <td class="num">3.46</td>
+      <td class="num">2.65, 4.52</td>
+      <td class="num">7 trials</td>
+      <td class="num">4.3</td>
+    </tr>
+    <tr>
+      <td>Adalimumab</td>
+      <td class="num">3.22</td>
+      <td class="num">2.51, 4.13</td>
+      <td class="num">8 trials</td>
+      <td class="num">4.6</td>
+    </tr>
+    <tr>
+      <td>Infliximab</td>
+      <td class="num">2.94</td>
+      <td class="num">2.19, 3.94</td>
+      <td class="num">6 trials</td>
+      <td class="num">5.0</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">NNT = number needed to treat, calculated assuming a baseline placebo response rate of 20%. OR = odds ratio; CrI = credible interval.</td></tr>
+  </tfoot>
+</table>
+
+### Active vs Active Comparisons
+
+Among the 10 pairwise comparisons between active treatments, only one reached statistical significance at the 95% credibility level:
+
+<div class="result-box">
+  <p class="result-label">Significant Pairwise Comparison</p>
+  <p class="result-text">Tocilizumab vs infliximab: OR 1.42 (95% CrI 1.04 to 1.94), favoring tocilizumab.</p>
+  <p class="result-detail">This comparison is informed by both indirect evidence (via the placebo node) and direct evidence (via the etanercept-tocilizumab and adalimumab-infliximab edges contributing to the network structure). The node-splitting analysis confirmed consistency between direct and indirect evidence for this comparison (p = 0.62).</p>
+</div>
+
+The remaining nine active-vs-active comparisons did not reach statistical significance. Point estimates for all comparisons are reported in the full league table.
+
+## Comparison-Adjusted Funnel Plot
+
+The comparison-adjusted funnel plot assesses small-study effects across the network. Each data point represents a study-specific treatment effect, centered on the comparison-specific network estimate.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Comparison-adjusted funnel plot showing study-level treatment effects against standard error for small-study bias assessment">
+    <rect x="0" y="0" width="720" height="440" fill="#0c0f16"/>
+    <!-- axes -->
+    <line x1="80" y1="50" x2="80" y2="380" stroke="#2a2f3e" stroke-width="1"/>
+    <line x1="80" y1="380" x2="680" y2="380" stroke="#2a2f3e" stroke-width="1"/>
+    <!-- axis labels -->
+    <text x="380" y="420" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="11" fill="#7e7a6e">Centered log-OR (study minus network estimate)</text>
+    <text x="24" y="215" text-anchor="middle" font-family="IBM Plex Sans" font-weight="600" font-size="11" fill="#7e7a6e" transform="rotate(-90 24 215)">Standard error</text>
+    <!-- x-axis ticks: -1.5, -1.0, -0.5, 0, 0.5, 1.0, 1.5 -->
+    <!-- x range: 80 to 680 = 600px for -1.5 to 1.5 -->
+    <text x="80" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">-1.5</text>
+    <text x="180" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">-1.0</text>
+    <text x="280" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">-0.5</text>
+    <text x="380" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.0</text>
+    <text x="480" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.5</text>
+    <text x="580" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">1.0</text>
+    <text x="680" y="398" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">1.5</text>
+    <!-- y-axis ticks: 0.0, 0.1, 0.2, 0.3, 0.4 (SE, top=0, bottom=0.4) -->
+    <!-- y range: 50 to 380 = 330px for 0 to 0.4 -->
+    <text x="70" y="54" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.0</text>
+    <text x="70" y="136.5" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.1</text>
+    <text x="70" y="219" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.2</text>
+    <text x="70" y="301.5" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.3</text>
+    <text x="70" y="384" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#4e4b42">0.4</text>
+    <!-- y gridlines -->
+    <line x1="80" y1="132.5" x2="680" y2="132.5" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <line x1="80" y1="215" x2="680" y2="215" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <line x1="80" y1="297.5" x2="680" y2="297.5" stroke="#1a1f2c" stroke-width="0.5" stroke-dasharray="3 4"/>
+    <!-- center line at x=0 -->
+    <line x1="380" y1="50" x2="380" y2="380" stroke="#5a8fba" stroke-width="1" stroke-dasharray="6 4"/>
+    <!-- funnel boundaries (95% CI) -->
+    <!-- At SE=0 (y=50): bounds at 0. At SE=0.4 (y=380): bounds at +/- 1.96*0.4 = +/- 0.784 -->
+    <!-- 0.784 in x = 0.784/1.5 * 300 = 156.8 px from center -->
+    <line x1="380" y1="50" x2="536.8" y2="380" stroke="#2a2f3e" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="380" y1="50" x2="223.2" y2="380" stroke="#2a2f3e" stroke-width="1" stroke-dasharray="4 3"/>
+    <!-- study points (scattered within and slightly outside funnel) -->
+    <!-- x = 380 + (centered_logOR / 1.5) * 300 -->
+    <!-- y = 50 + (SE / 0.4) * 330 -->
+    <!-- ADA vs PBO studies (blue) -->
+    <circle cx="395" cy="190" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="370" cy="165" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="410" cy="230" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="355" cy="250" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="385" cy="210" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="405" cy="280" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="362" cy="195" r="4" fill="#5a8fba" opacity="0.8"/>
+    <circle cx="390" cy="270" r="4" fill="#5a8fba" opacity="0.8"/>
+    <!-- ETN vs PBO studies (green) -->
+    <circle cx="375" cy="180" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="400" cy="200" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="360" cy="240" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="388" cy="175" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="345" cy="260" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="415" cy="290" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <circle cx="372" cy="215" r="4" fill="#6bbf6b" opacity="0.8"/>
+    <!-- IFX vs PBO studies (gold) -->
+    <circle cx="365" cy="195" r="4" fill="#d4a03c" opacity="0.8"/>
+    <circle cx="385" cy="170" r="4" fill="#d4a03c" opacity="0.8"/>
+    <circle cx="400" cy="245" r="4" fill="#d4a03c" opacity="0.8"/>
+    <circle cx="340" cy="285" r="4" fill="#d4a03c" opacity="0.8"/>
+    <circle cx="395" cy="220" r="4" fill="#d4a03c" opacity="0.8"/>
+    <circle cx="420" cy="300" r="4" fill="#d4a03c" opacity="0.8"/>
+    <!-- TCZ vs PBO studies (pink) -->
+    <circle cx="378" cy="155" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="390" cy="185" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="365" cy="210" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="405" cy="190" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="350" cy="250" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="392" cy="235" r="4" fill="#c45a7c" opacity="0.8"/>
+    <circle cx="375" cy="270" r="4" fill="#c45a7c" opacity="0.8"/>
+    <!-- TOF vs PBO studies (purple) -->
+    <circle cx="380" cy="200" r="4" fill="#9b6fd4" opacity="0.8"/>
+    <circle cx="405" cy="255" r="4" fill="#9b6fd4" opacity="0.8"/>
+    <circle cx="362" cy="225" r="4" fill="#9b6fd4" opacity="0.8"/>
+    <circle cx="395" cy="310" r="4" fill="#9b6fd4" opacity="0.8"/>
+    <circle cx="348" cy="295" r="4" fill="#9b6fd4" opacity="0.8"/>
+    <!-- Head-to-head studies (white outline) -->
+    <circle cx="388" cy="275" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="370" cy="310" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="405" cy="290" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="352" cy="325" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="395" cy="305" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="418" cy="340" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <circle cx="375" cy="335" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <!-- Legend -->
+    <circle cx="100" cy="430" r="4" fill="#5a8fba"/>
+    <text x="110" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">ADA</text>
+    <circle cx="160" cy="430" r="4" fill="#6bbf6b"/>
+    <text x="170" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">ETN</text>
+    <circle cx="220" cy="430" r="4" fill="#d4a03c"/>
+    <text x="230" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">IFX</text>
+    <circle cx="280" cy="430" r="4" fill="#c45a7c"/>
+    <text x="290" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">TCZ</text>
+    <circle cx="340" cy="430" r="4" fill="#9b6fd4"/>
+    <text x="350" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">TOF</text>
+    <circle cx="410" cy="430" r="4" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+    <text x="420" y="434" font-family="IBM Plex Sans" font-size="9" fill="#b0ac9e">Head-to-head</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 3.</span> Comparison-adjusted funnel plot for the network meta-analysis. Each point represents a study-specific treatment effect centered on the corresponding network estimate, plotted against its standard error. The dashed lines indicate the 95% pseudo-confidence region. The approximate symmetry around the zero line suggests no substantial small-study bias.</div>
+</figure>
+
+## Inconsistency Assessment
+
+Consistency between direct and indirect evidence is a fundamental assumption of network meta-analysis. We assessed consistency using the node-splitting approach, which separates each comparison into its direct and indirect components and tests for disagreement.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 8.</span> Node-splitting results for comparisons with both direct and indirect evidence.</caption>
+  <thead>
+    <tr>
+      <th>Comparison</th>
+      <th>Direct OR (95% CrI)</th>
+      <th>Indirect OR (95% CrI)</th>
+      <th>p (inconsistency)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>ADA vs ETN</td>
+      <td class="num">0.96 (0.61, 1.52)</td>
+      <td class="num">0.91 (0.62, 1.34)</td>
+      <td class="num">0.84</td>
+    </tr>
+    <tr>
+      <td>ADA vs IFX</td>
+      <td class="num">1.14 (0.64, 2.04)</td>
+      <td class="num">1.08 (0.72, 1.63)</td>
+      <td class="num">0.88</td>
+    </tr>
+    <tr>
+      <td>ETN vs TCZ</td>
+      <td class="num">0.80 (0.48, 1.32)</td>
+      <td class="num">0.86 (0.57, 1.30)</td>
+      <td class="num">0.78</td>
+    </tr>
+    <tr>
+      <td>ADA vs TOF</td>
+      <td class="num">0.92 (0.48, 1.76)</td>
+      <td class="num">0.84 (0.53, 1.34)</td>
+      <td class="num">0.80</td>
+    </tr>
+    <tr>
+      <td>TCZ vs TOF</td>
+      <td class="num">1.18 (0.58, 2.40)</td>
+      <td class="num">1.10 (0.69, 1.75)</td>
+      <td class="num">0.86</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">All inconsistency p-values exceed 0.10, indicating no statistically significant disagreement between direct and indirect evidence for any comparison.</td></tr>
+  </tfoot>
+</table>
+
+The global Wald test for inconsistency yielded chi-squared = 6.42 on 6 degrees of freedom (p = 0.38), providing no evidence of inconsistency at the network level. The design-by-treatment interaction model similarly detected no inconsistency (p = 0.44).

--- a/network-meta/content/sections/4-ranking-analysis.md
+++ b/network-meta/content/sections/4-ranking-analysis.md
@@ -1,0 +1,123 @@
++++
+title = "Ranking Analysis"
+description = "Treatment ranking probabilities, SUCRA values, rankograms, and cumulative ranking curves for ACR50 response."
+weight = 4
+template = "post"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
+[extra]
+section_number = "4"
++++
+
+## SUCRA Values
+
+The surface under the cumulative ranking curve (SUCRA) provides a single numeric summary of each treatment's ranking distribution. SUCRA ranges from 0% (certainly the worst) to 100% (certainly the best). Values close to 50% indicate that a treatment is equally likely to be among the better or worse options.
+
+<div class="result-box">
+  <p class="result-label">Ranking Order (SUCRA)</p>
+  <p class="result-text">Tocilizumab (87.2%) > Tofacitinib (78.4%) > Etanercept (65.1%) > Adalimumab (58.3%) > Infliximab (49.8%) > Placebo (1.2%)</p>
+  <p class="result-detail">SUCRA values are derived from 40,000 posterior samples (4 chains, 10,000 per chain after burn-in and thinning). The ranking order is consistent across all sensitivity analyses.</p>
+</div>
+
+### Probability of Being Best
+
+The probability of each treatment being the best (rank 1) among all six treatments:
+
+- Tocilizumab: 42%
+- Tofacitinib: 28%
+- Etanercept: 14%
+- Adalimumab: 10%
+- Infliximab: 6%
+- Placebo: 0%
+
+The concentration of rank-1 probability between tocilizumab and tofacitinib (70% combined) suggests that one of these two agents is most likely the most efficacious for ACR50 response, though the remaining 30% probability distributed among etanercept, adalimumab, and infliximab reflects meaningful uncertainty.
+
+## Cumulative Ranking Probabilities
+
+The cumulative ranking curve for each treatment shows the probability of being ranked among the top k treatments, for k = 1, 2, ..., 6. The SUCRA value equals the area under this curve, normalized to the number of competing treatments.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 9.</span> Cumulative ranking probabilities: P(rank &le; k) for each treatment.</caption>
+  <thead>
+    <tr>
+      <th>Treatment</th>
+      <th>P(rank 1)</th>
+      <th>P(rank 1-2)</th>
+      <th>P(rank 1-3)</th>
+      <th>P(rank 1-4)</th>
+      <th>P(rank 1-5)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tocilizumab</td>
+      <td class="num">0.42</td>
+      <td class="num">0.68</td>
+      <td class="num">0.84</td>
+      <td class="num">0.94</td>
+      <td class="num">0.98</td>
+    </tr>
+    <tr>
+      <td>Tofacitinib</td>
+      <td class="num">0.28</td>
+      <td class="num">0.58</td>
+      <td class="num">0.78</td>
+      <td class="num">0.92</td>
+      <td class="num">0.98</td>
+    </tr>
+    <tr>
+      <td>Etanercept</td>
+      <td class="num">0.14</td>
+      <td class="num">0.32</td>
+      <td class="num">0.60</td>
+      <td class="num">0.82</td>
+      <td class="num">0.96</td>
+    </tr>
+    <tr>
+      <td>Adalimumab</td>
+      <td class="num">0.10</td>
+      <td class="num">0.26</td>
+      <td class="num">0.48</td>
+      <td class="num">0.74</td>
+      <td class="num">0.96</td>
+    </tr>
+    <tr>
+      <td>Infliximab</td>
+      <td class="num">0.06</td>
+      <td class="num">0.16</td>
+      <td class="num">0.30</td>
+      <td class="num">0.54</td>
+      <td class="num">0.92</td>
+    </tr>
+    <tr>
+      <td>Placebo</td>
+      <td class="num">0.00</td>
+      <td class="num">0.00</td>
+      <td class="num">0.00</td>
+      <td class="num">0.04</td>
+      <td class="num">0.20</td>
+    </tr>
+  </tbody>
+</table>
+
+## Interpretation of Rankings
+
+### Clustering of Active Treatments
+
+The ranking analysis reveals two approximate clusters among the active treatments:
+
+1. **Higher-ranked cluster**: Tocilizumab and tofacitinib, with SUCRA values above 75% and a combined 70% probability of ranking first.
+2. **Middle-ranked cluster**: Etanercept, adalimumab, and infliximab, with SUCRA values between 49% and 65% and overlapping ranking distributions.
+
+The separation between these clusters is modest in absolute terms: the odds ratio between the first-ranked (tocilizumab) and fifth-ranked (infliximab) active treatment is 1.42, and among the middle three treatments, pairwise odds ratios range from 0.85 to 1.18 with all credible intervals crossing 1.
+
+### Caveats on Treatment Rankings
+
+Rankings from network meta-analysis should be interpreted with several caveats:
+
+- **SUCRA values are probabilities, not effect sizes.** A SUCRA of 87% does not mean that a treatment achieves ACR50 in 87% of patients; it means that the treatment has an 87% probability of being among the better options in this network.
+
+- **Small differences in SUCRA can reflect large uncertainty.** The difference between etanercept (SUCRA 65.1%) and adalimumab (SUCRA 58.3%) corresponds to heavily overlapping posterior distributions and a non-significant pairwise OR of 1.07 (95% CrI 0.78 to 1.47).
+
+- **Rankings do not account for safety, tolerability, route of administration, or cost.** Treatment selection should integrate efficacy rankings with patient preferences, comorbidities, and practical considerations.
+
+- **Rankings can be sensitive to the choice of outcome.** The ranking order for ACR50 may differ from rankings based on ACR20, ACR70, or radiographic progression outcomes.

--- a/network-meta/content/sections/5-discussion.md
+++ b/network-meta/content/sections/5-discussion.md
@@ -1,0 +1,105 @@
++++
+title = "Discussion"
+description = "Interpretation of findings, comparison with prior evidence, strengths and limitations, and clinical implications of the network meta-analysis."
+weight = 5
+template = "post"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
+[extra]
+section_number = "5"
++++
+
+## Summary of Findings
+
+This Bayesian network meta-analysis of 42 randomized controlled trials (n = 15,843) compared the efficacy of five biologic and targeted synthetic DMARDs for ACR50 response in adults with moderate-to-severe rheumatoid arthritis. The principal findings are:
+
+1. All five active treatments were significantly superior to placebo, with odds ratios ranging from 2.94 (infliximab) to 4.14 (tocilizumab).
+
+2. Tocilizumab had the highest SUCRA (87.2%) and the greatest probability of ranking first (42%), followed by tofacitinib (SUCRA 78.4%, P(best) 28%).
+
+3. Among active-vs-active comparisons, only tocilizumab vs infliximab reached statistical significance (OR 1.42, 95% CrI 1.04 to 1.94).
+
+4. No inconsistency was detected between direct and indirect evidence, and the comparison-adjusted funnel plot showed no evidence of small-study bias.
+
+## Comparison with Prior Evidence
+
+Our findings are broadly consistent with previous network meta-analyses in this area, while extending the evidence base with more recent trials.
+
+The 2019 Cochrane NMA of biologics for RA (Singh et al.) reported tocilizumab among the highest-ranked treatments for ACR50, consistent with our results. However, that analysis did not include tofacitinib and used a frequentist framework. Our Bayesian approach provides additional information through posterior ranking distributions and probabilistic statements.
+
+A 2022 NMA by Lee and colleagues included tofacitinib but used a narrower set of eligibility criteria (requiring methotrexate co-therapy in all arms), resulting in a smaller network. Our broader inclusion criteria produced a more connected network with greater statistical power for indirect comparisons.
+
+The relative positioning of infliximab as the lowest-ranked active treatment is consistent across multiple prior analyses. This may partly reflect the dosing and administration characteristics of infliximab (intravenous infusion at fixed intervals) compared to the other agents, though pharmacokinetic factors alone cannot fully explain the efficacy differences observed.
+
+## Strengths
+
+This analysis has several methodological strengths:
+
+- **Comprehensive search**: The systematic search covered four major databases and two trial registries with no language restrictions, reducing the risk of publication bias.
+
+- **Bayesian framework**: The Bayesian approach provides coherent posterior distributions for all parameters, enables probabilistic treatment rankings, and handles multi-arm trials naturally.
+
+- **Rigorous consistency assessment**: We used three complementary methods (node-splitting, global Wald test, and design-by-treatment interaction) to evaluate the consistency assumption, all of which were reassuring.
+
+- **Pre-specified sensitivity analyses**: The results were robust to exclusion of high-risk-of-bias studies, use of an informative prior for heterogeneity, and use of a fixed-effects model.
+
+- **Adequate model convergence**: Four independent chains with extensive burn-in and thinning yielded satisfactory convergence diagnostics across all monitored parameters.
+
+## Limitations
+
+Several limitations should be acknowledged:
+
+### Evidence Structure
+
+The network is hub-and-spoke in character, with placebo as the dominant common comparator. Only 7 of 42 trials (17%) directly compared two active treatments. This means that the majority of active-vs-active estimates rely heavily on indirect evidence, which is inherently less precise than direct evidence.
+
+### Outcome Selection
+
+ACR50 at 24 weeks was chosen as the primary outcome because it balances sensitivity and clinical meaningfulness. However, other outcomes -- including ACR20 (more sensitive), ACR70 (more stringent), DAS28 remission, radiographic progression, and patient-reported outcomes -- may yield different ranking orders. A complete assessment of comparative effectiveness should consider multiple outcomes.
+
+### Population Heterogeneity
+
+Despite the favorable transitivity assessment, some residual heterogeneity in patient populations is inevitable. Differences in disease duration, prior treatment history, geographic region, and concomitant therapy may modify the relative treatment effects. The random-effects model partially accounts for this through the between-study variance parameter, but cannot eliminate confounding across studies.
+
+### Missing Agents
+
+This analysis is limited to five agents and does not include other approved biologics (e.g., abatacept, rituximab, certolizumab, golimumab) or additional JAK inhibitors (baricitinib, upadacitinib). A more comprehensive network including all approved agents would provide a fuller picture but would also face greater challenges in maintaining network connectivity and transitivity.
+
+### Time Horizon
+
+All included trials had a minimum follow-up of 24 weeks. Longer-term efficacy and durability of response may differ from the 24-week estimates presented here.
+
+## Clinical Implications
+
+The results of this network meta-analysis support several clinical considerations:
+
+<div class="result-box">
+  <p class="result-label">Clinical Implication 1</p>
+  <p class="result-text">All five agents are effective treatments for moderate-to-severe RA, and the choice among them should not be based solely on relative efficacy rankings.</p>
+  <p class="result-detail">The absolute differences in efficacy among active treatments are modest. Safety profiles, route of administration, patient preference, insurance coverage, and cost should all factor into treatment selection.</p>
+</div>
+
+<div class="result-box">
+  <p class="result-label">Clinical Implication 2</p>
+  <p class="result-text">Tocilizumab may be a preferred option when ACR50 response is the primary treatment goal, particularly over infliximab.</p>
+  <p class="result-detail">Tocilizumab was the only agent to show a statistically significant advantage over another active treatment (infliximab) in this analysis. However, this finding should be weighed against the specific clinical context and patient characteristics.</p>
+</div>
+
+<div class="result-box">
+  <p class="result-label">Clinical Implication 3</p>
+  <p class="result-text">Tofacitinib, as an oral JAK inhibitor, provides a non-injectable alternative with efficacy comparable to the biologic agents.</p>
+  <p class="result-detail">Tofacitinib ranked second in our analysis. The oral route of administration may be preferred by patients who wish to avoid injection or infusion, though the cardiovascular safety signals reported in post-marketing studies of JAK inhibitors should be considered.</p>
+</div>
+
+## Directions for Future Research
+
+Future studies should prioritize:
+
+- Head-to-head trials comparing the highest-ranked treatments directly, to reduce reliance on indirect evidence
+- Network meta-analyses incorporating safety outcomes alongside efficacy, enabling benefit-risk assessments
+- Individual patient data NMA to explore treatment effect modification by patient characteristics
+- Inclusion of newer agents (upadacitinib, filgotinib) as sufficient trial data accumulate
+- Longer follow-up to assess durability of treatment response beyond 24 weeks
+
+## Conclusion
+
+This Bayesian network meta-analysis of 42 RCTs demonstrates that all five biologic and targeted synthetic DMARDs are substantially more efficacious than placebo for ACR50 response in moderate-to-severe RA. Tocilizumab has the highest probability of ranking first, and is the only active treatment with a statistically significant advantage over another active agent (infliximab). However, the differences among the five active treatments are generally modest, and treatment selection should integrate relative efficacy with safety, patient preference, and practical considerations.

--- a/network-meta/content/sections/_index.md
+++ b/network-meta/content/sections/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Section Index"
+description = "The five sections of the network meta-analysis manuscript."
+sort_by = "weight"
+tags = ["paper", "dark", "network", "meta-analysis", "comparative"]
++++
+
+The manuscript is organized into five sections covering the complete network meta-analysis from clinical background through discussion of findings. Each section builds on the preceding material.

--- a/network-meta/static/css/style.css
+++ b/network-meta/static/css/style.css
@@ -1,0 +1,709 @@
+/* ============================================================================
+   Network Meta-Analysis - Biologic Therapies for Rheumatoid Arthritis
+   Dark background, clinical typography. IBM Plex Sans / Inter for display,
+   STIX Two / Crimson Pro for body, JetBrains Mono for monospace & league
+   tables. No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0c0f16;
+  --bg-2: #141820;
+  --bg-3: #1a1f2c;
+  --rule: #2a2f3e;
+  --ink: #d0ccc0;
+  --ink-2: #b0ac9e;
+  --ink-3: #7e7a6e;
+  --ink-4: #4e4b42;
+  --accent: #5a8fba;
+  --accent-2: #4a7da6;
+  --node-placebo: #8e8a7e;
+  --node-ada: #5a8fba;
+  --node-eta: #6bbf6b;
+  --node-inf: #d4a03c;
+  --node-toc: #c45a7c;
+  --node-tof: #9b6fd4;
+  --favor-left: #5a8fba;
+  --favor-right: #d45a5a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding {
+  font-weight: 600;
+}
+
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+}
+
+/* ---------------- Network diagram figure ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- League table ---------------- */
+
+.league-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.league-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.league-table caption .tab-num {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.league-table th,
+.league-table td {
+  text-align: center;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--rule);
+  vertical-align: middle;
+  background: var(--bg-2);
+}
+
+.league-table th {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--bg-3);
+  color: var(--ink);
+  border-bottom: 2px solid var(--ink-4);
+}
+
+.league-table td.diagonal {
+  background: var(--bg-3);
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.league-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  text-align: right;
+  color: var(--ink-2);
+}
+
+.league-table td.favor-treatment {
+  color: var(--favor-left);
+}
+
+.league-table td.favor-comparator {
+  color: var(--favor-right);
+}
+
+.league-table tfoot td {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border: none;
+  background: transparent;
+  text-align: left;
+}
+
+/* ---------------- Standard paper table ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-4);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-article blockquote,
+.paper-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  font-style: italic;
+  color: var(--ink-2);
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Network-specific callout boxes ---------------- */
+
+.result-box {
+  background: var(--bg-2);
+  border: 2px solid var(--rule);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.result-box .result-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.4rem;
+}
+
+.result-box .result-text {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 600;
+  font-size: 1.2rem;
+  line-height: 1.4;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+}
+
+.result-box .result-detail {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.95rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Convergence / diagnostic box ---------------- */
+
+.diagnostic-box {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.2rem 1.6rem;
+  margin: 1.5rem 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.diagnostic-box .diag-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+  counter-reset: ref;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- League table overflow wrapper ---------------- */
+
+.table-wrap {
+  overflow-x: auto;
+  margin: 1.8rem 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-wrap .league-table {
+  margin: 0;
+  min-width: 640px;
+}
+
+/* ---------------- Rankogram bar chart area ---------------- */
+
+.rankogram-wrap {
+  margin: 2rem 0;
+}
+
+.rankogram-wrap svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .paper-title { font-size: 1.6rem; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .league-table { font-size: 0.72rem; }
+  .league-table th, .league-table td { padding: 0.35rem 0.4rem; }
+  .result-box .result-text { font-size: 1.05rem; }
+  .figure svg { padding: 0.4rem; }
+}

--- a/network-meta/templates/404.html
+++ b/network-meta/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / PAGE NOT FOUND</p>
+      <h1 class="paper-section-title">Comparison not found</h1>
+      <p>The reference you followed does not resolve to a section in this manuscript. Return to the abstract to navigate the network.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to the abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/network-meta/templates/footer.html
+++ b/network-meta/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#d0ccc0" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#d0ccc0" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Park J, Adeyemi F, Kowalski M, Chen W. Comparative Efficacy of Biologic Therapies for Rheumatoid Arthritis: A Bayesian Network Meta-Analysis. <em>Evid Synth Methods.</em> 2026;11(1):22-48. doi:10.52104/esm.2026.11.01.022</p>
+        <p class="footer-note">ISSN 2944-1082 &middot; Copyright &copy; 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/network-meta/templates/header.html
+++ b/network-meta/templates/header.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@500;600;700&family=Inter:wght@500;600;700&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#d0ccc0" stroke-width="1.5"/>
+          <circle cx="20" cy="14" r="5" fill="none" stroke="#5a8fba" stroke-width="1.5"/>
+          <circle cx="44" cy="14" r="4" fill="none" stroke="#5a8fba" stroke-width="1.5"/>
+          <circle cx="32" cy="30" r="6" fill="none" stroke="#5a8fba" stroke-width="1.5"/>
+          <line x1="24" y1="17" x2="28" y2="26" stroke="#d0ccc0" stroke-width="1"/>
+          <line x1="40" y1="17" x2="36" y2="26" stroke="#d0ccc0" stroke-width="1"/>
+          <line x1="25" y1="14" x2="40" y2="14" stroke="#d0ccc0" stroke-width="1"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Evidence Synthesis Methods</span>
+          <span class="journal-sub">Vol. 11 &middot; Issue 01 &middot; Mar 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/league-table/">LEAGUE TABLE</a>
+        <a href="{{ base_url }}/rankings/">RANKINGS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/network-meta/templates/page.html
+++ b/network-meta/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/network-meta/templates/post.html
+++ b/network-meta/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/network-meta/templates/section.html
+++ b/network-meta/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/network-meta/templates/shortcodes/alert.html
+++ b/network-meta/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/network-meta/templates/taxonomy.html
+++ b/network-meta/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Subject index and keyword cross-references for this network meta-analysis.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/network-meta/templates/taxonomy_term.html
+++ b/network-meta/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">SUBJECT INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Sections cross-referenced to this subject keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3979,5 +3979,12 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "network-meta": [
+    "paper",
+    "dark",
+    "network",
+    "meta-analysis",
+    "comparative"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds new network-meta example site for Issue #1635
- Network Comparison Paper with dark theme featuring SVG network geometry diagrams with node sizes/edge thickness, rankogram probability charts, league table displays in monospace, and comparison-adjusted funnel plots
- Uses IBM Plex Sans Bold/Inter Bold for display and STIX Two/Crimson Pro for body
- Updates tags.json with new entry: paper, dark, network, meta-analysis, comparative

## Test plan
- [ ] Verify `hwaro build` completes successfully in the network-meta directory
- [ ] Verify site renders correctly with `hwaro serve`
- [ ] Check all SVG diagrams render properly (network geometry, rankogram, funnel plot)
- [ ] Confirm league table displays with monospace numbers
- [ ] Verify tags.json is valid JSON with no missing entries