### PR TITLE
Add genome-paper example site

### DIFF
--- a/genome-paper/AGENTS.md
+++ b/genome-paper/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/genome-paper/config.toml
+++ b/genome-paper/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Genome Paper - Genomic Analysis Paper
+# Issue #1636 | Tags: paper, dark, genomics, bioinformatics, data-intensive
+# =============================================================================
+
+title = "Genome-Wide Association Study of Coronary Artery Disease"
+description = "A genome-wide association study identifying novel risk loci for coronary artery disease through large-scale genotyping and imputation across multi-ethnic cohorts."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/genome-paper/content/appendix.md
+++ b/genome-paper/content/appendix.md
@@ -1,0 +1,59 @@
++++
+title = "Appendix"
+description = "Supplementary methods, data availability statement, and CRediT author contribution roles."
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
++++
+
+## Supplementary Methods
+
+### Genotyping Quality Metrics
+
+Array-level quality was assessed by examining the distribution of GenTrain scores (Illumina) and dish QC values (Affymetrix). Samples with GenTrain score below 0.67 or dish QC below 0.82 were excluded before downstream analysis. Batch effects were evaluated using principal component analysis on genotype intensities (not genotype calls), and batches showing systematic deviation on the first two intensity PCs were flagged for re-clustering.
+
+### Imputation Accuracy Assessment
+
+Imputation accuracy was benchmarked by masking 5 pct of directly genotyped variants and comparing imputed dosages to observed genotypes. Concordance rates exceeded 0.98 for variants with MAF above 0.05 and 0.93 for variants with MAF between 0.01 and 0.05. The R-squared threshold of 0.3 was chosen to balance variant density against imputation noise, consistent with current consortium recommendations.
+
+### Conditional Analysis Procedure
+
+At each genome-wide significant locus, stepwise conditional analysis was performed by including the lead variant as a covariate and re-running association testing until no additional variant reached P < 1 x 10<sup>-6</sup> within a 1 Mb window. This procedure identified secondary signals at the 9p21.3 and <em>PCSK9</em> loci, suggesting allelic heterogeneity at these regions.
+
+## Data Availability
+
+Summary statistics from the cross-ancestry meta-analysis are deposited in the GWAS Catalog under accession GCST90XXXXX and are freely available for download. Individual-level genotype data are available through controlled access from the contributing cohorts via the European Genome-phenome Archive (EGA). Imputation was performed against the TOPMed r3 reference panel, which is available from the NHLBI BioData Catalyst repository.
+
+## Code Availability
+
+Analysis scripts for the full pipeline, from raw data processing through meta-analysis and fine-mapping, are available at the following repository: [https://github.com/okonkwo-lab/cad-gwas-2026](https://github.com/okonkwo-lab/cad-gwas-2026). The repository includes Singularity container definitions, Snakemake workflow files, and R scripts for all visualisations.
+
+## CRediT Author Contributions
+
+- **Adaeze Okonkwo** -- Conceptualisation, Methodology, Formal analysis, Writing (original draft), Supervision, Funding acquisition
+- **Haruki Yamamoto** -- Software, Formal analysis, Data curation, Visualisation
+- **Sigrid Eriksson** -- Methodology, Validation, Writing (review and editing), Resources
+- **Priya Bharadwaj** -- Investigation, Data curation, Writing (review and editing)
+
+## Funding
+
+This work was supported by the Wellcome Trust (grant 204141/Z/16/Z to A.O.), the Japan Society for the Promotion of Science (KAKENHI 22K15834 to H.Y.), the Swedish Research Council (2022-01234 to S.E.), and the Department of Biotechnology, Government of India (BT/PR40123/BID/7/908/2020 to P.B.).
+
+## Ethics Statement
+
+This study was approved by the institutional review boards of all contributing cohorts. All participants provided written informed consent. The study was conducted in accordance with the Declaration of Helsinki.
+
+## Competing Interests
+
+The authors declare no competing interests.
+
+## References
+
+<ol class="references-list">
+  <li>Nikpay M, Goel A, Won HH, et al. A comprehensive 1,000 Genomes-based genome-wide association meta-analysis of coronary artery disease. <em>Nat Genet.</em> 2015;47(10):1121-1130.</li>
+  <li>van der Harst P, Verweij N. Identification of 64 novel genetic loci provides an expanded view on the genetic architecture of coronary artery disease. <em>Circ Res.</em> 2018;122(3):433-443.</li>
+  <li>Aragam KG, Jiang T, Goel A, et al. Discovery and systematic characterization of risk variants and genes for coronary artery disease in over a million participants. <em>Nat Genet.</em> 2022;54(12):1803-1815.</li>
+  <li>Zhou W, Nielsen JB, Fritsche LG, et al. Efficiently controlling for case-control imbalance and sample relatedness in large-scale genetic association studies. <em>Nat Genet.</em> 2018;50(9):1335-1341.</li>
+  <li>Taliun D, Harris DN, Kessler MD, et al. Sequencing of 53,831 diverse genomes from the NHLBI TOPMed program. <em>Nature.</em> 2021;590(7845):290-299.</li>
+  <li>Wang G, Sarkar A, Carbonetto P, Stephens M. A simple new approach to variable selection in regression, with application to genetic fine-mapping. <em>J R Stat Soc B.</em> 2020;82(5):1273-1300.</li>
+  <li>Magi R, Horikoshi M, Sofer T, et al. Trans-ethnic meta-regression of genome-wide association studies accounting for ancestry increases power for discovery and improves fine-mapping resolution. <em>Hum Mol Genet.</em> 2017;26(18):3639-3650.</li>
+  <li>Delaneau O, Zagury JF, Robinson MR, Marchini JL, Dermitzakis ET. Accurate, scalable and integrative haplotype estimation. <em>Nat Commun.</em> 2019;10(1):5436.</li>
+</ol>

--- a/genome-paper/content/index.md
+++ b/genome-paper/content/index.md
@@ -1,0 +1,360 @@
++++
+title = "Abstract"
+description = "A genome-wide association study identifying eight novel risk loci for coronary artery disease through large-scale genotyping and imputation across multi-ethnic cohorts."
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Research &middot; Open Access</p>
+  <h1 class="paper-title">Genome-Wide Association Study of Coronary Artery Disease: Identification of Novel Risk Loci in Multi-Ethnic Cohorts</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Adaeze Okonkwo</span><sup>1</sup>,
+    Haruki Yamamoto<sup>2</sup>,
+    Sigrid Eriksson<sup>1,3</sup>,
+    Priya Bharadwaj<sup>4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Centre for Genomic Medicine, University of Lagos &middot;
+    <sup>2</sup>Department of Statistical Genetics, Kyoto University &middot;
+    <sup>3</sup>Broad Institute of MIT and Harvard &middot;
+    <sup>4</sup>National Centre for Biological Sciences, Bangalore
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/ghg.2026.28.03.187</a> &middot; <strong>Received:</strong> 14 Sep 2025 &middot; <strong>Accepted:</strong> 22 Feb 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Coronary artery disease (CAD) remains the leading cause of mortality worldwide. Prior genome-wide association studies have identified over 160 risk loci, yet a substantial portion of heritability remains unexplained, particularly in non-European populations.</dd>
+    <dt>Methods</dt>
+    <dd>We conducted a multi-ethnic GWAS meta-analysis comprising 184,726 CAD cases and 412,338 controls across four ancestry groups (European, East Asian, South Asian, and African). Genotyping was performed on Illumina Global Screening Array and Affymetrix Axiom platforms. Imputation used the TOPMed r3 reference panel. Association testing was performed with SAIGE, followed by cross-ancestry meta-analysis using MR-MEGA.</dd>
+    <dt>Results</dt>
+    <dd>We identified eight novel genome-wide significant loci (P &lt; 5 x 10<sup>-8</sup>), including variants near <em>ADAMTS7</em>, <em>PHACTR1</em>, <em>CXCL12</em>, and a previously unreported intergenic region on 9p21.3 (lead SNP rs4977574, OR = 1.29, P = 2.4 x 10<sup>-12</sup>). Fine-mapping with SuSiE identified 23 credible sets containing likely causal variants. Pathway enrichment analysis implicated vascular smooth muscle cell differentiation and lipid metabolism.</dd>
+    <dt>Conclusion</dt>
+    <dd>This multi-ethnic GWAS expands the catalogue of CAD risk loci and highlights the value of diverse cohorts for genetic discovery. The novel loci provide new targets for functional follow-up and potential therapeutic intervention.</dd>
+    <dt>Keywords</dt>
+    <dd><em>genome-wide association study; coronary artery disease; multi-ethnic; fine-mapping; risk loci; GWAS meta-analysis</em></dd>
+  </dl>
+</section>
+
+## Manhattan Plot
+
+<figure class="figure">
+  <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Manhattan plot showing genome-wide association results across 22 chromosomes with significant peaks above the genome-wide significance threshold">
+    <!-- Background -->
+    <rect x="60" y="20" width="640" height="280" fill="#0a0c12" stroke="#2a2f40" stroke-width="1"/>
+    <!-- Y-axis label -->
+    <text x="18" y="160" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#7a7870" letter-spacing="0.5" transform="rotate(-90 18 160)">-log10(P)</text>
+    <!-- Y-axis ticks -->
+    <g font-family="JetBrains Mono" font-size="9" fill="#7a7870" text-anchor="end">
+      <text x="55" y="296">0</text>
+      <text x="55" y="268">1</text>
+      <text x="55" y="240">2</text>
+      <text x="55" y="212">3</text>
+      <text x="55" y="184">4</text>
+      <text x="55" y="156">5</text>
+      <text x="55" y="128">6</text>
+      <text x="55" y="100">7</text>
+      <text x="55" y="72">8</text>
+      <text x="55" y="44">9</text>
+      <text x="55" y="26">10</text>
+    </g>
+    <!-- Y-axis grid lines -->
+    <g stroke="#2a2f40" stroke-width="0.5" opacity="0.4">
+      <line x1="60" y1="268" x2="700" y2="268"/>
+      <line x1="60" y1="240" x2="700" y2="240"/>
+      <line x1="60" y1="212" x2="700" y2="212"/>
+      <line x1="60" y1="184" x2="700" y2="184"/>
+      <line x1="60" y1="156" x2="700" y2="156"/>
+      <line x1="60" y1="128" x2="700" y2="128"/>
+      <line x1="60" y1="100" x2="700" y2="100"/>
+      <line x1="60" y1="72" x2="700" y2="72"/>
+    </g>
+    <!-- Genome-wide significance line at -log10(5e-8) = 7.3 -->
+    <line x1="60" y1="96" x2="700" y2="96" stroke="#c44a4a" stroke-width="1.5" stroke-dasharray="6 3"/>
+    <text x="706" y="99" font-family="JetBrains Mono" font-size="8" fill="#c44a4a" font-weight="700">P = 5e-8</text>
+    <!-- Suggestive significance line at -log10(1e-5) = 5 -->
+    <line x1="60" y1="156" x2="700" y2="156" stroke="#4e4d48" stroke-width="0.8" stroke-dasharray="3 4"/>
+    <!-- Chromosome labels -->
+    <g font-family="JetBrains Mono" font-size="8" fill="#7a7870" text-anchor="middle">
+      <text x="80" y="310">1</text>
+      <text x="108" y="310">2</text>
+      <text x="136" y="310">3</text>
+      <text x="160" y="310">4</text>
+      <text x="182" y="310">5</text>
+      <text x="204" y="310">6</text>
+      <text x="224" y="310">7</text>
+      <text x="244" y="310">8</text>
+      <text x="262" y="310">9</text>
+      <text x="282" y="310">10</text>
+      <text x="302" y="310">11</text>
+      <text x="322" y="310">12</text>
+      <text x="340" y="310">13</text>
+      <text x="358" y="310">14</text>
+      <text x="376" y="310">15</text>
+      <text x="394" y="310">16</text>
+      <text x="412" y="310">17</text>
+      <text x="430" y="310">18</text>
+      <text x="448" y="310">19</text>
+      <text x="468" y="310">20</text>
+      <text x="488" y="310">21</text>
+      <text x="508" y="310">22</text>
+    </g>
+    <text x="380" y="330" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#7a7870" letter-spacing="1">CHROMOSOME</text>
+    <!-- Chr 1 dots (blue) - scattered baseline -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="70" cy="278" r="1.5"/><circle cx="74" cy="262" r="1.5"/><circle cx="78" cy="284" r="1.5"/>
+      <circle cx="82" cy="270" r="1.5"/><circle cx="86" cy="258" r="1.5"/><circle cx="90" cy="276" r="1.5"/>
+      <circle cx="73" cy="248" r="1.5"/><circle cx="77" cy="272" r="1.5"/><circle cx="85" cy="266" r="1.5"/>
+      <circle cx="69" cy="286" r="1.5"/><circle cx="91" cy="254" r="1.5"/><circle cx="81" cy="240" r="1.5"/>
+      <circle cx="87" cy="232" r="1.8"/><circle cx="76" cy="244" r="1.5"/>
+    </g>
+    <!-- Chr 1 peak - PCSK9 locus -->
+    <g fill="#4a9aca">
+      <circle cx="84" cy="200" r="2"/><circle cx="86" cy="178" r="2"/><circle cx="85" cy="148" r="2.2"/>
+      <circle cx="84" cy="120" r="2.5"/><circle cx="85" cy="88" r="3"/>
+      <circle cx="83" cy="106" r="2.2"/><circle cx="87" cy="134" r="2"/>
+    </g>
+    <!-- Chr 2 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="100" cy="280" r="1.5"/><circle cx="104" cy="266" r="1.5"/><circle cx="108" cy="274" r="1.5"/>
+      <circle cx="112" cy="256" r="1.5"/><circle cx="116" cy="270" r="1.5"/><circle cx="102" cy="250" r="1.5"/>
+      <circle cx="110" cy="262" r="1.5"/><circle cx="106" cy="244" r="1.5"/>
+    </g>
+    <!-- Chr 3 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="126" cy="276" r="1.5"/><circle cx="130" cy="260" r="1.5"/><circle cx="134" cy="272" r="1.5"/>
+      <circle cx="138" cy="254" r="1.5"/><circle cx="142" cy="268" r="1.5"/><circle cx="128" cy="248" r="1.5"/>
+      <circle cx="136" cy="264" r="1.5"/>
+    </g>
+    <!-- Chr 4 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="150" cy="278" r="1.5"/><circle cx="154" cy="264" r="1.5"/><circle cx="158" cy="270" r="1.5"/>
+      <circle cx="162" cy="256" r="1.5"/><circle cx="166" cy="274" r="1.5"/><circle cx="152" cy="246" r="1.5"/>
+    </g>
+    <!-- Chr 5 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="174" cy="276" r="1.5"/><circle cx="178" cy="262" r="1.5"/><circle cx="182" cy="272" r="1.5"/>
+      <circle cx="186" cy="258" r="1.5"/><circle cx="190" cy="268" r="1.5"/><circle cx="176" cy="248" r="1.5"/>
+    </g>
+    <!-- Chr 6 dots (green) with PHACTR1 peak -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="196" cy="278" r="1.5"/><circle cx="200" cy="264" r="1.5"/><circle cx="204" cy="272" r="1.5"/>
+      <circle cx="208" cy="256" r="1.5"/><circle cx="212" cy="268" r="1.5"/>
+    </g>
+    <g fill="#6aaa6a">
+      <circle cx="205" cy="210" r="2"/><circle cx="207" cy="180" r="2"/><circle cx="206" cy="152" r="2.2"/>
+      <circle cx="205" cy="126" r="2.5"/><circle cx="206" cy="80" r="3"/>
+      <circle cx="204" cy="108" r="2.2"/><circle cx="208" cy="140" r="2"/>
+    </g>
+    <!-- Chr 7 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="218" cy="276" r="1.5"/><circle cx="222" cy="260" r="1.5"/><circle cx="226" cy="272" r="1.5"/>
+      <circle cx="230" cy="254" r="1.5"/><circle cx="220" cy="248" r="1.5"/>
+    </g>
+    <!-- Chr 8 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="236" cy="278" r="1.5"/><circle cx="240" cy="264" r="1.5"/><circle cx="244" cy="272" r="1.5"/>
+      <circle cx="248" cy="256" r="1.5"/><circle cx="252" cy="268" r="1.5"/>
+    </g>
+    <!-- Chr 9 dots (blue) with 9p21.3 peak - LEAD SIGNAL -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="256" cy="276" r="1.5"/><circle cx="260" cy="262" r="1.5"/><circle cx="264" cy="270" r="1.5"/>
+      <circle cx="268" cy="258" r="1.5"/>
+    </g>
+    <g fill="#4a9aca">
+      <circle cx="260" cy="218" r="2"/><circle cx="262" cy="190" r="2"/><circle cx="261" cy="160" r="2.2"/>
+      <circle cx="260" cy="130" r="2.5"/><circle cx="261" cy="100" r="2.8"/>
+      <circle cx="262" cy="60" r="3.5"/><circle cx="259" cy="46" r="3.8"/>
+      <circle cx="263" cy="114" r="2.2"/><circle cx="258" cy="144" r="2"/>
+    </g>
+    <!-- Chr 10 dots (green) with CXCL12 peak -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="274" cy="278" r="1.5"/><circle cx="278" cy="264" r="1.5"/><circle cx="282" cy="272" r="1.5"/>
+      <circle cx="286" cy="256" r="1.5"/><circle cx="290" cy="268" r="1.5"/>
+    </g>
+    <g fill="#6aaa6a">
+      <circle cx="283" cy="210" r="2"/><circle cx="285" cy="184" r="2"/><circle cx="284" cy="156" r="2.2"/>
+      <circle cx="283" cy="128" r="2.5"/><circle cx="284" cy="74" r="3"/>
+      <circle cx="282" cy="110" r="2.2"/><circle cx="286" cy="142" r="2"/>
+    </g>
+    <!-- Chr 11 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="296" cy="276" r="1.5"/><circle cx="300" cy="262" r="1.5"/><circle cx="304" cy="272" r="1.5"/>
+      <circle cx="308" cy="254" r="1.5"/><circle cx="298" cy="246" r="1.5"/>
+    </g>
+    <!-- Chr 12 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="314" cy="278" r="1.5"/><circle cx="318" cy="264" r="1.5"/><circle cx="322" cy="272" r="1.5"/>
+      <circle cx="326" cy="256" r="1.5"/><circle cx="330" cy="268" r="1.5"/>
+    </g>
+    <!-- Chr 13 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="334" cy="276" r="1.5"/><circle cx="338" cy="262" r="1.5"/><circle cx="342" cy="270" r="1.5"/>
+      <circle cx="346" cy="258" r="1.5"/>
+    </g>
+    <!-- Chr 14 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="352" cy="278" r="1.5"/><circle cx="356" cy="264" r="1.5"/><circle cx="360" cy="272" r="1.5"/>
+      <circle cx="364" cy="256" r="1.5"/>
+    </g>
+    <!-- Chr 15 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="370" cy="276" r="1.5"/><circle cx="374" cy="262" r="1.5"/><circle cx="378" cy="270" r="1.5"/>
+      <circle cx="382" cy="258" r="1.5"/>
+    </g>
+    <!-- Chr 16 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="388" cy="278" r="1.5"/><circle cx="392" cy="264" r="1.5"/><circle cx="396" cy="272" r="1.5"/>
+      <circle cx="400" cy="256" r="1.5"/>
+    </g>
+    <!-- Chr 17 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="406" cy="276" r="1.5"/><circle cx="410" cy="262" r="1.5"/><circle cx="414" cy="270" r="1.5"/>
+      <circle cx="418" cy="254" r="1.5"/>
+    </g>
+    <!-- Chr 18 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="424" cy="278" r="1.5"/><circle cx="428" cy="264" r="1.5"/><circle cx="432" cy="272" r="1.5"/>
+      <circle cx="436" cy="256" r="1.5"/>
+    </g>
+    <!-- Chr 19 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="442" cy="276" r="1.5"/><circle cx="446" cy="262" r="1.5"/><circle cx="450" cy="270" r="1.5"/>
+      <circle cx="454" cy="248" r="1.5"/>
+    </g>
+    <!-- Chr 20 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="462" cy="278" r="1.5"/><circle cx="466" cy="264" r="1.5"/><circle cx="470" cy="272" r="1.5"/>
+      <circle cx="474" cy="256" r="1.5"/>
+    </g>
+    <!-- Chr 21 dots (blue) -->
+    <g fill="#4a9aca" opacity="0.6">
+      <circle cx="482" cy="276" r="1.5"/><circle cx="486" cy="262" r="1.5"/><circle cx="490" cy="272" r="1.5"/>
+      <circle cx="494" cy="258" r="1.5"/>
+    </g>
+    <!-- Chr 22 dots (green) -->
+    <g fill="#6aaa6a" opacity="0.6">
+      <circle cx="500" cy="278" r="1.5"/><circle cx="504" cy="264" r="1.5"/><circle cx="508" cy="272" r="1.5"/>
+      <circle cx="512" cy="256" r="1.5"/>
+    </g>
+    <!-- Gene annotations for significant peaks -->
+    <g font-family="JetBrains Mono" font-size="9" font-weight="700">
+      <!-- PCSK9 on chr1 -->
+      <line x1="85" y1="86" x2="85" y2="50" stroke="#4a9aca" stroke-width="0.8"/>
+      <text x="85" y="44" text-anchor="middle" fill="#4a9aca" font-style="italic">PCSK9</text>
+      <!-- PHACTR1 on chr6 -->
+      <line x1="206" y1="78" x2="206" y2="42" stroke="#6aaa6a" stroke-width="0.8"/>
+      <text x="206" y="36" text-anchor="middle" fill="#6aaa6a" font-style="italic">PHACTR1</text>
+      <!-- 9p21.3 / CDKN2B-AS1 on chr9 -->
+      <line x1="260" y1="44" x2="260" y2="30" stroke="#4a9aca" stroke-width="0.8"/>
+      <text x="260" y="26" text-anchor="middle" fill="#c44a4a" font-style="italic">CDKN2B-AS1</text>
+      <!-- CXCL12 on chr10 -->
+      <line x1="284" y1="72" x2="284" y2="42" stroke="#6aaa6a" stroke-width="0.8"/>
+      <text x="284" y="36" text-anchor="middle" fill="#6aaa6a" font-style="italic">CXCL12</text>
+    </g>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Manhattan plot of the multi-ethnic GWAS meta-analysis for coronary artery disease. Each point represents a genotyped or imputed variant. Chromosomes are shown in alternating colours along the x-axis. The red dashed line indicates the genome-wide significance threshold (P = 5 x 10<sup>-8</sup>). Four loci with prominent peaks are annotated: <em>PCSK9</em> (chr1), <em>PHACTR1</em> (chr6), <em>CDKN2B-AS1</em> at 9p21.3 (chr9), and <em>CXCL12</em> (chr10).</figcaption>
+</figure>
+
+<section class="locus-callout">
+  <span class="callout-label">Lead Finding -- Novel Locus at 9p21.3</span>
+  <span class="callout-value">rs4977574<span class="unit">P = 2.4 x 10<sup>-12</sup></span></span>
+  <p class="callout-detail">Near <em>CDKN2B-AS1</em>. Odds ratio 1.29 (95 pct CI: 1.21 to 1.38). Effect allele frequency 0.48 in European, 0.52 in East Asian, 0.41 in African cohorts. SuSiE fine-mapping identified a single credible set of 3 variants spanning 12 kb. The lead variant overlaps a vascular smooth muscle cell enhancer annotated by ENCODE.</p>
+</section>
+
+## Summary of Genome-Wide Significant Loci
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Genome-wide significant loci associated with coronary artery disease (P &lt; 5 x 10<sup>-8</sup>).</caption>
+  <thead>
+    <tr>
+      <th>Locus</th>
+      <th>Chr</th>
+      <th>Lead SNP</th>
+      <th>Gene</th>
+      <th>OR (95 pct CI)</th>
+      <th>P-value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9p21.3</td>
+      <td class="num">9</td>
+      <td>rs4977574</td>
+      <td><em>CDKN2B-AS1</em></td>
+      <td class="num">1.29 (1.21-1.38)</td>
+      <td class="num">2.4 x 10<sup>-12</sup></td>
+    </tr>
+    <tr>
+      <td>1p32.3</td>
+      <td class="num">1</td>
+      <td>rs11591147</td>
+      <td><em>PCSK9</em></td>
+      <td class="num">1.22 (1.15-1.29)</td>
+      <td class="num">8.7 x 10<sup>-11</sup></td>
+    </tr>
+    <tr>
+      <td>6p24.1</td>
+      <td class="num">6</td>
+      <td>rs9349379</td>
+      <td><em>PHACTR1</em></td>
+      <td class="num">1.18 (1.12-1.24)</td>
+      <td class="num">3.1 x 10<sup>-10</sup></td>
+    </tr>
+    <tr>
+      <td>10q11.21</td>
+      <td class="num">10</td>
+      <td>rs501120</td>
+      <td><em>CXCL12</em></td>
+      <td class="num">1.16 (1.10-1.22)</td>
+      <td class="num">6.2 x 10<sup>-9</sup></td>
+    </tr>
+    <tr>
+      <td>15q25.1</td>
+      <td class="num">15</td>
+      <td>rs3825807</td>
+      <td><em>ADAMTS7</em></td>
+      <td class="num">1.14 (1.09-1.19)</td>
+      <td class="num">1.8 x 10<sup>-9</sup></td>
+    </tr>
+    <tr>
+      <td>2q33.1</td>
+      <td class="num">2</td>
+      <td>rs6725887</td>
+      <td><em>WDR12</em></td>
+      <td class="num">1.12 (1.08-1.17)</td>
+      <td class="num">4.5 x 10<sup>-9</sup></td>
+    </tr>
+    <tr>
+      <td>21q22.11</td>
+      <td class="num">21</td>
+      <td>rs28451064</td>
+      <td><em>KCNE2</em></td>
+      <td class="num">1.11 (1.07-1.15)</td>
+      <td class="num">7.3 x 10<sup>-9</sup></td>
+    </tr>
+    <tr>
+      <td>19p13.2</td>
+      <td class="num">19</td>
+      <td>rs1122608</td>
+      <td><em>LDLR</em></td>
+      <td class="num">1.15 (1.10-1.20)</td>
+      <td class="num">2.9 x 10<sup>-8</sup></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">OR = odds ratio; CI = confidence interval. All P-values are from the cross-ancestry fixed-effects meta-analysis. Gene annotations reflect the nearest gene or the gene with strongest eQTL evidence.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the section index. The full manuscript contains the following numbered sections.
+
+1. **Section 1. Study Design** -- cohort description, genotyping platforms, and ancestry composition
+2. **Section 2. Quality Control and Imputation** -- QC pipeline, imputation with TOPMed, and post-imputation filters
+3. **Section 3. Association Results** -- Manhattan plot analysis, locus-by-locus results, and conditional analyses
+4. **Section 4. Functional Annotation** -- pathway analysis, eQTL colocalisation, and chromatin state enrichment
+5. **Section 5. Discussion** -- novel findings, comparison to prior GWAS, and clinical implications

--- a/genome-paper/content/pipeline.md
+++ b/genome-paper/content/pipeline.md
@@ -1,0 +1,155 @@
++++
+title = "Bioinformatics Pipeline"
+description = "End-to-end computational workflow from raw genotyping array data through quality control, imputation, association testing, and meta-analysis."
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
++++
+
+## Analysis Pipeline Overview
+
+The bioinformatics pipeline comprises seven sequential stages, from raw array intensity data to the final cross-ancestry meta-analysis. Each stage was containerised using Singularity for reproducibility.
+
+<figure class="figure">
+  <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Flow diagram of the bioinformatics pipeline from raw reads through meta-analysis">
+    <defs>
+      <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#4a9aca"/>
+      </marker>
+      <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#6aaa6a"/>
+      </marker>
+    </defs>
+    <!-- Stage 1: Raw Reads -->
+    <rect x="20" y="20" width="140" height="50" fill="none" stroke="#4a9aca" stroke-width="2"/>
+    <text x="90" y="42" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">RAW INTENSITY</text>
+    <text x="90" y="56" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">DATA</text>
+    <text x="90" y="86" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">IDAT / CEL files</text>
+    <text x="90" y="98" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">N = 597,064 samples</text>
+    <!-- Arrow 1-2 -->
+    <line x1="160" y1="45" x2="200" y2="45" stroke="#4a9aca" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <!-- Stage 2: Genotype Calling -->
+    <rect x="200" y="20" width="140" height="50" fill="none" stroke="#4a9aca" stroke-width="2"/>
+    <text x="270" y="42" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">GENOTYPE</text>
+    <text x="270" y="56" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">CALLING</text>
+    <text x="270" y="86" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">GenomeStudio / APT</text>
+    <text x="270" y="98" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">GenCall / AxiomGT1</text>
+    <!-- Arrow 2-3 -->
+    <line x1="340" y1="45" x2="380" y2="45" stroke="#4a9aca" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <!-- Stage 3: Sample QC -->
+    <rect x="380" y="20" width="140" height="50" fill="none" stroke="#6aaa6a" stroke-width="2"/>
+    <text x="450" y="42" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">SAMPLE QC</text>
+    <text x="450" y="86" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">Call rate, sex check,</text>
+    <text x="450" y="98" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">relatedness, PCA</text>
+    <!-- Arrow 3-4 -->
+    <line x1="520" y1="45" x2="560" y2="45" stroke="#6aaa6a" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+    <!-- Stage 4: Variant QC -->
+    <rect x="560" y="20" width="140" height="50" fill="none" stroke="#6aaa6a" stroke-width="2"/>
+    <text x="630" y="42" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">VARIANT QC</text>
+    <text x="630" y="86" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">MAF, HWE, missingness,</text>
+    <text x="630" y="98" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">strand alignment</text>
+    <!-- Arrow 4-5 (down then left) -->
+    <line x1="630" y1="70" x2="630" y2="150" stroke="#4a9aca" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <!-- Stage 5: Imputation -->
+    <rect x="470" y="150" width="160" height="50" fill="none" stroke="#4a9aca" stroke-width="2"/>
+    <text x="550" y="172" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">IMPUTATION</text>
+    <text x="550" y="216" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">TOPMed r3 reference panel</text>
+    <text x="550" y="228" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">Minimac4, R-sq &gt; 0.3</text>
+    <!-- Arrow 5-6 -->
+    <line x1="470" y1="175" x2="430" y2="175" stroke="#4a9aca" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <!-- Stage 6: Association Testing -->
+    <rect x="200" y="150" width="230" height="50" fill="none" stroke="#c44a4a" stroke-width="2"/>
+    <text x="315" y="172" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">ASSOCIATION TESTING</text>
+    <text x="315" y="216" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">SAIGE (mixed model)</text>
+    <text x="315" y="228" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">Per-ancestry, additive model</text>
+    <!-- Arrow 6-7 -->
+    <line x1="315" y1="200" x2="315" y2="280" stroke="#c44a4a" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <!-- Stage 7: Meta-Analysis -->
+    <rect x="200" y="280" width="230" height="50" fill="none" stroke="#c44a4a" stroke-width="2"/>
+    <text x="315" y="302" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#ccc8bc" letter-spacing="0.5">CROSS-ANCESTRY META-ANALYSIS</text>
+    <text x="315" y="346" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">MR-MEGA, random effects</text>
+    <text x="315" y="358" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">Heterogeneity filtering</text>
+    <!-- Output arrow -->
+    <line x1="315" y1="330" x2="315" y2="390" stroke="#4a9aca" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <text x="315" y="408" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="11" fill="#4a9aca" letter-spacing="1">SUMMARY STATISTICS</text>
+    <!-- Side annotation: sample counts -->
+    <rect x="20" y="150" width="140" height="50" fill="none" stroke="#2a2f40" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="90" y="170" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870">POST-QC</text>
+    <text x="90" y="184" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#4a9aca">184,726 cases</text>
+    <text x="90" y="196" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6aaa6a">412,338 controls</text>
+    <line x1="160" y1="175" x2="200" y2="175" stroke="#2a2f40" stroke-width="1" stroke-dasharray="3 3"/>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Bioinformatics pipeline for the GWAS of coronary artery disease. Blue boxes indicate data processing steps, green boxes indicate quality control, and red boxes indicate statistical analysis. Dashed box shows post-QC sample counts. All steps were containerised with Singularity v3.11 for reproducibility.</figcaption>
+</figure>
+
+## Pipeline Stage Details
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 1 -- Genotype Calling</span>
+  <span class="step">Platform A (Illumina GSA):</span> <span class="tool">GenomeStudio v2.0.5 with GenCall algorithm</span><br>
+  <span class="step">Platform B (Affymetrix Axiom):</span> <span class="tool">Axiom Analysis Suite v5.2 with AxiomGT1</span><br>
+  <span class="note">Both platforms aligned to GRCh38 coordinate system before merging</span>
+</div>
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 2 -- Sample Quality Control</span>
+  <span class="step">Call rate filter:</span> <span class="tool">&gt; 0.97 per sample (PLINK v2.0)</span><br>
+  <span class="step">Sex check:</span> <span class="tool">F-statistic on X chromosome (F &lt; 0.2 female, F &gt; 0.8 male)</span><br>
+  <span class="step">Relatedness:</span> <span class="tool">KING v2.3.2, kinship &gt; 0.0884 flagged (second-degree or closer)</span><br>
+  <span class="step">Population structure:</span> <span class="tool">PCA with 1000 Genomes Phase 3 as reference (smartpca v7.2)</span><br>
+  <span class="note">14,291 samples removed at this stage (2.4 pct of total)</span>
+</div>
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 3 -- Variant Quality Control</span>
+  <span class="step">Call rate:</span> <span class="tool">&gt; 0.98 per variant</span><br>
+  <span class="step">Hardy-Weinberg equilibrium:</span> <span class="tool">P &gt; 1 x 10<sup>-6</sup> in controls</span><br>
+  <span class="step">Minor allele frequency:</span> <span class="tool">&gt; 0.005 (per ancestry group)</span><br>
+  <span class="step">Strand alignment:</span> <span class="tool">Strand consensus via SHAPEIT4 pre-phasing</span><br>
+  <span class="note">587,431 variants passed all filters across both platforms</span>
+</div>
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 4 -- Imputation</span>
+  <span class="step">Pre-phasing:</span> <span class="tool">SHAPEIT4 v4.2.2</span><br>
+  <span class="step">Imputation server:</span> <span class="tool">Minimac4 v4.1 with TOPMed r3 reference panel</span><br>
+  <span class="step">Post-imputation filter:</span> <span class="tool">R-squared &gt; 0.3 and MAF &gt; 0.001</span><br>
+  <span class="note">~28.4 million variants available after imputation and filtering</span>
+</div>
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 5 -- Association Testing</span>
+  <span class="step">Method:</span> <span class="tool">SAIGE v1.3.0 (saddle-point approximation for case-control imbalance)</span><br>
+  <span class="step">Model:</span> <span class="tool">Logistic mixed model, additive genotype coding</span><br>
+  <span class="step">Covariates:</span> <span class="tool">Age, sex, genotyping batch, and top 10 PCs per ancestry</span><br>
+  <span class="note">Run separately for each of the four ancestry groups</span>
+</div>
+
+<div class="pipeline-box">
+  <span class="pipeline-label">Stage 6 -- Cross-Ancestry Meta-Analysis</span>
+  <span class="step">Software:</span> <span class="tool">MR-MEGA v0.2</span><br>
+  <span class="step">Model:</span> <span class="tool">Random-effects, accounting for allelic heterogeneity across ancestries</span><br>
+  <span class="step">Heterogeneity filter:</span> <span class="tool">Cochran Q P &gt; 1 x 10<sup>-4</sup></span><br>
+  <span class="note">Final summary statistics deposited in GWAS Catalog under accession GCST90XXXXX</span>
+</div>
+
+## Software Versions
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S1.</span> Key software tools and versions used in the analysis pipeline.</caption>
+  <thead>
+    <tr>
+      <th>Tool</th>
+      <th>Version</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>PLINK</td><td>v2.0-alpha-6</td><td>Sample and variant QC</td></tr>
+    <tr><td>KING</td><td>v2.3.2</td><td>Kinship estimation</td></tr>
+    <tr><td>SHAPEIT4</td><td>v4.2.2</td><td>Pre-phasing</td></tr>
+    <tr><td>Minimac4</td><td>v4.1</td><td>Genotype imputation</td></tr>
+    <tr><td>SAIGE</td><td>v1.3.0</td><td>Single-variant association testing</td></tr>
+    <tr><td>MR-MEGA</td><td>v0.2</td><td>Cross-ancestry meta-analysis</td></tr>
+    <tr><td>SuSiE</td><td>v0.12.35</td><td>Fine-mapping</td></tr>
+    <tr><td>FUMA</td><td>v1.5.6</td><td>Functional annotation</td></tr>
+  </tbody>
+</table>

--- a/genome-paper/content/results.md
+++ b/genome-paper/content/results.md
@@ -1,0 +1,74 @@
++++
+title = "Key Results"
+description = "Summary of principal genomic findings including novel loci, effect sizes, and ancestry-specific patterns."
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
++++
+
+## Principal Findings
+
+The cross-ancestry meta-analysis of 184,726 CAD cases and 412,338 controls yielded eight genome-wide significant loci (P < 5 x 10<sup>-8</sup>). Of these, three represent novel associations not reported in prior GWAS catalogues as of the analysis date.
+
+### Novel Loci
+
+The strongest novel signal mapped to the 9p21.3 region, with lead SNP rs4977574 reaching P = 2.4 x 10<sup>-12</sup> (OR = 1.29). This variant lies within the non-coding RNA gene <em>CDKN2B-AS1</em>, which has been implicated in cell cycle regulation and vascular smooth muscle cell proliferation. Fine-mapping with SuSiE identified a credible set of three variants within a 12 kb window, all overlapping ENCODE-annotated enhancer elements active in coronary artery smooth muscle cells.
+
+The second novel locus on chromosome 15q25.1 (rs3825807, P = 1.8 x 10<sup>-9</sup>) implicates <em>ADAMTS7</em>, a metalloproteinase gene previously linked to atherosclerotic plaque stability in functional studies but not previously reaching genome-wide significance in a GWAS context.
+
+The third novel locus at 21q22.11 (rs28451064, P = 7.3 x 10<sup>-9</sup>) maps near <em>KCNE2</em>, encoding a potassium channel subunit expressed in cardiac tissue.
+
+### Replicated Loci
+
+Five of the eight significant loci replicate associations reported in prior European-ancestry GWAS. These include the well-established <em>PCSK9</em> locus on 1p32.3, the <em>PHACTR1</em> locus on 6p24.1, the <em>CXCL12</em> locus on 10q11.21, the <em>WDR12</em> locus on 2q33.1, and the <em>LDLR</em> locus on 19p13.2. In all cases, the direction of effect was consistent across ancestry groups.
+
+## Ancestry-Specific Effects
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Lead variant effect sizes by ancestry group for the three novel loci.</caption>
+  <thead>
+    <tr>
+      <th>Locus</th>
+      <th>Gene</th>
+      <th>EUR OR</th>
+      <th>EAS OR</th>
+      <th>SAS OR</th>
+      <th>AFR OR</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9p21.3</td>
+      <td><em>CDKN2B-AS1</em></td>
+      <td class="num">1.31</td>
+      <td class="num">1.27</td>
+      <td class="num">1.30</td>
+      <td class="num">1.24</td>
+    </tr>
+    <tr>
+      <td>15q25.1</td>
+      <td><em>ADAMTS7</em></td>
+      <td class="num">1.15</td>
+      <td class="num">1.12</td>
+      <td class="num">1.16</td>
+      <td class="num">1.10</td>
+    </tr>
+    <tr>
+      <td>21q22.11</td>
+      <td><em>KCNE2</em></td>
+      <td class="num">1.12</td>
+      <td class="num">1.09</td>
+      <td class="num">1.13</td>
+      <td class="num">1.08</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">EUR = European; EAS = East Asian; SAS = South Asian; AFR = African. OR = odds ratio for effect allele. All effects are directionally consistent across ancestries (Cochran Q P > 0.05).</td></tr>
+  </tfoot>
+</table>
+
+## Fine-Mapping Summary
+
+SuSiE fine-mapping was performed at each of the eight genome-wide significant loci. A total of 23 credible sets were identified, containing a median of 5 variants per set (range: 2 to 14). At the 9p21.3 locus, a single credible set of 3 variants was identified, with the lead variant (rs4977574) assigned a posterior inclusion probability (PIP) of 0.87.
+
+## Polygenic Risk Score
+
+A polygenic risk score (PRS) constructed from the eight lead variants explained 2.1 pct of variance in CAD liability on the observed scale. When combined with 155 previously reported GWAS variants, the expanded PRS explained 8.4 pct of variance, representing a 0.6 percentage point improvement over the prior PRS based on known variants alone.

--- a/genome-paper/content/sections/1-study-design.md
+++ b/genome-paper/content/sections/1-study-design.md
@@ -1,0 +1,76 @@
++++
+title = "1. Study Design"
+description = "Cohort assembly, genotyping platform selection, ancestry composition, and phenotype definition for the multi-ethnic GWAS of coronary artery disease."
+weight = 1
+template = "post"
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Cohort description
+
+The study combined individual-level genotype data from 12 contributing cohorts spanning four continental ancestry groups. Cohorts were selected based on the availability of genotyping array data, a minimum sample size of 2,000 cases, and consistent CAD phenotype definitions compatible with ICD-10 codes I20-I25.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Contributing cohorts by ancestry group.</caption>
+  <thead>
+    <tr>
+      <th>Ancestry</th>
+      <th>Cohorts</th>
+      <th>Cases</th>
+      <th>Controls</th>
+      <th>Platform</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>European</td>
+      <td class="num">5</td>
+      <td class="num">98,412</td>
+      <td class="num">234,816</td>
+      <td>Illumina GSA v3</td>
+    </tr>
+    <tr>
+      <td>East Asian</td>
+      <td class="num">3</td>
+      <td class="num">42,187</td>
+      <td class="num">89,324</td>
+      <td>Illumina GSA v3</td>
+    </tr>
+    <tr>
+      <td>South Asian</td>
+      <td class="num">2</td>
+      <td class="num">28,916</td>
+      <td class="num">58,112</td>
+      <td>Affymetrix Axiom</td>
+    </tr>
+    <tr>
+      <td>African</td>
+      <td class="num">2</td>
+      <td class="num">15,211</td>
+      <td class="num">30,086</td>
+      <td>Illumina GSA v3</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Total: 184,726 cases and 412,338 controls across 12 cohorts.</td></tr>
+  </tfoot>
+</table>
+
+## 1.2 Genotyping platforms
+
+Two array platforms were used across the contributing cohorts. The Illumina Global Screening Array v3 (GSA-v3) contains approximately 654,000 markers with enhanced coverage of pharmacogenomic and multi-ethnic variants. The Affymetrix Axiom array contains approximately 818,000 markers with dense coverage of coding variants. Platform-specific genotype calling was performed prior to harmonisation.
+
+## 1.3 Phenotype definition
+
+Coronary artery disease was defined as the presence of any of the following: myocardial infarction (ICD-10 I21-I22), chronic ischaemic heart disease (I25), angina pectoris (I20), or a documented history of coronary revascularisation (percutaneous coronary intervention or coronary artery bypass grafting). Controls were defined as individuals with no recorded CAD diagnosis or revascularisation event and a minimum age of 50 years at last follow-up.
+
+## 1.4 Ancestry assignment
+
+Ancestry group membership was determined by projecting study samples onto the principal component space defined by the 1000 Genomes Phase 3 reference panel. Samples were assigned to an ancestry group if they fell within 6 standard deviations of the corresponding reference cluster centroid on the first four principal components. Samples that did not map to any reference cluster were excluded from the analysis (N = 1,847; 0.3 pct of total).
+
+## 1.5 Power calculations
+
+Pre-study power calculations indicated that the combined sample size provides greater than 80 pct power to detect a variant with MAF of 0.10 and an odds ratio of 1.10 at genome-wide significance (alpha = 5 x 10<sup>-8</sup>), and greater than 95 pct power for OR of 1.15 at the same allele frequency. Power was computed using the Genetic Power Calculator with a disease prevalence of 6 pct.

--- a/genome-paper/content/sections/2-quality-control.md
+++ b/genome-paper/content/sections/2-quality-control.md
@@ -1,0 +1,101 @@
++++
+title = "2. Quality Control and Imputation"
+description = "Sample and variant quality control pipeline, genotype imputation against the TOPMed r3 reference panel, and post-imputation filtering criteria."
+weight = 2
+template = "post"
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Sample quality control
+
+Sample-level QC was performed independently within each cohort before merging. The following sequential filters were applied:
+
+1. **Call rate** -- samples with genotype call rate below 0.97 were excluded
+2. **Sex check** -- X-chromosome F-statistic was computed; samples with ambiguous sex determination (0.2 < F < 0.8) or sex discordant with clinical records were removed
+3. **Heterozygosity** -- samples with autosomal heterozygosity rate deviating by more than 3 standard deviations from the cohort mean were flagged as potential contamination or consanguinity
+4. **Relatedness** -- pairwise kinship coefficients were estimated using KING v2.3.2; from each pair with kinship above 0.0884 (second-degree or closer), the sample with the lower call rate was removed
+5. **Population outliers** -- principal component analysis with the 1000 Genomes reference identified and excluded samples that did not cluster with their declared ancestry group
+
+A total of 14,291 samples (2.4 pct) were removed across all cohorts at this stage.
+
+## 2.2 Variant quality control
+
+Variant-level QC was performed within each ancestry group:
+
+- **Call rate** -- variants with call rate below 0.98 were excluded
+- **Hardy-Weinberg equilibrium** -- variants with HWE P < 1 x 10<sup>-6</sup> in controls were removed; this threshold is lenient enough to retain true association signals while excluding genotyping artefacts
+- **Minor allele frequency** -- variants with MAF below 0.005 within the ancestry group were excluded, as imputation accuracy is low for very rare variants on array platforms
+- **Duplicate and monomorphic variants** -- removed prior to imputation
+
+After variant QC, 587,431 directly genotyped variants remained for imputation scaffolding.
+
+## 2.3 Pre-phasing
+
+Pre-phasing was performed using SHAPEIT4 v4.2.2 with default parameters. Each chromosome was phased independently, using the genetic map from the HapMap Phase II recombination rate estimates lifted to GRCh38 coordinates. Phasing was run per-cohort to avoid batch effects from joint phasing.
+
+## 2.4 Imputation
+
+Genotype imputation was performed using Minimac4 v4.1 against the Trans-Omics for Precision Medicine (TOPMed) r3 reference panel, which contains 97,256 deeply sequenced genomes and over 308 million variants. Imputation was run on the TOPMed Imputation Server with the following settings:
+
+- Reference panel: TOPMed r3
+- Phasing: Eagle v2.4 (server default)
+- Population: mixed (all ancestries combined in a single run per cohort)
+- Output format: VCF with dosage fields
+
+## 2.5 Post-imputation filtering
+
+Imputed variants were filtered using two criteria:
+
+1. **Imputation quality** -- variants with Minimac R-squared below 0.3 were excluded
+2. **Minor allele frequency** -- variants with MAF below 0.001 in the combined sample were excluded
+
+After imputation and filtering, approximately 28.4 million variants were available for association testing. The mean imputation R-squared was 0.86 across all retained variants.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Imputation quality metrics by ancestry group.</caption>
+  <thead>
+    <tr>
+      <th>Ancestry</th>
+      <th>Variants input</th>
+      <th>Variants after imputation</th>
+      <th>Mean R-sq</th>
+      <th>Variants R-sq &gt; 0.8</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>European</td>
+      <td class="num">587,431</td>
+      <td class="num">29.1M</td>
+      <td class="num">0.89</td>
+      <td class="num">22.4M</td>
+    </tr>
+    <tr>
+      <td>East Asian</td>
+      <td class="num">587,431</td>
+      <td class="num">27.8M</td>
+      <td class="num">0.87</td>
+      <td class="num">20.6M</td>
+    </tr>
+    <tr>
+      <td>South Asian</td>
+      <td class="num">587,431</td>
+      <td class="num">28.2M</td>
+      <td class="num">0.85</td>
+      <td class="num">19.8M</td>
+    </tr>
+    <tr>
+      <td>African</td>
+      <td class="num">587,431</td>
+      <td class="num">32.6M</td>
+      <td class="num">0.82</td>
+      <td class="num">18.1M</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Higher variant counts in African ancestry reflect greater genetic diversity. Lower mean R-sq in African ancestry reflects shorter LD blocks and less dense reference coverage.</td></tr>
+  </tfoot>
+</table>

--- a/genome-paper/content/sections/3-association-results.md
+++ b/genome-paper/content/sections/3-association-results.md
@@ -1,0 +1,140 @@
++++
+title = "3. Association Results"
+description = "Genome-wide association results, Manhattan plot analysis, locus-by-locus description of significant findings, and conditional analyses at multi-signal loci."
+weight = 3
+template = "post"
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Genome-wide results overview
+
+The cross-ancestry meta-analysis tested approximately 24.8 million variants that passed quality filters in at least two ancestry groups. The genomic inflation factor (lambda-GC) was 1.06 in the combined analysis, consistent with polygenicity rather than systematic confounding. The LD score regression intercept was 1.02 (SE = 0.01), confirming that the modest inflation is attributable to true polygenic signal.
+
+Eight loci reached genome-wide significance (P < 5 x 10<sup>-8</sup>). An additional 14 loci reached suggestive significance (P < 1 x 10<sup>-5</sup>) and are reported in Supplementary Table S3.
+
+## 3.2 Chromosome ideogram of significant loci
+
+<figure class="figure">
+  <svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Chromosome ideogram showing the genomic positions of the eight significant loci identified in this study">
+    <!-- Chromosome 1 -->
+    <rect x="30" y="40" width="18" height="180" rx="9" fill="none" stroke="#4a9aca" stroke-width="1.2"/>
+    <rect x="30" y="92" width="18" height="4" fill="#2a2f40"/>
+    <!-- Centromere -->
+    <text x="39" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">1</text>
+    <!-- PCSK9 marker at 1p32.3 -->
+    <rect x="24" y="62" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="54" y1="64" x2="72" y2="64" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="74" y="67" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">PCSK9</text>
+    <!-- Banding pattern -->
+    <rect x="32" y="48" width="14" height="8" fill="#2a2f40" opacity="0.3"/>
+    <rect x="32" y="110" width="14" height="12" fill="#2a2f40" opacity="0.2"/>
+    <rect x="32" y="150" width="14" height="8" fill="#2a2f40" opacity="0.3"/>
+    <rect x="32" y="180" width="14" height="10" fill="#2a2f40" opacity="0.2"/>
+    <!-- Chromosome 2 -->
+    <rect x="130" y="40" width="18" height="170" rx="9" fill="none" stroke="#6aaa6a" stroke-width="1.2"/>
+    <rect x="130" y="100" width="18" height="4" fill="#2a2f40"/>
+    <text x="139" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">2</text>
+    <!-- WDR12 marker at 2q33.1 -->
+    <rect x="124" y="155" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="154" y1="157" x2="172" y2="157" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="174" y="160" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">WDR12</text>
+    <rect x="132" y="55" width="14" height="10" fill="#2a2f40" opacity="0.3"/>
+    <rect x="132" y="120" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <rect x="132" y="170" width="14" height="10" fill="#2a2f40" opacity="0.3"/>
+    <!-- Chromosome 6 -->
+    <rect x="230" y="40" width="18" height="140" rx="9" fill="none" stroke="#4a9aca" stroke-width="1.2"/>
+    <rect x="230" y="85" width="18" height="4" fill="#2a2f40"/>
+    <text x="239" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">6</text>
+    <!-- PHACTR1 marker at 6p24.1 -->
+    <rect x="224" y="54" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="254" y1="56" x2="272" y2="56" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="274" y="59" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">PHACTR1</text>
+    <rect x="232" y="65" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <rect x="232" y="110" width="14" height="10" fill="#2a2f40" opacity="0.3"/>
+    <rect x="232" y="145" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <!-- Chromosome 9 -->
+    <rect x="330" y="40" width="18" height="120" rx="9" fill="none" stroke="#6aaa6a" stroke-width="1.2"/>
+    <rect x="330" y="78" width="18" height="4" fill="#2a2f40"/>
+    <text x="339" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">9</text>
+    <!-- CDKN2B-AS1 marker at 9p21.3 (lead signal) -->
+    <rect x="324" y="58" width="30" height="6" rx="1" fill="#c44a4a"/>
+    <line x1="354" y1="61" x2="372" y2="61" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="374" y="64" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">CDKN2B-AS1</text>
+    <rect x="332" y="48" width="14" height="6" fill="#2a2f40" opacity="0.3"/>
+    <rect x="332" y="95" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <rect x="332" y="130" width="14" height="8" fill="#2a2f40" opacity="0.3"/>
+    <!-- Chromosome 10 -->
+    <rect x="430" y="40" width="18" height="122" rx="9" fill="none" stroke="#4a9aca" stroke-width="1.2"/>
+    <rect x="430" y="80" width="18" height="4" fill="#2a2f40"/>
+    <text x="439" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">10</text>
+    <!-- CXCL12 marker at 10q11.21 -->
+    <rect x="424" y="90" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="454" y1="92" x2="472" y2="92" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="474" y="95" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">CXCL12</text>
+    <rect x="432" y="50" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <rect x="432" y="110" width="14" height="10" fill="#2a2f40" opacity="0.3"/>
+    <rect x="432" y="135" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <!-- Chromosome 15 -->
+    <rect x="530" y="40" width="18" height="100" rx="9" fill="none" stroke="#6aaa6a" stroke-width="1.2"/>
+    <rect x="530" y="70" width="18" height="4" fill="#2a2f40"/>
+    <text x="539" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">15</text>
+    <!-- ADAMTS7 marker at 15q25.1 -->
+    <rect x="524" y="112" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="554" y1="114" x2="572" y2="114" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="574" y="117" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">ADAMTS7</text>
+    <rect x="532" y="48" width="14" height="6" fill="#2a2f40" opacity="0.3"/>
+    <rect x="532" y="82" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <!-- Chromosome 19 -->
+    <rect x="630" y="40" width="18" height="80" rx="9" fill="none" stroke="#4a9aca" stroke-width="1.2"/>
+    <rect x="630" y="62" width="18" height="4" fill="#2a2f40"/>
+    <text x="639" y="32" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">19</text>
+    <!-- LDLR marker at 19p13.2 -->
+    <rect x="624" y="50" width="30" height="4" rx="1" fill="#c44a4a"/>
+    <line x1="654" y1="52" x2="672" y2="52" stroke="#c44a4a" stroke-width="0.8"/>
+    <text x="674" y="55" font-family="JetBrains Mono" font-size="7" fill="#c44a4a" font-weight="700" font-style="italic">LDLR</text>
+    <rect x="632" y="72" width="14" height="8" fill="#2a2f40" opacity="0.2"/>
+    <rect x="632" y="95" width="14" height="8" fill="#2a2f40" opacity="0.3"/>
+    <!-- Legend -->
+    <rect x="30" y="240" width="12" height="4" rx="1" fill="#c44a4a"/>
+    <text x="48" y="246" font-family="STIX Two Text" font-size="9" fill="#7a7870">Genome-wide significant locus</text>
+    <rect x="200" y="240" width="12" height="4" rx="1" fill="none" stroke="#4a9aca" stroke-width="1"/>
+    <text x="218" y="246" font-family="STIX Two Text" font-size="9" fill="#7a7870">Odd chromosomes</text>
+    <rect x="340" y="240" width="12" height="4" rx="1" fill="none" stroke="#6aaa6a" stroke-width="1"/>
+    <text x="358" y="246" font-family="STIX Two Text" font-size="9" fill="#7a7870">Even chromosomes</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 3.</span> Chromosome ideogram showing the genomic positions of the eight genome-wide significant loci. Red bars indicate the cytogenetic band of each locus, with gene annotations. Chromosomes are drawn to approximate relative scale. Not all 22 autosomes are shown; only those harbouring significant loci are depicted.</figcaption>
+</figure>
+
+## 3.3 Locus-by-locus results
+
+### 9p21.3 -- <em>CDKN2B-AS1</em>
+
+The lead signal at 9p21.3 (rs4977574, P = 2.4 x 10<sup>-12</sup>, OR = 1.29) represents the strongest novel association in this study. The variant maps to an intron of the long non-coding RNA <em>CDKN2B-AS1</em> (also known as <em>ANRIL</em>), which regulates expression of the neighbouring cyclin-dependent kinase inhibitors <em>CDKN2A</em> and <em>CDKN2B</em>. Conditional analysis identified no independent secondary signals within 1 Mb of the lead variant.
+
+### 1p32.3 -- <em>PCSK9</em>
+
+The <em>PCSK9</em> locus (rs11591147, P = 8.7 x 10<sup>-11</sup>, OR = 1.22) replicates a well-established CAD risk locus. <em>PCSK9</em> encodes proprotein convertase subtilisin/kexin type 9, a key regulator of LDL receptor degradation and a validated drug target for cholesterol lowering. Conditional analysis revealed a secondary signal 340 kb downstream (rs2479409, conditional P = 4.1 x 10<sup>-7</sup>), suggesting allelic heterogeneity.
+
+### 6p24.1 -- <em>PHACTR1</em>
+
+The <em>PHACTR1</em> locus (rs9349379, P = 3.1 x 10<sup>-10</sup>, OR = 1.18) has been previously reported in European GWAS. The variant is an eQTL for <em>PHACTR1</em> in coronary artery tissue. Our multi-ethnic analysis confirms the association with consistent effect direction across all four ancestry groups.
+
+### 10q11.21 -- <em>CXCL12</em>
+
+The <em>CXCL12</em> locus (rs501120, P = 6.2 x 10<sup>-9</sup>, OR = 1.16) replicates a previously reported signal. <em>CXCL12</em> encodes stromal cell-derived factor 1, a chemokine involved in inflammatory cell recruitment to atherosclerotic plaques.
+
+### Other significant loci
+
+The remaining four loci -- <em>ADAMTS7</em> (15q25.1), <em>WDR12</em> (2q33.1), <em>KCNE2</em> (21q22.11), and <em>LDLR</em> (19p13.2) -- are described in detail in the Results summary page with effect sizes tabulated in Table 1.
+
+## 3.4 Conditional and joint analysis
+
+Stepwise conditional analysis using GCTA-COJO was performed at each of the eight loci. Secondary signals (conditional P < 1 x 10<sup>-6</sup>) were identified at two loci:
+
+- **1p32.3** (<em>PCSK9</em>): one secondary signal (rs2479409, conditional P = 4.1 x 10<sup>-7</sup>)
+- **9p21.3** (<em>CDKN2B-AS1</em>): no secondary signals detected despite the strong primary signal
+
+The absence of secondary signals at 9p21.3 is consistent with a single causal variant (or a small set of variants in tight LD) driving the entire association at this locus.

--- a/genome-paper/content/sections/4-functional-annotation.md
+++ b/genome-paper/content/sections/4-functional-annotation.md
@@ -1,0 +1,192 @@
++++
+title = "4. Functional Annotation"
+description = "Pathway enrichment analysis, eQTL colocalisation, chromatin state annotation, and linkage disequilibrium structure at significant loci."
+weight = 4
+template = "post"
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Pathway analysis
+
+Gene set enrichment analysis was performed using FUMA v1.5.6, mapping lead variants and variants in LD (r-squared > 0.6) to genes within 10 kb. The following Gene Ontology biological process terms were significantly enriched after Bonferroni correction (adjusted P < 0.05):
+
+- **Vascular smooth muscle cell differentiation** (GO:0035886) -- P = 3.2 x 10<sup>-6</sup>
+- **Lipid metabolic process** (GO:0006629) -- P = 8.4 x 10<sup>-6</sup>
+- **Regulation of blood coagulation** (GO:0030193) -- P = 2.1 x 10<sup>-5</sup>
+- **Inflammatory response** (GO:0006954) -- P = 4.7 x 10<sup>-5</sup>
+- **Extracellular matrix organisation** (GO:0030198) -- P = 6.8 x 10<sup>-5</sup>
+
+The enrichment of vascular smooth muscle cell differentiation is consistent with the known biology of the 9p21.3 locus, where <em>CDKN2B-AS1</em> regulates proliferation of smooth muscle cells in the vascular wall.
+
+## 4.2 eQTL colocalisation
+
+Colocalisation analysis was performed between GWAS signals and eQTL data from GTEx v8 (coronary artery, aorta, whole blood, and liver tissues) using the coloc R package. Evidence of colocalisation (posterior probability H4 > 0.8) was found at five of the eight loci:
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> eQTL colocalisation results at genome-wide significant loci.</caption>
+  <thead>
+    <tr>
+      <th>Locus</th>
+      <th>Gene</th>
+      <th>Tissue</th>
+      <th>PP.H4</th>
+      <th>eQTL direction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9p21.3</td>
+      <td><em>CDKN2B-AS1</em></td>
+      <td>Coronary artery</td>
+      <td class="num">0.94</td>
+      <td>Risk allele decreases expression</td>
+    </tr>
+    <tr>
+      <td>1p32.3</td>
+      <td><em>PCSK9</em></td>
+      <td>Liver</td>
+      <td class="num">0.91</td>
+      <td>Risk allele increases expression</td>
+    </tr>
+    <tr>
+      <td>6p24.1</td>
+      <td><em>PHACTR1</em></td>
+      <td>Coronary artery</td>
+      <td class="num">0.88</td>
+      <td>Risk allele decreases expression</td>
+    </tr>
+    <tr>
+      <td>10q11.21</td>
+      <td><em>CXCL12</em></td>
+      <td>Whole blood</td>
+      <td class="num">0.85</td>
+      <td>Risk allele increases expression</td>
+    </tr>
+    <tr>
+      <td>19p13.2</td>
+      <td><em>LDLR</em></td>
+      <td>Liver</td>
+      <td class="num">0.83</td>
+      <td>Risk allele decreases expression</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">PP.H4 = posterior probability of hypothesis 4 (shared causal variant between GWAS and eQTL). Colocalisation was performed using the coloc R package v5.2.2 with default priors.</td></tr>
+  </tfoot>
+</table>
+
+## 4.3 Chromatin state enrichment
+
+Enrichment of GWAS variants in chromatin states annotated by the Roadmap Epigenomics Project was assessed using LDSC-SEG. The strongest enrichment was observed in:
+
+1. **Active enhancers** in coronary artery smooth muscle cells (enrichment = 8.4, P = 1.2 x 10<sup>-4</sup>)
+2. **Active promoters** in aorta tissue (enrichment = 6.2, P = 3.8 x 10<sup>-4</sup>)
+3. **Flanking active TSS** in liver (enrichment = 5.1, P = 8.4 x 10<sup>-4</sup>)
+
+These results suggest that CAD-associated variants preferentially act through regulatory elements in vascular and hepatic tissues.
+
+## 4.4 LD structure at the 9p21.3 locus
+
+<figure class="figure">
+  <svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Linkage disequilibrium heatmap showing r-squared values between SNPs at the 9p21.3 locus in a triangular matrix pattern">
+    <!-- Title -->
+    <text x="360" y="20" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="11" fill="#ccc8bc" letter-spacing="0.5">LD STRUCTURE AT 9p21.3 (r-squared)</text>
+    <!-- SNP labels across top -->
+    <g font-family="JetBrains Mono" font-size="8" fill="#7a7870" text-anchor="middle">
+      <text x="160" y="50">rs4977574</text>
+      <text x="230" y="50">rs1333049</text>
+      <text x="300" y="50">rs10757278</text>
+      <text x="370" y="50">rs2383206</text>
+      <text x="440" y="50">rs10116277</text>
+      <text x="510" y="50">rs1537370</text>
+    </g>
+    <!-- Vertical tick lines from labels -->
+    <g stroke="#2a2f40" stroke-width="0.5">
+      <line x1="160" y1="54" x2="160" y2="62"/>
+      <line x1="230" y1="54" x2="230" y2="62"/>
+      <line x1="300" y1="54" x2="300" y2="62"/>
+      <line x1="370" y1="54" x2="370" y2="62"/>
+      <line x1="440" y1="54" x2="440" y2="62"/>
+      <line x1="510" y1="54" x2="510" y2="62"/>
+    </g>
+    <!-- Triangular LD heatmap - row 1 (rs4977574 vs others) -->
+    <!-- r2 with rs1333049 = 0.95 (very high) -->
+    <rect x="180" y="65" width="32" height="32" fill="#c44a4a" opacity="0.95" transform="rotate(45 196 81)"/>
+    <!-- r2 with rs10757278 = 0.88 -->
+    <rect x="215" y="100" width="32" height="32" fill="#c44a4a" opacity="0.88" transform="rotate(45 231 116)"/>
+    <!-- r2 with rs2383206 = 0.72 -->
+    <rect x="250" y="135" width="32" height="32" fill="#c44a4a" opacity="0.72" transform="rotate(45 266 151)"/>
+    <!-- r2 with rs10116277 = 0.41 -->
+    <rect x="285" y="170" width="32" height="32" fill="#4a9aca" opacity="0.6" transform="rotate(45 301 186)"/>
+    <!-- r2 with rs1537370 = 0.18 -->
+    <rect x="320" y="205" width="32" height="32" fill="#4a9aca" opacity="0.25" transform="rotate(45 336 221)"/>
+    <!-- Row 2 (rs1333049 vs others) -->
+    <!-- r2 with rs10757278 = 0.91 -->
+    <rect x="250" y="65" width="32" height="32" fill="#c44a4a" opacity="0.91" transform="rotate(45 266 81)"/>
+    <!-- r2 with rs2383206 = 0.76 -->
+    <rect x="285" y="100" width="32" height="32" fill="#c44a4a" opacity="0.76" transform="rotate(45 301 116)"/>
+    <!-- r2 with rs10116277 = 0.44 -->
+    <rect x="320" y="135" width="32" height="32" fill="#4a9aca" opacity="0.6" transform="rotate(45 336 151)"/>
+    <!-- r2 with rs1537370 = 0.22 -->
+    <rect x="355" y="170" width="32" height="32" fill="#4a9aca" opacity="0.3" transform="rotate(45 371 186)"/>
+    <!-- Row 3 (rs10757278 vs others) -->
+    <!-- r2 with rs2383206 = 0.82 -->
+    <rect x="320" y="65" width="32" height="32" fill="#c44a4a" opacity="0.82" transform="rotate(45 336 81)"/>
+    <!-- r2 with rs10116277 = 0.38 -->
+    <rect x="355" y="100" width="32" height="32" fill="#4a9aca" opacity="0.5" transform="rotate(45 371 116)"/>
+    <!-- r2 with rs1537370 = 0.15 -->
+    <rect x="390" y="135" width="32" height="32" fill="#4a9aca" opacity="0.2" transform="rotate(45 406 151)"/>
+    <!-- Row 4 (rs2383206 vs others) -->
+    <!-- r2 with rs10116277 = 0.52 -->
+    <rect x="390" y="65" width="32" height="32" fill="#4a9aca" opacity="0.7" transform="rotate(45 406 81)"/>
+    <!-- r2 with rs1537370 = 0.28 -->
+    <rect x="425" y="100" width="32" height="32" fill="#4a9aca" opacity="0.35" transform="rotate(45 441 116)"/>
+    <!-- Row 5 (rs10116277 vs rs1537370) -->
+    <!-- r2 = 0.61 -->
+    <rect x="460" y="65" width="32" height="32" fill="#6aaa6a" opacity="0.7" transform="rotate(45 476 81)"/>
+    <!-- r-squared value annotations -->
+    <g font-family="JetBrains Mono" font-size="7" fill="#ccc8bc" text-anchor="middle" font-weight="500">
+      <text x="196" y="84">0.95</text>
+      <text x="231" y="119">0.88</text>
+      <text x="266" y="154">0.72</text>
+      <text x="301" y="189">0.41</text>
+      <text x="336" y="224">0.18</text>
+      <text x="266" y="84">0.91</text>
+      <text x="301" y="119">0.76</text>
+      <text x="336" y="84">0.82</text>
+      <text x="406" y="84">0.52</text>
+      <text x="476" y="84">0.61</text>
+    </g>
+    <!-- Legend -->
+    <text x="160" y="280" font-family="JetBrains Mono" font-size="9" fill="#7a7870" font-weight="700">r-squared scale:</text>
+    <rect x="260" y="272" width="20" height="10" fill="#4a9aca" opacity="0.2"/>
+    <text x="284" y="280" font-family="JetBrains Mono" font-size="8" fill="#7a7870">0.0-0.2</text>
+    <rect x="320" y="272" width="20" height="10" fill="#4a9aca" opacity="0.5"/>
+    <text x="344" y="280" font-family="JetBrains Mono" font-size="8" fill="#7a7870">0.2-0.5</text>
+    <rect x="380" y="272" width="20" height="10" fill="#4a9aca" opacity="0.8"/>
+    <text x="404" y="280" font-family="JetBrains Mono" font-size="8" fill="#7a7870">0.5-0.7</text>
+    <rect x="440" y="272" width="20" height="10" fill="#c44a4a" opacity="0.8"/>
+    <text x="464" y="280" font-family="JetBrains Mono" font-size="8" fill="#7a7870">0.7-0.9</text>
+    <rect x="500" y="272" width="20" height="10" fill="#c44a4a" opacity="1"/>
+    <text x="524" y="280" font-family="JetBrains Mono" font-size="8" fill="#7a7870">0.9-1.0</text>
+    <!-- Note -->
+    <text x="360" y="310" text-anchor="middle" font-family="STIX Two Text" font-size="9" fill="#7a7870">LD computed in European-ancestry subsample (N = 333,228)</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 4.</span> Linkage disequilibrium heatmap at the 9p21.3 locus. Each diamond represents the pairwise r-squared between two SNPs. Red indicates high LD (r-squared > 0.7), blue indicates moderate to low LD, and green indicates intermediate values. The three lead credible set variants (rs4977574, rs1333049, rs10757278) form a tight LD block with r-squared exceeding 0.88.</figcaption>
+</figure>
+
+## 4.5 Tissue-specific gene expression
+
+Analysis of gene expression across 54 GTEx tissues revealed that genes at the eight significant loci show preferential expression in cardiovascular tissues. <em>PCSK9</em> is most highly expressed in liver, consistent with its role in LDL receptor regulation. <em>CDKN2B-AS1</em> shows broad expression but is notably enriched in coronary artery and aorta. <em>PHACTR1</em> expression is highest in coronary artery and tibial artery.
+
+## 4.6 Druggability assessment
+
+Two of the eight loci harbour genes that are targets of approved or investigational therapies:
+
+- <em>PCSK9</em> -- target of evolocumab and alirocumab (approved PCSK9 inhibitors for hypercholesterolaemia)
+- <em>LDLR</em> -- indirectly targeted by statins, which upregulate LDLR expression
+
+The remaining six loci represent potential novel drug targets. <em>ADAMTS7</em> is of particular interest given its protease activity and the directional consistency of the GWAS signal with loss-of-function protective effects observed in preclinical models.

--- a/genome-paper/content/sections/5-discussion.md
+++ b/genome-paper/content/sections/5-discussion.md
@@ -1,0 +1,75 @@
++++
+title = "5. Discussion"
+description = "Interpretation of novel findings, comparison to prior genome-wide association studies of coronary artery disease, limitations, and clinical implications."
+weight = 5
+template = "post"
+tags = ["paper", "dark", "genomics", "bioinformatics", "data-intensive"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of novel findings
+
+This multi-ethnic GWAS meta-analysis of coronary artery disease identified eight genome-wide significant loci, three of which are novel. The lead finding at 9p21.3 near <em>CDKN2B-AS1</em> achieved the strongest statistical significance (P = 2.4 x 10<sup>-12</sup>) and implicates a long non-coding RNA with established roles in cell cycle regulation and vascular smooth muscle cell biology. The novel associations at <em>ADAMTS7</em> and <em>KCNE2</em> expand the catalogue of CAD risk genes into metalloproteinase and ion channel pathways, respectively.
+
+## 5.2 Comparison to prior GWAS
+
+Previous large-scale GWAS for CAD, including the CARDIoGRAMplusC4D consortium meta-analyses and the recent UK Biobank and FinnGen studies, have collectively identified over 160 risk loci. Our study extends this catalogue by three novel loci while replicating five previously reported associations. The consistency of replication across ancestry groups provides strong evidence that these loci reflect genuine biological effects rather than population-specific confounding.
+
+Several factors contributed to our ability to detect novel signals:
+
+1. **Multi-ethnic design** -- by combining data from four ancestry groups, we increased effective sample size and leveraged different LD patterns to improve resolution
+2. **TOPMed reference panel** -- use of the most comprehensive imputation reference panel available increased variant density, particularly for low-frequency variants
+3. **SAIGE association testing** -- the saddle-point approximation in SAIGE provides better calibration of test statistics at low minor allele counts compared to traditional logistic regression
+
+## 5.3 Biological insights
+
+The pathway analysis results converge on three principal biological themes:
+
+### Vascular smooth muscle cell biology
+
+The 9p21.3 locus (<em>CDKN2B-AS1</em>) and the eQTL evidence at <em>PHACTR1</em> both point to regulation of vascular smooth muscle cell (VSMC) phenotype. <em>CDKN2B-AS1</em> modulates expression of <em>CDKN2A</em> and <em>CDKN2B</em>, which control cell cycle progression in VSMCs. Dysregulation of VSMC proliferation is a key process in atherosclerotic plaque formation and stability.
+
+### Lipid metabolism
+
+The <em>PCSK9</em> and <em>LDLR</em> loci are central nodes in the LDL cholesterol pathway. The co-identification of these loci in our multi-ethnic analysis, with consistent effect directions, reinforces the causal role of LDL cholesterol in CAD risk across populations. This finding has direct clinical relevance given the availability of PCSK9 inhibitor therapies.
+
+### Extracellular matrix remodelling
+
+The novel <em>ADAMTS7</em> locus encodes a metalloproteinase that cleaves cartilage oligomeric matrix protein (COMP) and has been shown to promote VSMC migration through the extracellular matrix. Loss-of-function variants in <em>ADAMTS7</em> are associated with reduced CAD risk in preclinical studies, suggesting that therapeutic inhibition of ADAMTS7 activity could be protective.
+
+## 5.4 Clinical implications
+
+The findings have several translational implications:
+
+- **Risk prediction** -- the addition of three novel loci to existing polygenic risk scores improves CAD risk prediction by approximately 0.6 percentage points of variance explained (from 7.8 to 8.4 pct on the liability scale). While this increment is modest, it compounds with ongoing discovery efforts.
+
+- **Drug target prioritisation** -- <em>ADAMTS7</em> emerges as a high-priority therapeutic target. The directional evidence (loss-of-function is protective), the pathway biology (ECM remodelling in atherosclerosis), and the genome-wide significant association in a large multi-ethnic cohort collectively support further investment in ADAMTS7 inhibitor development.
+
+- **Ancestry-inclusive genomics** -- the inclusion of non-European populations was essential for discovering the <em>KCNE2</em> locus at 21q22.11, where the effect allele frequency differs substantially between ancestries (EUR 0.08, EAS 0.15, AFR 0.22). This locus would have been underpowered in a European-only GWAS.
+
+## 5.5 Limitations
+
+Several limitations should be considered when interpreting these results:
+
+1. **Phenotype heterogeneity** -- CAD was defined using ICD-10 codes, which may capture a spectrum of disease severity from stable angina to acute myocardial infarction. More granular phenotyping could reveal locus-specific effects on disease subtypes.
+
+2. **Imputation accuracy for rare variants** -- although the TOPMed reference panel is the most comprehensive available, imputation accuracy for variants with MAF below 0.01 remains limited, particularly in African-ancestry samples. Whole-genome sequencing in large cohorts is needed to fully capture rare variant contributions.
+
+3. **Fine-mapping resolution** -- fine-mapping was performed in the European-ancestry subsample due to larger sample size. Cross-ancestry fine-mapping using methods such as SuSiEx could further narrow credible sets by leveraging LD differences across populations.
+
+4. **Functional validation** -- the causal variants and mechanisms at the novel loci remain to be established through experimental validation. The eQTL colocalisation and chromatin annotation results provide hypotheses but do not constitute proof of causality.
+
+## 5.6 Future directions
+
+Several lines of investigation are warranted:
+
+- Whole-genome sequencing GWAS in African-ancestry populations, which have the shortest LD blocks and therefore the greatest fine-mapping resolution
+- CRISPR-based functional studies at the 9p21.3, <em>ADAMTS7</em>, and <em>KCNE2</em> loci to validate causal variants and elucidate mechanisms
+- Integration with single-cell RNA sequencing of atherosclerotic plaques to identify the cell types mediating the effects of GWAS variants
+- Development of ancestry-calibrated polygenic risk scores that incorporate the novel loci identified here
+
+## 5.7 Conclusion
+
+This study demonstrates the continued value of expanding GWAS to diverse populations and leveraging improved imputation reference panels. The three novel CAD risk loci identified here provide new biological insights into coronary artery disease pathogenesis and offer potential targets for therapeutic development. The 9p21.3 locus near <em>CDKN2B-AS1</em> and the <em>ADAMTS7</em> locus are particularly promising candidates for functional follow-up.

--- a/genome-paper/content/sections/_index.md
+++ b/genome-paper/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The manuscript is organised into five numbered sections. Each section addresses a distinct phase of the genomic analysis, from cohort design and quality control through association testing, functional annotation, and interpretation of results.

--- a/genome-paper/static/css/style.css
+++ b/genome-paper/static/css/style.css
@@ -1,0 +1,633 @@
+/* ============================================================================
+   Genome-Wide Association Study - Genomic Analysis Paper
+   Dark background, monospace gene names, serif body, Manhattan plots.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0a0c12;
+  --bg-2: #12151e;
+  --bg-3: #1a1e2a;
+  --rule: #2a2f40;
+  --ink: #ccc8bc;
+  --ink-2: #aaa69a;
+  --ink-3: #7a7870;
+  --ink-4: #4e4d48;
+  --accent: #4a9aca;
+  --accent-2: #3878a0;
+  --sig-line: #c44a4a;
+  --chr-a: #4a9aca;
+  --chr-b: #6aaa6a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding {
+  font-weight: 600;
+}
+
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "STIX Two Text", Georgia, serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--accent);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--bg-3);
+  border: 1px solid var(--rule);
+  padding: 1.2rem 1.4rem;
+  overflow-x: auto;
+  border-radius: 2px;
+  margin: 1.5rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+/* ---------------- Gene names ---------------- */
+
+.gene-name {
+  font-style: italic;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* ---------------- Section header ---------------- */
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Locus callout ---------------- */
+
+.locus-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.locus-callout .callout-label {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.locus-callout .callout-value {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.locus-callout .callout-value .unit {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.locus-callout .callout-detail {
+  font-family: "STIX Two Text", Georgia, serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.92rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Pipeline box ---------------- */
+
+.pipeline-box {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.4rem 1.6rem;
+  margin: 2rem 0;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  color: var(--ink);
+  overflow-x: auto;
+}
+
+.pipeline-box .pipeline-label {
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.pipeline-box .step { color: var(--accent); font-weight: 700; }
+.pipeline-box .tool { color: var(--ink-2); }
+.pipeline-box .note { color: var(--ink-4); font-style: italic; }
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "STIX Two Text", Georgia, serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 500;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- References ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 1.6rem;
+  margin: 1rem 0;
+  counter-reset: ref;
+}
+
+.references-list li {
+  margin: 0.6rem 0;
+  padding-left: 0.2rem;
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.references-list li em { color: var(--ink); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "STIX Two Text", Georgia, serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .locus-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .pipeline-box { padding: 1rem; }
+}

--- a/genome-paper/templates/404.html
+++ b/genome-paper/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 &mdash; Locus Not Found</h1>
+      <p>The requested genomic region does not exist in this assembly.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/genome-paper/templates/footer.html
+++ b/genome-paper/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#2a2f40" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#2a2f40" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Okonkwo A, Yamamoto H, Eriksson S, Bharadwaj P. Genome-Wide Association Study of Coronary Artery Disease: Identification of Novel Risk Loci in Multi-Ethnic Cohorts. <em>Genom Hum Genet.</em> 2026;28(3):187-214. doi:10.48127/ghg.2026.28.03.187</p>
+        <p class="footer-note">ISSN 2891-0417 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/genome-paper/templates/header.html
+++ b/genome-paper/templates/header.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- DNA double helix abstract -->
+          <path d="M12 4 C20 10, 20 18, 12 24 C4 30, 4 34, 12 38" fill="none" stroke="#4a9aca" stroke-width="2" stroke-linecap="round"/>
+          <path d="M28 4 C20 10, 20 18, 28 24 C36 30, 36 34, 28 38" fill="none" stroke="#6aaa6a" stroke-width="2" stroke-linecap="round"/>
+          <!-- Rungs -->
+          <line x1="14" y1="9" x2="26" y2="9" stroke="#4a9aca" stroke-width="1" opacity="0.6"/>
+          <line x1="12" y1="14" x2="28" y2="14" stroke="#4a9aca" stroke-width="1" opacity="0.4"/>
+          <line x1="14" y1="19" x2="26" y2="19" stroke="#6aaa6a" stroke-width="1" opacity="0.6"/>
+          <line x1="12" y1="28" x2="28" y2="28" stroke="#6aaa6a" stroke-width="1" opacity="0.4"/>
+          <line x1="14" y1="33" x2="26" y2="33" stroke="#4a9aca" stroke-width="1" opacity="0.6"/>
+          <!-- Chromosome bar -->
+          <rect x="40" y="8" width="18" height="24" rx="9" fill="none" stroke="#4a9aca" stroke-width="1.5"/>
+          <line x1="40" y1="18" x2="58" y2="18" stroke="#4a9aca" stroke-width="1" opacity="0.5"/>
+          <rect x="43" y="12" width="4" height="3" fill="#c44a4a" opacity="0.7"/>
+          <rect x="50" y="22" width="4" height="3" fill="#4a9aca" opacity="0.7"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Genomics and Human Genetics</span>
+          <span class="journal-sub">Vol. 28 &middot; Issue 03 &middot; Mar 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/pipeline/">PIPELINE</a>
+        <a href="{{ base_url }}/results/">RESULTS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/genome-paper/templates/page.html
+++ b/genome-paper/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/genome-paper/templates/post.html
+++ b/genome-paper/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/genome-paper/templates/section.html
+++ b/genome-paper/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/genome-paper/templates/shortcodes/alert.html
+++ b/genome-paper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/genome-paper/templates/taxonomy.html
+++ b/genome-paper/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/genome-paper/templates/taxonomy_term.html
+++ b/genome-paper/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3993,5 +3993,12 @@
     "portfolio",
     "bold",
     "elegant"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds new genome-paper example site for Issue #1636
- Genomic Analysis Paper with dark theme featuring SVG Manhattan plot visualizations with genome-wide significance lines, chromosome ideogram diagrams with highlighted loci, bioinformatics pipeline flow diagrams, and linkage disequilibrium heatmap patterns
- Uses JetBrains Mono Bold/Fira Code Bold for gene names (displayed in italic) and STIX Two for body text
- Updates tags.json with new entry: paper, dark, genomics, bioinformatics, data-intensive

## Test plan
- [ ] Verify `hwaro build` completes successfully in the genome-paper directory
- [ ] Verify site renders correctly with `hwaro serve`
- [ ] Check all SVG diagrams render properly (Manhattan plot, chromosome ideogram, pipeline flow, LD heatmap)
- [ ] Confirm gene names appear in italic monospace
- [ ] Verify dark theme colors and typography hierarchy
- [ ] Verify tags.json is valid JSON with no missing entries