### PR TITLE
feat: add longitudinal example site (closes #1622)

### DIFF
--- a/longitudinal/AGENTS.md
+++ b/longitudinal/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/longitudinal/config.toml
+++ b/longitudinal/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Longitudinal - Time-Series Study Paper
+# Issue #1622 | Tags: paper, dark, longitudinal, temporal, tracking
+# =============================================================================
+
+title = "Longitudinal Cognition Study"
+description = "A time-series study paper tracking cognitive trajectories across five measurement waves with growth curve models, spaghetti plots, and attrition analysis."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/longitudinal/content/appendix.md
+++ b/longitudinal/content/appendix.md
@@ -1,0 +1,50 @@
++++
+title = "Appendix"
+description = "Supplementary materials including reproducibility details, Mplus syntax, data availability, author contributions, and conflict-of-interest disclosures."
+tags = ["longitudinal", "appendix", "reproducibility"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## A. Reproducibility
+
+All analyses were conducted in Mplus 8.9 (Muthen and Muthen, 2024) running on Ubuntu 22.04 LTS. Mplus input files, simulated demonstration data, and R scripts for figure generation are archived at Zenodo (doi: 10.5281/zenodo.example.2026.longitudinal). The random seed for all Monte Carlo simulations was fixed at 20140901 (study start date).
+
+## B. Mplus syntax (linear LGCM)
+
+```
+TITLE: Processing Speed Linear Growth Model;
+DATA: FILE = scac_ps.dat;
+VARIABLE: NAMES = id ps_t1 ps_t2 ps_t3 ps_t4 ps_t5
+          age edu apoe4 cvr;
+          MISSING = ALL(-999);
+          USEVARIABLES = ps_t1-ps_t5 age edu apoe4 cvr;
+ANALYSIS: ESTIMATOR = MLR;
+MODEL:
+  i s | ps_t1@0 ps_t2@1 ps_t3@2 ps_t4@3 ps_t5@4;
+  i s ON age edu apoe4 cvr;
+OUTPUT: STDYX CINTERVAL;
+```
+
+## C. Data availability
+
+The original participant-level data cannot be shared publicly due to Swedish ethical and data-protection regulations. Researchers may request access through the Karolinska Institute Data Access Committee (contact: data-access@ki.se). A fully synthetic dataset with identical distributional properties is provided in the Zenodo archive to allow replication of all reported analyses.
+
+## D. CRediT author contributions
+
+- **Renate Hartmann:** Conceptualisation, Methodology, Formal Analysis, Writing - Original Draft, Supervision
+- **Joseph Okonkwo:** Methodology, Formal Analysis, Writing - Review and Editing
+- **Anna Lindberg:** Investigation, Data Curation, Project Administration
+- **Shinji Nakamura:** Formal Analysis, Visualisation, Software
+- **Giulia Russo:** Investigation, Writing - Review and Editing
+
+## E. Conflict of interest
+
+The authors declare no competing interests.
+
+## F. Funding
+
+This work was supported by the Swedish Research Council (grant 2013-04815), the Karolinska Institute Strategic Research Programme in Epidemiology, and the US National Institute on Aging (grant R01 AG058302). The funders had no role in study design, data collection, analysis, or manuscript preparation.

--- a/longitudinal/content/index.md
+++ b/longitudinal/content/index.md
@@ -1,0 +1,393 @@
++++
+title = "Abstract"
+description = "A five-wave longitudinal study of cognitive trajectories from early adulthood through midlife, modelled with latent growth curves and individual spaghetti plots."
+tags = ["paper", "dark", "longitudinal", "temporal", "tracking"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Research &middot; Open Access</p>
+  <h1 class="paper-title">Cognitive Trajectories Across Five Measurement Waves: A Latent Growth Curve Analysis of Processing Speed, Working Memory, and Executive Function</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Renate Hartmann</span><sup>1</sup>,
+    Joseph Okonkwo<sup>2</sup>,
+    Anna Lindberg<sup>1,3</sup>,
+    Shinji Nakamura<sup>4</sup>,
+    Giulia Russo<sup>2</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Cognitive Ageing Lab, Karolinska Institute &middot;
+    <sup>2</sup>Department of Psychology, Emory University &middot;
+    <sup>3</sup>Stockholm Gerontology Centre &middot;
+    <sup>4</sup>Brain Imaging Unit, Kyoto University
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/dtq.2026.34.02.118</a> &middot; <strong>Received:</strong> 11 Sep 2025 &middot; <strong>Accepted:</strong> 14 Jan 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>To characterise individual differences in cognitive change across five measurement waves (T1-T5) spanning 12 years and to identify predictors of accelerated decline.</dd>
+    <dt>Methods</dt>
+    <dd>N = 1,842 adults (age 30-65 at baseline) completed assessments of processing speed (DSST), working memory (digit span backward), and executive function (trail-making B-A) at waves T1, T2, T3, T4, and T5 (0, 3, 6, 9, and 12 years). Latent growth curve models (LGCM) estimated intercept and slope factors. Time-invariant covariates included education, APOE-e4 carrier status, and baseline cardiovascular risk score.</dd>
+    <dt>Results</dt>
+    <dd>Processing speed declined linearly (mean slope = -0.38 SD per decade, SE = 0.04, p < 0.001). Working memory showed negligible mean change (slope = -0.06, p = 0.22) but substantial individual variation (slope variance = 0.14, p < 0.001). Executive function exhibited non-linear decline best captured by a quadratic model (quadratic term = -0.09, p = 0.003). APOE-e4 carriers showed steeper processing-speed decline (delta-slope = -0.18, p = 0.008). Attrition was 28.6 pct by T5, predicted by lower baseline scores and older age.</dd>
+    <dt>Conclusion</dt>
+    <dd>Cognitive trajectories are heterogeneous across domains. Individual spaghetti plots reveal a substantial minority with stable or improving performance even at older ages, underscoring the importance of person-level modelling in longitudinal cognition research.</dd>
+    <dt>Keywords</dt>
+    <dd><em>longitudinal; cognitive ageing; latent growth curve; processing speed; attrition; spaghetti plot; individual differences</em></dd>
+  </dl>
+</section>
+
+## Longitudinal Timeline
+
+<figure class="figure">
+  <svg viewBox="0 0 720 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Timeline showing five measurement waves T1 through T5 across 12 years">
+    <!-- Horizontal axis -->
+    <line x1="60" y1="80" x2="680" y2="80" stroke="#525b72" stroke-width="2"/>
+    <!-- Tick marks and wave points -->
+    <line x1="100" y1="72" x2="100" y2="88" stroke="#525b72" stroke-width="1.5"/>
+    <circle cx="100" cy="80" r="10" fill="none" stroke="#f5a673" stroke-width="2.5"/>
+    <circle cx="100" cy="80" r="4" fill="#f5a673"/>
+    <text x="100" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="13" fill="#f5a673">T1</text>
+    <text x="100" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">Baseline</text>
+    <text x="100" y="135" text-anchor="middle" font-family="Crimson Pro" font-size="9" fill="#7e889e">Year 0</text>
+
+    <line x1="240" y1="72" x2="240" y2="88" stroke="#525b72" stroke-width="1.5"/>
+    <circle cx="240" cy="80" r="10" fill="none" stroke="#e8d45a" stroke-width="2.5"/>
+    <circle cx="240" cy="80" r="4" fill="#e8d45a"/>
+    <text x="240" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="13" fill="#e8d45a">T2</text>
+    <text x="240" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">Wave 2</text>
+    <text x="240" y="135" text-anchor="middle" font-family="Crimson Pro" font-size="9" fill="#7e889e">Year 3</text>
+
+    <line x1="380" y1="72" x2="380" y2="88" stroke="#525b72" stroke-width="1.5"/>
+    <circle cx="380" cy="80" r="10" fill="none" stroke="#73d4a0" stroke-width="2.5"/>
+    <circle cx="380" cy="80" r="4" fill="#73d4a0"/>
+    <text x="380" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="13" fill="#73d4a0">T3</text>
+    <text x="380" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">Wave 3</text>
+    <text x="380" y="135" text-anchor="middle" font-family="Crimson Pro" font-size="9" fill="#7e889e">Year 6</text>
+
+    <line x1="520" y1="72" x2="520" y2="88" stroke="#525b72" stroke-width="1.5"/>
+    <circle cx="520" cy="80" r="10" fill="none" stroke="#5ab8e8" stroke-width="2.5"/>
+    <circle cx="520" cy="80" r="4" fill="#5ab8e8"/>
+    <text x="520" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="13" fill="#5ab8e8">T4</text>
+    <text x="520" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">Wave 4</text>
+    <text x="520" y="135" text-anchor="middle" font-family="Crimson Pro" font-size="9" fill="#7e889e">Year 9</text>
+
+    <line x1="640" y1="72" x2="640" y2="88" stroke="#525b72" stroke-width="1.5"/>
+    <circle cx="640" cy="80" r="10" fill="none" stroke="#b285e8" stroke-width="2.5"/>
+    <circle cx="640" cy="80" r="4" fill="#b285e8"/>
+    <text x="640" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="13" fill="#b285e8">T5</text>
+    <text x="640" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">Wave 5</text>
+    <text x="640" y="135" text-anchor="middle" font-family="Crimson Pro" font-size="9" fill="#7e889e">Year 12</text>
+
+    <!-- Inter-wave arrows -->
+    <line x1="115" y1="80" x2="225" y2="80" stroke="#282e40" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="255" y1="80" x2="365" y2="80" stroke="#282e40" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="395" y1="80" x2="505" y2="80" stroke="#282e40" stroke-width="1" stroke-dasharray="4 3"/>
+    <line x1="535" y1="80" x2="625" y2="80" stroke="#282e40" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- N labels -->
+    <text x="100" y="22" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#dfe4ed">N=1842</text>
+    <text x="240" y="22" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#dfe4ed">N=1694</text>
+    <text x="380" y="22" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#dfe4ed">N=1561</text>
+    <text x="520" y="22" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#dfe4ed">N=1418</text>
+    <text x="640" y="22" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#dfe4ed">N=1315</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Measurement timeline showing the five assessment waves (T1-T5) over 12 years. Sample sizes at each wave reflect cumulative attrition. All participants completed identical cognitive batteries at each wave.</figcaption>
+</figure>
+
+<section class="model-callout">
+  <span class="callout-label">Processing Speed Decline</span>
+  <span class="callout-value">-0.38 SD<span class="unit">per decade (SE = 0.04)</span></span>
+  <p class="callout-detail">Linear slope from latent growth curve model. Significant individual variation in slope (variance = 0.22, p < 0.001). APOE-e4 carriers declined 0.18 SD faster per decade.</p>
+</section>
+
+## Spaghetti Plot: Individual Trajectories
+
+<figure class="figure">
+  <svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Spaghetti plot showing individual cognitive trajectories across five waves for processing speed">
+    <!-- Axes -->
+    <line x1="80" y1="20" x2="80" y2="320" stroke="#525b72" stroke-width="1.5"/>
+    <line x1="80" y1="320" x2="680" y2="320" stroke="#525b72" stroke-width="1.5"/>
+    <!-- Y-axis labels -->
+    <text x="70" y="25" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">2.0</text>
+    <text x="70" y="95" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">1.0</text>
+    <text x="70" y="170" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">0.0</text>
+    <text x="70" y="245" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">-1.0</text>
+    <text x="70" y="320" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">-2.0</text>
+    <text x="20" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#7e889e" transform="rotate(-90 20 170)">DSST Z-SCORE</text>
+    <!-- Grid lines -->
+    <line x1="80" y1="95" x2="680" y2="95" stroke="#282e40" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="80" y1="170" x2="680" y2="170" stroke="#282e40" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="80" y1="245" x2="680" y2="245" stroke="#282e40" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <!-- X-axis wave markers -->
+    <text x="130" y="345" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#f5a673">T1</text>
+    <text x="270" y="345" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#e8d45a">T2</text>
+    <text x="400" y="345" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#73d4a0">T3</text>
+    <text x="530" y="345" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#5ab8e8">T4</text>
+    <text x="650" y="345" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="12" fill="#b285e8">T5</text>
+    <text x="400" y="370" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#7e889e" letter-spacing="1">MEASUREMENT WAVE</text>
+    <!-- Individual trajectories (light, low opacity) -->
+    <polyline points="130,80 270,90 400,105 530,125 650,140" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,100 270,95 400,110 530,130 650,155" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,120 270,135 400,145 530,165 650,185" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,140 270,140 400,150 530,160 650,175" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,90 270,110 400,130 530,155 650,180" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,160 270,155 400,165 530,175 650,190" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,170 270,180 400,195 530,215 650,240" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,190 270,195 400,210 530,225 650,245" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,200 270,210 400,220 530,240 650,260" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,220 270,225 400,240 530,255 650,275" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,240 270,248 400,260 530,270 650,290" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,150 270,148 400,155 530,158 650,160" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,175 270,170 400,168 530,170 650,172" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,110 270,100 400,95 530,100 650,105" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <polyline points="130,250 270,265 400,275 530,288 650,295" fill="none" stroke="#8a9ff5" stroke-width="0.8" opacity="0.15"/>
+    <!-- Highlighted individual: steep decliner -->
+    <polyline points="130,100 270,130 400,175 530,225 650,270" fill="none" stroke="#f5a673" stroke-width="2"/>
+    <circle cx="130" cy="100" r="3" fill="#f5a673"/>
+    <circle cx="270" cy="130" r="3" fill="#f5a673"/>
+    <circle cx="400" cy="175" r="3" fill="#f5a673"/>
+    <circle cx="530" cy="225" r="3" fill="#f5a673"/>
+    <circle cx="650" cy="270" r="3" fill="#f5a673"/>
+    <!-- Highlighted individual: stable performer -->
+    <polyline points="130,140 270,135 400,138 530,140 650,142" fill="none" stroke="#73d4a0" stroke-width="2"/>
+    <circle cx="130" cy="140" r="3" fill="#73d4a0"/>
+    <circle cx="270" cy="135" r="3" fill="#73d4a0"/>
+    <circle cx="400" cy="138" r="3" fill="#73d4a0"/>
+    <circle cx="530" cy="140" r="3" fill="#73d4a0"/>
+    <circle cx="650" cy="142" r="3" fill="#73d4a0"/>
+    <!-- Mean trajectory (bold) -->
+    <polyline points="130,155 270,165 400,182 530,200 650,218" fill="none" stroke="#8a9ff5" stroke-width="2.5"/>
+    <circle cx="130" cy="155" r="4" fill="#8a9ff5"/>
+    <circle cx="270" cy="165" r="4" fill="#8a9ff5"/>
+    <circle cx="400" cy="182" r="4" fill="#8a9ff5"/>
+    <circle cx="530" cy="200" r="4" fill="#8a9ff5"/>
+    <circle cx="650" cy="218" r="4" fill="#8a9ff5"/>
+    <!-- Legend -->
+    <line x1="90" y1="365" x2="110" y2="365" stroke="#8a9ff5" stroke-width="2.5"/>
+    <text x="115" y="368" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Mean trajectory</text>
+    <line x1="230" y1="365" x2="250" y2="365" stroke="#f5a673" stroke-width="2"/>
+    <text x="255" y="368" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Steep decliner</text>
+    <line x1="380" y1="365" x2="400" y2="365" stroke="#73d4a0" stroke-width="2"/>
+    <text x="405" y="368" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Stable performer</text>
+    <line x1="530" y1="365" x2="550" y2="365" stroke="#8a9ff5" stroke-width="0.8" opacity="0.3"/>
+    <text x="555" y="368" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Individual (n=1842)</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Spaghetti plot of processing speed (DSST z-score) across five waves. Light lines represent individual trajectories; the bold blue line shows the sample mean. Two individuals are highlighted: an APOE-e4 carrier with steep decline (orange) and a physically active participant with stable performance (green).</figcaption>
+</figure>
+
+## Growth Curve Model
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Latent growth curve model diagram showing intercept and slope factors connected to five observed waves">
+    <!-- Latent factors (circles) -->
+    <circle cx="250" cy="60" r="40" fill="none" stroke="#8a9ff5" stroke-width="2"/>
+    <text x="250" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#dfe4ed">INTERCEPT</text>
+    <text x="250" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">(i)</text>
+
+    <circle cx="470" cy="60" r="40" fill="none" stroke="#b285e8" stroke-width="2"/>
+    <text x="470" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#dfe4ed">SLOPE</text>
+    <text x="470" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">(s)</text>
+
+    <!-- Covariance arc -->
+    <path d="M 290 55 Q 360 10 430 55" fill="none" stroke="#525b72" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="360" y="20" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">cov(i,s)</text>
+
+    <!-- Observed variables (boxes) -->
+    <rect x="60" y="220" width="60" height="40" fill="none" stroke="#f5a673" stroke-width="1.5"/>
+    <text x="90" y="244" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#f5a673">T1</text>
+
+    <rect x="190" y="220" width="60" height="40" fill="none" stroke="#e8d45a" stroke-width="1.5"/>
+    <text x="220" y="244" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#e8d45a">T2</text>
+
+    <rect x="320" y="220" width="60" height="40" fill="none" stroke="#73d4a0" stroke-width="1.5"/>
+    <text x="350" y="244" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#73d4a0">T3</text>
+
+    <rect x="460" y="220" width="60" height="40" fill="none" stroke="#5ab8e8" stroke-width="1.5"/>
+    <text x="490" y="244" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#5ab8e8">T4</text>
+
+    <rect x="590" y="220" width="60" height="40" fill="none" stroke="#b285e8" stroke-width="1.5"/>
+    <text x="620" y="244" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#b285e8">T5</text>
+
+    <!-- Factor loadings from intercept (all = 1) -->
+    <line x1="230" y1="98" x2="90" y2="220" stroke="#8a9ff5" stroke-width="1"/>
+    <line x1="240" y1="98" x2="220" y2="220" stroke="#8a9ff5" stroke-width="1"/>
+    <line x1="250" y1="100" x2="350" y2="220" stroke="#8a9ff5" stroke-width="1"/>
+    <line x1="260" y1="98" x2="490" y2="220" stroke="#8a9ff5" stroke-width="1"/>
+    <line x1="270" y1="98" x2="620" y2="220" stroke="#8a9ff5" stroke-width="1"/>
+    <text x="148" y="160" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#8a9ff5">1</text>
+    <text x="222" y="160" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#8a9ff5">1</text>
+    <text x="298" y="160" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#8a9ff5">1</text>
+    <text x="380" y="160" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#8a9ff5">1</text>
+    <text x="458" y="155" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#8a9ff5">1</text>
+
+    <!-- Factor loadings from slope (0, 1, 2, 3, 4) -->
+    <line x1="450" y1="98" x2="90" y2="220" stroke="#b285e8" stroke-width="1" stroke-dasharray="3 2"/>
+    <line x1="455" y1="98" x2="220" y2="220" stroke="#b285e8" stroke-width="1" stroke-dasharray="3 2"/>
+    <line x1="465" y1="100" x2="350" y2="220" stroke="#b285e8" stroke-width="1"/>
+    <line x1="475" y1="98" x2="490" y2="220" stroke="#b285e8" stroke-width="1"/>
+    <line x1="490" y1="98" x2="620" y2="220" stroke="#b285e8" stroke-width="1"/>
+    <text x="258" y="175" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#b285e8">0</text>
+    <text x="330" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#b285e8">1</text>
+    <text x="408" y="168" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#b285e8">2</text>
+    <text x="490" y="168" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#b285e8">3</text>
+    <text x="562" y="162" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#b285e8">4</text>
+
+    <!-- Error terms -->
+    <text x="90" y="280" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#525b72">e1</text>
+    <text x="220" y="280" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#525b72">e2</text>
+    <text x="350" y="280" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#525b72">e3</text>
+    <text x="490" y="280" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#525b72">e4</text>
+    <text x="620" y="280" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#525b72">e5</text>
+
+    <!-- Legend -->
+    <rect x="60" y="300" width="600" height="1" fill="#282e40"/>
+    <circle cx="100" cy="315" r="5" fill="none" stroke="#8a9ff5" stroke-width="1.5"/>
+    <text x="112" y="318" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Latent factor</text>
+    <rect x="210" y="310" width="12" height="10" fill="none" stroke="#73d4a0" stroke-width="1.5"/>
+    <text x="230" y="318" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Observed variable</text>
+    <line x1="370" y1="315" x2="390" y2="315" stroke="#8a9ff5" stroke-width="1"/>
+    <text x="398" y="318" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Intercept loading (=1)</text>
+    <line x1="545" y1="315" x2="565" y2="315" stroke="#b285e8" stroke-width="1"/>
+    <text x="573" y="318" font-family="Crimson Pro" font-size="10" fill="#bfc6d4">Slope loading</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 3.</span> Latent growth curve model specification. Intercept (i) loadings are fixed to 1 across all waves. Slope (s) loadings are fixed to 0, 1, 2, 3, 4 representing equally spaced 3-year intervals. The covariance between intercept and slope captures whether initial level predicts rate of change.</figcaption>
+</figure>
+
+## Attrition Flow
+
+<figure class="figure">
+  <svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Attrition flow diagram showing participant retention and dropout at each wave">
+    <!-- Wave boxes -->
+    <rect x="20" y="30" width="120" height="55" fill="none" stroke="#f5a673" stroke-width="2"/>
+    <text x="80" y="52" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#f5a673">T1</text>
+    <text x="80" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#dfe4ed">N = 1,842</text>
+
+    <rect x="170" y="30" width="120" height="55" fill="none" stroke="#e8d45a" stroke-width="2"/>
+    <text x="230" y="52" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#e8d45a">T2</text>
+    <text x="230" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#dfe4ed">N = 1,694</text>
+
+    <rect x="320" y="30" width="120" height="55" fill="none" stroke="#73d4a0" stroke-width="2"/>
+    <text x="380" y="52" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#73d4a0">T3</text>
+    <text x="380" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#dfe4ed">N = 1,561</text>
+
+    <rect x="470" y="30" width="120" height="55" fill="none" stroke="#5ab8e8" stroke-width="2"/>
+    <text x="530" y="52" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#5ab8e8">T4</text>
+    <text x="530" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#dfe4ed">N = 1,418</text>
+
+    <rect x="620" y="30" width="80" height="55" fill="none" stroke="#b285e8" stroke-width="2"/>
+    <text x="660" y="52" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="11" fill="#b285e8">T5</text>
+    <text x="660" y="70" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#dfe4ed">N = 1,315</text>
+
+    <!-- Arrows between waves -->
+    <line x1="140" y1="57" x2="170" y2="57" stroke="#525b72" stroke-width="1.5" marker-end="url(#arrowGray)"/>
+    <line x1="290" y1="57" x2="320" y2="57" stroke="#525b72" stroke-width="1.5" marker-end="url(#arrowGray)"/>
+    <line x1="440" y1="57" x2="470" y2="57" stroke="#525b72" stroke-width="1.5" marker-end="url(#arrowGray)"/>
+    <line x1="590" y1="57" x2="620" y2="57" stroke="#525b72" stroke-width="1.5" marker-end="url(#arrowGray)"/>
+
+    <!-- Dropout arrows (downward) -->
+    <line x1="155" y1="85" x2="155" y2="140" stroke="#525b72" stroke-width="1" stroke-dasharray="3 2"/>
+    <rect x="110" y="140" width="90" height="40" fill="none" stroke="#525b72" stroke-width="1"/>
+    <text x="155" y="157" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">DROPPED</text>
+    <text x="155" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">n = 148</text>
+
+    <line x1="305" y1="85" x2="305" y2="140" stroke="#525b72" stroke-width="1" stroke-dasharray="3 2"/>
+    <rect x="260" y="140" width="90" height="40" fill="none" stroke="#525b72" stroke-width="1"/>
+    <text x="305" y="157" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">DROPPED</text>
+    <text x="305" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">n = 133</text>
+
+    <line x1="455" y1="85" x2="455" y2="140" stroke="#525b72" stroke-width="1" stroke-dasharray="3 2"/>
+    <rect x="410" y="140" width="90" height="40" fill="none" stroke="#525b72" stroke-width="1"/>
+    <text x="455" y="157" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">DROPPED</text>
+    <text x="455" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">n = 143</text>
+
+    <line x1="605" y1="85" x2="605" y2="140" stroke="#525b72" stroke-width="1" stroke-dasharray="3 2"/>
+    <rect x="560" y="140" width="90" height="40" fill="none" stroke="#525b72" stroke-width="1"/>
+    <text x="605" y="157" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">DROPPED</text>
+    <text x="605" y="170" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#7e889e">n = 103</text>
+
+    <!-- Dropout reasons -->
+    <text x="155" y="200" text-anchor="middle" font-family="Crimson Pro" font-size="8" fill="#525b72">Moved: 62</text>
+    <text x="155" y="212" text-anchor="middle" font-family="Crimson Pro" font-size="8" fill="#525b72">Refused: 51</text>
+    <text x="155" y="224" text-anchor="middle" font-family="Crimson Pro" font-size="8" fill="#525b72">Deceased: 14</text>
+    <text x="155" y="236" text-anchor="middle" font-family="Crimson Pro" font-size="8" fill="#525b72">Health: 21</text>
+
+    <!-- Arrow marker -->
+    <defs>
+      <marker id="arrowGray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#525b72"/>
+      </marker>
+    </defs>
+
+    <!-- Retention summary -->
+    <text x="360" y="265" text-anchor="middle" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#7e889e" letter-spacing="0.5">CUMULATIVE ATTRITION: 28.6 PCT BY T5 (527 OF 1,842)</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 4.</span> Attrition flow across five measurement waves. Dropout reasons are detailed for the T1-to-T2 transition; similar distributions were observed at later waves. Attrition was predicted by lower baseline cognitive scores (OR = 1.34 per SD) and older age (OR = 1.22 per decade).</figcaption>
+</figure>
+
+## Key Results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Latent growth curve model estimates for three cognitive domains across five waves (T1-T5).</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Processing Speed</th>
+      <th>Working Memory</th>
+      <th>Executive Function</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Mean intercept (SE)</td>
+      <td class="num">0.00 (--)</td>
+      <td class="num">0.00 (--)</td>
+      <td class="num">0.00 (--)</td>
+    </tr>
+    <tr>
+      <td>Intercept variance</td>
+      <td class="num">0.87</td>
+      <td class="num">0.72</td>
+      <td class="num">0.91</td>
+    </tr>
+    <tr>
+      <td>Mean slope (SE)</td>
+      <td class="num">-0.38 (0.04)</td>
+      <td class="num">-0.06 (0.05)</td>
+      <td class="num">-0.21 (0.04)</td>
+    </tr>
+    <tr>
+      <td>Slope variance</td>
+      <td class="num">0.22</td>
+      <td class="num">0.14</td>
+      <td class="num">0.18</td>
+    </tr>
+    <tr>
+      <td>Intercept-slope covariance</td>
+      <td class="num">-0.08</td>
+      <td class="num">-0.03</td>
+      <td class="num">-0.11</td>
+    </tr>
+    <tr>
+      <td>CFI / RMSEA</td>
+      <td class="num">0.968 / 0.042</td>
+      <td class="num">0.981 / 0.034</td>
+      <td class="num">0.955 / 0.048</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Slopes are in SD units per 3-year interval. CFI above 0.95 and RMSEA below 0.06 indicate acceptable fit. All intercepts centred at T1.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the section index. The full manuscript contains the following numbered sections.
+
+1. **Section 1. Study Design** -- cohort description, inclusion criteria, and wave schedule
+2. **Section 2. Cognitive Battery** -- measures, administration, and scoring procedures
+3. **Section 3. Growth Curve Models** -- specification, estimation, and model comparison
+4. **Section 4. Attrition Analysis** -- predictors, patterns, and sensitivity to missingness
+5. **Section 5. Discussion** -- interpretation, limitations, and implications for ageing research

--- a/longitudinal/content/methodology.md
+++ b/longitudinal/content/methodology.md
@@ -1,0 +1,35 @@
++++
+title = "Methodology"
+description = "Detailed analytical framework including latent growth curve specifications, missing data handling, and model comparison strategy."
+tags = ["longitudinal", "methodology", "SEM"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Detailed Methodology</h1>
+</header>
+
+## Analytical framework
+
+The analytical strategy proceeded in three stages. First, unconditional linear growth models were fitted to each cognitive domain separately. Second, quadratic extensions were tested where linear fit was inadequate. Third, conditional models incorporated time-invariant predictors to explain individual differences in intercept and slope.
+
+## Model estimation
+
+All models were estimated in Mplus 8.9 using maximum likelihood with robust standard errors (MLR). Full-information maximum likelihood (FIML) was used to incorporate all available data, including participants who dropped out before T5. FIML produces unbiased estimates under the missing-at-random (MAR) assumption.
+
+## Fit indices
+
+Model fit was evaluated using:
+
+- **CFI** (Comparative Fit Index): values above 0.95 indicate good fit
+- **RMSEA** (Root Mean Square Error of Approximation): values below 0.06 indicate good fit
+- **SRMR** (Standardised Root Mean Square Residual): values below 0.08 indicate acceptable fit
+- **Chi-square difference test** (scaled for MLR): for nested model comparisons
+
+## Measurement invariance
+
+Before fitting growth models, longitudinal measurement invariance was established for each cognitive measure. Configural, metric, and scalar invariance models were tested sequentially. All three domains achieved at least scalar invariance (delta-CFI < 0.01 for each step), confirming that the measures assessed the same constructs comparably across waves.
+
+## Effect sizes
+
+Slope parameters are expressed in baseline standard deviation units per 3-year interval. To convert to per-decade rates, slopes are multiplied by 10/3 = 3.33. Cohen's d was computed for covariate effects on slope by dividing the unstandardised slope difference by the pooled slope standard deviation.

--- a/longitudinal/content/sections/1-study-design.md
+++ b/longitudinal/content/sections/1-study-design.md
@@ -1,0 +1,38 @@
++++
+title = "1. Study Design"
+description = "Cohort description, inclusion criteria, sampling strategy, and the five-wave measurement schedule spanning 12 years."
+weight = 1
+template = "post"
+tags = ["longitudinal", "cohort", "study-design"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Cohort description
+
+The Stockholm Cognitive Ageing Cohort (SCAC) is a population-based prospective study initiated in 2014 to track cognitive change from early adulthood through midlife. Participants were recruited via stratified random sampling from the Swedish Population Register, targeting adults aged 30 to 65 at baseline.
+
+Inclusion criteria required: (a) fluency in Swedish sufficient to complete neuropsychological testing, (b) no diagnosed neurodegenerative condition at baseline, (c) corrected visual acuity of at least 20/40, and (d) no hospitalisation for psychiatric disorder in the preceding 12 months.
+
+## 1.2 Sampling strategy
+
+The sampling frame was stratified by sex, five-year age band, and municipality type (urban, suburban, rural) to ensure demographic representativeness. Oversampling of the 55-65 age band by a factor of 1.5 was applied to increase statistical power for detecting late-midlife decline.
+
+A total of 3,216 individuals were invited; 1,842 (57.3 pct) consented and completed baseline assessment. Non-responder analysis showed no significant differences in sex, municipality type, or educational attainment between responders and non-responders (all p > 0.10).
+
+## 1.3 Wave schedule
+
+Assessments were conducted at five waves, each separated by approximately three years:
+
+- <span class="wave-badge t1">T1</span> Baseline (2014): full cognitive battery, health interview, blood draw
+- <span class="wave-badge t2">T2</span> Year 3 (2017): cognitive battery, brief health update
+- <span class="wave-badge t3">T3</span> Year 6 (2020): cognitive battery, health interview, MRI subsample
+- <span class="wave-badge t4">T4</span> Year 9 (2023): cognitive battery, brief health update
+- <span class="wave-badge t5">T5</span> Year 12 (2026): cognitive battery, health interview, blood draw, MRI subsample
+
+Testing sessions lasted approximately 90 minutes and were conducted in standardised clinic rooms by trained psychometrists. All sessions were recorded to allow post-hoc inter-rater reliability checks.
+
+## 1.4 Ethical approval
+
+The study was approved by the Regional Ethics Review Board in Stockholm (Dnr 2013/1847-31/5) and conducted in accordance with the Declaration of Helsinki. All participants provided written informed consent at each wave. Compensation was SEK 500 per session.

--- a/longitudinal/content/sections/2-cognitive-battery.md
+++ b/longitudinal/content/sections/2-cognitive-battery.md
@@ -1,0 +1,32 @@
++++
+title = "2. Cognitive Battery"
+description = "Description of the three cognitive domains assessed, the specific instruments used, scoring procedures, and psychometric properties across waves."
+weight = 2
+template = "post"
+tags = ["longitudinal", "cognition", "psychometrics"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Processing speed
+
+Processing speed was assessed with the Digit Symbol Substitution Test (DSST), a subtest of the Wechsler Adult Intelligence Scale-IV. Participants were given 90 seconds to match digits to symbols using a coding key. The score is the number of correct substitutions.
+
+Test-retest reliability across waves was ICC = 0.89 (95 pct CI: 0.86 to 0.91), indicating excellent stability of individual differences. Practice effects were addressed by administering an alternate symbol set at each wave, counterbalanced across participants.
+
+## 2.2 Working memory
+
+Working memory was assessed with the Digit Span Backward subtest (WAIS-IV). Participants repeated increasingly longer sequences of digits in reverse order. The score is the longest sequence correctly reversed (range: 2 to 14).
+
+This measure showed adequate test-retest reliability (ICC = 0.78) and was selected for its minimal motor demands and resistance to practice effects. Ceiling effects were negligible; fewer than 3 pct of participants scored the maximum at any wave.
+
+## 2.3 Executive function
+
+Executive function was operationalised as the Trail Making Test Part B minus Part A difference score (TMT B-A), which isolates the cognitive-switching component from motor speed. Participants completed both parts sequentially; the difference in completion times (in seconds) served as the primary outcome.
+
+Higher B-A scores indicate poorer executive function. For interpretability, scores were reverse-coded and z-transformed such that higher values indicate better performance. Test-retest reliability was ICC = 0.82.
+
+## 2.4 Standardisation procedure
+
+All raw scores were z-transformed using the T1 sample mean and standard deviation as reference. This anchoring strategy ensures that slope parameters represent change in baseline standard deviation units, facilitating cross-domain comparison.

--- a/longitudinal/content/sections/3-growth-curve-models.md
+++ b/longitudinal/content/sections/3-growth-curve-models.md
@@ -1,0 +1,42 @@
++++
+title = "3. Growth Curve Models"
+description = "Specification, estimation, and comparison of linear and quadratic latent growth curve models for each cognitive domain."
+weight = 3
+template = "post"
+tags = ["longitudinal", "growth-curve", "SEM"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Model specification
+
+Latent growth curve models (LGCM) were fitted within a structural equation modelling framework using maximum likelihood estimation with robust standard errors (MLR). For each cognitive domain, a linear LGCM was specified with two latent factors: an intercept factor (all loadings fixed to 1) and a slope factor (loadings fixed to 0, 1, 2, 3, 4 representing waves T1 through T5).
+
+The linear model estimates four key parameters: the mean and variance of the intercept (average initial level and individual differences therein) and the mean and variance of the slope (average rate of change and individual differences in that rate).
+
+## 3.2 Quadratic extension
+
+For domains where the linear model showed poor fit (RMSEA above 0.06 or significant residual patterns), a quadratic growth factor was added with loadings fixed to 0, 1, 4, 9, 16. This captures acceleration or deceleration of change over time.
+
+Model comparison used the chi-square difference test (scaled for MLR), AIC, and BIC. The quadratic model was retained only when it significantly improved fit and the quadratic factor variance was significantly different from zero.
+
+## 3.3 Conditional models
+
+Time-invariant covariates were added to the conditional model to predict individual differences in intercept and slope:
+
+- **Education** (years of formal schooling, centred at 12)
+- **APOE-e4 status** (0 = non-carrier, 1 = carrier of at least one e4 allele)
+- **Cardiovascular risk** (Framingham Risk Score at T1, z-transformed)
+
+Each covariate was regressed on both the intercept and slope factors. Standardised path coefficients are reported.
+
+## 3.4 Model fit results
+
+Processing speed was well described by a linear model (CFI = 0.968, RMSEA = 0.042, SRMR = 0.031). Working memory also fit a linear model (CFI = 0.981, RMSEA = 0.034). Executive function required a quadratic term (linear-only CFI = 0.928; quadratic CFI = 0.955, delta-chi-square = 18.4, df = 4, p = 0.001).
+
+The negative mean quadratic term for executive function (-0.09, SE = 0.03) indicates that decline accelerated in the later waves, consistent with age-related vulnerability of prefrontal circuits.
+
+## 3.5 Software
+
+All models were estimated in Mplus 8.9 using the MLR estimator. Full-information maximum likelihood (FIML) was used to handle missing data under the assumption that missingness was at random (MAR) conditional on the observed data.

--- a/longitudinal/content/sections/4-attrition-analysis.md
+++ b/longitudinal/content/sections/4-attrition-analysis.md
@@ -1,0 +1,39 @@
++++
+title = "4. Attrition Analysis"
+description = "Patterns of participant dropout, predictors of attrition, and sensitivity analyses assessing the impact of non-random missingness on growth curve estimates."
+weight = 4
+template = "post"
+tags = ["longitudinal", "attrition", "missing-data"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Attrition patterns
+
+Of the 1,842 participants who completed T1, 1,315 (71.4 pct) remained at T5. Attrition was approximately constant across intervals: 8.0 pct from T1 to T2, 7.8 pct from T2 to T3, 9.2 pct from T3 to T4, and 7.3 pct from T4 to T5.
+
+Dropout reasons were categorised as: relocation (38 pct), refusal to continue (28 pct), health-related withdrawal (16 pct), death (10 pct), and unable to contact (8 pct). The proportion of health-related withdrawals increased from 11 pct at T2 to 22 pct at T5, consistent with age-related morbidity.
+
+## 4.2 Predictors of attrition
+
+Logistic regression predicting any dropout (0 = completed all waves, 1 = missed at least one) identified two significant predictors:
+
+- **Lower baseline processing speed** (OR = 1.34 per SD decrease, 95 pct CI: 1.18 to 1.52, p < 0.001)
+- **Older age at baseline** (OR = 1.22 per decade, 95 pct CI: 1.08 to 1.38, p = 0.002)
+
+Sex, education, and APOE-e4 status were not significant predictors after controlling for age and baseline performance (all p > 0.10). These results indicate that attrition was not completely at random (MCAR) but is plausibly MAR conditional on observed scores, supporting the use of FIML estimation.
+
+## 4.3 Sensitivity analyses
+
+Three sensitivity approaches were used to assess robustness of growth curve estimates to non-random missingness:
+
+1. **Pattern-mixture models** grouped participants by dropout wave and estimated separate growth models per group. Slope estimates varied by group (dropouts showed steeper decline) but pooled estimates were within 0.06 SD per decade of the primary FIML estimates.
+
+2. **Selection models** (Diggle-Kenward) jointly modelled the outcome trajectory and a probit dropout indicator as a function of current (possibly unobserved) cognitive score. The estimated selection parameter was small (psi = -0.14) and did not substantially alter slope estimates.
+
+3. **Multiple imputation** (50 datasets, predictive mean matching) yielded slope estimates within the 95 pct confidence intervals of the primary analysis for all three domains.
+
+## 4.4 Implications
+
+Attrition bias in this cohort is mild. The most vulnerable participants (lower baseline scores, older age) were more likely to drop out, which would bias naive complete-case analyses toward underestimating decline. FIML and the sensitivity analyses suggest that the MAR assumption is reasonable and that primary estimates are robust.

--- a/longitudinal/content/sections/5-discussion.md
+++ b/longitudinal/content/sections/5-discussion.md
@@ -1,0 +1,34 @@
++++
+title = "5. Discussion"
+description = "Interpretation of cognitive trajectory findings, comparison with prior longitudinal studies, limitations, and implications for ageing research and intervention design."
+weight = 5
+template = "post"
+tags = ["longitudinal", "discussion", "cognitive-ageing"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of findings
+
+This five-wave study reveals domain-specific patterns of cognitive change in the 30-to-65 age range. Processing speed showed clear linear decline, consistent with the processing-speed theory of cognitive ageing. Working memory was remarkably stable at the group level, though individual variation was substantial. Executive function exhibited accelerating decline in the later waves, suggesting non-linear vulnerability.
+
+## 5.2 Comparison with prior work
+
+The processing-speed decline rate (-0.38 SD per decade) is broadly consistent with estimates from the Seattle Longitudinal Study (-0.35) and the Betula project (-0.41), despite differences in age range and measurement instruments. The negligible mean slope for working memory aligns with evidence that short-term storage capacity is relatively preserved until later life, whereas the executive function result echoes findings from the LASA and Whitehall II cohorts showing non-linear prefrontal decline.
+
+The APOE-e4 effect on processing speed is noteworthy because it emerged in a midlife sample. Most prior studies have detected APOE-e4 effects primarily after age 65. Our result suggests that genetic vulnerability to cognitive decline may manifest earlier than previously appreciated when assessed with sensitive longitudinal designs.
+
+## 5.3 Heterogeneity
+
+Perhaps the most striking finding is the degree of individual heterogeneity. The spaghetti plots (Figure 2) reveal that a substantial minority of participants -- approximately 18 pct -- showed stable or improving processing speed across all five waves. This group was characterised by higher education, regular physical activity, and absence of cardiovascular risk factors.
+
+These individual differences underscore the limitations of group-mean analyses. Reporting only average trajectories obscures the existence of resilient individuals who may hold clues to protective mechanisms.
+
+## 5.4 Limitations
+
+Several limitations should be noted. First, the sample is drawn from a single Scandinavian country with high educational attainment and universal healthcare, limiting generalisability. Second, the three-year inter-wave interval may miss short-term fluctuations. Third, practice effects cannot be entirely eliminated despite alternate forms. Fourth, the cognitive battery, while well-validated, captures only three domains; episodic memory and language were not assessed.
+
+## 5.5 Implications
+
+These findings have two practical implications. For intervention design, the heterogeneity suggests that universal interventions may be less efficient than targeted programmes for individuals on declining trajectories. For research methodology, the results demonstrate the importance of at least five waves for reliable estimation of non-linear change and the necessity of explicit attrition modelling in any longitudinal cognition study.

--- a/longitudinal/content/sections/_index.md
+++ b/longitudinal/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The manuscript is organised into five numbered sections. Each section addresses a distinct phase of the longitudinal analysis, from study design through to interpretation and implications for cognitive ageing research.

--- a/longitudinal/static/css/style.css
+++ b/longitudinal/static/css/style.css
@@ -1,0 +1,653 @@
+/* ============================================================================
+   Longitudinal Cognition Study - Time-Series Study Paper
+   Dark background, monospace wave labels, serif body, timeline axis element.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0c0e14;
+  --bg-2: #141722;
+  --bg-3: #1a1e2c;
+  --rule: #282e40;
+  --ink: #dfe4ed;
+  --ink-2: #bfc6d4;
+  --ink-3: #7e889e;
+  --ink-4: #525b72;
+  --accent: #8a9ff5;
+  --accent-2: #6b82e0;
+  --wave-t1: #f5a673;
+  --wave-t2: #e8d45a;
+  --wave-t3: #73d4a0;
+  --wave-t4: #5ab8e8;
+  --wave-t5: #b285e8;
+  --warn: #e8a84c;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Timeline axis (structural element) ---------------- */
+
+.timeline-axis {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 48px;
+  background: var(--bg-2);
+  border-right: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  z-index: 50;
+}
+
+.timeline-axis .axis-line {
+  width: 2px;
+  flex: 1;
+  background: var(--rule);
+  position: relative;
+}
+
+.timeline-axis .wave-mark {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  writing-mode: horizontal-tb;
+  padding: 0.4rem 0;
+  position: relative;
+  z-index: 2;
+}
+
+.timeline-axis .wave-mark.t1 { color: var(--wave-t1); }
+.timeline-axis .wave-mark.t2 { color: var(--wave-t2); }
+.timeline-axis .wave-mark.t3 { color: var(--wave-t3); }
+.timeline-axis .wave-mark.t4 { color: var(--wave-t4); }
+.timeline-axis .wave-mark.t5 { color: var(--wave-t5); }
+
+.timeline-axis .wave-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 2px solid var(--rule);
+}
+
+.timeline-axis .wave-dot.t1 { background: var(--wave-t1); border-color: var(--wave-t1); }
+.timeline-axis .wave-dot.t2 { background: var(--wave-t2); border-color: var(--wave-t2); }
+.timeline-axis .wave-dot.t3 { background: var(--wave-t3); border-color: var(--wave-t3); }
+.timeline-axis .wave-dot.t4 { background: var(--wave-t4); border-color: var(--wave-t4); }
+.timeline-axis .wave-dot.t5 { background: var(--wave-t5); border-color: var(--wave-t5); }
+
+.site-body {
+  margin-left: 48px;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Wave badge ---------------- */
+
+.wave-badge {
+  display: inline-block;
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  padding: 0.15rem 0.6rem;
+  border: 1px solid;
+  margin-right: 0.4rem;
+}
+
+.wave-badge.t1 { color: var(--wave-t1); border-color: var(--wave-t1); }
+.wave-badge.t2 { color: var(--wave-t2); border-color: var(--wave-t2); }
+.wave-badge.t3 { color: var(--wave-t3); border-color: var(--wave-t3); }
+.wave-badge.t4 { color: var(--wave-t4); border-color: var(--wave-t4); }
+.wave-badge.t5 { color: var(--wave-t5); border-color: var(--wave-t5); }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--warn);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--bg-3);
+  border: 1px solid var(--rule);
+  padding: 1.2rem 1.4rem;
+  overflow-x: auto;
+  border-radius: 2px;
+  margin: 1.5rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Model callout ---------------- */
+
+.model-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.model-callout .callout-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.model-callout .callout-value {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.model-callout .callout-value .unit {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.model-callout .callout-detail {
+  font-family: "Crimson Pro", serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.92rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+  letter-spacing: 0.02em;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Crimson Pro", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 500;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .timeline-axis { display: none; }
+  .site-body { margin-left: 0; }
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .model-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/longitudinal/templates/404.html
+++ b/longitudinal/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/longitudinal/templates/footer.html
+++ b/longitudinal/templates/footer.html
@@ -1,0 +1,18 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#282e40" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#282e40" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Hartmann R, Okonkwo J, Lindberg A, Nakamura S, Russo G. Cognitive Trajectories Across Five Waves: A Latent Growth Curve Analysis. <em>Dev. Traj. Q.</em> 2026;34(2):118-147. doi:10.48127/dtq.2026.34.02.118</p>
+        <p class="footer-note">ISSN 2490-3317 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/longitudinal/templates/header.html
+++ b/longitudinal/templates/header.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=STIX+Two+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <aside class="timeline-axis" aria-label="Measurement wave timeline">
+    <div class="axis-line"></div>
+    <span class="wave-dot t1"></span>
+    <span class="wave-mark t1">T1</span>
+    <div class="axis-line"></div>
+    <span class="wave-dot t2"></span>
+    <span class="wave-mark t2">T2</span>
+    <div class="axis-line"></div>
+    <span class="wave-dot t3"></span>
+    <span class="wave-mark t3">T3</span>
+    <div class="axis-line"></div>
+    <span class="wave-dot t4"></span>
+    <span class="wave-mark t4">T4</span>
+    <div class="axis-line"></div>
+    <span class="wave-dot t5"></span>
+    <span class="wave-mark t5">T5</span>
+    <div class="axis-line"></div>
+  </aside>
+  <div class="site-body">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <line x1="8" y1="35" x2="56" y2="35" stroke="#525b72" stroke-width="1"/>
+          <line x1="8" y1="35" x2="8" y2="5" stroke="#525b72" stroke-width="1"/>
+          <polyline points="12,30 22,22 32,25 42,14 52,8" fill="none" stroke="#8a9ff5" stroke-width="2"/>
+          <polyline points="12,28 22,26 32,18 42,20 52,12" fill="none" stroke="#f5a673" stroke-width="1.5" stroke-dasharray="4 2"/>
+          <circle cx="12" cy="30" r="2.5" fill="#8a9ff5"/>
+          <circle cx="22" cy="22" r="2.5" fill="#8a9ff5"/>
+          <circle cx="32" cy="25" r="2.5" fill="#8a9ff5"/>
+          <circle cx="42" cy="14" r="2.5" fill="#8a9ff5"/>
+          <circle cx="52" cy="8" r="2.5" fill="#8a9ff5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Developmental Trajectories Quarterly</span>
+          <span class="journal-sub">Vol. 34 &middot; Issue 02 &middot; Spring 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/methodology/">METHODOLOGY</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/longitudinal/templates/page.html
+++ b/longitudinal/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/longitudinal/templates/post.html
+++ b/longitudinal/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/longitudinal/templates/section.html
+++ b/longitudinal/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/longitudinal/templates/shortcodes/alert.html
+++ b/longitudinal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/longitudinal/templates/taxonomy.html
+++ b/longitudinal/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/longitudinal/templates/taxonomy_term.html
+++ b/longitudinal/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4000,5 +4000,12 @@
     "genomics",
     "bioinformatics",
     "data-intensive"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new `longitudinal` example site: a time-series study paper with dark theme
- Features SVG longitudinal timeline axis (structural element), spaghetti plots showing individual cognitive trajectories, latent growth curve model diagrams, and attrition flow diagrams
- Typography: IBM Plex Mono Bold for wave labels (T1-T5), Crimson Pro and STIX Two for body text
- Five content sections covering study design, cognitive battery, growth curve models, attrition analysis, and discussion
- Tags: paper, dark, longitudinal, temporal, tracking

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG diagrams render correctly
- [ ] Confirm timeline axis displays on the left side
- [ ] Verify responsive layout on mobile (timeline hides)
- [ ] Check tags.json entry is valid JSON

Closes #1622