### PR TITLE
feat: add bench-report example site (closes #1623)

### DIFF
--- a/bench-report/AGENTS.md
+++ b/bench-report/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/bench-report/config.toml
+++ b/bench-report/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Bench Report - Laboratory Bench Paper
+# Issue #1623 | Tags: paper, light, laboratory, bench, experimental
+# =============================================================================
+
+title = "Kinase Inhibitor Screening"
+description = "A laboratory bench paper documenting kinase inhibitor screening with gel electrophoresis band diagrams, Western blot visualizations, equipment setup diagrams, and workflow pipelines."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/bench-report/content/appendix.md
+++ b/bench-report/content/appendix.md
@@ -1,0 +1,83 @@
++++
+title = "Appendix"
+description = "Supplementary materials including reagent sources, equipment list, data availability, author contributions, and conflict-of-interest disclosures."
+tags = ["laboratory", "appendix", "reagents"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## A. Key Reagents and Antibodies
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Antibodies used in this study.</caption>
+  <thead>
+    <tr>
+      <th>Antibody</th>
+      <th>Source</th>
+      <th>Cat. No.</th>
+      <th>Dilution</th>
+      <th>Species</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Anti-phospho-Rb (Ser780)</td>
+      <td>Cell Signaling</td>
+      <td class="num">#9307</td>
+      <td class="num">1:1000</td>
+      <td>Rabbit mAb</td>
+    </tr>
+    <tr>
+      <td>Anti-phospho-Rb (Ser795)</td>
+      <td>Cell Signaling</td>
+      <td class="num">#9301</td>
+      <td class="num">1:1000</td>
+      <td>Rabbit pAb</td>
+    </tr>
+    <tr>
+      <td>Anti-Rb (total)</td>
+      <td>Cell Signaling</td>
+      <td class="num">#9309</td>
+      <td class="num">1:2000</td>
+      <td>Mouse mAb</td>
+    </tr>
+    <tr>
+      <td>Anti-beta-actin</td>
+      <td>Sigma-Aldrich</td>
+      <td class="num">#A5316</td>
+      <td class="num">1:5000</td>
+      <td>Mouse mAb</td>
+    </tr>
+  </tbody>
+</table>
+
+## B. Equipment
+
+- Bio-Rad Mini-PROTEAN Tetra Cell electrophoresis system
+- Bio-Rad Mini Trans-Blot wet transfer cell
+- Bio-Rad ChemiDoc MP imaging system
+- Thermo Fisher BCA Protein Assay Kit
+- Eppendorf 5424R refrigerated centrifuge
+- VWR incubated orbital shaker
+
+## C. Data Availability
+
+Raw Western blot images (16-bit TIFF), densitometry analysis files (ImageJ), and dose-response curve fitting files (GraphPad Prism) are deposited at Zenodo (doi: 10.5281/zenodo.example.2026.bench). The compound structures and physicochemical data are provided in Supplementary Table S1 (available at the journal website).
+
+## D. CRediT Author Contributions
+
+- **Wei-Lin Chen:** Conceptualisation, Investigation, Formal Analysis, Writing - Original Draft
+- **Tokunbo Adeyemi:** Investigation, Methodology, Writing - Review and Editing
+- **Karin Johansson:** Resources, Supervision, Writing - Review and Editing
+- **Pablo Morales:** Conceptualisation, Supervision, Funding Acquisition
+
+## E. Conflict of Interest
+
+WLC and PM are listed as inventors on a provisional patent application (PCT/EP2026/XXXXXX) covering PYR-14 and related analogues. KJ and TA declare no competing interests.
+
+## F. Funding
+
+This work was supported by the Swedish Research Council (grant 2024-03871), the Karolinska Institute KID grant programme, and a European Research Council Starting Grant (ERC-StG-2023-101076432, to PM).

--- a/bench-report/content/index.md
+++ b/bench-report/content/index.md
@@ -1,0 +1,309 @@
++++
+title = "Abstract"
+description = "A bench report documenting selective kinase inhibitor screening using gel electrophoresis and Western blot analysis of phosphorylation targets."
+tags = ["paper", "light", "laboratory", "bench", "experimental"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Laboratory Report &middot; <span class="exp-id">EXP-2026-0847</span></p>
+  <h1 class="paper-title">Selective Screening of Novel Pyrimidine-Based Kinase Inhibitors: Gel Electrophoresis and Western Blot Characterisation of Phosphorylation Targets</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Wei-Lin Chen</span><sup>1</sup>,
+    Tokunbo Adeyemi<sup>1</sup>,
+    Karin Johansson<sup>2</sup>,
+    Pablo Morales<sup>1,3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Chemical Biology Core, Karolinska Institute &middot;
+    <sup>2</sup>Department of Structural Biology, Uppsala University &middot;
+    <sup>3</sup>Centre for Molecular Therapeutics, Barcelona
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/mbp.2026.42.11.284</a> &middot; <strong>Received:</strong> 18 Jun 2026 &middot; <strong>Accepted:</strong> 04 Sep 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>To screen a focused library of 24 pyrimidine-based compounds for selective inhibition of CDK2, CDK4, and CDK6 using in vitro kinase assays followed by gel electrophoresis and Western blot confirmation.</dd>
+    <dt>Methods</dt>
+    <dd>HeLa cell lysates were treated with compounds at 1 uM for 4 hours. Phosphorylation of Rb (Ser780, Ser795, Ser807/811) was assessed by SDS-PAGE and Western blot. Band intensities were quantified by densitometry and normalised to beta-actin loading controls. IC50 values were determined for the three most potent hits.</dd>
+    <dt>Results</dt>
+    <dd>Compound PYR-14 showed selective CDK4/6 inhibition (IC50 = 48 nM for pRb-Ser780) with more than 200-fold selectivity over CDK2. Western blot confirmed dose-dependent reduction of pRb-Ser780 and pRb-Ser795 without affecting total Rb levels. Gel electrophoresis of kinase reaction products confirmed target engagement.</dd>
+    <dt>Conclusion</dt>
+    <dd>PYR-14 is a potent and selective CDK4/6 inhibitor suitable for further preclinical development. The screening pipeline combining kinase assays, gel electrophoresis, and Western blot provides orthogonal validation of target specificity.</dd>
+    <dt>Keywords</dt>
+    <dd><em>kinase inhibitor; CDK4/6; Western blot; gel electrophoresis; phosphorylation; selectivity screening</em></dd>
+  </dl>
+</section>
+
+## Gel Electrophoresis: Kinase Reaction Products
+
+<figure class="figure">
+  <svg viewBox="0 0 720 340" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SDS-PAGE gel electrophoresis diagram showing protein bands across eight lanes with molecular weight markers">
+    <!-- Gel background -->
+    <rect x="60" y="30" width="600" height="260" fill="#e8e6de" stroke="#c8c4b8" stroke-width="1"/>
+    <!-- Lane dividers -->
+    <line x1="135" y1="30" x2="135" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="210" y1="30" x2="210" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="285" y1="30" x2="285" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="360" y1="30" x2="360" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="435" y1="30" x2="435" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="510" y1="30" x2="510" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <line x1="585" y1="30" x2="585" y2="290" stroke="#d5d2c8" stroke-width="0.5"/>
+    <!-- MW marker lane (lane 1) -->
+    <rect x="72" y="52" width="50" height="5" fill="#1c2030" rx="1"/>
+    <rect x="72" y="82" width="50" height="4" fill="#1c2030" rx="1"/>
+    <rect x="72" y="115" width="50" height="4" fill="#1c2030" rx="1"/>
+    <rect x="72" y="155" width="50" height="3" fill="#1c2030" rx="1"/>
+    <rect x="72" y="198" width="50" height="3" fill="#1c2030" rx="1"/>
+    <rect x="72" y="245" width="50" height="3" fill="#1c2030" rx="1"/>
+    <!-- MW labels -->
+    <text x="55" y="57" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">250</text>
+    <text x="55" y="87" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">130</text>
+    <text x="55" y="120" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">100</text>
+    <text x="55" y="160" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">70</text>
+    <text x="55" y="203" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">55</text>
+    <text x="55" y="250" text-anchor="end" font-family="Roboto Mono" font-size="8" fill="#6b7085">35</text>
+    <text x="55" y="15" text-anchor="end" font-family="Roboto Mono" font-weight="500" font-size="8" fill="#6b7085">kDa</text>
+    <!-- Lane 2: DMSO control - strong pRb band -->
+    <rect x="147" y="108" width="50" height="8" fill="#2e3246" opacity="0.85" rx="1"/>
+    <rect x="147" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="147" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 3: PYR-03 - moderate reduction -->
+    <rect x="222" y="108" width="50" height="7" fill="#2e3246" opacity="0.65" rx="1"/>
+    <rect x="222" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="222" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 4: PYR-08 - moderate reduction -->
+    <rect x="297" y="108" width="50" height="6" fill="#2e3246" opacity="0.55" rx="1"/>
+    <rect x="297" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="297" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 5: PYR-14 - strong reduction (hit) -->
+    <rect x="372" y="108" width="50" height="5" fill="#2e3246" opacity="0.15" rx="1"/>
+    <rect x="372" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="372" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 6: PYR-19 - minimal effect -->
+    <rect x="447" y="108" width="50" height="7" fill="#2e3246" opacity="0.75" rx="1"/>
+    <rect x="447" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="447" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 7: PYR-22 - moderate reduction -->
+    <rect x="522" y="108" width="50" height="6" fill="#2e3246" opacity="0.45" rx="1"/>
+    <rect x="522" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="522" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane 8: Palbociclib (positive control) -->
+    <rect x="597" y="108" width="50" height="5" fill="#2e3246" opacity="0.1" rx="1"/>
+    <rect x="597" y="195" width="50" height="5" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="597" y="240" width="50" height="6" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- Lane labels -->
+    <text x="97" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#1c2030">MW</text>
+    <text x="172" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#1c2030">DMSO</text>
+    <text x="247" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#4a6b8a">PYR-03</text>
+    <text x="322" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#4a6b8a">PYR-08</text>
+    <text x="397" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#2a6b4f">PYR-14</text>
+    <text x="472" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#4a6b8a">PYR-19</text>
+    <text x="547" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#4a6b8a">PYR-22</text>
+    <text x="622" y="308" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#b85c2a">Palbo</text>
+    <!-- Band annotations -->
+    <text x="672" y="114" font-family="Noto Serif" font-style="italic" font-size="9" fill="#6b7085">pRb (110 kDa)</text>
+    <text x="672" y="202" font-family="Noto Serif" font-style="italic" font-size="9" fill="#6b7085">CDK4 (34 kDa)</text>
+    <text x="672" y="248" font-family="Noto Serif" font-style="italic" font-size="9" fill="#6b7085">beta-actin</text>
+    <!-- Hit arrow -->
+    <line x1="397" y1="96" x2="397" y2="105" stroke="#2a6b4f" stroke-width="1.5" marker-end="url(#arrowG)"/>
+    <text x="397" y="92" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="8" fill="#2a6b4f">HIT</text>
+    <defs>
+      <marker id="arrowG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#2a6b4f"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> SDS-PAGE gel electrophoresis of kinase reaction products. HeLa lysates treated with candidate compounds at 1 uM for 4 hours. Lanes show molecular weight marker, DMSO vehicle control, five test compounds, and palbociclib positive control. PYR-14 shows near-complete abolition of the pRb band at 110 kDa while preserving CDK4 and beta-actin loading control bands.</figcaption>
+</figure>
+
+<section class="model-callout">
+  <span class="callout-label">Lead Compound IC50</span>
+  <span class="callout-value">48 nM<span class="unit">PYR-14 against pRb-Ser780</span></span>
+  <p class="callout-detail">Selectivity: more than 200-fold over CDK2 (IC50 above 10 uM). Comparable potency to palbociclib (IC50 = 32 nM) with improved aqueous solubility (LogS = -3.8 vs -5.1).</p>
+</section>
+
+## Western Blot: Dose-Response
+
+<figure class="figure">
+  <svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Western blot visualization showing dose-dependent reduction of pRb-Ser780 by PYR-14 across six concentrations">
+    <!-- Blot background -->
+    <rect x="80" y="20" width="560" height="60" fill="#eae8e0" stroke="#c8c4b8" stroke-width="1"/>
+    <rect x="80" y="90" width="560" height="60" fill="#eae8e0" stroke="#c8c4b8" stroke-width="1"/>
+    <rect x="80" y="160" width="560" height="60" fill="#eae8e0" stroke="#c8c4b8" stroke-width="1"/>
+    <!-- Row labels -->
+    <text x="70" y="55" text-anchor="end" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#1c2030">pRb-S780</text>
+    <text x="70" y="125" text-anchor="end" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#1c2030">Total Rb</text>
+    <text x="70" y="195" text-anchor="end" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#1c2030">beta-actin</text>
+    <!-- MW markers -->
+    <text x="650" y="55" font-family="Roboto Mono" font-size="8" fill="#6b7085">110 kDa</text>
+    <text x="650" y="125" font-family="Roboto Mono" font-size="8" fill="#6b7085">110 kDa</text>
+    <text x="650" y="195" font-family="Roboto Mono" font-size="8" fill="#6b7085">42 kDa</text>
+    <!-- pRb-S780 bands (decreasing intensity) -->
+    <rect x="105" y="38" width="60" height="12" fill="#2e3246" opacity="0.85" rx="1"/>
+    <rect x="190" y="39" width="60" height="11" fill="#2e3246" opacity="0.7" rx="1"/>
+    <rect x="275" y="40" width="60" height="10" fill="#2e3246" opacity="0.5" rx="1"/>
+    <rect x="360" y="41" width="60" height="9" fill="#2e3246" opacity="0.3" rx="1"/>
+    <rect x="445" y="42" width="60" height="8" fill="#2e3246" opacity="0.12" rx="1"/>
+    <rect x="530" y="43" width="60" height="7" fill="#2e3246" opacity="0.05" rx="1"/>
+    <!-- Total Rb bands (constant) -->
+    <rect x="105" y="110" width="60" height="11" fill="#2e3246" opacity="0.7" rx="1"/>
+    <rect x="190" y="110" width="60" height="11" fill="#2e3246" opacity="0.68" rx="1"/>
+    <rect x="275" y="110" width="60" height="11" fill="#2e3246" opacity="0.72" rx="1"/>
+    <rect x="360" y="110" width="60" height="11" fill="#2e3246" opacity="0.7" rx="1"/>
+    <rect x="445" y="110" width="60" height="11" fill="#2e3246" opacity="0.66" rx="1"/>
+    <rect x="530" y="110" width="60" height="11" fill="#2e3246" opacity="0.7" rx="1"/>
+    <!-- beta-actin bands (constant) -->
+    <rect x="105" y="182" width="60" height="10" fill="#2e3246" opacity="0.65" rx="1"/>
+    <rect x="190" y="182" width="60" height="10" fill="#2e3246" opacity="0.63" rx="1"/>
+    <rect x="275" y="182" width="60" height="10" fill="#2e3246" opacity="0.67" rx="1"/>
+    <rect x="360" y="182" width="60" height="10" fill="#2e3246" opacity="0.65" rx="1"/>
+    <rect x="445" y="182" width="60" height="10" fill="#2e3246" opacity="0.64" rx="1"/>
+    <rect x="530" y="182" width="60" height="10" fill="#2e3246" opacity="0.66" rx="1"/>
+    <!-- Concentration labels -->
+    <text x="135" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#1c2030">DMSO</text>
+    <text x="220" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#4a6b8a">1 nM</text>
+    <text x="305" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#4a6b8a">10 nM</text>
+    <text x="390" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#4a6b8a">50 nM</text>
+    <text x="475" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#2a6b4f">100 nM</text>
+    <text x="560" y="242" text-anchor="middle" font-family="Roboto" font-weight="700" font-size="9" fill="#2a6b4f">1 uM</text>
+    <!-- Densitometry values -->
+    <text x="135" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">1.00</text>
+    <text x="220" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">0.82</text>
+    <text x="305" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">0.58</text>
+    <text x="390" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">0.34</text>
+    <text x="475" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">0.12</text>
+    <text x="560" y="258" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#6b7085">0.04</text>
+    <text x="360" y="280" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#6b7085" letter-spacing="0.5">PYR-14 CONCENTRATION</text>
+    <text x="360" y="295" text-anchor="middle" font-family="Noto Serif" font-style="italic" font-size="8" fill="#9095a5">Densitometry normalised to beta-actin, relative to DMSO control</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Western blot dose-response for PYR-14. Top row: phospho-Rb (Ser780) shows dose-dependent signal reduction. Middle row: total Rb remains constant, confirming that PYR-14 inhibits phosphorylation rather than promoting Rb degradation. Bottom row: beta-actin loading control confirms equal protein loading across lanes. Densitometry values below each lane are normalised to beta-actin and expressed relative to DMSO control.</figcaption>
+</figure>
+
+## Experimental Workflow
+
+<figure class="figure">
+  <svg viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Laboratory workflow pipeline showing five stages from cell culture to data analysis">
+    <!-- Stage boxes -->
+    <rect x="10" y="40" width="120" height="65" fill="none" stroke="#2a6b4f" stroke-width="1.5" rx="2"/>
+    <text x="70" y="62" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#2a6b4f" letter-spacing="0.5">STEP 1</text>
+    <text x="70" y="78" text-anchor="middle" font-family="Noto Serif" font-size="9" fill="#1c2030">Cell culture</text>
+    <text x="70" y="92" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#6b7085">HeLa, 24h seed</text>
+
+    <rect x="155" y="40" width="120" height="65" fill="none" stroke="#2a6b4f" stroke-width="1.5" rx="2"/>
+    <text x="215" y="62" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#2a6b4f" letter-spacing="0.5">STEP 2</text>
+    <text x="215" y="78" text-anchor="middle" font-family="Noto Serif" font-size="9" fill="#1c2030">Compound treat</text>
+    <text x="215" y="92" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#6b7085">1 uM, 4h, 37C</text>
+
+    <rect x="300" y="40" width="120" height="65" fill="none" stroke="#4a6b8a" stroke-width="1.5" rx="2"/>
+    <text x="360" y="62" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#4a6b8a" letter-spacing="0.5">STEP 3</text>
+    <text x="360" y="78" text-anchor="middle" font-family="Noto Serif" font-size="9" fill="#1c2030">Lysis + SDS-PAGE</text>
+    <text x="360" y="92" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#6b7085">RIPA, 10% gel</text>
+
+    <rect x="445" y="40" width="120" height="65" fill="none" stroke="#4a6b8a" stroke-width="1.5" rx="2"/>
+    <text x="505" y="62" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#4a6b8a" letter-spacing="0.5">STEP 4</text>
+    <text x="505" y="78" text-anchor="middle" font-family="Noto Serif" font-size="9" fill="#1c2030">Western blot</text>
+    <text x="505" y="92" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#6b7085">anti-pRb, ECL</text>
+
+    <rect x="590" y="40" width="120" height="65" fill="none" stroke="#b85c2a" stroke-width="1.5" rx="2"/>
+    <text x="650" y="62" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#b85c2a" letter-spacing="0.5">STEP 5</text>
+    <text x="650" y="78" text-anchor="middle" font-family="Noto Serif" font-size="9" fill="#1c2030">Densitometry</text>
+    <text x="650" y="92" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#6b7085">ImageJ, IC50</text>
+
+    <!-- Arrows -->
+    <line x1="130" y1="72" x2="155" y2="72" stroke="#c8c4b8" stroke-width="1.5" marker-end="url(#arrowR)"/>
+    <line x1="275" y1="72" x2="300" y2="72" stroke="#c8c4b8" stroke-width="1.5" marker-end="url(#arrowR)"/>
+    <line x1="420" y1="72" x2="445" y2="72" stroke="#c8c4b8" stroke-width="1.5" marker-end="url(#arrowR)"/>
+    <line x1="565" y1="72" x2="590" y2="72" stroke="#c8c4b8" stroke-width="1.5" marker-end="url(#arrowR)"/>
+
+    <!-- Time annotations -->
+    <text x="70" y="125" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#9095a5">Day 1</text>
+    <text x="215" y="125" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#9095a5">Day 2</text>
+    <text x="360" y="125" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#9095a5">Day 2</text>
+    <text x="505" y="125" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#9095a5">Day 3</text>
+    <text x="650" y="125" text-anchor="middle" font-family="Roboto Mono" font-size="8" fill="#9095a5">Day 4</text>
+
+    <!-- Experiment ID -->
+    <text x="360" y="160" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#6b7085" letter-spacing="1">EXP-2026-0847 WORKFLOW PIPELINE</text>
+
+    <defs>
+      <marker id="arrowR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#c8c4b8"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 3.</span> Experimental workflow pipeline for kinase inhibitor screening. Green-bordered steps involve biological sample preparation; blue-bordered steps involve analytical techniques; the orange-bordered step covers quantitative analysis. Total turnaround time from cell seeding to IC50 determination is four days.</figcaption>
+</figure>
+
+## Screening Results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Screening results for top-five compounds from the 24-member pyrimidine library.</caption>
+  <thead>
+    <tr>
+      <th>Compound</th>
+      <th>pRb-S780 (%ctrl)</th>
+      <th>pRb-S795 (%ctrl)</th>
+      <th>Total Rb (%ctrl)</th>
+      <th>CDK4/6 IC50</th>
+      <th>CDK2 IC50</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>PYR-14</strong></td>
+      <td class="num">8</td>
+      <td class="num">12</td>
+      <td class="num">98</td>
+      <td class="num">48 nM</td>
+      <td class="num">&gt;10 uM</td>
+    </tr>
+    <tr>
+      <td>PYR-22</td>
+      <td class="num">32</td>
+      <td class="num">38</td>
+      <td class="num">95</td>
+      <td class="num">180 nM</td>
+      <td class="num">4.2 uM</td>
+    </tr>
+    <tr>
+      <td>PYR-08</td>
+      <td class="num">45</td>
+      <td class="num">52</td>
+      <td class="num">97</td>
+      <td class="num">340 nM</td>
+      <td class="num">2.8 uM</td>
+    </tr>
+    <tr>
+      <td>PYR-03</td>
+      <td class="num">58</td>
+      <td class="num">62</td>
+      <td class="num">96</td>
+      <td class="num">620 nM</td>
+      <td class="num">1.9 uM</td>
+    </tr>
+    <tr>
+      <td>Palbociclib</td>
+      <td class="num">5</td>
+      <td class="num">8</td>
+      <td class="num">99</td>
+      <td class="num">32 nM</td>
+      <td class="num">&gt;10 uM</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">Values are mean of three independent experiments. %ctrl = band intensity normalised to beta-actin, expressed as percentage of DMSO control. IC50 determined by four-parameter logistic fit.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the section index. The full report contains the following numbered sections.
+
+1. **Section 1. Compound Library** -- design rationale, chemical scaffolds, and physicochemical properties
+2. **Section 2. Cell Culture and Treatment** -- HeLa maintenance, seeding densities, and compound handling
+3. **Section 3. Gel Electrophoresis** -- SDS-PAGE conditions, staining, and band identification
+4. **Section 4. Western Blot Analysis** -- transfer, antibodies, detection, and densitometry
+5. **Section 5. Discussion** -- structure-activity relationships, selectivity, and next steps

--- a/bench-report/content/protocols.md
+++ b/bench-report/content/protocols.md
@@ -1,0 +1,55 @@
++++
+title = "Protocols"
+description = "Detailed step-by-step laboratory protocols for all experimental procedures used in this study."
+tags = ["laboratory", "protocols", "bench"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Laboratory Protocols</h1>
+</header>
+
+## Overview
+
+All protocols were performed in the Chemical Biology Core facility at the Karolinska Institute. Standard biosafety level 1 (BSL-1) procedures were followed. Protocols are assigned unique identifiers within the experiment series <span class="exp-id">EXP-2026-0847</span>.
+
+<div class="protocol-steps">
+  <span class="protocol-title">Protocol P03: SDS-PAGE Gel Casting</span>
+  <ol>
+    <li>Clean glass plates and spacers with 70 pct ethanol. Assemble the casting stand.</li>
+    <li>Prepare 10 pct resolving gel: mix 3.3 mL 30 pct acrylamide, 2.5 mL 1.5M Tris pH 8.8, 100 uL 10 pct SDS, 4.0 mL ddH2O.</li>
+    <li>Add 100 uL 10 pct APS and 4 uL TEMED. Mix by gentle inversion (do not vortex).</li>
+    <li>Pour resolving gel to 1 cm below the comb line. Overlay with water-saturated butanol.</li>
+    <li>Allow polymerisation for 30 to 45 min at room temperature.</li>
+    <li>Decant butanol overlay and rinse top of gel with ddH2O.</li>
+    <li>Prepare 4 pct stacking gel: 0.67 mL acrylamide, 0.5 mL 1.0M Tris pH 6.8, 40 uL SDS, 2.77 mL ddH2O, 40 uL APS, 4 uL TEMED.</li>
+    <li>Pour stacking gel and insert 10-well comb. Polymerise for 20 min.</li>
+  </ol>
+</div>
+
+<div class="protocol-steps">
+  <span class="protocol-title">Protocol P04: Western Blot Transfer</span>
+  <ol>
+    <li>Equilibrate gel, PVDF membrane, filter papers, and sponges in transfer buffer (25 mM Tris, 192 mM glycine, 20 pct methanol) for 15 min.</li>
+    <li>Activate PVDF membrane in methanol for 30 seconds, then equilibrate in transfer buffer.</li>
+    <li>Assemble transfer sandwich: sponge, filter paper, gel, membrane, filter paper, sponge.</li>
+    <li>Place cassette in transfer tank with membrane toward the anode (positive electrode).</li>
+    <li>Add ice pack and stir bar. Fill tank with transfer buffer.</li>
+    <li>Transfer at 100 V for 90 min at 4 C with stirring.</li>
+    <li>Disassemble and stain membrane with Ponceau S for 2 min to confirm transfer.</li>
+    <li>Destain with ddH2O until bands are visible. Image for records.</li>
+  </ol>
+</div>
+
+<div class="protocol-steps">
+  <span class="protocol-title">Protocol P05: ECL Detection and Imaging</span>
+  <ol>
+    <li>Prepare ECL working solution by mixing equal volumes of reagent A and reagent B (Pierce).</li>
+    <li>Drain excess wash buffer from membrane and place protein-side up on clean surface.</li>
+    <li>Pipette ECL solution evenly across membrane. Incubate 1 min at room temperature.</li>
+    <li>Place membrane in ChemiDoc imaging tray. Select chemi-luminescence acquisition mode.</li>
+    <li>Acquire image with auto-exposure (typical exposure: 10 to 120 seconds depending on signal).</li>
+    <li>Acquire white-light reference image for molecular weight marker alignment.</li>
+    <li>Export images as 16-bit TIFF for densitometric analysis.</li>
+  </ol>
+</div>

--- a/bench-report/content/sections/1-compound-library.md
+++ b/bench-report/content/sections/1-compound-library.md
@@ -1,0 +1,32 @@
++++
+title = "1. Compound Library"
+description = "Design rationale for the 24-member pyrimidine-based kinase inhibitor library, chemical scaffold selection, and physicochemical property assessment."
+weight = 1
+template = "post"
+tags = ["laboratory", "medicinal-chemistry", "kinase"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Design rationale
+
+The compound library was designed around a 2,4-diaminopyrimidine core, a privileged scaffold in kinase inhibitor drug discovery. The pyrimidine nitrogen atoms form key hydrogen bonds with the hinge region of the ATP-binding pocket, providing a baseline affinity that can be modulated through substitution at the 2-, 4-, 5-, and 6-positions.
+
+Twenty-four analogues were synthesised with systematic variation at three positions: the C-5 aryl substituent (six variants), the N-4 linker length (two variants), and the C-2 amine (two variants). This 6 x 2 x 2 combinatorial design provides efficient coverage of the relevant chemical space.
+
+## 1.2 Physicochemical properties
+
+All compounds were assessed for drug-likeness using Lipinski's Rule of Five. Key ranges across the library:
+
+- **Molecular weight:** 324 to 478 Da
+- **cLogP:** 1.8 to 4.2
+- **Hydrogen bond donors:** 2 to 3
+- **Hydrogen bond acceptors:** 4 to 7
+- **Aqueous solubility (LogS):** -2.9 to -5.1
+
+No compound violated more than one Lipinski criterion. PYR-14, the eventual lead, had MW = 412 Da, cLogP = 2.9, and LogS = -3.8, placing it in a favourable range for oral bioavailability.
+
+## 1.3 Purity and identity confirmation
+
+All compounds were confirmed by LC-MS (purity above 95 pct by UV at 254 nm) and 1H-NMR (400 MHz, DMSO-d6). Compound stock solutions (10 mM in DMSO) were aliquoted and stored at -20 C. Working dilutions were prepared fresh on the day of each experiment.

--- a/bench-report/content/sections/2-cell-culture.md
+++ b/bench-report/content/sections/2-cell-culture.md
@@ -1,0 +1,49 @@
++++
+title = "2. Cell Culture and Treatment"
+description = "HeLa cell maintenance, seeding densities, compound handling, and treatment protocol for the kinase inhibitor screening assay."
+weight = 2
+template = "post"
+tags = ["laboratory", "cell-culture", "protocol"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Cell line and maintenance
+
+HeLa cells (ATCC CCL-2) were maintained in DMEM supplemented with 10 pct FBS, 100 U/mL penicillin, and 100 ug/mL streptomycin at 37 C in a humidified atmosphere of 5 pct CO2. Cells were passaged every 3 to 4 days at a 1:6 split ratio and used between passages 10 and 25.
+
+<div class="protocol-steps">
+  <span class="protocol-title">Protocol: Cell Seeding (EXP-2026-0847-P01)</span>
+  <ol>
+    <li>Aspirate medium from T75 flask and wash monolayer with 10 mL warm PBS.</li>
+    <li>Add 2 mL trypsin-EDTA (0.25 pct) and incubate at 37 C for 3 to 5 min until cells detach.</li>
+    <li>Neutralise with 8 mL complete medium and transfer to 15 mL conical tube.</li>
+    <li>Centrifuge at 200 x g for 4 min. Aspirate supernatant and resuspend in fresh medium.</li>
+    <li>Count cells using a haemocytometer. Adjust to 2.5 x 10^5 cells/mL.</li>
+    <li>Plate 2 mL per well in 6-well plates (5 x 10^5 cells/well).</li>
+    <li>Incubate overnight (18 to 24 hours) to allow attachment before compound treatment.</li>
+  </ol>
+</div>
+
+## 2.2 Compound treatment
+
+After overnight attachment, medium was replaced with fresh complete medium containing either DMSO vehicle (0.1 pct final) or test compound at the indicated concentration. For the primary screen, all 24 compounds were tested at a single concentration of 1 uM. For dose-response experiments, PYR-14 was tested at 1 nM, 10 nM, 50 nM, 100 nM, 500 nM, and 1 uM.
+
+Treatment duration was 4 hours, based on prior kinetics data showing maximal pRb dephosphorylation at 3 to 6 hours post-treatment for CDK4/6 inhibitors. Palbociclib (1 uM) served as a positive control in every experiment.
+
+## 2.3 Cell lysis
+
+<div class="protocol-steps">
+  <span class="protocol-title">Protocol: Cell Lysis (EXP-2026-0847-P02)</span>
+  <ol>
+    <li>Remove medium and wash cells once with ice-cold PBS.</li>
+    <li>Add 150 uL RIPA buffer supplemented with protease inhibitor cocktail (1x) and phosphatase inhibitors (1 mM Na3VO4, 10 mM NaF).</li>
+    <li>Incubate on ice for 15 min, scraping once at 7 min.</li>
+    <li>Transfer lysate to pre-chilled microcentrifuge tube.</li>
+    <li>Centrifuge at 14,000 x g for 15 min at 4 C.</li>
+    <li>Transfer supernatant to fresh tube. Determine protein concentration by BCA assay.</li>
+    <li>Adjust all samples to 2 mg/mL with RIPA buffer. Add 4x Laemmli sample buffer (1:3 ratio).</li>
+    <li>Heat at 95 C for 5 min. Store at -20 C or load immediately onto gel.</li>
+  </ol>
+</div>

--- a/bench-report/content/sections/3-gel-electrophoresis.md
+++ b/bench-report/content/sections/3-gel-electrophoresis.md
@@ -1,0 +1,32 @@
++++
+title = "3. Gel Electrophoresis"
+description = "SDS-PAGE conditions, gel preparation, sample loading, electrophoresis parameters, and Coomassie staining for protein visualisation."
+weight = 3
+template = "post"
+tags = ["laboratory", "gel-electrophoresis", "SDS-PAGE"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Gel preparation
+
+SDS-polyacrylamide gels were cast using the Bio-Rad Mini-PROTEAN system. Resolving gels (10 pct acrylamide) were prepared from a 30 pct acrylamide/bis-acrylamide stock (37.5:1 ratio) in 375 mM Tris-HCl pH 8.8 with 0.1 pct SDS. Polymerisation was initiated with 0.1 pct ammonium persulphate and 0.04 pct TEMED. Stacking gels (4 pct acrylamide) were cast in 125 mM Tris-HCl pH 6.8.
+
+## 3.2 Sample loading and electrophoresis
+
+Equal volumes of prepared lysate (20 ug total protein per lane) were loaded alongside a pre-stained protein standard (Bio-Rad Precision Plus, 10-250 kDa). Gels were run at 80 V through the stacking gel and 120 V through the resolving gel in Tris-glycine-SDS running buffer until the dye front reached the bottom of the gel (approximately 90 minutes).
+
+## 3.3 Coomassie staining
+
+For total protein visualisation (used to confirm equal loading prior to Western blotting), companion gels were stained with Coomassie Brilliant Blue R-250 (0.1 pct in 50 pct methanol, 10 pct acetic acid) for 1 hour at room temperature with gentle agitation. Destaining was performed with 50 pct methanol and 10 pct acetic acid, refreshed three times over 4 hours, until bands were visible against a clear background.
+
+## 3.4 Band identification
+
+The primary screen gel (Figure 1 in the Abstract) shows three major bands of interest:
+
+- **110 kDa band (pRb):** This is the phosphorylated retinoblastoma protein. Intensity reflects CDK4/6 activity. Compounds that inhibit CDK4/6 reduce this band relative to the DMSO control.
+- **34 kDa band (CDK4):** Total CDK4 protein level, expected to remain constant across treatments (target engagement should not affect total protein abundance at 4 hours).
+- **42 kDa band (beta-actin):** Loading control confirming equal protein input across all lanes.
+
+PYR-14 (lane 5) shows near-complete loss of the pRb band while preserving CDK4 and beta-actin bands, indicating specific kinase inhibition without cytotoxic effects at this concentration and timepoint.

--- a/bench-report/content/sections/4-western-blot.md
+++ b/bench-report/content/sections/4-western-blot.md
@@ -1,0 +1,37 @@
++++
+title = "4. Western Blot Analysis"
+description = "Protein transfer, primary and secondary antibody incubation, ECL detection, and densitometric quantification of phospho-Rb levels."
+weight = 4
+template = "post"
+tags = ["laboratory", "western-blot", "immunodetection"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Protein transfer
+
+Proteins were transferred from SDS-PAGE gels to PVDF membranes (0.45 um pore size, Immobilon-P) using the Bio-Rad wet transfer system. Transfer was performed in Tris-glycine transfer buffer containing 20 pct methanol at 100 V for 90 minutes at 4 C. Successful transfer was confirmed by Ponceau S staining of the membrane.
+
+## 4.2 Blocking and primary antibody
+
+Membranes were blocked in 5 pct BSA in TBS-T (20 mM Tris pH 7.4, 150 mM NaCl, 0.1 pct Tween-20) for 1 hour at room temperature. Primary antibodies were diluted in 5 pct BSA in TBS-T and incubated overnight at 4 C with gentle rocking:
+
+- **Anti-phospho-Rb (Ser780):** Cell Signaling Technology #9307, rabbit monoclonal, 1:1000
+- **Anti-phospho-Rb (Ser795):** Cell Signaling Technology #9301, rabbit polyclonal, 1:1000
+- **Anti-Rb (total):** Cell Signaling Technology #9309, mouse monoclonal, 1:2000
+- **Anti-beta-actin:** Sigma-Aldrich #A5316, mouse monoclonal, 1:5000
+
+## 4.3 Secondary antibody and detection
+
+After three 10-minute washes in TBS-T, membranes were incubated with HRP-conjugated secondary antibodies (1:5000, anti-rabbit or anti-mouse IgG, Cell Signaling Technology) for 1 hour at room temperature. Detection was performed using Pierce ECL Western Blotting Substrate. Images were acquired on a Bio-Rad ChemiDoc MP system with automatic exposure optimisation.
+
+## 4.4 Densitometric quantification
+
+Band intensities were quantified using ImageJ (NIH, version 1.54). Background was subtracted using the rolling-ball method (radius = 50 pixels). Each phospho-Rb signal was normalised to the corresponding beta-actin band in the same lane. Values were then expressed as a fraction of the DMSO control lane.
+
+For dose-response curves, normalised intensities were plotted against log-concentration and fitted with a four-parameter logistic model (Hill equation) using GraphPad Prism 10. IC50 values and Hill slopes were extracted from the fitted curves.
+
+## 4.5 Stripping and reprobing
+
+For membranes probed with phospho-specific antibodies, stripping was performed with Restore Western Blot Stripping Buffer (Thermo Fisher) for 15 minutes at room temperature, followed by re-blocking and reprobing with total-Rb or beta-actin antibodies. Effective stripping was confirmed by the absence of signal after ECL exposure prior to reprobing.

--- a/bench-report/content/sections/5-discussion.md
+++ b/bench-report/content/sections/5-discussion.md
@@ -1,0 +1,37 @@
++++
+title = "5. Discussion"
+description = "Structure-activity relationships derived from the screening campaign, selectivity analysis, comparison with existing CDK4/6 inhibitors, and next steps for lead optimisation."
+weight = 5
+template = "post"
+tags = ["laboratory", "discussion", "SAR"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Structure-activity relationships
+
+Analysis of the 24-compound library reveals clear structure-activity relationships at the C-5 position. Compounds bearing a 3-fluorophenyl group (PYR-14, PYR-15, PYR-16) showed the highest potency, with IC50 values below 500 nM. The fluorine atom likely enhances binding through an electrostatic interaction with the gatekeeper residue (Thr107 in CDK4). Replacement with chlorine (PYR-08 series) reduced potency by approximately 5-fold, while unsubstituted phenyl (PYR-03 series) showed 10-fold lower activity.
+
+## 5.2 Selectivity profile
+
+PYR-14 exhibits greater than 200-fold selectivity for CDK4/6 over CDK2, comparable to the clinical agent palbociclib. This selectivity is therapeutically desirable because CDK2 inhibition causes bone marrow suppression. The selectivity likely arises from a favourable interaction between the N-4 linker of PYR-14 and a pocket unique to CDK4/6 that is occluded in CDK2 by a bulkier gatekeeper residue.
+
+Broader kinase profiling (against a panel of 50 kinases) is warranted before progressing to animal studies. Off-target kinase inhibition at clinically relevant concentrations could cause unexpected toxicity.
+
+## 5.3 Comparison with clinical agents
+
+Three CDK4/6 inhibitors are currently approved: palbociclib (Pfizer), ribociclib (Novartis), and abemaciclib (Eli Lilly). PYR-14 matches palbociclib in potency (48 nM vs 32 nM) and selectivity, but offers improved aqueous solubility (LogS = -3.8 vs -5.1). Poor solubility has been a formulation challenge for palbociclib, contributing to food-effect variability in patients. PYR-14's improved solubility suggests potential for a more consistent pharmacokinetic profile.
+
+## 5.4 Limitations
+
+This study has several limitations. First, HeLa cells are a cervical cancer line and may not recapitulate the signalling context of CDK4/6-driven tumours such as HR+ breast cancer. Second, the 4-hour treatment window captures only acute effects; chronic treatment experiments are needed to assess cell-cycle arrest and growth inhibition. Third, Western blot is semi-quantitative; ELISA or mass spectrometry-based phosphoproteomics would provide more precise quantification.
+
+## 5.5 Next steps
+
+Based on these results, the following experiments are planned:
+
+- Selectivity profiling against a 50-kinase panel (Eurofins DiscoverX scanMAX)
+- Cell viability assays in MCF-7 and T-47D breast cancer lines (72-hour MTT)
+- Pharmacokinetic assessment in mice (single oral dose, 50 mg/kg)
+- Co-crystal structure determination of PYR-14 bound to CDK4/cyclin D1

--- a/bench-report/content/sections/_index.md
+++ b/bench-report/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The laboratory report is organised into five sections covering compound design, experimental procedures, analytical techniques, and interpretation of results.

--- a/bench-report/static/css/style.css
+++ b/bench-report/static/css/style.css
@@ -1,0 +1,631 @@
+/* ============================================================================
+   Kinase Inhibitor Screening - Laboratory Bench Paper
+   Light background, wet-lab aesthetics, sans display, serif body.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #f7f6f2;
+  --bg-2: #efeee8;
+  --bg-3: #e6e4dc;
+  --rule: #c8c4b8;
+  --ink: #1c2030;
+  --ink-2: #2e3246;
+  --ink-3: #6b7085;
+  --ink-4: #9095a5;
+  --accent: #2a6b4f;
+  --accent-2: #1e5238;
+  --protocol: #4a6b8a;
+  --warn: #b85c2a;
+  --error: #a83232;
+  --lane-bg: #e0ddd4;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Noto Serif", "Crimson Pro", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Experiment ID badge ---------------- */
+
+.exp-id {
+  display: inline-block;
+  font-family: "Roboto", "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  background: var(--bg-2);
+  border: 1px solid var(--accent);
+  padding: 0.15rem 0.6rem;
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Noto Serif", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Noto Serif", serif;
+}
+
+/* ---------------- Protocol steps ---------------- */
+
+.protocol-steps {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.4rem 1.6rem;
+  margin: 2rem 0;
+}
+
+.protocol-steps .protocol-title {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.15em;
+  color: var(--protocol);
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.protocol-steps ol {
+  margin: 0;
+  padding-left: 1.6rem;
+  counter-reset: protocol;
+  list-style: none;
+}
+
+.protocol-steps ol li {
+  counter-increment: protocol;
+  position: relative;
+  padding: 0.4rem 0 0.4rem 0.4rem;
+  font-family: "Noto Serif", serif;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  border-bottom: 1px dashed var(--rule);
+}
+
+.protocol-steps ol li:last-child { border-bottom: none; }
+
+.protocol-steps ol li::before {
+  content: counter(protocol) ".";
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--protocol);
+  position: absolute;
+  left: -1.4rem;
+  font-size: 0.88rem;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "Roboto Mono", "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--warn);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.2rem 1.4rem;
+  overflow-x: auto;
+  border-radius: 2px;
+  margin: 1.5rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Roboto", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Noto Serif", serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Model callout ---------------- */
+
+.model-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.model-callout .callout-label {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.model-callout .callout-value {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.model-callout .callout-value .unit {
+  font-family: "Noto Serif", serif;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.model-callout .callout-detail {
+  font-family: "Noto Serif", serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.92rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #ffffff;
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Noto Serif", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Noto Serif", serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Noto Serif", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Noto Serif", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .model-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .protocol-steps { padding: 1rem; }
+}

--- a/bench-report/templates/404.html
+++ b/bench-report/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bench-report/templates/footer.html
+++ b/bench-report/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c8c4b8" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c8c4b8" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Chen W, Adeyemi T, Johansson K, Morales P. Selective Kinase Inhibitor Screening via Western Blot and Gel Electrophoresis. <em>Mol. Biol. Protoc.</em> 2026;42(11):284-312. doi:10.48127/mbp.2026.42.11.284</p>
+        <p class="footer-note">ISSN 1872-4405 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/bench-report/templates/header.html
+++ b/bench-report/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&family=Roboto:wght@400;700&family=Roboto+Mono:wght@400;500&family=Noto+Serif:ital,wght@0,400;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Flask / beaker icon -->
+          <rect x="22" y="4" width="20" height="6" fill="none" stroke="#2a6b4f" stroke-width="1.5" rx="1"/>
+          <path d="M 25 10 L 18 32 Q 17 36 21 36 L 43 36 Q 47 36 46 32 L 39 10" fill="none" stroke="#2a6b4f" stroke-width="1.5"/>
+          <line x1="20" y1="26" x2="44" y2="26" stroke="#4a6b8a" stroke-width="1" stroke-dasharray="3 2"/>
+          <circle cx="28" cy="30" r="2" fill="#2a6b4f" opacity="0.5"/>
+          <circle cx="36" cy="32" r="1.5" fill="#2a6b4f" opacity="0.4"/>
+          <circle cx="32" cy="28" r="1" fill="#2a6b4f" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Molecular Biology Protocols</span>
+          <span class="journal-sub">Vol. 42 &middot; Issue 11 &middot; Nov 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/protocols/">PROTOCOLS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/bench-report/templates/page.html
+++ b/bench-report/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bench-report/templates/post.html
+++ b/bench-report/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bench-report/templates/section.html
+++ b/bench-report/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bench-report/templates/shortcodes/alert.html
+++ b/bench-report/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/bench-report/templates/taxonomy.html
+++ b/bench-report/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bench-report/templates/taxonomy_term.html
+++ b/bench-report/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4014,5 +4014,12 @@
     "protocol",
     "pre-registration",
     "rigorous"
+  ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new `bench-report` example site: a laboratory bench paper with light theme
- Features SVG gel electrophoresis band diagrams with lane labels and MW markers, Western blot dose-response visualizations, and experimental workflow pipeline diagrams
- Typography: IBM Plex Sans Bold and Roboto Bold for experiment IDs (EXP-2026-0847), Noto Serif and Crimson Pro for body text
- Protocol steps presented in numbered checkbox format with dedicated styling
- Five content sections covering compound library, cell culture, gel electrophoresis, Western blot analysis, and discussion
- Tags: paper, light, laboratory, bench, experimental

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG diagrams render correctly with proper lane labels
- [ ] Confirm protocol steps display with numbered format
- [ ] Verify light theme colors and serif body typography
- [ ] Check tags.json entry is valid JSON

Closes #1623