### PR TITLE
feat: add errata-sheet example site (closes #1618)

### DIFF
--- a/errata-sheet/AGENTS.md
+++ b/errata-sheet/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/errata-sheet/config.toml
+++ b/errata-sheet/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Errata Sheet - Correction Notice with Full Transparency
+# Issue #1618 | Tags: paper, light, errata, correction, transparent
+# =============================================================================
+
+title = "Erratum: Correction to Thermal Conductivity Measurements"
+description = "A correction notice with full transparency featuring before/after comparison diagrams, correction impact assessment charts, version diff displays, and correction severity ratings."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/errata-sheet/content/appendix.md
+++ b/errata-sheet/content/appendix.md
@@ -1,0 +1,62 @@
++++
+title = "Appendix"
+description = "Supplementary materials including corrected supplementary data, author contributions, and version history."
+tags = ["paper", "light", "errata", "correction", "transparent"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## Corrected Supplementary Data
+
+The complete corrected dataset is available as supplementary material accompanying this erratum. Files include:
+
+- **Table S1 (corrected):** Full thermal conductivity measurement dataset with corrected calibration
+- **Table S2 (corrected):** Recalculated ZT values with propagated uncertainties
+- **Figure S3 (corrected):** Thickness-dependent thermal conductivity with corrected Callaway model fit
+- **Calibration audit report:** Independent verification of the corrected calibration factor
+
+All corrected supplementary files are archived at the journal repository and linked from the original article page.
+
+## Version History
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 5.</span> Publication version history.</caption>
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Date</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>v1.0</td>
+      <td class="num">2025-08-15</td>
+      <td>Original publication</td>
+    </tr>
+    <tr>
+      <td>v1.1</td>
+      <td class="num">2026-04-10</td>
+      <td>Erratum published; corrections C-1 through C-5 applied</td>
+    </tr>
+  </tbody>
+</table>
+
+## CRediT Author Contributions (Erratum)
+
+- **Adaeze Okonkwo:** Investigation (verification), Writing -- Original Draft (erratum), Supervision
+- **Magnus Lindgren:** Formal Analysis (recalculation), Data Curation, Writing -- Review
+- **Sora Tanaka:** Investigation (calibration audit), Resources
+
+## Acknowledgments
+
+The authors thank Dr. Hiroshi Yamamoto (National Metrology Institute of Japan) for independent verification of the corrected calibration factor, and the journal editor for facilitating rapid publication of this correction.
+
+## References
+
+The reference list of the original paper is unchanged. The following additional reference is cited in this erratum:
+
+1. Cahill DG, Watson SK, Pohl RO. Lower limit to the thermal conductivity of disordered crystals. <em>Phys Rev B.</em> 1992;46(10):6131-6140.

--- a/errata-sheet/content/impact.md
+++ b/errata-sheet/content/impact.md
@@ -1,0 +1,86 @@
++++
+title = "Impact Assessment"
+description = "Comprehensive assessment of how the corrections affect the original paper's conclusions, citing works, and downstream research."
+tags = ["paper", "light", "errata", "correction", "transparent"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">IMPACT ASSESSMENT</p>
+  <h1 class="paper-section-title">Correction Impact Analysis</h1>
+  <p class="paper-lede">Assessment of how the corrections affect the original conclusions, derivative works, and the broader literature.</p>
+</header>
+
+## Overall Impact Statement
+
+The corrections change the quantitative magnitude of the reported thermoelectric enhancement but do not invalidate the principal scientific finding. Nanostructured Bi2Te3 thin films remain effective thermoelectric materials with ZT > 1 at room temperature. The corrected values are more consistent with independently reported measurements in the literature.
+
+## Impact by Category
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> Impact assessment matrix.</caption>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>Original claim</th>
+      <th>Corrected claim</th>
+      <th>Validity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Primary finding</td>
+      <td>Nanostructuring reduces kappa</td>
+      <td>Unchanged</td>
+      <td><span class="severity-badge" style="color:#2a7a4a; border-color:#2a7a4a;">VALID</span></td>
+    </tr>
+    <tr>
+      <td>Reduction magnitude</td>
+      <td>78 pct reduction</td>
+      <td>63 pct reduction</td>
+      <td><span class="severity-badge major">REVISED</span></td>
+    </tr>
+    <tr>
+      <td>ZT > 1 achievement</td>
+      <td>All films above ZT = 1</td>
+      <td>Unchanged</td>
+      <td><span class="severity-badge" style="color:#2a7a4a; border-color:#2a7a4a;">VALID</span></td>
+    </tr>
+    <tr>
+      <td>ZT peak value</td>
+      <td>ZT = 1.82</td>
+      <td>ZT = 1.48</td>
+      <td><span class="severity-badge major">REVISED</span></td>
+    </tr>
+    <tr>
+      <td>Callaway model fit</td>
+      <td>Good fit (R-sq = 0.98)</td>
+      <td>Good fit (R-sq = 0.97)</td>
+      <td><span class="severity-badge" style="color:#2a7a4a; border-color:#2a7a4a;">VALID</span></td>
+    </tr>
+    <tr>
+      <td>Proximity to amorphous limit</td>
+      <td>Within 39 pct</td>
+      <td>Within 71 pct</td>
+      <td><span class="severity-badge major">REVISED</span></td>
+    </tr>
+  </tbody>
+</table>
+
+## Citing Works Advisory
+
+As of the correction date, the original paper has been cited 14 times. Authors of citing works are advised to verify whether their analyses depend on the specific numerical values corrected herein. Works citing the qualitative finding (nanostructuring reduces thermal conductivity) are unaffected. Works that used the original ZT values or thermal conductivity data for comparison or meta-analysis should update their references.
+
+The journal has issued a CrossRef correction notice linking this erratum to the original article DOI. The original article now carries a prominent correction banner linking to this erratum.
+
+## Root Cause and Prevention
+
+The error originated from a manual lookup of the fused silica reference thermal conductivity value. The value at 298 K (1.38 W/m-K) was used instead of the value at the actual measurement temperature of 295 K (1.12 W/m-K). Contributing factors:
+
+1. The reference value lookup table was indexed by 5 K intervals; 295 K fell between entries
+2. No automated temperature-matching validation was in place
+3. The calibration protocol did not require a second independent check
+
+**Preventive measures adopted:**
+- Calibration procedure now includes automated temperature logging with software-matched reference value lookup
+- All calibration calculations reviewed by a second team member before data processing
+- Laboratory temperature recorded automatically in the measurement metadata

--- a/errata-sheet/content/index.md
+++ b/errata-sheet/content/index.md
@@ -1,0 +1,164 @@
++++
+title = "Erratum Notice"
+description = "Correction notice for thermal conductivity measurements in nanostructured bismuth telluride thin films, with full transparency on errors, impact assessment, and corrected values."
+tags = ["paper", "light", "errata", "correction", "transparent"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Erratum &middot; Correction Notice &middot; Open Access</p>
+  <h1 class="paper-title">Erratum: Correction to Thermal Conductivity Measurements in Nanostructured Bismuth Telluride Thin Films</h1>
+  <p class="paper-authors">
+    Adaeze Okonkwo<sup>1</sup>,
+    Magnus Lindgren<sup>2</sup>,
+    Sora Tanaka<sup>1,3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Materials Engineering, ETH Zurich &middot;
+    <sup>2</sup>Division of Thermal Physics, Lund University &middot;
+    <sup>3</sup>RIKEN Center for Emergent Matter Science
+  </p>
+  <p class="paper-doi"><strong>Original DOI:</strong> <a href="#">10.41093/jmsl.2025.40.08.1142</a> &middot; <strong>Erratum DOI:</strong> <a href="#">10.41093/jmsl.2026.41.04.e012</a></p>
+
+  <div class="dates-display">
+    <div class="date-box">
+      <p class="date-label">Original published</p>
+      <p class="date-value">15 August 2025</p>
+    </div>
+    <div class="date-box">
+      <p class="date-label">Error discovered</p>
+      <p class="date-value">03 January 2026</p>
+    </div>
+    <div class="date-box">
+      <p class="date-label">Correction published</p>
+      <p class="date-value">10 April 2026</p>
+    </div>
+  </div>
+</header>
+
+<div class="erratum-banner">
+  <p class="banner-label">Correction Notice</p>
+  <p class="banner-text">The authors regret that the thermal conductivity values reported in the original publication contained systematic errors due to an incorrect calibration factor applied to the 3-omega measurement system. This erratum corrects all affected values, figures, and derived conclusions. The corrected data do not alter the principal finding that nanostructuring reduces lattice thermal conductivity, but the magnitude of the reduction is smaller than originally reported.</p>
+</div>
+
+## Correction Summary
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Before/after comparison of thermal conductivity values showing original erroneous values versus corrected values">
+    <rect x="0" y="0" width="720" height="320" fill="#fafaf7"/>
+    <!-- Title -->
+    <text x="360" y="28" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="13" fill="#1a2030" letter-spacing="0.5">Before/After Comparison: Thermal Conductivity (W/m-K)</text>
+    <!-- Axes -->
+    <line x1="100" y1="50" x2="100" y2="270" stroke="#1a2030" stroke-width="1.5"/>
+    <line x1="100" y1="270" x2="660" y2="270" stroke="#1a2030" stroke-width="1.5"/>
+    <!-- Y-axis labels -->
+    <g font-family="JetBrains Mono" font-size="10" fill="#5b6272" text-anchor="end">
+      <text x="92" y="74">2.0</text>
+      <text x="92" y="118">1.5</text>
+      <text x="92" y="162">1.0</text>
+      <text x="92" y="206">0.5</text>
+      <text x="92" y="250">0.2</text>
+    </g>
+    <!-- Y-axis title -->
+    <text x="30" y="165" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2030" transform="rotate(-90,30,165)">kappa (W/m-K)</text>
+    <!-- Grid lines -->
+    <g stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="3 3">
+      <line x1="100" y1="70" x2="660" y2="70"/>
+      <line x1="100" y1="114" x2="660" y2="114"/>
+      <line x1="100" y1="158" x2="660" y2="158"/>
+      <line x1="100" y1="202" x2="660" y2="202"/>
+      <line x1="100" y1="246" x2="660" y2="246"/>
+    </g>
+    <!-- Sample labels -->
+    <g font-family="IBM Plex Sans" font-weight="600" font-size="10" fill="#1a2030" text-anchor="middle">
+      <text x="180" y="290">Bulk</text>
+      <text x="300" y="290">Film A (200nm)</text>
+      <text x="420" y="290">Film B (80nm)</text>
+      <text x="540" y="290">Film C (30nm)</text>
+    </g>
+    <!-- Original values (red, strikethrough) -->
+    <g>
+      <rect x="155" y="70" width="20" height="200" fill="#c44a3a" opacity="0.25"/>
+      <line x1="155" y1="70" x2="175" y2="70" stroke="#c44a3a" stroke-width="2"/>
+      <rect x="275" y="158" width="20" height="112" fill="#c44a3a" opacity="0.25"/>
+      <line x1="275" y1="158" x2="295" y2="158" stroke="#c44a3a" stroke-width="2"/>
+      <rect x="395" y="202" width="20" height="68" fill="#c44a3a" opacity="0.25"/>
+      <line x1="395" y1="202" x2="415" y2="202" stroke="#c44a3a" stroke-width="2"/>
+      <rect x="515" y="228" width="20" height="42" fill="#c44a3a" opacity="0.25"/>
+      <line x1="515" y1="228" x2="535" y2="228" stroke="#c44a3a" stroke-width="2"/>
+    </g>
+    <!-- Corrected values (green) -->
+    <g>
+      <rect x="185" y="70" width="20" height="200" fill="#2a7a4a" opacity="0.4"/>
+      <line x1="185" y1="70" x2="205" y2="70" stroke="#2a7a4a" stroke-width="2"/>
+      <rect x="305" y="126" width="20" height="144" fill="#2a7a4a" opacity="0.4"/>
+      <line x1="305" y1="126" x2="325" y2="126" stroke="#2a7a4a" stroke-width="2"/>
+      <rect x="425" y="158" width="20" height="112" fill="#2a7a4a" opacity="0.4"/>
+      <line x1="425" y1="158" x2="445" y2="158" stroke="#2a7a4a" stroke-width="2"/>
+      <rect x="545" y="190" width="20" height="80" fill="#2a7a4a" opacity="0.4"/>
+      <line x1="545" y1="190" x2="565" y2="190" stroke="#2a7a4a" stroke-width="2"/>
+    </g>
+    <!-- Legend -->
+    <rect x="440" y="40" width="12" height="12" fill="#c44a3a" opacity="0.4"/>
+    <text x="458" y="51" font-family="IBM Plex Sans" font-size="10" fill="#c44a3a">Original (erroneous)</text>
+    <rect x="560" y="40" width="12" height="12" fill="#2a7a4a" opacity="0.5"/>
+    <text x="578" y="51" font-family="IBM Plex Sans" font-size="10" fill="#2a7a4a">Corrected</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Before/after comparison of thermal conductivity values for bulk Bi2Te3 and nanostructured thin films. Red bars (left) show original erroneous values; green bars (right) show corrected values. The bulk reference value is unchanged. Film measurements were systematically underestimated due to an incorrect calibration factor.</div>
+</figure>
+
+## Correction Severity Ratings
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary of corrections with severity ratings and affected sections.</caption>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>Severity</th>
+      <th>Section</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>C-1</td>
+      <td><span class="severity-badge critical">CRITICAL</span></td>
+      <td>Table 2, Fig. 3</td>
+      <td>Thermal conductivity values for Films A, B, C incorrect by factor of 1.23x</td>
+    </tr>
+    <tr>
+      <td>C-2</td>
+      <td><span class="severity-badge major">MAJOR</span></td>
+      <td>Section 4.2</td>
+      <td>Derived ZT figure-of-merit values recalculated with corrected kappa</td>
+    </tr>
+    <tr>
+      <td>C-3</td>
+      <td><span class="severity-badge major">MAJOR</span></td>
+      <td>Abstract, Sec. 5</td>
+      <td>Lattice thermal conductivity reduction percentage revised from 78 pct to 63 pct</td>
+    </tr>
+    <tr>
+      <td>C-4</td>
+      <td><span class="severity-badge minor">MINOR</span></td>
+      <td>Section 3.1</td>
+      <td>Calibration reference temperature corrected from 298 K to 295 K</td>
+    </tr>
+    <tr>
+      <td>C-5</td>
+      <td><span class="severity-badge typo">TYPO</span></td>
+      <td>Section 2.3</td>
+      <td>Unit label corrected from "W/cm-K" to "W/m-K" in paragraph text</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Severity: CRITICAL = affects primary conclusions; MAJOR = affects derived quantities; MINOR = affects methods detail; TYPO = no scientific impact.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Erratum
+
+1. **Correction 1. Thermal Conductivity Values** -- corrected measurements with before/after diff for Table 2 and Figure 3
+2. **Correction 2. ZT Figure of Merit** -- recalculated thermoelectric performance values
+3. **Correction 3. Conclusions Revision** -- updated lattice reduction percentages and discussion text
+4. **Correction 4. Calibration Details** -- corrected reference temperature in methods
+5. **Correction 5. Unit Label** -- typographical correction in Section 2.3

--- a/errata-sheet/content/sections/1-thermal-conductivity.md
+++ b/errata-sheet/content/sections/1-thermal-conductivity.md
@@ -1,0 +1,97 @@
++++
+title = "C-1. Thermal Conductivity Values"
+description = "Critical correction to thermal conductivity measurements in Table 2 and Figure 3 due to incorrect 3-omega calibration factor."
+weight = 1
+template = "post"
+tags = ["paper", "light", "errata", "correction", "transparent"]
+categories = ["sections"]
+
+[extra]
+section_number = "C-1"
++++
+
+<span class="severity-badge critical">CRITICAL</span>
+
+## Error Description
+
+The 3-omega measurement system used for thermal conductivity characterization of thin-film samples was calibrated using a reference standard (SRM 1453, fused silica) with an assumed thermal conductivity of 1.38 W/m-K at 298 K. Post-publication audit revealed that the reference value should have been 1.12 W/m-K at 295 K (the actual measurement temperature), yielding a systematic overestimation factor of 1.23x for all thin-film measurements.
+
+The bulk Bi2Te3 reference samples were measured using the laser flash method (not 3-omega) and are unaffected.
+
+## Corrected Table
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2 (Corrected).</span> Thermal conductivity of Bi2Te3 samples at 300 K.</caption>
+  <thead>
+    <tr>
+      <th>Sample</th>
+      <th>Thickness</th>
+      <th>Original kappa (W/m-K)</th>
+      <th>Corrected kappa (W/m-K)</th>
+      <th>Change</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bulk reference</td>
+      <td class="num">--</td>
+      <td class="num">1.95</td>
+      <td class="added-cell">1.95 (unchanged)</td>
+      <td class="num">0 pct</td>
+    </tr>
+    <tr>
+      <td>Film A</td>
+      <td class="num">200 nm</td>
+      <td class="removed-cell">1.02</td>
+      <td class="added-cell">1.26</td>
+      <td class="num">+23.5 pct</td>
+    </tr>
+    <tr>
+      <td>Film B</td>
+      <td class="num">80 nm</td>
+      <td class="removed-cell">0.61</td>
+      <td class="added-cell">0.75</td>
+      <td class="num">+23.0 pct</td>
+    </tr>
+    <tr>
+      <td>Film C</td>
+      <td class="num">30 nm</td>
+      <td class="removed-cell">0.43</td>
+      <td class="added-cell">0.53</td>
+      <td class="num">+23.3 pct</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Correction factor: 1.23x applied uniformly to all 3-omega derived measurements. Uncertainty bounds are rescaled proportionally.</td></tr>
+  </tfoot>
+</table>
+
+## Diff Display
+
+<div class="diff-block">
+  <div class="diff-header">Table 2, Row: Film A (200 nm)</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Sample: Film A, Thickness: 200 nm, Method: 3-omega</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>kappa = 1.02 +/- 0.08 W/m-K (calibrated at 298 K, ref: 1.38 W/m-K)</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>kappa = 1.26 +/- 0.10 W/m-K (calibrated at 295 K, ref: 1.12 W/m-K)</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Measurement temperature: 300 K, Atmosphere: vacuum (10e-4 Pa)</div>
+</div>
+
+<div class="diff-block">
+  <div class="diff-header">Table 2, Row: Film B (80 nm)</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Sample: Film B, Thickness: 80 nm, Method: 3-omega</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>kappa = 0.61 +/- 0.05 W/m-K</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>kappa = 0.75 +/- 0.06 W/m-K</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Measurement temperature: 300 K, Atmosphere: vacuum (10e-4 Pa)</div>
+</div>
+
+<div class="diff-block">
+  <div class="diff-header">Table 2, Row: Film C (30 nm)</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Sample: Film C, Thickness: 30 nm, Method: 3-omega</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>kappa = 0.43 +/- 0.04 W/m-K</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>kappa = 0.53 +/- 0.05 W/m-K</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Measurement temperature: 300 K, Atmosphere: vacuum (10e-4 Pa)</div>
+</div>
+
+## Impact on Figure 3
+
+Figure 3 in the original paper (thermal conductivity versus film thickness) is replaced with corrected values. The shape of the curve is preserved, but all thin-film data points shift upward by approximately 23 pct. The fitted Callaway model parameters are updated accordingly: the grain boundary scattering mean free path changes from 42 nm to 38 nm.

--- a/errata-sheet/content/sections/2-zt-figure-of-merit.md
+++ b/errata-sheet/content/sections/2-zt-figure-of-merit.md
@@ -1,0 +1,105 @@
++++
+title = "C-2. ZT Figure of Merit"
+description = "Major correction to thermoelectric figure-of-merit values derived from corrected thermal conductivity data."
+weight = 2
+template = "post"
+tags = ["paper", "light", "errata", "correction", "transparent"]
+categories = ["sections"]
+
+[extra]
+section_number = "C-2"
++++
+
+<span class="severity-badge major">MAJOR</span>
+
+## Error Description
+
+The dimensionless thermoelectric figure of merit ZT = S^2 sigma T / kappa depends inversely on thermal conductivity. Because the corrected kappa values are higher than originally reported, the ZT values decrease proportionally.
+
+## Corrected Values
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3 (Corrected).</span> Thermoelectric figure of merit at 300 K.</caption>
+  <thead>
+    <tr>
+      <th>Sample</th>
+      <th>Original ZT</th>
+      <th>Corrected ZT</th>
+      <th>Change</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bulk reference</td>
+      <td class="num">0.72</td>
+      <td class="added-cell">0.72 (unchanged)</td>
+      <td class="num">0 pct</td>
+    </tr>
+    <tr>
+      <td>Film A (200 nm)</td>
+      <td class="removed-cell">1.18</td>
+      <td class="added-cell">0.96</td>
+      <td class="num">-18.6 pct</td>
+    </tr>
+    <tr>
+      <td>Film B (80 nm)</td>
+      <td class="removed-cell">1.54</td>
+      <td class="added-cell">1.25</td>
+      <td class="num">-18.8 pct</td>
+    </tr>
+    <tr>
+      <td>Film C (30 nm)</td>
+      <td class="removed-cell">1.82</td>
+      <td class="added-cell">1.48</td>
+      <td class="num">-18.7 pct</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Seebeck coefficient and electrical conductivity values are unchanged. ZT is recalculated using corrected kappa only.</td></tr>
+  </tfoot>
+</table>
+
+## Diff Display
+
+<div class="diff-block">
+  <div class="diff-header">Section 4.2, Paragraph 3</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>The thermoelectric figure of merit for the thinnest film (30 nm)</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>reached ZT = 1.82, representing a 153 pct enhancement over bulk.</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>reached ZT = 1.48, representing a 106 pct enhancement over bulk.</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>This enhancement is primarily attributed to the reduction in lattice</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>thermal conductivity through phonon-boundary scattering.</div>
+</div>
+
+## Impact Assessment
+
+The corrected ZT values remain above unity for all nanostructured films, which is the threshold for practical thermoelectric applications. The qualitative conclusion that nanostructuring improves thermoelectric performance is preserved. However, the quantitative improvement is less dramatic than originally reported (106 pct vs. 153 pct enhancement for Film C).
+
+<figure class="figure">
+  <svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Correction impact assessment chart showing the magnitude of change for each affected quantity">
+    <rect x="0" y="0" width="720" height="260" fill="#fafaf7"/>
+    <text x="360" y="28" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="13" fill="#1a2030" letter-spacing="0.5">Correction Impact: Percentage Change by Quantity</text>
+    <!-- Axes -->
+    <line x1="200" y1="50" x2="200" y2="220" stroke="#1a2030" stroke-width="1"/>
+    <line x1="200" y1="220" x2="680" y2="220" stroke="#1a2030" stroke-width="1"/>
+    <!-- Zero line -->
+    <line x1="400" y1="50" x2="400" y2="220" stroke="#1a2030" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="400" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#5b6272">0%</text>
+    <text x="200" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#5b6272">-25%</text>
+    <text x="600" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#5b6272">+25%</text>
+    <!-- Labels -->
+    <text x="190" y="80" text-anchor="end" font-family="IBM Plex Sans" font-weight="600" font-size="10" fill="#1a2030">kappa (films)</text>
+    <text x="190" y="115" text-anchor="end" font-family="IBM Plex Sans" font-weight="600" font-size="10" fill="#1a2030">ZT (films)</text>
+    <text x="190" y="150" text-anchor="end" font-family="IBM Plex Sans" font-weight="600" font-size="10" fill="#1a2030">Reduction pct</text>
+    <text x="190" y="185" text-anchor="end" font-family="IBM Plex Sans" font-weight="600" font-size="10" fill="#1a2030">Callaway MFP</text>
+    <!-- Bars -->
+    <rect x="400" y="68" width="188" height="20" fill="#2a7a4a" opacity="0.5"/>
+    <text x="594" y="82" font-family="JetBrains Mono" font-size="10" fill="#2a7a4a">+23%</text>
+    <rect x="248" y="103" width="152" height="20" fill="#c44a3a" opacity="0.5"/>
+    <text x="242" y="117" text-anchor="end" font-family="JetBrains Mono" font-size="10" fill="#c44a3a">-19%</text>
+    <rect x="280" y="138" width="120" height="20" fill="#c44a3a" opacity="0.5"/>
+    <text x="274" y="152" text-anchor="end" font-family="JetBrains Mono" font-size="10" fill="#c44a3a">-15pp</text>
+    <rect x="336" y="173" width="64" height="20" fill="#c44a3a" opacity="0.5"/>
+    <text x="330" y="187" text-anchor="end" font-family="JetBrains Mono" font-size="10" fill="#c44a3a">-10%</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Correction impact assessment. Green bars indicate quantities that increased after correction; red bars indicate decreases. kappa = thermal conductivity; ZT = figure of merit; Reduction pct = lattice kappa reduction relative to bulk; MFP = Callaway model mean free path.</div>
+</figure>

--- a/errata-sheet/content/sections/3-conclusions-revision.md
+++ b/errata-sheet/content/sections/3-conclusions-revision.md
@@ -1,0 +1,58 @@
++++
+title = "C-3. Conclusions Revision"
+description = "Major correction to lattice thermal conductivity reduction percentages and associated discussion text."
+weight = 3
+template = "post"
+tags = ["paper", "light", "errata", "correction", "transparent"]
+categories = ["sections"]
+
+[extra]
+section_number = "C-3"
++++
+
+<span class="severity-badge major">MAJOR</span>
+
+## Affected Text: Abstract
+
+<div class="diff-block">
+  <div class="diff-header">Abstract, Results sentence</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>Nanostructuring reduced lattice thermal conductivity by up to 78 pct</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>relative to bulk, yielding ZT = 1.82 at 300 K for the 30 nm film.</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>Nanostructuring reduced lattice thermal conductivity by up to 63 pct</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>relative to bulk, yielding ZT = 1.48 at 300 K for the 30 nm film.</div>
+</div>
+
+## Affected Text: Section 5 (Discussion)
+
+<div class="diff-block">
+  <div class="diff-header">Section 5, Paragraph 1</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>The principal finding of this study is that nanostructured Bi2Te3</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>thin films exhibit substantially reduced lattice thermal conductivity</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>compared to bulk crystals. The 30 nm film showed a 78 pct reduction,</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>approaching the amorphous limit predicted by Cahill et al. (1992).</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>compared to bulk crystals. The 30 nm film showed a 63 pct reduction,</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>which remains well above the amorphous limit predicted by Cahill et al.</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>(1992), suggesting further optimization potential.</div>
+</div>
+
+<div class="diff-block">
+  <div class="diff-header">Section 5, Paragraph 4</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Comparing our results with the theoretical minimum lattice thermal</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>conductivity of 0.31 W/m-K (Cahill model), the 30 nm film (0.43 W/m-K)</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>approaches within 39 pct of this limit, indicating that phonon-boundary</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>scattering at grain interfaces is approaching maximum effectiveness.</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>conductivity of 0.31 W/m-K (Cahill model), the 30 nm film (0.53 W/m-K)</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>is within 71 pct of this limit, indicating substantial room for further</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>optimization through grain boundary engineering or alloying strategies.</div>
+</div>
+
+## Impact on Conclusions
+
+The original paper concluded that nanostructuring approached the amorphous limit of thermal conductivity. The corrected data show that the films are further from this limit than originally reported. This changes the nuance of the conclusion: rather than having nearly exhausted the nanostructuring approach, there is significant room for further improvement. The corrected conclusion is actually more optimistic for future research directions.
+
+The following original conclusions remain valid:
+
+- Nanostructuring systematically reduces lattice thermal conductivity
+- The reduction scales with decreasing grain size
+- All nanostructured films achieve ZT > 1 at 300 K
+- The Callaway model provides a good fit to the thickness-dependent data

--- a/errata-sheet/content/sections/4-calibration-details.md
+++ b/errata-sheet/content/sections/4-calibration-details.md
@@ -1,0 +1,32 @@
++++
+title = "C-4. Calibration Reference Temperature"
+description = "Minor correction to the calibration reference temperature reported in the methods section."
+weight = 4
+template = "post"
+tags = ["paper", "light", "errata", "correction", "transparent"]
+categories = ["sections"]
+
+[extra]
+section_number = "C-4"
++++
+
+<span class="severity-badge minor">MINOR</span>
+
+## Error Description
+
+Section 3.1 of the original paper stated that the 3-omega calibration was performed at 298 K (25 C). The laboratory records confirm the actual calibration temperature was 295 K (22 C), consistent with the laboratory thermostat setting. This discrepancy contributed to the selection of the incorrect reference thermal conductivity value (see Correction C-1).
+
+## Diff Display
+
+<div class="diff-block">
+  <div class="diff-header">Section 3.1, Paragraph 2</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>The 3-omega measurement system was calibrated using NIST SRM 1453</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>(fused silica, kappa = 1.38 W/m-K) at a reference temperature of 298 K.</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>(fused silica, kappa = 1.12 W/m-K) at a reference temperature of 295 K.</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>Heater linewidths of 5 um and 30 um were used for thin-film and</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>substrate measurements, respectively.</div>
+</div>
+
+## Impact Assessment
+
+This correction is classified as minor because it affects the methods description only. The scientific impact is already captured in Correction C-1 (recalculated thermal conductivity values). No additional recalculation is needed beyond what is described in C-1.

--- a/errata-sheet/content/sections/5-unit-label.md
+++ b/errata-sheet/content/sections/5-unit-label.md
@@ -1,0 +1,31 @@
++++
+title = "C-5. Unit Label Correction"
+description = "Typographical correction of thermal conductivity unit from W/cm-K to W/m-K in Section 2.3."
+weight = 5
+template = "post"
+tags = ["paper", "light", "errata", "correction", "transparent"]
+categories = ["sections"]
+
+[extra]
+section_number = "C-5"
++++
+
+<span class="severity-badge typo">TYPO</span>
+
+## Error Description
+
+A single instance in Section 2.3, paragraph 4, incorrectly displays the thermal conductivity unit as "W/cm-K" instead of "W/m-K". All numerical values in the paper use W/m-K consistently; this is a typographical error in the unit label only.
+
+## Diff Display
+
+<div class="diff-block">
+  <div class="diff-header">Section 2.3, Paragraph 4</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>The expected lattice thermal conductivity for nanostructured Bi2Te3</div>
+  <div class="diff-line removed"><span class="diff-marker">-</span>falls in the range 0.3-1.5 W/cm-K depending on grain size and</div>
+  <div class="diff-line added"><span class="diff-marker">+</span>falls in the range 0.3-1.5 W/m-K depending on grain size and</div>
+  <div class="diff-line context"><span class="diff-marker"> </span>crystallographic texture (Poudel et al., 2008).</div>
+</div>
+
+## Impact Assessment
+
+No scientific impact. The numerical values are consistent with W/m-K throughout the paper. This was a transcription error in one unit label.

--- a/errata-sheet/content/sections/_index.md
+++ b/errata-sheet/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Corrections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Individual corrections listed by severity, with before/after diffs and impact assessments for each erratum item.

--- a/errata-sheet/static/css/style.css
+++ b/errata-sheet/static/css/style.css
@@ -1,0 +1,574 @@
+/* ============================================================================
+   Errata Sheet - Correction Notice with Full Transparency
+   Light background, red/green diff styling (flat colors only). IBM Plex Sans
+   Bold for correction headers. Noto Serif / Crimson Pro body. No gradients.
+   ============================================================================ */
+
+:root {
+  --paper: #fafaf7;
+  --paper-2: #f0efe8;
+  --rule: #ccc8ba;
+  --ink: #1a2030;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #8a2a2a;
+  --accent-2: #6a1a1a;
+  --removed: #c44a3a;
+  --removed-bg: #fdf0ee;
+  --added: #2a7a4a;
+  --added-bg: #edf7f0;
+  --severity-critical: #b82a2a;
+  --severity-major: #c46a2a;
+  --severity-minor: #7a7a2a;
+  --severity-typo: #5b6272;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Noto Serif", "Crimson Pro", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Erratum banner ---------------- */
+
+.erratum-banner {
+  background: var(--removed-bg);
+  border: 2px solid var(--removed);
+  padding: 1rem 1.4rem;
+  margin: 1.5rem 0;
+  font-family: "IBM Plex Sans", sans-serif;
+}
+
+.erratum-banner .banner-label {
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+  color: var(--removed);
+  text-transform: uppercase;
+  margin: 0 0 0.3rem;
+}
+
+.erratum-banner .banner-text {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin: 0.3rem 0 0;
+}
+
+/* ---------------- Dates display ---------------- */
+
+.dates-display {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+.date-box {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.85rem;
+}
+
+.date-box .date-label {
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.date-box .date-value {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.9rem;
+  color: var(--ink);
+}
+
+/* ---------------- Severity badge ---------------- */
+
+.severity-badge {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border: 1.5px solid;
+}
+
+.severity-badge.critical { color: var(--severity-critical); border-color: var(--severity-critical); }
+.severity-badge.major { color: var(--severity-major); border-color: var(--severity-major); }
+.severity-badge.minor { color: var(--severity-minor); border-color: var(--severity-minor); }
+.severity-badge.typo { color: var(--severity-typo); border-color: var(--severity-typo); }
+
+/* ---------------- Diff display ---------------- */
+
+.diff-block {
+  margin: 1.5rem 0;
+  border: 1px solid var(--rule);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.diff-header {
+  background: var(--paper-2);
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--rule);
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+}
+
+.diff-line {
+  padding: 0.25rem 1rem;
+  border-bottom: 1px solid var(--paper-2);
+}
+
+.diff-line.removed {
+  background: var(--removed-bg);
+  color: var(--removed);
+}
+
+.diff-line.added {
+  background: var(--added-bg);
+  color: var(--added);
+}
+
+.diff-line.context {
+  color: var(--ink-3);
+}
+
+.diff-line .diff-marker {
+  display: inline-block;
+  width: 1.2em;
+  font-weight: 700;
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-affiliations {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure .caption {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table td.removed-cell {
+  background: var(--removed-bg);
+  color: var(--removed);
+  text-decoration: line-through;
+}
+
+.paper-table td.added-cell {
+  background: var(--added-bg);
+  color: var(--added);
+  font-weight: 600;
+}
+
+.paper-table tfoot td {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "Noto Serif", "Crimson Pro", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .dates-display { flex-direction: column; gap: 0.8rem; }
+  .diff-block { font-size: 0.78rem; }
+}

--- a/errata-sheet/templates/404.html
+++ b/errata-sheet/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / PAGE NOT FOUND</p>
+      <h1 class="paper-section-title">Reference not found</h1>
+      <p>The correction you followed does not resolve to a section in this erratum. Return to the notice to navigate the corrections.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to the erratum</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/errata-sheet/templates/footer.html
+++ b/errata-sheet/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2030" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2030" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Erratum for: Okonkwo A, Lindgren M, Tanaka S. Thermal Conductivity of Nanostructured Bismuth Telluride Thin Films. <em>J Mater Sci Lett.</em> 2025;40(8):1142-1158. doi:10.41093/jmsl.2025.40.08.1142</p>
+        <p class="footer-note">ISSN 2891-5510 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/errata-sheet/templates/header.html
+++ b/errata-sheet/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@500;600;700&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#1a2030" stroke-width="1.5"/>
+          <line x1="10" y1="12" x2="54" y2="12" stroke="#ccc8ba" stroke-width="1"/>
+          <line x1="10" y1="18" x2="54" y2="18" stroke="#c44a3a" stroke-width="1.5" stroke-dasharray="4 2"/>
+          <line x1="10" y1="24" x2="54" y2="24" stroke="#2a7a4a" stroke-width="1.5"/>
+          <line x1="10" y1="30" x2="54" y2="30" stroke="#ccc8ba" stroke-width="1"/>
+          <text x="56" y="20" font-family="IBM Plex Sans" font-size="8" font-weight="700" fill="#c44a3a">-</text>
+          <text x="56" y="28" font-family="IBM Plex Sans" font-size="8" font-weight="700" fill="#2a7a4a">+</text>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Materials Science Letters</span>
+          <span class="journal-sub">Erratum &middot; Vol. 41 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ERRATUM</a>
+        <a href="{{ base_url }}/sections/">CORRECTIONS</a>
+        <a href="{{ base_url }}/impact/">IMPACT</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/errata-sheet/templates/page.html
+++ b/errata-sheet/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/errata-sheet/templates/post.html
+++ b/errata-sheet/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Correction {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to corrections index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/errata-sheet/templates/section.html
+++ b/errata-sheet/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">CORRECTIONS INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/errata-sheet/templates/shortcodes/alert.html
+++ b/errata-sheet/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #8a2a2a; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/errata-sheet/templates/taxonomy.html
+++ b/errata-sheet/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Subject index and keyword cross-references for this erratum.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/errata-sheet/templates/taxonomy_term.html
+++ b/errata-sheet/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">SUBJECT INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Corrections cross-referenced to this subject keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4014,5 +4014,12 @@
     "protocol",
     "pre-registration",
     "rigorous"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new errata-sheet example site: a correction notice with full transparency
- Features SVG before/after comparison diagrams, correction impact assessment charts, and version diff displays
- Red/green diff styling with flat colors for removed/added content
- Correction severity ratings (CRITICAL, MAJOR, MINOR, TYPO)
- Original publication date and correction date prominently displayed
- Uses IBM Plex Sans Bold display with Noto Serif/Crimson Pro body

Closes #1618