### PR TITLE
feat: add cohort-study example site (closes #1624)

### DIFF
--- a/cohort-study/AGENTS.md
+++ b/cohort-study/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/cohort-study/config.toml
+++ b/cohort-study/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Cohort Study - Population Tracking Paper
+# Issue #1624 | Tags: paper, light, cohort, survival, epidemiological
+# =============================================================================
+
+title = "Occupational Benzene Cohort"
+description = "A population tracking paper with Kaplan-Meier survival curves, hazard ratio forest plots, cohort flow diagrams, and directed acyclic graph causal models."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/cohort-study/content/appendix.md
+++ b/cohort-study/content/appendix.md
@@ -1,0 +1,70 @@
++++
+title = "Appendix"
+description = "Supplementary materials including DAG specification, data availability, author contributions, and conflict-of-interest disclosures."
+tags = ["cohort", "appendix", "DAG"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## A. Directed Acyclic Graph (DAG)
+
+<figure class="figure">
+  <svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Directed acyclic graph showing causal relationships between benzene exposure, confounders, and haematological malignancy">
+    <!-- Exposure -->
+    <rect x="40" y="80" width="140" height="45" fill="none" stroke="#2a5c8a" stroke-width="2"/>
+    <text x="110" y="100" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a5c8a">BENZENE</text>
+    <text x="110" y="115" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#1a2030">Cumulative ppm-yr</text>
+    <!-- Outcome -->
+    <rect x="520" y="80" width="160" height="45" fill="none" stroke="#b85c2a" stroke-width="2"/>
+    <text x="600" y="100" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#b85c2a">HAEM. MALIGNANCY</text>
+    <text x="600" y="115" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#1a2030">ICD-10 C81-C96</text>
+    <!-- Causal arrow -->
+    <line x1="180" y1="102" x2="520" y2="102" stroke="#1a2030" stroke-width="2" marker-end="url(#arrowC)"/>
+    <!-- Confounders -->
+    <rect x="260" y="10" width="100" height="35" fill="none" stroke="#667080" stroke-width="1.5"/>
+    <text x="310" y="32" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#667080">Age, Sex</text>
+    <rect x="400" y="10" width="100" height="35" fill="none" stroke="#667080" stroke-width="1.5"/>
+    <text x="450" y="32" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#667080">Smoking</text>
+    <rect x="260" y="170" width="120" height="35" fill="none" stroke="#667080" stroke-width="1.5"/>
+    <text x="320" y="192" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#667080">Toluene/Xylene</text>
+    <!-- Confounder arrows -->
+    <line x1="310" y1="45" x2="150" y2="80" stroke="#667080" stroke-width="1" marker-end="url(#arrowC)"/>
+    <line x1="310" y1="45" x2="560" y2="80" stroke="#667080" stroke-width="1" marker-end="url(#arrowC)"/>
+    <line x1="450" y1="45" x2="580" y2="80" stroke="#667080" stroke-width="1" marker-end="url(#arrowC)"/>
+    <line x1="320" y1="170" x2="150" y2="125" stroke="#667080" stroke-width="1" marker-end="url(#arrowC)"/>
+    <line x1="320" y1="170" x2="560" y2="125" stroke="#667080" stroke-width="1" marker-end="url(#arrowC)"/>
+    <defs>
+      <marker id="arrowC" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#667080"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure A1.</span> Directed acyclic graph (DAG) for the association between cumulative benzene exposure and haematological malignancy. Age, sex, smoking, and co-exposure to toluene/xylene are identified as confounders requiring adjustment. The DAG was constructed using DAGitty and reviewed by two epidemiologists.</figcaption>
+</figure>
+
+## B. Software
+
+All analyses were conducted in R version 4.3.2 using the survival (version 3.5-7), survminer (version 0.4.9), and timereg (version 2.0.5) packages. DAG analysis was performed in DAGitty version 3.0. Reproducible analysis scripts are archived at Zenodo (doi: 10.5281/zenodo.example.2026.cohort).
+
+## C. Data Availability
+
+Individual-level data cannot be shared publicly due to occupational health confidentiality agreements. Aggregate data tables and analysis scripts are available from the corresponding author upon reasonable request. A synthetic dataset preserving distributional properties is provided in the Zenodo archive.
+
+## D. CRediT Author Contributions
+
+- **Chioma Okafor:** Conceptualisation, Methodology, Formal Analysis, Writing - Original Draft
+- **Erik Lindstrom:** Exposure Assessment, Data Curation, Writing - Review and Editing
+- **Rashida Patel:** Methodology, Supervision, Writing - Review and Editing
+- **Hideo Nakamura:** Formal Analysis, Visualisation
+- **Felipe da Silva:** Investigation, Data Curation
+
+## E. Conflict of Interest
+
+The authors declare no competing interests.
+
+## F. Funding
+
+This work was supported by UK Research and Innovation (UKRI grant MR/S024654/1), the Swedish Research Council for Health, Working Life and Welfare (FORTE 2020-00123), and the Japan Society for the Promotion of Science (KAKENHI 22K10462).

--- a/cohort-study/content/index.md
+++ b/cohort-study/content/index.md
@@ -1,0 +1,278 @@
++++
+title = "Abstract"
+description = "A 25-year prospective cohort study of occupational benzene exposure and haematological malignancy incidence with Kaplan-Meier survival analysis and Cox proportional hazards modelling."
+tags = ["paper", "light", "cohort", "survival", "epidemiological"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Research &middot; <span class="strobe-badge">STROBE Compliant</span></p>
+  <h1 class="paper-title">Occupational Benzene Exposure and Haematological Malignancy: A 25-Year Prospective Cohort Study with Survival Analysis</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Chioma Okafor</span><sup>1</sup>,
+    Erik Lindstrom<sup>2</sup>,
+    Rashida Patel<sup>1,3</sup>,
+    Hideo Nakamura<sup>4</sup>,
+    Felipe da Silva<sup>2</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Epidemiology, London School of Hygiene and Tropical Medicine &middot;
+    <sup>2</sup>Institute of Environmental Medicine, Karolinska Institute &middot;
+    <sup>3</sup>UK Health Security Agency &middot;
+    <sup>4</sup>Division of Occupational Health, University of Tokyo
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/jer.2026.61.04.412</a> &middot; <strong>Received:</strong> 22 Aug 2025 &middot; <strong>Accepted:</strong> 07 Jan 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>To estimate the association between cumulative occupational benzene exposure and incidence of haematological malignancy in a prospective cohort of petrochemical workers followed for 25 years.</dd>
+    <dt>Methods</dt>
+    <dd>N = 8,412 workers enrolled between 1998 and 2001 at four UK petrochemical facilities. Cumulative benzene exposure was estimated from personal dosimetry and job-exposure matrices. Kaplan-Meier survival curves and Cox proportional hazards models were used to estimate hazard ratios (HR) with 95 pct confidence intervals, adjusted for age, sex, smoking status, and co-exposures. Directed acyclic graphs (DAGs) guided confounder selection.</dd>
+    <dt>Results</dt>
+    <dd>Over 178,924 person-years of follow-up, 214 haematological malignancies were diagnosed (incidence rate: 1.20 per 1,000 person-years). Workers in the highest cumulative exposure quartile (above 40 ppm-years) had <strong>HR = 2.34 (95 pct CI: 1.62 to 3.38)</strong> compared with the lowest quartile (below 5 ppm-years). The Kaplan-Meier curves showed clear separation from year 10 onward. No evidence of non-proportional hazards was found (Schoenfeld test p = 0.42).</dd>
+    <dt>Conclusion</dt>
+    <dd>Cumulative occupational benzene exposure above 40 ppm-years is associated with a more than two-fold increased risk of haematological malignancy. These findings support strengthening occupational exposure limits and ongoing health surveillance for exposed workers.</dd>
+    <dt>Keywords</dt>
+    <dd><em>cohort study; benzene; haematological malignancy; survival analysis; Kaplan-Meier; hazard ratio; occupational health</em></dd>
+  </dl>
+</section>
+
+## Kaplan-Meier Survival Curves
+
+<figure class="figure">
+  <svg viewBox="0 0 720 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Kaplan-Meier survival curves showing event-free survival for high and low benzene exposure groups over 25 years">
+    <!-- Axes -->
+    <line x1="80" y1="20" x2="80" y2="310" stroke="#1a2030" stroke-width="1.5"/>
+    <line x1="80" y1="310" x2="680" y2="310" stroke="#1a2030" stroke-width="1.5"/>
+    <!-- Y-axis labels -->
+    <text x="70" y="25" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">1.00</text>
+    <text x="70" y="83" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.95</text>
+    <text x="70" y="140" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.90</text>
+    <text x="70" y="198" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.85</text>
+    <text x="70" y="255" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.80</text>
+    <text x="70" y="310" text-anchor="end" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.75</text>
+    <text x="18" y="170" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#667080" transform="rotate(-90 18 170)">EVENT-FREE SURVIVAL</text>
+    <!-- Grid lines -->
+    <line x1="80" y1="83" x2="680" y2="83" stroke="#c4c0b4" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="80" y1="140" x2="680" y2="140" stroke="#c4c0b4" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="80" y1="198" x2="680" y2="198" stroke="#c4c0b4" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="80" y1="255" x2="680" y2="255" stroke="#c4c0b4" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <!-- X-axis labels -->
+    <text x="80" y="330" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">0</text>
+    <text x="200" y="330" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">5</text>
+    <text x="320" y="330" text-anchor="middle" font-size="9" font-family="IBM Plex Mono" fill="#667080">10</text>
+    <text x="440" y="330" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">15</text>
+    <text x="560" y="330" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">20</text>
+    <text x="680" y="330" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">25</text>
+    <text x="380" y="352" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#667080" letter-spacing="1">FOLLOW-UP (YEARS)</text>
+    <!-- Low exposure curve (step function) -->
+    <polyline points="80,20 200,22 200,28 320,32 320,42 440,48 440,60 560,65 560,78 680,85" fill="none" stroke="#5cba7d" stroke-width="2.5"/>
+    <!-- High exposure curve (step function) -->
+    <polyline points="80,20 200,26 200,40 320,52 320,82 440,105 440,145 560,172 560,210 680,238" fill="none" stroke="#2a5c8a" stroke-width="2.5"/>
+    <!-- Risk table -->
+    <text x="80" y="370" text-anchor="start" font-family="IBM Plex Sans" font-weight="700" font-size="8" fill="#667080">AT RISK</text>
+    <text x="80" y="382" text-anchor="start" font-family="IBM Plex Sans" font-size="8" fill="#5cba7d">Low:</text>
+    <text x="120" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">4206</text>
+    <text x="220" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">4118</text>
+    <text x="340" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">3982</text>
+    <text x="460" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">3814</text>
+    <text x="580" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">3590</text>
+    <text x="680" y="382" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#5cba7d">3412</text>
+    <text x="80" y="395" text-anchor="start" font-family="IBM Plex Sans" font-size="8" fill="#2a5c8a">High:</text>
+    <text x="120" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">4206</text>
+    <text x="220" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">4082</text>
+    <text x="340" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">3764</text>
+    <text x="460" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">3398</text>
+    <text x="580" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">2984</text>
+    <text x="680" y="395" text-anchor="middle" font-family="IBM Plex Mono" font-size="8" fill="#2a5c8a">2618</text>
+    <!-- Legend -->
+    <line x1="450" y1="40" x2="480" y2="40" stroke="#5cba7d" stroke-width="2.5"/>
+    <text x="485" y="44" font-family="STIX Two Text" font-size="10" fill="#1a2030">Low exposure (&lt;5 ppm-yr)</text>
+    <line x1="450" y1="58" x2="480" y2="58" stroke="#2a5c8a" stroke-width="2.5"/>
+    <text x="485" y="62" font-family="STIX Two Text" font-size="10" fill="#1a2030">High exposure (&gt;40 ppm-yr)</text>
+    <!-- Log-rank annotation -->
+    <text x="450" y="80" font-family="IBM Plex Mono" font-size="9" fill="#667080">Log-rank p &lt; 0.001</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Kaplan-Meier event-free survival curves for haematological malignancy by cumulative benzene exposure group. The curves diverge visibly from year 10 onward. Number-at-risk table is shown below the plot. Log-rank test: p &lt; 0.001.</figcaption>
+</figure>
+
+<section class="model-callout">
+  <span class="callout-label">Adjusted Hazard Ratio</span>
+  <span class="callout-value">HR = 2.34<span class="unit">(95 pct CI: 1.62 to 3.38)</span></span>
+  <p class="callout-detail">Highest vs lowest quartile of cumulative benzene exposure. Adjusted for age at entry, sex, smoking pack-years, and co-exposure to toluene and xylene. Schoenfeld residual test for proportional hazards: p = 0.42.</p>
+</section>
+
+## Hazard Ratio Forest Plot
+
+<figure class="figure">
+  <svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Forest plot showing hazard ratios for haematological malignancy by benzene exposure quartile">
+    <!-- Reference line at HR=1 -->
+    <line x1="380" y1="30" x2="380" y2="230" stroke="#c4c0b4" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <!-- Axis labels -->
+    <text x="180" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.5</text>
+    <text x="280" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">0.75</text>
+    <text x="380" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">1.0</text>
+    <text x="480" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">1.5</text>
+    <text x="580" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">2.5</text>
+    <text x="650" y="258" text-anchor="middle" font-family="IBM Plex Mono" font-size="9" fill="#667080">4.0</text>
+    <line x1="140" y1="245" x2="680" y2="245" stroke="#1a2030" stroke-width="1"/>
+    <text x="400" y="275" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#667080" letter-spacing="1">HAZARD RATIO (LOG SCALE)</text>
+    <!-- Row labels -->
+    <text x="30" y="55" text-anchor="start" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#1a2030">Q1 (&lt;5 ppm-yr)</text>
+    <text x="30" y="105" text-anchor="start" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#1a2030">Q2 (5-15 ppm-yr)</text>
+    <text x="30" y="155" text-anchor="start" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#1a2030">Q3 (15-40 ppm-yr)</text>
+    <text x="30" y="205" text-anchor="start" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a5c8a">Q4 (&gt;40 ppm-yr)</text>
+    <!-- HR values on right -->
+    <text x="700" y="55" text-anchor="end" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#1a2030">Ref</text>
+    <text x="700" y="105" text-anchor="end" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#1a2030">1.18 (0.74-1.88)</text>
+    <text x="700" y="155" text-anchor="end" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#1a2030">1.67 (1.12-2.49)</text>
+    <text x="700" y="205" text-anchor="end" font-family="IBM Plex Mono" font-weight="700" font-size="10" fill="#2a5c8a">2.34 (1.62-3.38)</text>
+    <!-- Q1: reference (diamond at 1.0) -->
+    <polygon points="380,45 388,50 380,55 372,50" fill="#8e96a4"/>
+    <!-- Q2: HR=1.18, CI 0.74-1.88 -->
+    <line x1="310" y1="100" x2="465" y2="100" stroke="#1a2030" stroke-width="1.5"/>
+    <rect x="393" y="93" width="10" height="14" fill="#1a2030"/>
+    <!-- Q3: HR=1.67, CI 1.12-2.49 -->
+    <line x1="395" y1="150" x2="530" y2="150" stroke="#1a2030" stroke-width="1.5"/>
+    <rect x="438" y="143" width="10" height="14" fill="#1a2030"/>
+    <!-- Q4: HR=2.34, CI 1.62-3.38 -->
+    <line x1="442" y1="200" x2="594" y2="200" stroke="#2a5c8a" stroke-width="2"/>
+    <rect x="508" y="192" width="12" height="16" fill="#2a5c8a"/>
+    <!-- Favour labels -->
+    <text x="250" y="240" text-anchor="middle" font-family="STIX Two Text" font-style="italic" font-size="9" fill="#667080">Favours no association</text>
+    <text x="550" y="240" text-anchor="middle" font-family="STIX Two Text" font-style="italic" font-size="9" fill="#667080">Favours increased risk</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Forest plot of adjusted hazard ratios for haematological malignancy by quartile of cumulative benzene exposure. Q1 (reference), Q2, Q3, and Q4 show a dose-response relationship. Horizontal lines represent 95 pct confidence intervals. Square size is proportional to the number of events in each group.</figcaption>
+</figure>
+
+## Cohort Flow Diagram
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Cohort flow diagram showing enrollment, exclusions, and final analytic sample">
+    <!-- Enrollment -->
+    <rect x="220" y="10" width="280" height="50" fill="none" stroke="#2a5c8a" stroke-width="2"/>
+    <text x="360" y="32" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2030">ENROLLED</text>
+    <text x="360" y="48" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#1a2030">N = 9,847</text>
+    <!-- Arrow down -->
+    <line x1="360" y1="60" x2="360" y2="90" stroke="#667080" stroke-width="1.5" marker-end="url(#arrowD)"/>
+    <!-- Exclusion box -->
+    <rect x="480" y="65" width="220" height="55" fill="none" stroke="#b85c2a" stroke-width="1.5"/>
+    <text x="590" y="82" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="9" fill="#b85c2a">EXCLUDED (n = 1,435)</text>
+    <text x="590" y="95" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#667080">Prior haem. malignancy: 84</text>
+    <text x="590" y="107" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#667080">Incomplete exposure data: 912</text>
+    <text x="590" y="119" text-anchor="middle" font-family="Noto Serif" font-size="8" fill="#667080">Lost before first follow-up: 439</text>
+    <line x1="480" y1="90" x2="420" y2="90" stroke="#b85c2a" stroke-width="1" stroke-dasharray="3 2"/>
+    <!-- Eligible -->
+    <rect x="220" y="90" width="280" height="50" fill="none" stroke="#2a5c8a" stroke-width="2"/>
+    <text x="360" y="112" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="11" fill="#1a2030">ELIGIBLE COHORT</text>
+    <text x="360" y="128" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#1a2030">N = 8,412</text>
+    <!-- Arrow down to split -->
+    <line x1="360" y1="140" x2="360" y2="170" stroke="#667080" stroke-width="1.5"/>
+    <!-- Split into exposure groups -->
+    <line x1="180" y1="170" x2="540" y2="170" stroke="#667080" stroke-width="1.5"/>
+    <line x1="180" y1="170" x2="180" y2="195" stroke="#667080" stroke-width="1.5" marker-end="url(#arrowD)"/>
+    <line x1="540" y1="170" x2="540" y2="195" stroke="#667080" stroke-width="1.5" marker-end="url(#arrowD)"/>
+    <!-- Low exposure -->
+    <rect x="80" y="195" width="200" height="50" fill="none" stroke="#5cba7d" stroke-width="2"/>
+    <text x="180" y="215" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#5cba7d">LOW EXPOSURE (Q1-Q2)</text>
+    <text x="180" y="232" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#1a2030">n = 4,206 | Events: 68</text>
+    <!-- High exposure -->
+    <rect x="440" y="195" width="200" height="50" fill="none" stroke="#2a5c8a" stroke-width="2"/>
+    <text x="540" y="215" text-anchor="middle" font-family="IBM Plex Sans" font-weight="700" font-size="10" fill="#2a5c8a">HIGH EXPOSURE (Q3-Q4)</text>
+    <text x="540" y="232" text-anchor="middle" font-family="IBM Plex Mono" font-size="10" fill="#1a2030">n = 4,206 | Events: 146</text>
+    <!-- Analysis -->
+    <line x1="180" y1="245" x2="180" y2="270" stroke="#667080" stroke-width="1.5" marker-end="url(#arrowD)"/>
+    <line x1="540" y1="245" x2="540" y2="270" stroke="#667080" stroke-width="1.5" marker-end="url(#arrowD)"/>
+    <rect x="80" y="270" width="200" height="35" fill="none" stroke="#667080" stroke-width="1.5"/>
+    <text x="180" y="292" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#667080">Censored: 4,138 | Lost: 312</text>
+    <rect x="440" y="270" width="200" height="35" fill="none" stroke="#667080" stroke-width="1.5"/>
+    <text x="540" y="292" text-anchor="middle" font-family="IBM Plex Sans" font-size="9" fill="#667080">Censored: 4,060 | Lost: 527</text>
+    <defs>
+      <marker id="arrowD" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#667080"/>
+      </marker>
+    </defs>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 3.</span> Cohort flow diagram showing participant enrollment, exclusion criteria, and final analytic sample. Of 9,847 enrolled workers, 1,435 were excluded. The remaining 8,412 were split at the median cumulative exposure for visual comparison; the primary analysis uses quartile-based Cox models.</figcaption>
+</figure>
+
+## Key Results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Baseline characteristics and outcomes by benzene exposure quartile.</caption>
+  <thead>
+    <tr>
+      <th>Characteristic</th>
+      <th>Q1 (&lt;5)</th>
+      <th>Q2 (5-15)</th>
+      <th>Q3 (15-40)</th>
+      <th>Q4 (&gt;40)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>N</td>
+      <td class="num">2,103</td>
+      <td class="num">2,103</td>
+      <td class="num">2,103</td>
+      <td class="num">2,103</td>
+    </tr>
+    <tr>
+      <td>Mean age at entry (yr)</td>
+      <td class="num">38.2</td>
+      <td class="num">39.1</td>
+      <td class="num">40.8</td>
+      <td class="num">42.4</td>
+    </tr>
+    <tr>
+      <td>Male (%)</td>
+      <td class="num">82</td>
+      <td class="num">84</td>
+      <td class="num">88</td>
+      <td class="num">91</td>
+    </tr>
+    <tr>
+      <td>Current smokers (%)</td>
+      <td class="num">24</td>
+      <td class="num">28</td>
+      <td class="num">31</td>
+      <td class="num">34</td>
+    </tr>
+    <tr>
+      <td>Haem. malignancy events</td>
+      <td class="num">32</td>
+      <td class="num">36</td>
+      <td class="num">58</td>
+      <td class="num">88</td>
+    </tr>
+    <tr>
+      <td>Person-years of follow-up</td>
+      <td class="num">48,214</td>
+      <td class="num">46,892</td>
+      <td class="num">44,106</td>
+      <td class="num">39,712</td>
+    </tr>
+    <tr>
+      <td>Adjusted HR (95% CI)</td>
+      <td class="num">Ref</td>
+      <td class="num"><strong>1.18</strong> (0.74-1.88)</td>
+      <td class="num"><strong>1.67</strong> (1.12-2.49)</td>
+      <td class="num"><strong>2.34</strong> (1.62-3.38)</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Exposure in ppm-years. HR adjusted for age, sex, smoking pack-years, and toluene/xylene co-exposure. Hazard ratios in bold with 95 pct CI.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+Navigate the paper through the section index.
+
+1. **Section 1. Study Population** -- cohort assembly, eligibility criteria, and baseline demographics
+2. **Section 2. Exposure Assessment** -- personal dosimetry, job-exposure matrices, and cumulative exposure calculation
+3. **Section 3. Statistical Methods** -- Kaplan-Meier estimation, Cox regression, DAG-guided confounder selection
+4. **Section 4. Results** -- survival curves, hazard ratios, sensitivity analyses, and subgroup findings
+5. **Section 5. Discussion** -- comparison with prior studies, biological plausibility, limitations, and policy implications

--- a/cohort-study/content/sections/1-study-population.md
+++ b/cohort-study/content/sections/1-study-population.md
@@ -1,0 +1,26 @@
++++
+title = "1. Study Population"
+description = "Cohort assembly from four UK petrochemical facilities, eligibility criteria, and baseline demographic and occupational characteristics."
+weight = 1
+template = "post"
+tags = ["cohort", "epidemiology", "study-design"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Setting and recruitment
+
+The UK Petrochemical Workers Health Study (UKPWHS) is a prospective cohort assembled between January 1998 and December 2001 at four facilities: two refineries in northern England, one chemical manufacturing plant in Scotland, and one petrochemical complex in South Wales. All workers employed for at least 12 months and aged 18 or older were eligible. Written informed consent was obtained at enrollment.
+
+## 1.2 Eligibility criteria
+
+Participants were excluded if they had: (a) a prior diagnosis of haematological malignancy, (b) incomplete occupational exposure records preventing cumulative dose estimation, or (c) no follow-up data beyond the enrollment visit. Of 9,847 workers initially enrolled, 1,435 were excluded, yielding an analytic cohort of 8,412.
+
+## 1.3 Baseline characteristics
+
+The cohort was predominantly male (86 pct), with a mean age at entry of 40.1 years (SD 10.2). Twenty-nine percent were current smokers and 34 pct were former smokers. The median duration of employment at enrollment was 12.4 years (IQR: 6.8 to 19.1). Participants in the highest exposure quartile were older, more likely to be male, and had longer job tenure, reflecting the accumulation of benzene exposure over time.
+
+## 1.4 Ethical approval
+
+The study was approved by the NHS Health Research Authority (IRAS 1997/2814) and the occupational health departments of all four facilities. Annual data linkage with the National Cancer Registry and the Office for National Statistics mortality database was approved under Section 251 of the NHS Act 2006.

--- a/cohort-study/content/sections/2-exposure-assessment.md
+++ b/cohort-study/content/sections/2-exposure-assessment.md
@@ -1,0 +1,26 @@
++++
+title = "2. Exposure Assessment"
+description = "Benzene exposure estimation using personal dosimetry, job-exposure matrices, and cumulative dose calculation over the 25-year follow-up period."
+weight = 2
+template = "post"
+tags = ["cohort", "exposure", "dosimetry"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Personal dosimetry
+
+Personal air sampling was conducted using passive organic vapour badges (3M 3500) worn for full 8-hour shifts. Each worker contributed a minimum of four measurements per year, rotated across seasons to capture temporal variation. Samples were analysed by gas chromatography with flame ionisation detection (GC-FID). The limit of detection was 0.01 ppm.
+
+## 2.2 Job-exposure matrix
+
+For periods without personal measurements (particularly pre-enrollment years), a facility-specific job-exposure matrix (JEM) was constructed by industrial hygienists. Jobs were classified into 48 exposure groups based on task descriptions, proximity to benzene sources, and engineering controls. Each group was assigned a time-weighted average (TWA) exposure level derived from historical area monitoring and analogous personal measurements.
+
+## 2.3 Cumulative exposure calculation
+
+Cumulative benzene exposure (ppm-years) was computed as the sum of annual average exposures across all years of employment. For the JEM-based years, the group-level TWA was used; for the dosimetry-based years (1998 onward), the individual's annual geometric mean was used. This hybrid approach has been validated in prior benzene cohort studies with Spearman correlations of 0.78 to 0.85 against expert assessments.
+
+## 2.4 Exposure quartiles
+
+The cohort was divided into four quartiles of cumulative exposure: Q1 (below 5 ppm-years), Q2 (5 to 15 ppm-years), Q3 (15 to 40 ppm-years), and Q4 (above 40 ppm-years). Each quartile contained 2,103 workers. The quartile boundaries were pre-specified in the protocol based on prior literature suggesting a threshold effect around 40 ppm-years.

--- a/cohort-study/content/sections/3-statistical-methods.md
+++ b/cohort-study/content/sections/3-statistical-methods.md
@@ -1,0 +1,30 @@
++++
+title = "3. Statistical Methods"
+description = "Kaplan-Meier survival estimation, Cox proportional hazards regression, DAG-guided confounder selection, and sensitivity analyses for the cohort analysis."
+weight = 3
+template = "post"
+tags = ["cohort", "survival-analysis", "Cox-regression"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Time-to-event definition
+
+The primary outcome was incident haematological malignancy (ICD-10 codes C81-C96), ascertained through linkage with the National Cancer Registry. Person-time accrued from the date of enrollment to the earliest of: diagnosis of haematological malignancy, death from any cause, emigration, or administrative censoring at 31 December 2023.
+
+## 3.2 Kaplan-Meier estimation
+
+Non-parametric survival curves were estimated using the Kaplan-Meier method. Curves were plotted for two exposure strata (below vs above median cumulative exposure) and for all four quartiles. Differences between curves were assessed with the log-rank test. Number-at-risk tables were displayed at 5-year intervals.
+
+## 3.3 Cox proportional hazards models
+
+The primary analysis used Cox proportional hazards regression with cumulative benzene exposure modelled as a categorical variable (quartiles). The proportional hazards assumption was tested using Schoenfeld residuals and visual inspection of log(-log(survival)) plots. No violation was detected (global test p = 0.42).
+
+## 3.4 Confounder selection via DAG
+
+A directed acyclic graph (DAG) was constructed a priori to identify the minimal sufficient adjustment set for estimating the total effect of benzene exposure on haematological malignancy. The DAG identified age at entry, sex, smoking status (pack-years), and co-exposure to toluene and xylene as confounders. Body mass index and alcohol consumption were identified as non-confounders and were not included in the primary model.
+
+## 3.5 Sensitivity analyses
+
+Four sensitivity analyses were conducted: (a) excluding the first 5 years of follow-up to address reverse causation, (b) using continuous cumulative exposure with restricted cubic splines (4 knots), (c) treating exposure as a time-varying covariate updated annually, and (d) applying inverse probability of censoring weights to address informative censoring.

--- a/cohort-study/content/sections/4-results.md
+++ b/cohort-study/content/sections/4-results.md
@@ -1,0 +1,30 @@
++++
+title = "4. Results"
+description = "Survival analysis results including Kaplan-Meier curves, Cox regression hazard ratios, dose-response assessment, and sensitivity analyses."
+weight = 4
+template = "post"
+tags = ["cohort", "results", "hazard-ratio"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Follow-up summary
+
+The cohort contributed 178,924 person-years over a median follow-up of 22.8 years (IQR: 20.4 to 24.1). A total of 214 haematological malignancies were diagnosed, yielding an overall incidence rate of 1.20 per 1,000 person-years. The most common subtypes were non-Hodgkin lymphoma (n = 98, 46 pct), acute myeloid leukaemia (n = 52, 24 pct), and myelodysplastic syndromes (n = 34, 16 pct).
+
+## 4.2 Kaplan-Meier analysis
+
+The Kaplan-Meier curves (Figure 1 in the Abstract) showed that the two exposure groups tracked closely for the first 8 to 10 years, after which the high-exposure group diverged with accelerating event incidence. At 25 years, event-free survival was 96.1 pct in the low-exposure group versus 88.7 pct in the high-exposure group (log-rank p < 0.001).
+
+## 4.3 Cox regression
+
+In the fully adjusted model, hazard ratios showed a clear dose-response gradient across exposure quartiles: Q2 **HR = 1.18** (95 pct CI: 0.74 to 1.88), Q3 **HR = 1.67** (95 pct CI: 1.12 to 2.49), and Q4 **HR = 2.34** (95 pct CI: 1.62 to 3.38), relative to Q1. The trend test was highly significant (p for trend < 0.001).
+
+## 4.4 Sensitivity analyses
+
+All four sensitivity analyses yielded results consistent with the primary analysis. Excluding the first 5 years of follow-up slightly attenuated the Q4 estimate (HR = 2.18, 95 pct CI: 1.48 to 3.21), suggesting minimal reverse causation. The restricted cubic spline model showed a monotonically increasing dose-response curve with no evidence of a threshold or plateau below 60 ppm-years.
+
+## 4.5 Subtype analysis
+
+The association was strongest for acute myeloid leukaemia (Q4 HR = 3.12, 95 pct CI: 1.68 to 5.80) and myelodysplastic syndromes (Q4 HR = 2.89, 95 pct CI: 1.34 to 6.22). The association with non-Hodgkin lymphoma was attenuated (Q4 HR = 1.78, 95 pct CI: 1.08 to 2.94), consistent with benzene's stronger effect on myeloid lineages.

--- a/cohort-study/content/sections/5-discussion.md
+++ b/cohort-study/content/sections/5-discussion.md
@@ -1,0 +1,30 @@
++++
+title = "5. Discussion"
+description = "Comparison with prior benzene cohort studies, biological plausibility, study limitations, and implications for occupational exposure limits and worker surveillance."
+weight = 5
+template = "post"
+tags = ["cohort", "discussion", "policy"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary
+
+This 25-year prospective cohort study demonstrates a clear dose-response relationship between cumulative occupational benzene exposure and haematological malignancy incidence. Workers in the highest exposure quartile (above 40 ppm-years) had a more than two-fold increased risk compared with the lowest quartile.
+
+## 5.2 Comparison with prior studies
+
+Our findings are consistent with the Chinese benzene cohort (Yin et al., 1996), which reported a relative risk of 2.6 for leukaemia among workers with more than 40 ppm-years of exposure, and the Pliofilm cohort (Rinsky et al., 1987), which found a standardised mortality ratio of 3.37 for acute myeloid leukaemia. The present study extends these findings with longer follow-up, more precise exposure assessment, and DAG-guided confounding control.
+
+## 5.3 Biological plausibility
+
+Benzene is metabolised to toxic intermediates (benzene oxide, hydroquinone, muconic acid) that damage haematopoietic stem cells through oxidative stress and DNA adduct formation. The preferential effect on myeloid lineages observed in our subtype analysis aligns with in vitro evidence that myeloid progenitors have higher expression of CYP2E1, the enzyme responsible for benzene bioactivation.
+
+## 5.4 Limitations
+
+First, despite the hybrid exposure assessment, measurement error in pre-enrollment exposure estimates may attenuate dose-response relationships. Second, confounding by unmeasured occupational co-exposures (e.g. 1,3-butadiene) cannot be excluded. Third, the cohort is predominantly male and white British, limiting generalisability. Fourth, haematological malignancy is a heterogeneous outcome; subtype-specific analyses had limited statistical power.
+
+## 5.5 Policy implications
+
+The current UK workplace exposure limit for benzene is 1 ppm (8-hour TWA). Our dose-response analysis suggests that cumulative exposures above 40 ppm-years -- achievable in 40 years at the current limit -- carry meaningful excess risk. These findings support ongoing calls to lower the exposure limit and to implement mandatory haematological surveillance for workers in high-exposure occupations.

--- a/cohort-study/content/sections/_index.md
+++ b/cohort-study/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The manuscript is organised into five sections following STROBE guidelines for reporting observational studies.

--- a/cohort-study/content/strobe.md
+++ b/cohort-study/content/strobe.md
@@ -1,0 +1,106 @@
++++
+title = "STROBE Checklist"
+description = "STROBE (Strengthening the Reporting of Observational Studies in Epidemiology) compliance checklist for this cohort study."
+tags = ["cohort", "STROBE", "reporting-guideline"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">REPORTING GUIDELINE</p>
+  <h1 class="paper-section-title">STROBE Compliance Checklist</h1>
+  <p class="paper-lede">This study adheres to the STROBE Statement for reporting cohort studies (von Elm et al., 2007).</p>
+</header>
+
+<span class="strobe-badge">STROBE Compliant</span>
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S1.</span> STROBE checklist for cohort studies with page/section references.</caption>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>STROBE Requirement</th>
+      <th>Location</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="num">1</td>
+      <td>Indicate the study design in the title or abstract</td>
+      <td>Title, Abstract</td>
+    </tr>
+    <tr>
+      <td class="num">2</td>
+      <td>Provide an informative abstract</td>
+      <td>Abstract</td>
+    </tr>
+    <tr>
+      <td class="num">3</td>
+      <td>Explain the scientific background and rationale</td>
+      <td>Section 1.1</td>
+    </tr>
+    <tr>
+      <td class="num">4</td>
+      <td>State specific objectives and hypotheses</td>
+      <td>Abstract (Objective)</td>
+    </tr>
+    <tr>
+      <td class="num">5</td>
+      <td>Present key elements of study design</td>
+      <td>Section 1</td>
+    </tr>
+    <tr>
+      <td class="num">6</td>
+      <td>Describe the setting, locations, and dates</td>
+      <td>Section 1.1</td>
+    </tr>
+    <tr>
+      <td class="num">7</td>
+      <td>Give eligibility criteria and sources of participants</td>
+      <td>Section 1.2</td>
+    </tr>
+    <tr>
+      <td class="num">8</td>
+      <td>Define all outcomes, exposures, confounders</td>
+      <td>Sections 2, 3</td>
+    </tr>
+    <tr>
+      <td class="num">12</td>
+      <td>Describe all statistical methods</td>
+      <td>Section 3</td>
+    </tr>
+    <tr>
+      <td class="num">13</td>
+      <td>Report numbers at each stage (flow diagram)</td>
+      <td>Figure 3</td>
+    </tr>
+    <tr>
+      <td class="num">14</td>
+      <td>Give characteristics of participants</td>
+      <td>Table 1</td>
+    </tr>
+    <tr>
+      <td class="num">15</td>
+      <td>Report numbers of outcome events</td>
+      <td>Section 4.1, Table 1</td>
+    </tr>
+    <tr>
+      <td class="num">16</td>
+      <td>Give unadjusted and adjusted estimates</td>
+      <td>Section 4.3, Figure 2</td>
+    </tr>
+    <tr>
+      <td class="num">18</td>
+      <td>Summarise key results</td>
+      <td>Section 5.1</td>
+    </tr>
+    <tr>
+      <td class="num">19</td>
+      <td>Discuss limitations</td>
+      <td>Section 5.4</td>
+    </tr>
+    <tr>
+      <td class="num">22</td>
+      <td>Give source of funding</td>
+      <td>Appendix F</td>
+    </tr>
+  </tbody>
+</table>

--- a/cohort-study/static/css/style.css
+++ b/cohort-study/static/css/style.css
@@ -1,0 +1,551 @@
+/* ============================================================================
+   Occupational Benzene Cohort - Population Tracking Paper
+   Light background, sans display headings, serif body, survival curves.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #f6f5f0;
+  --bg-2: #eceae2;
+  --bg-3: #e2e0d6;
+  --rule: #c4c0b4;
+  --ink: #1a2030;
+  --ink-2: #2c3448;
+  --ink-3: #667080;
+  --ink-4: #8e96a4;
+  --accent: #2a5c8a;
+  --accent-2: #1e4870;
+  --strobe: #3a8a5c;
+  --hazard: #b85c2a;
+  --curve-exposed: #2a5c8a;
+  --curve-control: #5cba7d;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "STIX Two Text", "Noto Serif", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Source Sans 3", sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Sans", "Source Sans 3", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- STROBE badge ---------------- */
+
+.strobe-badge {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  color: var(--strobe);
+  border: 1px solid var(--strobe);
+  padding: 0.15rem 0.6rem;
+  text-transform: uppercase;
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Source Sans 3", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "STIX Two Text", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 700; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "STIX Two Text", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", "Source Sans 3", sans-serif;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--hazard);
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Source Sans 3", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Model callout ---------------- */
+
+.model-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.4rem;
+  align-items: center;
+}
+
+.model-callout .callout-label {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.model-callout .callout-value {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.model-callout .callout-value .unit {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: 0.3em;
+}
+
+.model-callout .callout-detail {
+  font-family: "STIX Two Text", serif;
+  color: var(--ink-2);
+  font-style: italic;
+  font-size: 0.92rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--rule);
+  padding-top: 0.8rem;
+  margin: 0;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #ffffff;
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "STIX Two Text", serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons / Footer ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+.error-page { text-align: center; padding: 3rem 0; }
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .model-callout { grid-template-columns: 1fr; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/cohort-study/templates/404.html
+++ b/cohort-study/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cohort-study/templates/footer.html
+++ b/cohort-study/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c4c0b4" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c4c0b4" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Okafor C, Lindstrom E, Patel R, Nakamura H, da Silva F. Occupational Benzene Exposure and Haematological Malignancy: A 25-Year Prospective Cohort. <em>J. Epidemiol. Res.</em> 2026;61(4):412-441. doi:10.48127/jer.2026.61.04.412</p>
+        <p class="footer-note">ISSN 0340-6199 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cohort-study/templates/header.html
+++ b/cohort-study/templates/header.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&family=IBM+Plex+Mono:wght@400;500;700&family=Source+Sans+3:wght@400;600;700&family=STIX+Two+Text:ital,wght@0,400;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Population/cohort icon -->
+          <circle cx="20" cy="14" r="5" fill="none" stroke="#2a5c8a" stroke-width="1.5"/>
+          <circle cx="32" cy="10" r="5" fill="none" stroke="#2a5c8a" stroke-width="1.5"/>
+          <circle cx="44" cy="14" r="5" fill="none" stroke="#2a5c8a" stroke-width="1.5"/>
+          <path d="M 12 28 Q 12 22 20 22 Q 28 22 28 28" fill="none" stroke="#2a5c8a" stroke-width="1.2"/>
+          <path d="M 24 26 Q 24 20 32 20 Q 40 20 40 26" fill="none" stroke="#2a5c8a" stroke-width="1.2"/>
+          <path d="M 36 28 Q 36 22 44 22 Q 52 22 52 28" fill="none" stroke="#2a5c8a" stroke-width="1.2"/>
+          <line x1="10" y1="34" x2="54" y2="34" stroke="#5cba7d" stroke-width="1.5"/>
+          <polyline points="10,34 20,30 32,32 44,28 54,26" fill="none" stroke="#5cba7d" stroke-width="1.2" stroke-dasharray="3 2"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Epidemiological Research</span>
+          <span class="journal-sub">Vol. 61 &middot; Issue 04 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/strobe/">STROBE</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/cohort-study/templates/page.html
+++ b/cohort-study/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cohort-study/templates/post.html
+++ b/cohort-study/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cohort-study/templates/section.html
+++ b/cohort-study/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cohort-study/templates/shortcodes/alert.html
+++ b/cohort-study/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/cohort-study/templates/taxonomy.html
+++ b/cohort-study/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cohort-study/templates/taxonomy_term.html
+++ b/cohort-study/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4035,5 +4035,12 @@
     "review",
     "literature",
     "synthesis"
+  ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new `cohort-study` example site: a population tracking paper with light theme
- Features SVG Kaplan-Meier survival curves with number-at-risk tables, hazard ratio forest plots, cohort flow diagrams, and directed acyclic graph (DAG) causal models
- Typography: IBM Plex Sans Bold / Source Sans Pro Bold for display, STIX Two and Noto Serif for body
- Hazard ratios presented in bold with 95% confidence intervals throughout
- STROBE compliance checklist page with section references
- Tags: paper, light, cohort, survival, epidemiological

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG diagrams render correctly
- [ ] Confirm STROBE badge styling displays properly
- [ ] Verify light theme serif body typography
- [ ] Check tags.json entry is valid JSON

Closes #1624