### PR TITLE
feat: add raw-data example site (closes #1620)

### DIFF
--- a/raw-data/AGENTS.md
+++ b/raw-data/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/raw-data/config.toml
+++ b/raw-data/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Raw Data - Unprocessed Data Paper
+# Issue #1620 | Tags: paper, light, raw, data, tables
+# =============================================================================
+
+title = "Raw Dataset: Arctic Sea Ice Thickness Transects"
+description = "An unprocessed data paper presenting raw electromagnetic induction measurements of Arctic sea ice thickness along three transects, with minimal prose and maximum tables and SVG data visualizations."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/raw-data/content/appendix.md
+++ b/raw-data/content/appendix.md
@@ -1,0 +1,40 @@
++++
+title = "Appendix"
+description = "Data access, file formats, author contributions, funding, and references."
+tags = ["paper", "light", "raw", "data", "tables"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## Data Access
+
+The complete raw dataset is available in CSV format at the DOI repository (10.41093/pdr.2026.9.ds0041). Files include:
+
+- `transect_A_raw.csv` (61 records, 12 columns)
+- `transect_B_raw.csv` (44 records, 12 columns)
+- `transect_C_raw.csv` (76 records, 12 columns)
+- `quality_flags.csv` (181 records, flag assignments with criteria codes)
+- `environment_log.csv` (weather station data at 1-min intervals)
+- `instrument_calibration.pdf` (factory calibration certificate)
+
+All files use UTF-8 encoding with comma delimiters. Missing values are encoded as `NaN`. Column headers are described in `README_columns.txt`.
+
+## CRediT Author Contributions
+
+- **Kristin Halvorsen:** Investigation (field data collection), Data Curation, Writing -- Original Draft
+- **Mwamba Ilunga:** Methodology (EM processing), Software, Formal Analysis
+- **Yuki Okamoto:** Investigation (field data collection), Resources, Writing -- Review
+
+## Funding
+
+Norwegian Polar Institute internal grant NPI-2024-ICE-08. Japan Society for the Promotion of Science Postdoctoral Fellowship (to Y.O.).
+
+## References
+
+<ol style="list-style: decimal; padding-left: 2rem; font-size: 0.92rem; color: #2a3448;">
+  <li>Haas C, Lobach J, Hendricks S, et al. Multiyear sea ice thickness retrieval using ground-based electromagnetic induction sounding. <em>Cold Reg Sci Technol.</em> 2009;55(1):94-103.</li>
+  <li>Kovacs A, Morey RM. Electromagnetic measurements of multi-year sea ice using impulse radar. <em>Cold Reg Sci Technol.</em> 1986;12(1):67-93.</li>
+</ol>

--- a/raw-data/content/index.md
+++ b/raw-data/content/index.md
@@ -1,0 +1,160 @@
++++
+title = "Dataset Overview"
+description = "Raw electromagnetic induction measurements of Arctic sea ice thickness along three Beaufort Sea transects, with data quality flags and instrument specifications."
+tags = ["paper", "light", "raw", "data", "tables"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Data Paper &middot; Unprocessed Dataset &middot; Open Access</p>
+  <h1 class="paper-title">Raw Dataset: Electromagnetic Induction Measurements of Arctic Sea Ice Thickness, Beaufort Sea Transects 2025</h1>
+  <p class="paper-authors">
+    Kristin Halvorsen<sup>1</sup>,
+    Mwamba Ilunga<sup>2</sup>,
+    Yuki Okamoto<sup>1,3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Norwegian Polar Institute, Tromso &middot;
+    <sup>2</sup>Department of Geophysics, University of Cape Town &middot;
+    <sup>3</sup>National Institute of Polar Research, Tachikawa
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.41093/pdr.2026.9.ds0041</a> &middot; <strong>Collection dates:</strong> 12-18 Mar 2025 &middot; <strong>Published:</strong> 08 Apr 2026</p>
+</header>
+
+Data quality flags: <span class="flag-badge valid">V = valid</span> <span class="flag-badge suspect">S = suspect</span> <span class="flag-badge invalid">X = invalid</span>
+
+## Raw Time Series (Transect A)
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Raw time series of sea ice thickness measurements along Transect A showing full measurement noise">
+    <rect x="0" y="0" width="720" height="320" fill="#fafaf7"/>
+    <text x="360" y="24" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="12" fill="#1a2030">Transect A: Raw EM Ice Thickness (no smoothing)</text>
+    <!-- Axes -->
+    <line x1="70" y1="40" x2="70" y2="260" stroke="#1a2030" stroke-width="1.5"/>
+    <line x1="70" y1="260" x2="690" y2="260" stroke="#1a2030" stroke-width="1.5"/>
+    <!-- Y labels -->
+    <g font-family="JetBrains Mono" font-size="9" fill="#5b6272" text-anchor="end">
+      <text x="62" y="52">4.0</text><text x="62" y="96">3.0</text><text x="62" y="140">2.0</text>
+      <text x="62" y="184">1.0</text><text x="62" y="228">0.5</text><text x="62" y="262">0</text>
+    </g>
+    <text x="24" y="155" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#1a2030" transform="rotate(-90,24,155)">Thickness (m)</text>
+    <!-- X labels -->
+    <g font-family="JetBrains Mono" font-size="9" fill="#5b6272" text-anchor="middle">
+      <text x="70" y="278">0</text><text x="194" y="278">5</text><text x="318" y="278">10</text>
+      <text x="442" y="278">15</text><text x="566" y="278">20</text><text x="690" y="278">25 km</text>
+    </g>
+    <!-- Grid lines -->
+    <g stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="3 3">
+      <line x1="70" y1="96" x2="690" y2="96"/><line x1="70" y1="140" x2="690" y2="140"/>
+      <line x1="70" y1="184" x2="690" y2="184"/>
+    </g>
+    <!-- Raw data points (noisy scatter, no trend line) -->
+    <g fill="#2a5a8a" opacity="0.5">
+      <circle cx="82" cy="168" r="2"/><circle cx="90" cy="172" r="2"/><circle cx="98" cy="160" r="2"/>
+      <circle cx="106" cy="166" r="2"/><circle cx="114" cy="158" r="2"/><circle cx="122" cy="174" r="2"/>
+      <circle cx="130" cy="152" r="2"/><circle cx="138" cy="148" r="2"/><circle cx="146" cy="156" r="2"/>
+      <circle cx="154" cy="142" r="2"/><circle cx="162" cy="138" r="2"/><circle cx="170" cy="144" r="2"/>
+      <circle cx="178" cy="130" r="2"/><circle cx="186" cy="126" r="2"/><circle cx="194" cy="134" r="2"/>
+      <circle cx="202" cy="120" r="2"/><circle cx="210" cy="128" r="2"/><circle cx="218" cy="118" r="2"/>
+      <circle cx="226" cy="112" r="2"/><circle cx="234" cy="106" r="2"/><circle cx="242" cy="114" r="2"/>
+      <circle cx="250" cy="108" r="2"/><circle cx="258" cy="102" r="2"/><circle cx="266" cy="96" r="2"/>
+      <circle cx="274" cy="104" r="2"/><circle cx="282" cy="98" r="2"/><circle cx="290" cy="92" r="2"/>
+      <circle cx="298" cy="88" r="2"/><circle cx="306" cy="96" r="2"/><circle cx="314" cy="82" r="2"/>
+      <circle cx="322" cy="90" r="2"/><circle cx="330" cy="86" r="2"/><circle cx="338" cy="78" r="2"/>
+      <circle cx="346" cy="84" r="2"/><circle cx="354" cy="76" r="2"/><circle cx="362" cy="72" r="2"/>
+      <circle cx="370" cy="80" r="2"/><circle cx="378" cy="74" r="2"/><circle cx="386" cy="68" r="2"/>
+      <circle cx="394" cy="76" r="2"/><circle cx="402" cy="82" r="2"/><circle cx="410" cy="72" r="2"/>
+      <circle cx="418" cy="88" r="2"/><circle cx="426" cy="94" r="2"/><circle cx="434" cy="86" r="2"/>
+      <circle cx="442" cy="102" r="2"/><circle cx="450" cy="108" r="2"/><circle cx="458" cy="96" r="2"/>
+      <circle cx="466" cy="112" r="2"/><circle cx="474" cy="118" r="2"/><circle cx="482" cy="106" r="2"/>
+      <circle cx="490" cy="124" r="2"/><circle cx="498" cy="130" r="2"/><circle cx="506" cy="120" r="2"/>
+      <circle cx="514" cy="136" r="2"/><circle cx="522" cy="142" r="2"/><circle cx="530" cy="132" r="2"/>
+      <circle cx="538" cy="148" r="2"/><circle cx="546" cy="154" r="2"/><circle cx="554" cy="144" r="2"/>
+      <circle cx="562" cy="158" r="2"/><circle cx="570" cy="164" r="2"/><circle cx="578" cy="152" r="2"/>
+      <circle cx="586" cy="168" r="2"/><circle cx="594" cy="174" r="2"/><circle cx="602" cy="162" r="2"/>
+    </g>
+    <!-- Suspect points (yellow) -->
+    <g fill="#c4a42a">
+      <circle cx="418" cy="88" r="3.5"/><circle cx="426" cy="94" r="3.5"/>
+    </g>
+    <!-- Invalid point (red) -->
+    <circle cx="354" cy="232" r="4" fill="#c44a3a"/>
+    <text x="364" y="236" font-family="JetBrains Mono" font-size="8" fill="#c44a3a">X</text>
+    <!-- Legend -->
+    <circle cx="500" y="295" cx="500" cy="295" r="3" fill="#2a5a8a" opacity="0.5"/>
+    <text x="508" y="298" font-family="JetBrains Mono" font-size="8" fill="#5b6272">Valid (n=58)</text>
+    <circle cx="570" cy="295" r="3" fill="#c4a42a"/>
+    <text x="578" y="298" font-family="JetBrains Mono" font-size="8" fill="#5b6272">Suspect (n=2)</text>
+    <circle cx="640" cy="295" r="3" fill="#c44a3a"/>
+    <text x="648" y="298" font-family="JetBrains Mono" font-size="8" fill="#5b6272">Invalid (n=1)</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> Raw electromagnetic induction ice thickness measurements along Transect A (25.1 km). No smoothing, filtering, or trend line fitting applied. Each point represents a single EM sounding at 400 m intervals. Yellow points flagged as suspect due to elevated instrument temperature. Red point flagged as invalid (negative apparent conductivity).</div>
+</figure>
+
+## Dataset Summary Statistics
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary statistics for raw ice thickness measurements across all three transects.</caption>
+  <thead>
+    <tr>
+      <th>Transect</th>
+      <th>Length (km)</th>
+      <th>n obs</th>
+      <th>n valid</th>
+      <th>n suspect</th>
+      <th>n invalid</th>
+      <th>Mean (m)</th>
+      <th>SD (m)</th>
+      <th>Min (m)</th>
+      <th>Max (m)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>A (71.2N, 152.4W)</td>
+      <td>25.1</td>
+      <td>61</td>
+      <td>58</td>
+      <td>2</td>
+      <td>1</td>
+      <td>1.84</td>
+      <td>0.72</td>
+      <td>0.42</td>
+      <td>3.61</td>
+    </tr>
+    <tr>
+      <td>B (72.0N, 150.8W)</td>
+      <td>18.4</td>
+      <td>44</td>
+      <td>42</td>
+      <td>1</td>
+      <td>1</td>
+      <td>2.31</td>
+      <td>0.88</td>
+      <td>0.38</td>
+      <td>4.12</td>
+    </tr>
+    <tr>
+      <td>C (72.8N, 148.2W)</td>
+      <td>31.6</td>
+      <td>76</td>
+      <td>74</td>
+      <td>2</td>
+      <td>0</td>
+      <td>2.68</td>
+      <td>0.94</td>
+      <td>0.56</td>
+      <td>4.47</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10">Statistics computed on valid observations only. SD = standard deviation. All measurements in meters. Observations at 400 m intervals along transect.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Dataset
+
+1. **Dataset 1. Transect A Raw Observations** -- 61 EM soundings along 71.2N, 152.4W
+2. **Dataset 2. Transect B Raw Observations** -- 44 EM soundings along 72.0N, 150.8W
+3. **Dataset 3. Transect C Raw Observations** -- 76 EM soundings along 72.8N, 148.2W
+4. **Dataset 4. Data Quality Flags** -- flag definitions, criteria, and per-observation assignments
+5. **Dataset 5. Environmental Conditions** -- concurrent meteorological and ice surface observations

--- a/raw-data/content/instruments.md
+++ b/raw-data/content/instruments.md
@@ -1,0 +1,70 @@
++++
+title = "Instrument Specifications"
+description = "Measurement instrument specifications, calibration details, and operating parameters for the EM31-ICE system."
+tags = ["paper", "light", "raw", "data", "tables"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">INSTRUMENT SPECIFICATIONS</p>
+  <h1 class="paper-section-title">Measurement System</h1>
+</header>
+
+<div class="instrument-spec">
+  <p class="spec-label">Primary Instrument</p>
+  <p>Geonics EM31-ICE ground-conductivity meter, serial #4821, firmware v3.2.1</p>
+</div>
+
+<figure class="figure">
+  <svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Instrument specification diagram showing EM31-ICE sled-mounted configuration with transmitter and receiver coil separation">
+    <rect x="0" y="0" width="720" height="220" fill="#fafaf7"/>
+    <text x="360" y="24" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="12" fill="#1a2030">EM31-ICE Sled Configuration (not to scale)</text>
+    <!-- Ice surface -->
+    <line x1="60" y1="140" x2="660" y2="140" stroke="#2a5a8a" stroke-width="2"/>
+    <text x="670" y="144" font-family="JetBrains Mono" font-size="9" fill="#2a5a8a">ice surface</text>
+    <!-- Sled -->
+    <rect x="160" y="110" width="400" height="26" fill="none" stroke="#1a2030" stroke-width="1.5"/>
+    <text x="360" y="128" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a2030">SLED PLATFORM</text>
+    <!-- Tx coil -->
+    <circle cx="220" cy="100" r="14" fill="none" stroke="#2a5a8a" stroke-width="2"/>
+    <text x="220" y="104" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="9" fill="#2a5a8a">Tx</text>
+    <text x="220" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#5b6272">9.8 kHz</text>
+    <!-- Rx coil -->
+    <circle cx="500" cy="100" r="14" fill="none" stroke="#5a3a7a" stroke-width="2"/>
+    <text x="500" y="104" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="9" fill="#5a3a7a">Rx</text>
+    <!-- Separation arrow -->
+    <line x1="236" y1="70" x2="484" y2="70" stroke="#1a2030" stroke-width="1"/>
+    <line x1="236" y1="66" x2="236" y2="74" stroke="#1a2030" stroke-width="1"/>
+    <line x1="484" y1="66" x2="484" y2="74" stroke="#1a2030" stroke-width="1"/>
+    <text x="360" y="64" text-anchor="middle" font-family="JetBrains Mono" font-weight="700" font-size="10" fill="#1a2030">3.66 m coil separation</text>
+    <!-- Height above ice -->
+    <line x1="140" y1="110" x2="140" y2="140" stroke="#7a5a2a" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="132" y="128" text-anchor="end" font-family="JetBrains Mono" font-size="8" fill="#7a5a2a">0.4 m</text>
+    <!-- Ice layers -->
+    <rect x="100" y="140" width="520" height="30" fill="#2a5a8a" opacity="0.15"/>
+    <text x="360" y="160" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#2a5a8a">SEA ICE (h_ice)</text>
+    <rect x="100" y="170" width="520" height="30" fill="#2a5a8a" opacity="0.3"/>
+    <text x="360" y="190" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#fafaf7">SEAWATER (conductive)</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Schematic of the EM31-ICE sled-mounted measurement configuration. The transmitter (Tx) coil at 9.8 kHz induces eddy currents in the conductive seawater below the ice; the receiver (Rx) coil measures the secondary field. Ice thickness is derived from the apparent conductivity via a one-dimensional layered earth model.</div>
+</figure>
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 8.</span> EM31-ICE instrument specifications.</caption>
+  <thead>
+    <tr><th>Parameter</th><th>Value</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Operating frequency</td><td>9.8 kHz</td></tr>
+    <tr><td>Coil separation</td><td>3.66 m</td></tr>
+    <tr><td>Coil orientation</td><td>Horizontal coplanar</td></tr>
+    <tr><td>Measurement height</td><td>0.4 m above ice surface (sled-mounted)</td></tr>
+    <tr><td>Measurement rate</td><td>1 Hz (averaged to 10 s for each observation)</td></tr>
+    <tr><td>Conductivity range</td><td>0-1000 mS/m</td></tr>
+    <tr><td>Conductivity accuracy</td><td>+/- 5 pct at 100 mS/m</td></tr>
+    <tr><td>Operating temperature</td><td>-40 to +50 C (calibrated: -35 to -15 C)</td></tr>
+    <tr><td>Power supply</td><td>12V lithium battery, 8h capacity at -30 C</td></tr>
+    <tr><td>Data logger</td><td>Campbell CR1000X, sampling at 1 Hz</td></tr>
+    <tr><td>GPS</td><td>Trimble R10 GNSS, horizontal accuracy < 0.02 m</td></tr>
+    <tr><td>Snow depth sensor</td><td>Magna-Probe, manual insertion every 400 m</td></tr>
+  </tbody>
+</table>

--- a/raw-data/content/sections/1-transect-a.md
+++ b/raw-data/content/sections/1-transect-a.md
@@ -1,0 +1,45 @@
++++
+title = "D-1. Transect A Raw Observations"
+description = "61 electromagnetic induction soundings along Transect A (71.2N, 152.4W), collected 12 March 2025."
+weight = 1
+template = "post"
+tags = ["paper", "light", "raw", "data", "tables"]
+categories = ["sections"]
+
+[extra]
+section_number = "D-1"
++++
+
+Collection date: 12 March 2025. Transect bearing: 045 degrees true. Start: 71.18N 152.42W. End: 71.34N 152.14W.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Transect A raw observations (first 20 of 61 records).</caption>
+  <thead>
+    <tr><th>Obs</th><th>Dist (km)</th><th>Lat (N)</th><th>Lon (W)</th><th>h_ice (m)</th><th>h_snow (m)</th><th>Cond (mS/m)</th><th>T_inst (C)</th><th>Flag</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>A001</td><td>0.0</td><td>71.180</td><td>152.420</td><td>1.22</td><td>0.08</td><td>42.3</td><td>-18.2</td><td class="flag-v">V</td></tr>
+    <tr><td>A002</td><td>0.4</td><td>71.183</td><td>152.416</td><td>1.18</td><td>0.09</td><td>44.1</td><td>-18.1</td><td class="flag-v">V</td></tr>
+    <tr><td>A003</td><td>0.8</td><td>71.186</td><td>152.412</td><td>1.34</td><td>0.07</td><td>38.8</td><td>-18.0</td><td class="flag-v">V</td></tr>
+    <tr><td>A004</td><td>1.2</td><td>71.189</td><td>152.408</td><td>1.28</td><td>0.10</td><td>40.2</td><td>-17.9</td><td class="flag-v">V</td></tr>
+    <tr><td>A005</td><td>1.6</td><td>71.192</td><td>152.404</td><td>1.42</td><td>0.06</td><td>36.4</td><td>-17.8</td><td class="flag-v">V</td></tr>
+    <tr><td>A006</td><td>2.0</td><td>71.195</td><td>152.400</td><td>1.38</td><td>0.11</td><td>37.6</td><td>-17.6</td><td class="flag-v">V</td></tr>
+    <tr><td>A007</td><td>2.4</td><td>71.198</td><td>152.396</td><td>1.56</td><td>0.08</td><td>33.2</td><td>-17.5</td><td class="flag-v">V</td></tr>
+    <tr><td>A008</td><td>2.8</td><td>71.201</td><td>152.392</td><td>1.62</td><td>0.07</td><td>31.8</td><td>-17.4</td><td class="flag-v">V</td></tr>
+    <tr><td>A009</td><td>3.2</td><td>71.204</td><td>152.388</td><td>1.48</td><td>0.09</td><td>35.0</td><td>-17.2</td><td class="flag-v">V</td></tr>
+    <tr><td>A010</td><td>3.6</td><td>71.207</td><td>152.384</td><td>1.72</td><td>0.06</td><td>29.4</td><td>-17.1</td><td class="flag-v">V</td></tr>
+    <tr><td>A011</td><td>4.0</td><td>71.210</td><td>152.380</td><td>1.78</td><td>0.08</td><td>28.2</td><td>-17.0</td><td class="flag-v">V</td></tr>
+    <tr><td>A012</td><td>4.4</td><td>71.213</td><td>152.376</td><td>1.84</td><td>0.10</td><td>27.0</td><td>-16.8</td><td class="flag-v">V</td></tr>
+    <tr><td>A013</td><td>4.8</td><td>71.216</td><td>152.372</td><td>1.96</td><td>0.07</td><td>25.4</td><td>-16.7</td><td class="flag-v">V</td></tr>
+    <tr><td>A014</td><td>5.2</td><td>71.219</td><td>152.368</td><td>2.08</td><td>0.09</td><td>23.8</td><td>-16.5</td><td class="flag-v">V</td></tr>
+    <tr><td>A015</td><td>5.6</td><td>71.222</td><td>152.364</td><td>2.14</td><td>0.08</td><td>22.6</td><td>-16.4</td><td class="flag-v">V</td></tr>
+    <tr><td>A016</td><td>6.0</td><td>71.225</td><td>152.360</td><td>2.22</td><td>0.06</td><td>21.2</td><td>-16.2</td><td class="flag-v">V</td></tr>
+    <tr><td>A017</td><td>6.4</td><td>71.228</td><td>152.356</td><td>2.38</td><td>0.07</td><td>19.6</td><td>-16.1</td><td class="flag-v">V</td></tr>
+    <tr><td>A018</td><td>6.8</td><td>71.231</td><td>152.352</td><td>2.44</td><td>0.08</td><td>18.8</td><td>-15.8</td><td class="flag-v">V</td></tr>
+    <tr><td>A019</td><td>7.2</td><td>71.234</td><td>152.348</td><td>2.56</td><td>0.10</td><td>17.4</td><td>-15.6</td><td class="flag-v">V</td></tr>
+    <tr><td>A020</td><td>7.6</td><td>71.237</td><td>152.344</td><td>2.62</td><td>0.09</td><td>16.8</td><td>-15.4</td><td class="flag-v">V</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="9">Showing 20 of 61 records. Full dataset in CSV at DOI repository. h_ice = total ice thickness. h_snow = snow depth. Cond = apparent conductivity. T_inst = instrument temperature. V = valid, S = suspect, X = invalid.</td></tr>
+  </tfoot>
+</table>

--- a/raw-data/content/sections/2-transect-b.md
+++ b/raw-data/content/sections/2-transect-b.md
@@ -1,0 +1,45 @@
++++
+title = "D-2. Transect B Raw Observations"
+description = "44 electromagnetic induction soundings along Transect B (72.0N, 150.8W), collected 14 March 2025."
+weight = 2
+template = "post"
+tags = ["paper", "light", "raw", "data", "tables"]
+categories = ["sections"]
+
+[extra]
+section_number = "D-2"
++++
+
+Collection date: 14 March 2025. Transect bearing: 030 degrees true. Start: 71.96N 150.82W. End: 72.10N 150.58W.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Transect B raw observations (first 20 of 44 records).</caption>
+  <thead>
+    <tr><th>Obs</th><th>Dist (km)</th><th>Lat (N)</th><th>Lon (W)</th><th>h_ice (m)</th><th>h_snow (m)</th><th>Cond (mS/m)</th><th>T_inst (C)</th><th>Flag</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>B001</td><td>0.0</td><td>71.960</td><td>150.820</td><td>1.88</td><td>0.12</td><td>26.4</td><td>-22.1</td><td class="flag-v">V</td></tr>
+    <tr><td>B002</td><td>0.4</td><td>71.963</td><td>150.814</td><td>2.04</td><td>0.14</td><td>24.2</td><td>-22.0</td><td class="flag-v">V</td></tr>
+    <tr><td>B003</td><td>0.8</td><td>71.966</td><td>150.808</td><td>1.92</td><td>0.11</td><td>25.8</td><td>-21.8</td><td class="flag-v">V</td></tr>
+    <tr><td>B004</td><td>1.2</td><td>71.969</td><td>150.802</td><td>2.18</td><td>0.13</td><td>22.6</td><td>-21.6</td><td class="flag-v">V</td></tr>
+    <tr><td>B005</td><td>1.6</td><td>71.972</td><td>150.796</td><td>2.34</td><td>0.10</td><td>20.8</td><td>-21.4</td><td class="flag-v">V</td></tr>
+    <tr><td>B006</td><td>2.0</td><td>71.975</td><td>150.790</td><td>2.42</td><td>0.15</td><td>19.6</td><td>-21.2</td><td class="flag-v">V</td></tr>
+    <tr><td>B007</td><td>2.4</td><td>71.978</td><td>150.784</td><td>0.38</td><td>0.02</td><td>-4.2</td><td>-21.0</td><td class="flag-x">X</td></tr>
+    <tr><td>B008</td><td>2.8</td><td>71.981</td><td>150.778</td><td>2.56</td><td>0.12</td><td>18.2</td><td>-20.8</td><td class="flag-v">V</td></tr>
+    <tr><td>B009</td><td>3.2</td><td>71.984</td><td>150.772</td><td>2.68</td><td>0.14</td><td>17.0</td><td>-20.6</td><td class="flag-v">V</td></tr>
+    <tr><td>B010</td><td>3.6</td><td>71.987</td><td>150.766</td><td>2.74</td><td>0.11</td><td>16.2</td><td>-20.4</td><td class="flag-v">V</td></tr>
+    <tr><td>B011</td><td>4.0</td><td>71.990</td><td>150.760</td><td>2.88</td><td>0.13</td><td>15.0</td><td>-20.2</td><td class="flag-v">V</td></tr>
+    <tr><td>B012</td><td>4.4</td><td>71.993</td><td>150.754</td><td>3.02</td><td>0.10</td><td>13.8</td><td>-20.0</td><td class="flag-v">V</td></tr>
+    <tr><td>B013</td><td>4.8</td><td>71.996</td><td>150.748</td><td>2.96</td><td>0.16</td><td>14.4</td><td>-19.8</td><td class="flag-v">V</td></tr>
+    <tr><td>B014</td><td>5.2</td><td>71.999</td><td>150.742</td><td>3.14</td><td>0.12</td><td>12.6</td><td>-19.6</td><td class="flag-v">V</td></tr>
+    <tr><td>B015</td><td>5.6</td><td>72.002</td><td>150.736</td><td>3.28</td><td>0.14</td><td>11.4</td><td>-19.4</td><td class="flag-v">V</td></tr>
+    <tr><td>B016</td><td>6.0</td><td>72.005</td><td>150.730</td><td>3.36</td><td>0.11</td><td>10.8</td><td>-8.2</td><td class="flag-s">S</td></tr>
+    <tr><td>B017</td><td>6.4</td><td>72.008</td><td>150.724</td><td>3.42</td><td>0.13</td><td>10.2</td><td>-19.0</td><td class="flag-v">V</td></tr>
+    <tr><td>B018</td><td>6.8</td><td>72.011</td><td>150.718</td><td>3.18</td><td>0.15</td><td>12.2</td><td>-18.8</td><td class="flag-v">V</td></tr>
+    <tr><td>B019</td><td>7.2</td><td>72.014</td><td>150.712</td><td>3.06</td><td>0.10</td><td>13.4</td><td>-18.6</td><td class="flag-v">V</td></tr>
+    <tr><td>B020</td><td>7.6</td><td>72.017</td><td>150.706</td><td>2.92</td><td>0.12</td><td>14.8</td><td>-18.4</td><td class="flag-v">V</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="9">Showing 20 of 44 records. B007 flagged X: negative apparent conductivity (-4.2 mS/m) indicates instrument malfunction. B016 flagged S: anomalous instrument temperature jump (from -19.4 to -8.2 C) suggesting brief sensor housing opening.</td></tr>
+  </tfoot>
+</table>

--- a/raw-data/content/sections/3-transect-c.md
+++ b/raw-data/content/sections/3-transect-c.md
@@ -1,0 +1,45 @@
++++
+title = "D-3. Transect C Raw Observations"
+description = "76 electromagnetic induction soundings along Transect C (72.8N, 148.2W), collected 18 March 2025."
+weight = 3
+template = "post"
+tags = ["paper", "light", "raw", "data", "tables"]
+categories = ["sections"]
+
+[extra]
+section_number = "D-3"
++++
+
+Collection date: 18 March 2025. Transect bearing: 015 degrees true. Start: 72.74N 148.24W. End: 72.98N 147.88W.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> Transect C raw observations (first 20 of 76 records).</caption>
+  <thead>
+    <tr><th>Obs</th><th>Dist (km)</th><th>Lat (N)</th><th>Lon (W)</th><th>h_ice (m)</th><th>h_snow (m)</th><th>Cond (mS/m)</th><th>T_inst (C)</th><th>Flag</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>C001</td><td>0.0</td><td>72.740</td><td>148.240</td><td>2.14</td><td>0.16</td><td>22.8</td><td>-24.6</td><td class="flag-v">V</td></tr>
+    <tr><td>C002</td><td>0.4</td><td>72.743</td><td>148.234</td><td>2.28</td><td>0.18</td><td>21.0</td><td>-24.4</td><td class="flag-v">V</td></tr>
+    <tr><td>C003</td><td>0.8</td><td>72.746</td><td>148.228</td><td>2.36</td><td>0.14</td><td>19.8</td><td>-24.2</td><td class="flag-v">V</td></tr>
+    <tr><td>C004</td><td>1.2</td><td>72.749</td><td>148.222</td><td>2.52</td><td>0.20</td><td>18.2</td><td>-24.0</td><td class="flag-v">V</td></tr>
+    <tr><td>C005</td><td>1.6</td><td>72.752</td><td>148.216</td><td>2.64</td><td>0.15</td><td>16.8</td><td>-23.8</td><td class="flag-v">V</td></tr>
+    <tr><td>C006</td><td>2.0</td><td>72.755</td><td>148.210</td><td>2.78</td><td>0.17</td><td>15.4</td><td>-23.6</td><td class="flag-v">V</td></tr>
+    <tr><td>C007</td><td>2.4</td><td>72.758</td><td>148.204</td><td>2.92</td><td>0.19</td><td>14.0</td><td>-23.4</td><td class="flag-v">V</td></tr>
+    <tr><td>C008</td><td>2.8</td><td>72.761</td><td>148.198</td><td>3.06</td><td>0.16</td><td>12.8</td><td>-23.2</td><td class="flag-v">V</td></tr>
+    <tr><td>C009</td><td>3.2</td><td>72.764</td><td>148.192</td><td>2.88</td><td>0.18</td><td>14.4</td><td>-23.0</td><td class="flag-v">V</td></tr>
+    <tr><td>C010</td><td>3.6</td><td>72.767</td><td>148.186</td><td>3.14</td><td>0.14</td><td>12.0</td><td>-22.8</td><td class="flag-v">V</td></tr>
+    <tr><td>C011</td><td>4.0</td><td>72.770</td><td>148.180</td><td>3.22</td><td>0.21</td><td>11.2</td><td>-22.6</td><td class="flag-v">V</td></tr>
+    <tr><td>C012</td><td>4.4</td><td>72.773</td><td>148.174</td><td>3.38</td><td>0.17</td><td>10.0</td><td>-22.4</td><td class="flag-v">V</td></tr>
+    <tr><td>C013</td><td>4.8</td><td>72.776</td><td>148.168</td><td>3.26</td><td>0.16</td><td>10.8</td><td>-22.2</td><td class="flag-v">V</td></tr>
+    <tr><td>C014</td><td>5.2</td><td>72.779</td><td>148.162</td><td>3.52</td><td>0.19</td><td>9.2</td><td>-22.0</td><td class="flag-v">V</td></tr>
+    <tr><td>C015</td><td>5.6</td><td>72.782</td><td>148.156</td><td>3.44</td><td>0.22</td><td>9.8</td><td>-9.4</td><td class="flag-s">S</td></tr>
+    <tr><td>C016</td><td>6.0</td><td>72.785</td><td>148.150</td><td>3.58</td><td>0.18</td><td>8.6</td><td>-10.2</td><td class="flag-s">S</td></tr>
+    <tr><td>C017</td><td>6.4</td><td>72.788</td><td>148.144</td><td>3.66</td><td>0.20</td><td>8.0</td><td>-21.4</td><td class="flag-v">V</td></tr>
+    <tr><td>C018</td><td>6.8</td><td>72.791</td><td>148.138</td><td>3.72</td><td>0.15</td><td>7.4</td><td>-21.2</td><td class="flag-v">V</td></tr>
+    <tr><td>C019</td><td>7.2</td><td>72.794</td><td>148.132</td><td>3.84</td><td>0.18</td><td>6.8</td><td>-21.0</td><td class="flag-v">V</td></tr>
+    <tr><td>C020</td><td>7.6</td><td>72.797</td><td>148.126</td><td>3.96</td><td>0.21</td><td>6.2</td><td>-20.8</td><td class="flag-v">V</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="9">Showing 20 of 76 records. C015-C016 flagged S: instrument temperature anomaly (brief warming to -9.4/-10.2 C from ambient -22 C). Thickness values appear plausible but should be verified against independent drill-hole measurements.</td></tr>
+  </tfoot>
+</table>

--- a/raw-data/content/sections/4-quality-flags.md
+++ b/raw-data/content/sections/4-quality-flags.md
@@ -1,0 +1,43 @@
++++
+title = "D-4. Data Quality Flags"
+description = "Flag definitions, assignment criteria, and per-transect quality summaries."
+weight = 4
+template = "post"
+tags = ["paper", "light", "raw", "data", "tables"]
+categories = ["sections"]
+
+[extra]
+section_number = "D-4"
++++
+
+## Flag Definitions
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 5.</span> Data quality flag definitions and assignment criteria.</caption>
+  <thead>
+    <tr><th>Flag</th><th>Label</th><th>Criteria</th><th>Action</th></tr>
+  </thead>
+  <tbody>
+    <tr><td class="flag-v">V</td><td>Valid</td><td>All instrument parameters within normal operating range</td><td>Use without restriction</td></tr>
+    <tr><td class="flag-s">S</td><td>Suspect</td><td>Instrument temperature > -15 C (outside calibrated range) OR single-channel signal anomaly</td><td>Use with caution; verify against independent data if available</td></tr>
+    <tr><td class="flag-x">X</td><td>Invalid</td><td>Negative apparent conductivity OR h_ice < 0 OR instrument power failure during measurement</td><td>Exclude from analysis</td></tr>
+  </tbody>
+</table>
+
+## Quality Summary by Transect
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 6.</span> Data quality flag counts by transect.</caption>
+  <thead>
+    <tr><th>Transect</th><th>Total obs</th><th><span class="flag-badge valid">V</span></th><th><span class="flag-badge suspect">S</span></th><th><span class="flag-badge invalid">X</span></th><th>Valid pct</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>A</td><td>61</td><td>58</td><td>2</td><td>1</td><td>95.1</td></tr>
+    <tr><td>B</td><td>44</td><td>42</td><td>1</td><td>1</td><td>95.5</td></tr>
+    <tr><td>C</td><td>76</td><td>74</td><td>2</td><td>0</td><td>97.4</td></tr>
+    <tr><td><strong>Total</strong></td><td><strong>181</strong></td><td><strong>174</strong></td><td><strong>5</strong></td><td><strong>2</strong></td><td><strong>96.1</strong></td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">Overall data quality: 96.1 pct valid, 2.8 pct suspect, 1.1 pct invalid. All suspect flags due to instrument temperature anomalies. Both invalid flags due to negative apparent conductivity readings.</td></tr>
+  </tfoot>
+</table>

--- a/raw-data/content/sections/5-environment.md
+++ b/raw-data/content/sections/5-environment.md
@@ -1,0 +1,33 @@
++++
+title = "D-5. Environmental Conditions"
+description = "Concurrent meteorological and ice surface observations recorded during each transect survey."
+weight = 5
+template = "post"
+tags = ["paper", "light", "raw", "data", "tables"]
+categories = ["sections"]
+
+[extra]
+section_number = "D-5"
++++
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 7.</span> Environmental conditions during transect surveys.</caption>
+  <thead>
+    <tr><th>Parameter</th><th>Transect A (12 Mar)</th><th>Transect B (14 Mar)</th><th>Transect C (18 Mar)</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Air temperature (C)</td><td>-24.2 to -18.6</td><td>-28.4 to -22.0</td><td>-30.1 to -24.8</td></tr>
+    <tr><td>Wind speed (m/s)</td><td>4.2 to 8.6</td><td>2.8 to 6.4</td><td>6.2 to 12.8</td></tr>
+    <tr><td>Wind direction (deg)</td><td>220 to 260</td><td>180 to 210</td><td>290 to 330</td></tr>
+    <tr><td>Cloud cover (oktas)</td><td>3</td><td>1</td><td>6</td></tr>
+    <tr><td>Visibility (km)</td><td>> 10</td><td>> 10</td><td>4 to 8</td></tr>
+    <tr><td>Surface type</td><td>FY smooth/ridged</td><td>MY ridged</td><td>MY heavily ridged</td></tr>
+    <tr><td>Snow surface</td><td>Wind-packed</td><td>Wind-packed/sastrugi</td><td>Deep drift, sastrugi</td></tr>
+    <tr><td>Melt ponds</td><td>None</td><td>None</td><td>None</td></tr>
+    <tr><td>Open water fraction</td><td>0 pct</td><td>0 pct</td><td>< 1 pct (1 lead)</td></tr>
+    <tr><td>Survey duration (h)</td><td>6.2</td><td>4.8</td><td>8.4</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">FY = first-year ice. MY = multi-year ice. Environmental data from automatic weather station on survey sled and visual observations by field team. Sastrugi = wind-sculpted snow ridges.</td></tr>
+  </tfoot>
+</table>

--- a/raw-data/content/sections/_index.md
+++ b/raw-data/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Data Tables"
+sort_by = "weight"
+page_template = "post"
++++
+
+Raw measurement tables for each transect, data quality flags, and concurrent environmental observations.

--- a/raw-data/static/css/style.css
+++ b/raw-data/static/css/style.css
@@ -1,0 +1,465 @@
+/* ============================================================================
+   Raw Data - Unprocessed Data Paper
+   Light background, data-dense layout. JetBrains Mono Bold / Fira Code Bold
+   for data labels. Crimson Pro / Noto Serif body. No gradients, no emojis.
+   90% data tables/figures, 10% prose.
+   ============================================================================ */
+
+:root {
+  --paper: #fafaf7;
+  --paper-2: #f0efe8;
+  --rule: #ccc8ba;
+  --ink: #1a2030;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #2a5a8a;
+  --accent-2: #1a4a7a;
+  --flag-valid: #2a7a4a;
+  --flag-valid-bg: #edf7f0;
+  --flag-suspect: #c4a42a;
+  --flag-suspect-bg: #fdf8e6;
+  --flag-invalid: #c44a3a;
+  --flag-invalid-bg: #fdf0ee;
+  --data-1: #2a5a8a;
+  --data-2: #5a3a7a;
+  --data-3: #7a5a2a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Data quality flag badges ---------------- */
+
+.flag-badge {
+  display: inline-block;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border: 1.5px solid;
+}
+
+.flag-badge.valid { color: var(--flag-valid); border-color: var(--flag-valid); background: var(--flag-valid-bg); }
+.flag-badge.suspect { color: var(--flag-suspect); border-color: var(--flag-suspect); background: var(--flag-suspect-bg); }
+.flag-badge.invalid { color: var(--flag-invalid); border-color: var(--flag-invalid); background: var(--flag-invalid-bg); }
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-affiliations {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: clamp(1.4rem, 2.8vw, 1.8rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure .caption {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables (data-dense) ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.82rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: right;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+  font-variant-numeric: tabular-nums;
+}
+
+.paper-table th:first-child,
+.paper-table td:first-child {
+  text-align: left;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+  font-size: 0.78rem;
+}
+
+.paper-table tfoot td {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.6rem;
+  border-bottom: none;
+  text-align: left;
+}
+
+/* Flag column styling */
+.paper-table td.flag-v { color: var(--flag-valid); font-weight: 700; }
+.paper-table td.flag-s { color: var(--flag-suspect); font-weight: 700; }
+.paper-table td.flag-x { color: var(--flag-invalid); font-weight: 700; }
+
+/* ---------------- Instrument spec box ---------------- */
+
+.instrument-spec {
+  background: var(--paper-2);
+  border: 1.5px solid var(--rule);
+  padding: 1rem 1.4rem;
+  margin: 1.5rem 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+}
+
+.instrument-spec .spec-label {
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.4rem;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 700;
+  text-decoration: none;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.88rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-weight: 700;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .paper-table { font-size: 0.75rem; }
+  .paper-table th, .paper-table td { padding: 0.3rem 0.4rem; }
+}

--- a/raw-data/templates/404.html
+++ b/raw-data/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <p class="paper-section-eyebrow">ERROR 404 / RECORD NOT FOUND</p>
+      <h1 class="paper-section-title">Dataset not found</h1>
+      <p>The record you requested does not exist in this dataset. Return to the overview.</p>
+      <p><a class="button-link" href="{{ base_url }}/">Return to overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/raw-data/templates/footer.html
+++ b/raw-data/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2030" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2030" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Halvorsen K, Ilunga M, Okamoto Y. Raw Dataset: Electromagnetic Induction Measurements of Arctic Sea Ice Thickness, Beaufort Sea Transects 2025. <em>Polar Data Repository.</em> 2026;9:DS-2026-0041. doi:10.41093/pdr.2026.9.ds0041</p>
+        <p class="footer-note">ISSN 3012-7741 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/raw-data/templates/header.html
+++ b/raw-data/templates/header.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Fira+Code:wght@400;500;700&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#1a2030" stroke-width="1.5"/>
+          <g fill="#2a5a8a" opacity="0.6">
+            <circle cx="12" cy="28" r="2"/><circle cx="18" cy="22" r="2"/><circle cx="24" cy="26" r="2"/>
+            <circle cx="30" cy="18" r="2"/><circle cx="36" cy="24" r="2"/><circle cx="42" cy="14" r="2"/>
+            <circle cx="48" cy="20" r="2"/><circle cx="54" cy="12" r="2"/>
+          </g>
+          <line x1="8" y1="32" x2="56" y2="32" stroke="#1a2030" stroke-width="1"/>
+          <line x1="8" y1="8" x2="8" y2="32" stroke="#1a2030" stroke-width="1"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Polar Data Repository</span>
+          <span class="journal-sub">Dataset &middot; Vol. 9 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">OVERVIEW</a>
+        <a href="{{ base_url }}/sections/">DATA</a>
+        <a href="{{ base_url }}/instruments/">INSTRUMENTS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/raw-data/templates/page.html
+++ b/raw-data/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/raw-data/templates/post.html
+++ b/raw-data/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Dataset {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to data index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/raw-data/templates/section.html
+++ b/raw-data/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">DATA INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/raw-data/templates/shortcodes/alert.html
+++ b/raw-data/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #2a5a8a; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/raw-data/templates/taxonomy.html
+++ b/raw-data/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Data index and keyword cross-references for this dataset.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/raw-data/templates/taxonomy_term.html
+++ b/raw-data/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <p class="paper-section-eyebrow">DATA INDEX</p>
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Records cross-referenced to this keyword.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4042,5 +4042,12 @@
     "cohort",
     "survival",
     "epidemiological"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new raw-data example site: an unprocessed data paper with minimal prose and maximum data
- Features SVG raw scatter plots (no trend lines), unprocessed time series with full noise, data quality flag indicators per observation, and measurement instrument specification diagrams
- 90% data tables/figures, 10% prose -- data-dense layout
- Uses JetBrains Mono Bold/Fira Code Bold for data labels with Crimson Pro/Noto Serif body
- Light theme with blue accent for scientific data styling

Closes #1620