### PR TITLE
feat: add qualitative-study example site (closes #1626)

### DIFF
--- a/qualitative-study/AGENTS.md
+++ b/qualitative-study/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/qualitative-study/config.toml
+++ b/qualitative-study/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Qualitative Study - Interview Analysis Paper
+# Issue #1626 | Tags: paper, light, qualitative, thematic, interpretive
+# =============================================================================
+
+title = "Pandemic Burnout Recovery"
+description = "A qualitative interview study of healthcare workers' experiences during pandemic burnout recovery with thematic analysis, code tree diagrams, and theme saturation visualizations."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries -- no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/qualitative-study/content/appendix.md
+++ b/qualitative-study/content/appendix.md
@@ -1,0 +1,54 @@
++++
+title = "Appendix"
+description = "Supplementary materials including interview guide excerpt, data availability, author contributions, and ethics information."
+tags = ["qualitative", "appendix", "supplementary"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</header>
+
+## A. Interview Guide Excerpt
+
+The following are selected questions from the semi-structured interview guide used in this study. The guide was used flexibly, with follow-up probes adapted to each participant's narrative.
+
+<ol class="interview-guide">
+  <li>Can you tell me about your professional life before the pandemic? What drew you to healthcare, and what kept you in it?</li>
+  <li>Take me through your experience during the pandemic. What stands out to you most from that time?</li>
+  <li>Was there a moment when you first recognised that you were experiencing burnout? What did that look like for you?</li>
+  <li>How would you describe the process of recovery -- or the attempt at recovery -- since then? Has it been a straightforward path, or something more complicated?</li>
+  <li>What has helped you most in your recovery? What has been least helpful or actively harmful?</li>
+  <li>How has your relationship to your work changed since the pandemic? Do you see yourself differently as a professional?</li>
+  <li>If you could speak directly to a hospital administrator about what healthcare workers need right now, what would you say?</li>
+  <li>Is there anything else you would like to share that we have not covered?</li>
+</ol>
+
+## B. Software and Tools
+
+Transcription was performed by a professional service with experience in health research. All transcripts were reviewed for accuracy by the first author. Coding was conducted using NVivo 14 (Lumivero, 2023). Analytical memos were maintained in a shared document. The thematic map was constructed iteratively using hand-drawn diagrams and later formalised digitally.
+
+## C. Data Availability
+
+Interview transcripts cannot be shared publicly due to the sensitive nature of the data and the requirements of the ethics approval. De-identified summary data (code frequencies, thematic maps, and analytical memos) are available from the corresponding author upon reasonable request. A full coding framework with exemplar quotes is archived at Zenodo (doi: 10.5281/zenodo.example.2026.qualitative).
+
+## D. CRediT Author Contributions
+
+- **Tunde Adeyemi:** Conceptualisation, Methodology, Data Collection, Formal Analysis, Writing - Original Draft
+- **Karin Johansson:** Methodology, Supervision, Writing - Review and Editing
+- **Lucia Reyes-Mendoza:** Conceptualisation, Participant Recruitment, Writing - Review and Editing
+- **Nkechi Okonkwo:** Formal Analysis, External Audit, Writing - Review and Editing
+- **Stefan Hartmann:** Data Curation, Visualisation
+- **Mika Takahashi:** Methodology, Writing - Review and Editing
+
+## E. Conflict of Interest
+
+The authors declare no competing interests. The first author (TA) is a registered nurse with frontline pandemic experience; this positionality is discussed in Section 1.3 and Section 5.4.
+
+## F. Funding
+
+This work was supported by the Australian Research Council (ARC Discovery Early Career Researcher Award DE240100287) and the National Health and Medical Research Council (NHMRC Ideas Grant APP2024318).
+
+## G. Ethics Approval
+
+University of Melbourne Human Research Ethics Committee (HREC-2024-1847). All participants provided written informed consent prior to data collection.

--- a/qualitative-study/content/index.md
+++ b/qualitative-study/content/index.md
@@ -1,0 +1,353 @@
++++
+title = "Abstract"
+description = "A qualitative interview study of healthcare workers' experiences during pandemic burnout recovery using reflexive thematic analysis, code tree diagrams, and theme saturation visualizations."
+tags = ["paper", "light", "qualitative", "thematic", "interpretive"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Qualitative Research &middot; Open Access</p>
+  <h1 class="paper-title">Navigating Recovery: Healthcare Workers' Lived Experiences of Pandemic Burnout and the Pathways to Professional Renewal</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Tunde Adeyemi</span><sup>1</sup>,
+    Karin Johansson<sup>2</sup>,
+    Lucia Reyes-Mendoza<sup>1,3</sup>,
+    Nkechi Okonkwo<sup>4</sup>,
+    Stefan Hartmann<sup>2</sup>,
+    Mika Takahashi<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>School of Health Sciences, University of Melbourne &middot;
+    <sup>2</sup>Department of Nursing Science, Karolinska Institute &middot;
+    <sup>3</sup>Centre for Healthcare Workforce Wellbeing, Monash Health &middot;
+    <sup>4</sup>Faculty of Medicine, University of Lagos &middot;
+    <sup>5</sup>Graduate School of Public Health, University of Tokyo
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/qhrl.2026.28.06.312</a> &middot; <strong>Received:</strong> 14 Sep 2025 &middot; <strong>Accepted:</strong> 03 Mar 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Objective</dt>
+    <dd>To explore healthcare workers' lived experiences of burnout recovery following the prolonged demands of the pandemic, and to identify pathways through which professional renewal was achieved or hindered.</dd>
+    <dt>Design</dt>
+    <dd>Qualitative descriptive study using semi-structured interviews analysed through Braun and Clarke's six-phase reflexive thematic analysis framework.</dd>
+    <dt>Participants</dt>
+    <dd>18 healthcare workers (8 nurses, 5 physicians, 5 allied health professionals) purposively sampled from two metropolitan teaching hospitals, with 3 to 28 years of clinical experience.</dd>
+    <dt>Analysis</dt>
+    <dd>Interviews were audio-recorded, transcribed verbatim, and coded inductively. A total of 42 codes were organised into 14 sub-themes and 6 overarching themes. Theme saturation was reached at interview 13, with no new themes emerging in subsequent interviews.</dd>
+    <dt>Findings</dt>
+    <dd>Six themes characterised the recovery experience: (1) The Weight of Accumulated Distress, (2) Institutional Silence and Moral Injury, (3) Permission to Not Be Okay, (4) Rebuilding Professional Identity, (5) Relational Anchoring, and (6) Finding Meaning After Crisis. Recovery was neither linear nor uniform; participants described oscillating between exhaustion and renewal, with institutional acknowledgement and peer solidarity identified as the most influential catalysts for recovery.</dd>
+    <dt>Conclusion</dt>
+    <dd>Healthcare worker burnout recovery requires sustained institutional commitment beyond individual self-care. Organisations must create structural conditions -- including protected time, peer support programmes, and meaningful workload reform -- that enable the slow, relational process of professional renewal.</dd>
+    <dt>Keywords</dt>
+    <dd><em>qualitative research; thematic analysis; healthcare workers; burnout recovery; pandemic; professional renewal; moral injury; lived experience</em></dd>
+  </dl>
+</section>
+
+## Code Tree Diagram
+
+<figure class="figure">
+  <svg viewBox="0 0 720 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Code tree diagram showing the hierarchical relationship between 6 themes, 14 sub-themes, and representative codes identified through reflexive thematic analysis">
+    <!-- Title -->
+    <text x="360" y="18" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-weight="700" font-size="11" fill="#2a2420">THEME HIERARCHY: 6 THEMES / 14 SUB-THEMES / 42 CODES</text>
+    <!-- Theme 1 -->
+    <rect x="10" y="34" width="110" height="28" fill="none" stroke="#6b3a5c" stroke-width="1.5" rx="2"/>
+    <text x="65" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#6b3a5c">T1: Weight of</text>
+    <text x="65" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#6b3a5c">Accumulated Distress</text>
+    <line x1="65" y1="62" x2="40" y2="78" stroke="#6b3a5c" stroke-width="0.8"/>
+    <line x1="65" y1="62" x2="90" y2="78" stroke="#6b3a5c" stroke-width="0.8"/>
+    <rect x="10" y="78" width="60" height="20" fill="#6b3a5c" fill-opacity="0.08" stroke="#6b3a5c" stroke-width="0.8" rx="2"/>
+    <text x="40" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#6b3a5c">Compounding</text>
+    <text x="40" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#6b3a5c">fatigue</text>
+    <rect x="75" y="78" width="60" height="20" fill="#6b3a5c" fill-opacity="0.08" stroke="#6b3a5c" stroke-width="0.8" rx="2"/>
+    <text x="105" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#6b3a5c">Delayed grief</text>
+    <text x="105" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#6b3a5c">processing</text>
+    <!-- Codes for T1 -->
+    <line x1="40" y1="98" x2="25" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <line x1="40" y1="98" x2="55" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="25" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">sleep disruption</text>
+    <text x="55" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">hypervigilance</text>
+    <line x1="105" y1="98" x2="105" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="105" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">unprocessed loss</text>
+    <!-- Theme 2 -->
+    <rect x="130" y="34" width="110" height="28" fill="none" stroke="#3a5c6b" stroke-width="1.5" rx="2"/>
+    <text x="185" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#3a5c6b">T2: Institutional</text>
+    <text x="185" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#3a5c6b">Silence / Moral Injury</text>
+    <line x1="185" y1="62" x2="160" y2="78" stroke="#3a5c6b" stroke-width="0.8"/>
+    <line x1="185" y1="62" x2="210" y2="78" stroke="#3a5c6b" stroke-width="0.8"/>
+    <rect x="130" y="78" width="60" height="20" fill="#3a5c6b" fill-opacity="0.08" stroke="#3a5c6b" stroke-width="0.8" rx="2"/>
+    <text x="160" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#3a5c6b">Betrayal by</text>
+    <text x="160" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#3a5c6b">leadership</text>
+    <rect x="195" y="78" width="60" height="20" fill="#3a5c6b" fill-opacity="0.08" stroke="#3a5c6b" stroke-width="0.8" rx="2"/>
+    <text x="225" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#3a5c6b">Forced silence</text>
+    <text x="225" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#3a5c6b">about suffering</text>
+    <line x1="160" y1="98" x2="150" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <line x1="160" y1="98" x2="170" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="150" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">lack of debrief</text>
+    <text x="170" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">gaslighting</text>
+    <line x1="225" y1="98" x2="225" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="225" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">hero narrative</text>
+    <!-- Theme 3 -->
+    <rect x="250" y="34" width="110" height="28" fill="none" stroke="#5c6b3a" stroke-width="1.5" rx="2"/>
+    <text x="305" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#5c6b3a">T3: Permission to</text>
+    <text x="305" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#5c6b3a">Not Be Okay</text>
+    <line x1="305" y1="62" x2="280" y2="78" stroke="#5c6b3a" stroke-width="0.8"/>
+    <line x1="305" y1="62" x2="330" y2="78" stroke="#5c6b3a" stroke-width="0.8"/>
+    <rect x="250" y="78" width="60" height="20" fill="#5c6b3a" fill-opacity="0.08" stroke="#5c6b3a" stroke-width="0.8" rx="2"/>
+    <text x="280" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#5c6b3a">Vulnerability</text>
+    <text x="280" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#5c6b3a">as strength</text>
+    <rect x="315" y="78" width="60" height="20" fill="#5c6b3a" fill-opacity="0.08" stroke="#5c6b3a" stroke-width="0.8" rx="2"/>
+    <text x="345" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#5c6b3a">Breaking the</text>
+    <text x="345" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#5c6b3a">stoic norm</text>
+    <line x1="280" y1="98" x2="280" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="280" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">asking for help</text>
+    <line x1="345" y1="98" x2="335" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <line x1="345" y1="98" x2="355" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="335" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">crying at work</text>
+    <text x="355" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">reduced hours</text>
+    <!-- Theme 4 -->
+    <rect x="370" y="34" width="110" height="28" fill="none" stroke="#8a5c3a" stroke-width="1.5" rx="2"/>
+    <text x="425" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#8a5c3a">T4: Rebuilding</text>
+    <text x="425" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#8a5c3a">Professional Identity</text>
+    <line x1="425" y1="62" x2="400" y2="78" stroke="#8a5c3a" stroke-width="0.8"/>
+    <line x1="425" y1="62" x2="425" y2="78" stroke="#8a5c3a" stroke-width="0.8"/>
+    <line x1="425" y1="62" x2="450" y2="78" stroke="#8a5c3a" stroke-width="0.8"/>
+    <rect x="370" y="78" width="60" height="20" fill="#8a5c3a" fill-opacity="0.08" stroke="#8a5c3a" stroke-width="0.8" rx="2"/>
+    <text x="400" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#8a5c3a">Role</text>
+    <text x="400" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#8a5c3a">renegotiation</text>
+    <rect x="395" y="78" width="60" height="20" fill="#8a5c3a" fill-opacity="0.08" stroke="#8a5c3a" stroke-width="0.8" rx="2"/>
+    <text x="425" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#8a5c3a">Clinical</text>
+    <text x="425" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#8a5c3a">confidence shifts</text>
+    <rect x="435" y="78" width="60" height="20" fill="#8a5c3a" fill-opacity="0.08" stroke="#8a5c3a" stroke-width="0.8" rx="2"/>
+    <text x="465" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#8a5c3a">Boundary</text>
+    <text x="465" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#8a5c3a">setting</text>
+    <line x1="400" y1="98" x2="400" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="400" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">career pivots</text>
+    <line x1="425" y1="98" x2="425" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="425" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">imposter feelings</text>
+    <line x1="465" y1="98" x2="465" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="465" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">saying no</text>
+    <!-- Theme 5 -->
+    <rect x="490" y="34" width="110" height="28" fill="none" stroke="#3a3a6b" stroke-width="1.5" rx="2"/>
+    <text x="545" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#3a3a6b">T5: Relational</text>
+    <text x="545" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#3a3a6b">Anchoring</text>
+    <line x1="545" y1="62" x2="520" y2="78" stroke="#3a3a6b" stroke-width="0.8"/>
+    <line x1="545" y1="62" x2="570" y2="78" stroke="#3a3a6b" stroke-width="0.8"/>
+    <rect x="490" y="78" width="60" height="20" fill="#3a3a6b" fill-opacity="0.08" stroke="#3a3a6b" stroke-width="0.8" rx="2"/>
+    <text x="520" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#3a3a6b">Peer solidarity</text>
+    <text x="520" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#3a3a6b">and witness</text>
+    <rect x="555" y="78" width="60" height="20" fill="#3a3a6b" fill-opacity="0.08" stroke="#3a3a6b" stroke-width="0.8" rx="2"/>
+    <text x="585" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#3a3a6b">Family and</text>
+    <text x="585" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#3a3a6b">home anchors</text>
+    <line x1="520" y1="98" x2="510" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <line x1="520" y1="98" x2="530" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="510" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">shared stories</text>
+    <text x="530" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">team rituals</text>
+    <line x1="585" y1="98" x2="585" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="585" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">home routines</text>
+    <!-- Theme 6 -->
+    <rect x="610" y="34" width="105" height="28" fill="none" stroke="#6b5c3a" stroke-width="1.5" rx="2"/>
+    <text x="662" y="52" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#6b5c3a">T6: Finding</text>
+    <text x="662" y="60" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="7" fill="#6b5c3a">Meaning After Crisis</text>
+    <line x1="662" y1="62" x2="640" y2="78" stroke="#6b5c3a" stroke-width="0.8"/>
+    <line x1="662" y1="62" x2="685" y2="78" stroke="#6b5c3a" stroke-width="0.8"/>
+    <rect x="610" y="78" width="60" height="20" fill="#6b5c3a" fill-opacity="0.08" stroke="#6b5c3a" stroke-width="0.8" rx="2"/>
+    <text x="640" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#6b5c3a">Post-traumatic</text>
+    <text x="640" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#6b5c3a">growth</text>
+    <rect x="670" y="78" width="60" height="20" fill="#6b5c3a" fill-opacity="0.08" stroke="#6b5c3a" stroke-width="0.8" rx="2"/>
+    <text x="700" y="91" text-anchor="middle" font-family="Crimson Pro, serif" font-size="6.5" fill="#6b5c3a">Purpose</text>
+    <text x="700" y="97" text-anchor="middle" font-family="Crimson Pro, serif" font-size="5.5" fill="#6b5c3a">reaffirmation</text>
+    <line x1="640" y1="98" x2="640" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="640" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">new priorities</text>
+    <line x1="700" y1="98" x2="700" y2="110" stroke="#a09888" stroke-width="0.5"/>
+    <text x="700" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="4.5" fill="#7a7268">advocacy work</text>
+    <!-- Legend -->
+    <rect x="200" y="128" width="320" height="18" fill="var(--bg-2, #f0ede6)" stroke="#ccc6b8" stroke-width="0.5" rx="2"/>
+    <rect x="210" y="132" width="8" height="10" fill="none" stroke="#2a2420" stroke-width="1"/>
+    <text x="222" y="141" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7268">Theme</text>
+    <rect x="260" y="132" width="8" height="10" fill="#ccc6b8" fill-opacity="0.3" stroke="#7a7268" stroke-width="0.5"/>
+    <text x="272" y="141" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7268">Sub-theme</text>
+    <circle cx="325" cy="137" r="2" fill="#a09888"/>
+    <text x="331" y="141" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7268">Code (42 total)</text>
+    <line x1="390" y1="137" x2="405" y2="137" stroke="#a09888" stroke-width="0.5"/>
+    <text x="410" y="141" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7268">Hierarchical link</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 1.</span> Code tree diagram showing the hierarchical relationship between the six themes, 14 sub-themes, and representative codes identified through reflexive thematic analysis. Each theme branch is colour-coded. A total of 42 codes were organised into this structure during iterative coding across 18 interview transcripts.</figcaption>
+</figure>
+
+<section class="model-callout">
+  <div class="callout-stat">
+    <span class="callout-value">18</span>
+    <span class="callout-label">Participants</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">6</span>
+    <span class="callout-label">Themes</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">42</span>
+    <span class="callout-label">Codes</span>
+  </div>
+</section>
+
+## Theme Saturation Diagram
+
+<figure class="figure">
+  <svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Theme saturation diagram showing cumulative number of new themes identified per interview, demonstrating saturation at interview 13">
+    <!-- Axes -->
+    <line x1="60" y1="20" x2="60" y2="170" stroke="#2a2420" stroke-width="1.2"/>
+    <line x1="60" y1="170" x2="690" y2="170" stroke="#2a2420" stroke-width="1.2"/>
+    <!-- Y-axis labels -->
+    <text x="50" y="170" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">0</text>
+    <text x="50" y="145" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">1</text>
+    <text x="50" y="120" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">2</text>
+    <text x="50" y="95" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">3</text>
+    <text x="50" y="70" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">4</text>
+    <text x="50" y="45" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">5</text>
+    <text x="50" y="20" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a7268">6</text>
+    <text x="14" y="100" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="9" fill="#7a7268" transform="rotate(-90 14 100)">CUMULATIVE THEMES</text>
+    <!-- Grid lines -->
+    <line x1="60" y1="145" x2="690" y2="145" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="60" y1="120" x2="690" y2="120" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="60" y1="95" x2="690" y2="95" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="60" y1="70" x2="690" y2="70" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="60" y1="45" x2="690" y2="45" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <line x1="60" y1="20" x2="690" y2="20" stroke="#e6e2d8" stroke-width="0.5" stroke-dasharray="3 3"/>
+    <!-- X-axis labels (interviews 1-18) -->
+    <text x="95" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">1</text>
+    <text x="130" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">2</text>
+    <text x="165" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">3</text>
+    <text x="200" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">4</text>
+    <text x="235" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">5</text>
+    <text x="270" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">6</text>
+    <text x="305" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">7</text>
+    <text x="340" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">8</text>
+    <text x="375" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">9</text>
+    <text x="410" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">10</text>
+    <text x="445" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">11</text>
+    <text x="480" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">12</text>
+    <text x="515" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">13</text>
+    <text x="550" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">14</text>
+    <text x="585" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">15</text>
+    <text x="620" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">16</text>
+    <text x="655" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">17</text>
+    <text x="690" y="184" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7268">18</text>
+    <text x="390" y="200" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="9" fill="#7a7268" letter-spacing="1">INTERVIEW NUMBER</text>
+    <!-- Saturation curve: steep rise, plateau after interview 13 -->
+    <!-- Int 1: 2 themes, Int 2: 3, Int 3: 3, Int 4: 4, Int 5: 4, Int 6: 5, Int 7: 5, Int 8: 5, Int 9: 5, Int 10: 5, Int 11: 6, Int 12: 6, Int 13: 6, ... plateau -->
+    <polyline points="95,120 130,95 165,95 200,70 235,70 270,45 305,45 340,45 375,45 410,45 445,20 480,20 515,20 550,20 585,20 620,20 655,20 690,20" fill="none" stroke="#6b3a5c" stroke-width="2.2"/>
+    <!-- Data points -->
+    <circle cx="95" cy="120" r="3" fill="#6b3a5c"/>
+    <circle cx="130" cy="95" r="3" fill="#6b3a5c"/>
+    <circle cx="165" cy="95" r="3" fill="#6b3a5c"/>
+    <circle cx="200" cy="70" r="3" fill="#6b3a5c"/>
+    <circle cx="235" cy="70" r="3" fill="#6b3a5c"/>
+    <circle cx="270" cy="45" r="3" fill="#6b3a5c"/>
+    <circle cx="305" cy="45" r="3" fill="#6b3a5c"/>
+    <circle cx="340" cy="45" r="3" fill="#6b3a5c"/>
+    <circle cx="375" cy="45" r="3" fill="#6b3a5c"/>
+    <circle cx="410" cy="45" r="3" fill="#6b3a5c"/>
+    <circle cx="445" cy="20" r="3" fill="#6b3a5c"/>
+    <circle cx="480" cy="20" r="3" fill="#6b3a5c"/>
+    <circle cx="515" cy="20" r="3.5" fill="#6b3a5c" stroke="#2a2420" stroke-width="1"/>
+    <circle cx="550" cy="20" r="3" fill="#a09888"/>
+    <circle cx="585" cy="20" r="3" fill="#a09888"/>
+    <circle cx="620" cy="20" r="3" fill="#a09888"/>
+    <circle cx="655" cy="20" r="3" fill="#a09888"/>
+    <circle cx="690" cy="20" r="3" fill="#a09888"/>
+    <!-- Saturation annotation -->
+    <line x1="515" y1="20" x2="515" y2="165" stroke="#6b3a5c" stroke-width="1" stroke-dasharray="4 3"/>
+    <text x="518" y="160" font-family="Crimson Pro, serif" font-style="italic" font-size="8" fill="#6b3a5c">Saturation reached</text>
+    <text x="518" y="168" font-family="Crimson Pro, serif" font-style="italic" font-size="7" fill="#7a7268">(interview 13)</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure 2.</span> Theme saturation diagram showing the cumulative number of new themes identified as successive interviews were analysed. The curve rises steeply in the first six interviews and reaches a plateau at interview 11 (6 themes). No new themes emerged after interview 13, confirming informational saturation. Interviews 14 to 18 (shown in grey) served as confirmatory cases.</figcaption>
+</figure>
+
+## Participant Summary
+
+<div class="demographic-grid">
+  <div class="demo-card">
+    <span class="demo-value">18</span>
+    <span class="demo-label">Participants</span>
+  </div>
+  <div class="demo-card">
+    <span class="demo-value">8 / 5 / 5</span>
+    <span class="demo-label">Nurses / Physicians / Allied</span>
+  </div>
+  <div class="demo-card">
+    <span class="demo-value">3--28 yr</span>
+    <span class="demo-label">Experience Range</span>
+  </div>
+  <div class="demo-card">
+    <span class="demo-value">12F / 6M</span>
+    <span class="demo-label">Gender Distribution</span>
+  </div>
+</div>
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Participant demographic summary by professional role.</caption>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>n</th>
+      <th>Experience (years)</th>
+      <th>Female</th>
+      <th>Male</th>
+      <th>Setting</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Registered Nurse</td>
+      <td class="num">8</td>
+      <td class="num">3--24</td>
+      <td class="num">6</td>
+      <td class="num">2</td>
+      <td>ICU, ED, General Ward</td>
+    </tr>
+    <tr>
+      <td>Physician</td>
+      <td class="num">5</td>
+      <td class="num">6--28</td>
+      <td class="num">3</td>
+      <td class="num">2</td>
+      <td>ED, Internal Medicine, ICU</td>
+    </tr>
+    <tr>
+      <td>Allied Health</td>
+      <td class="num">5</td>
+      <td class="num">4--18</td>
+      <td class="num">3</td>
+      <td class="num">2</td>
+      <td>Physiotherapy, Social Work, Psychology</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">Participants recruited from two metropolitan teaching hospitals in Melbourne, Australia. Experience measured from date of professional registration to interview date.</td></tr>
+  </tfoot>
+</table>
+
+## Illustrative Participant Voices
+
+<div class="participant-quote">
+  <p>I kept thinking, when does it stop? When do we get to grieve? We went from one wave to the next, and everyone just expected you to keep going. It was not until I physically could not get out of bed one morning that I realised -- this is not normal fatigue. This is something else entirely.</p>
+  <span class="quote-id">-- P04, Registered Nurse, ICU, 11 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>The hardest part was not the work itself. It was coming out the other side and being told to move on, as if nothing happened. No one from management ever sat us down and said: what you went through was extraordinary, and we see that. That silence -- it was worse than the crisis itself.</p>
+  <span class="quote-id">-- P11, Physician, Emergency Department, 19 years experience</span>
+</div>
+
+## Structure of the Paper
+
+Navigate the paper through the section index.
+
+1. **Section 1. Methodology** -- reflexive thematic analysis approach, Braun and Clarke framework, researcher positionality
+2. **Section 2. Data Collection** -- semi-structured interview design, interview guide, recording and transcription procedures
+3. **Section 3. Findings** -- the six themes with participant quotes, code frequencies, and thematic interpretations
+4. **Section 4. Theme Analysis** -- theme development process, coding decisions, analytical memo extracts
+5. **Section 5. Discussion** -- interpretation, comparison with existing literature, implications, reflexive considerations, and limitations

--- a/qualitative-study/content/participants.md
+++ b/qualitative-study/content/participants.md
@@ -1,0 +1,167 @@
++++
+title = "Participants"
+description = "Detailed demographic characteristics of all 18 participants in the qualitative interview study."
+tags = ["qualitative", "participants", "demographics"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">PARTICIPANT DEMOGRAPHICS</p>
+  <h1 class="paper-section-title">Participant Profiles</h1>
+</header>
+
+Eighteen healthcare workers were purposively sampled from two metropolitan teaching hospitals in Melbourne, Australia. The table below presents the demographic characteristics of each participant. All identifiers are pseudonymised; participant codes (P01 to P18) are used throughout the manuscript.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Demographic characteristics of all 18 participants.</caption>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Role</th>
+      <th>Experience (yr)</th>
+      <th>Gender</th>
+      <th>Setting</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>P01</td>
+      <td>Registered Nurse</td>
+      <td class="num">24</td>
+      <td>Female</td>
+      <td>ICU</td>
+    </tr>
+    <tr>
+      <td>P02</td>
+      <td>Registered Nurse</td>
+      <td class="num">7</td>
+      <td>Female</td>
+      <td>General Ward</td>
+    </tr>
+    <tr>
+      <td>P03</td>
+      <td>Registered Nurse</td>
+      <td class="num">15</td>
+      <td>Male</td>
+      <td>ICU</td>
+    </tr>
+    <tr>
+      <td>P04</td>
+      <td>Registered Nurse</td>
+      <td class="num">11</td>
+      <td>Female</td>
+      <td>ICU</td>
+    </tr>
+    <tr>
+      <td>P05</td>
+      <td>Physician</td>
+      <td class="num">14</td>
+      <td>Male</td>
+      <td>Internal Medicine</td>
+    </tr>
+    <tr>
+      <td>P06</td>
+      <td>Registered Nurse</td>
+      <td class="num">6</td>
+      <td>Female</td>
+      <td>ICU</td>
+    </tr>
+    <tr>
+      <td>P07</td>
+      <td>Physician</td>
+      <td class="num">22</td>
+      <td>Female</td>
+      <td>Internal Medicine</td>
+    </tr>
+    <tr>
+      <td>P08</td>
+      <td>Allied Health (Social Worker)</td>
+      <td class="num">10</td>
+      <td>Female</td>
+      <td>Psychosocial Services</td>
+    </tr>
+    <tr>
+      <td>P09</td>
+      <td>Registered Nurse</td>
+      <td class="num">9</td>
+      <td>Female</td>
+      <td>Emergency Department</td>
+    </tr>
+    <tr>
+      <td>P10</td>
+      <td>Allied Health (Physiotherapist)</td>
+      <td class="num">4</td>
+      <td>Male</td>
+      <td>Rehabilitation</td>
+    </tr>
+    <tr>
+      <td>P11</td>
+      <td>Physician</td>
+      <td class="num">19</td>
+      <td>Male</td>
+      <td>Emergency Department</td>
+    </tr>
+    <tr>
+      <td>P12</td>
+      <td>Registered Nurse</td>
+      <td class="num">5</td>
+      <td>Female</td>
+      <td>General Ward</td>
+    </tr>
+    <tr>
+      <td>P13</td>
+      <td>Allied Health (Psychologist)</td>
+      <td class="num">8</td>
+      <td>Female</td>
+      <td>Mental Health Services</td>
+    </tr>
+    <tr>
+      <td>P14</td>
+      <td>Physician</td>
+      <td class="num">16</td>
+      <td>Male</td>
+      <td>Emergency Department</td>
+    </tr>
+    <tr>
+      <td>P15</td>
+      <td>Allied Health (Physiotherapist)</td>
+      <td class="num">12</td>
+      <td>Female</td>
+      <td>ICU / Rehabilitation</td>
+    </tr>
+    <tr>
+      <td>P16</td>
+      <td>Registered Nurse</td>
+      <td class="num">3</td>
+      <td>Female</td>
+      <td>Emergency Department</td>
+    </tr>
+    <tr>
+      <td>P17</td>
+      <td>Allied Health (Social Worker)</td>
+      <td class="num">18</td>
+      <td>Male</td>
+      <td>Psychosocial Services</td>
+    </tr>
+    <tr>
+      <td>P18</td>
+      <td>Physician</td>
+      <td class="num">28</td>
+      <td>Female</td>
+      <td>Internal Medicine</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">All participants were recruited from two metropolitan teaching hospitals in Melbourne, Australia. Experience is measured in years from date of professional registration to the interview date. Gender is self-reported.</td></tr>
+  </tfoot>
+</table>
+
+## Recruitment Summary
+
+- **Expressions of interest received:** 26
+- **Enrolled and interviewed:** 18
+- **Not enrolled (scheduling conflicts):** 4
+- **Not enrolled (variation criteria):** 4
+- **Interview period:** March to August 2025
+- **Interview duration range:** 47 to 92 minutes (mean: 68 minutes)
+- **In-person interviews:** 14
+- **Video interviews:** 4

--- a/qualitative-study/content/sections/1-methodology.md
+++ b/qualitative-study/content/sections/1-methodology.md
@@ -1,0 +1,30 @@
++++
+title = "1. Methodology"
+description = "Reflexive thematic analysis approach, Braun and Clarke framework, epistemological stance, and researcher positionality."
+weight = 1
+template = "post"
+tags = ["qualitative", "thematic-analysis", "methodology"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Epistemological stance
+
+This study is situated within a critical realist ontology and a contextualist epistemology. We acknowledge that participants' accounts reflect genuine experiences of burnout and recovery, while also recognising that these accounts are shaped by the social, institutional, and cultural contexts in which they are produced. This position aligns with Braun and Clarke's articulation of reflexive thematic analysis as a method that moves beyond a purely descriptive account to engage with latent meanings and the conditions that structure experience.
+
+## 1.2 Reflexive thematic analysis
+
+We employed the six-phase reflexive thematic analysis (RTA) framework as described by Braun and Clarke (2019, 2021). This approach treats coding as an active, interpretive process -- not a mechanical application of labels -- and emphasises the researcher's role in constructing themes rather than discovering them. The six phases were followed iteratively rather than linearly: (1) familiarisation with the data, (2) systematic coding, (3) generating initial themes, (4) reviewing and developing themes, (5) refining, defining, and naming themes, and (6) writing up.
+
+A total of 42 codes were generated during Phase 2 and organised into 14 sub-themes and 6 overarching themes during Phases 3 through 5. The coding process involved two complete passes through all transcripts, with analytic memos maintained throughout.
+
+## 1.3 Researcher positionality
+
+The first author (TA) is a registered nurse and qualitative researcher with 12 years of clinical experience, including frontline pandemic work. This insider perspective shaped both access to participants and the analytical lens applied to the data. Reflexive journaling was undertaken after each interview and at key analytical decision points. The research team included members with clinical backgrounds in nursing, medicine, and allied health, as well as researchers with no clinical experience, to provide methodological counterbalance.
+
+We acknowledge that our positionality may have facilitated deeper rapport with some participants while potentially reinforcing shared assumptions. Regular team debriefing sessions and an external audit of the coding framework by a qualitative methodologist (not otherwise involved in the study) were used to promote analytical rigour.
+
+## 1.4 Ethical considerations
+
+This study received ethics approval from the University of Melbourne Human Research Ethics Committee (HREC-2024-1847). All participants provided written informed consent. Pseudonymised participant identifiers (P01 to P18) are used throughout to protect confidentiality. Audio recordings were stored in encrypted institutional repositories and will be destroyed five years after publication.

--- a/qualitative-study/content/sections/2-data-collection.md
+++ b/qualitative-study/content/sections/2-data-collection.md
@@ -1,0 +1,44 @@
++++
+title = "2. Data Collection"
+description = "Semi-structured interview design, interview guide development, recording and transcription procedures, and sampling strategy."
+weight = 2
+template = "post"
+tags = ["qualitative", "interviews", "data-collection"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Sampling strategy
+
+Purposive sampling was used to recruit healthcare workers who self-identified as having experienced burnout during or following the pandemic period (2020 to 2023) and who had been in clinical roles during at least one major surge. We sought maximum variation across three dimensions: professional role (nursing, medicine, allied health), years of clinical experience, and clinical setting (ICU, emergency department, general ward, outpatient services).
+
+Recruitment occurred through two metropolitan teaching hospitals in Melbourne, Australia. Flyers were distributed in staff common areas and through internal email lists. Potential participants contacted the research team directly to preserve anonymity from their employers. Of 26 expressions of interest, 18 participants were enrolled and interviewed. Eight individuals were not enrolled due to scheduling conflicts (n = 4) or because they fell outside the targeted variation criteria (n = 4).
+
+## 2.2 Interview guide
+
+A semi-structured interview guide was developed through three iterations: an initial draft informed by the literature on healthcare worker burnout and moral injury, a revised version following pilot testing with two healthcare workers (whose data were not included in the analysis), and a final version refined after the first four interviews in response to emerging topics.
+
+The guide contained five core domains:
+
+1. Pre-pandemic professional identity and motivations
+2. Experiences during the peak pandemic period
+3. Recognition and onset of burnout symptoms
+4. The process of recovery (or ongoing struggle)
+5. Current professional outlook and meaning-making
+
+Each domain included open-ended primary questions and optional follow-up probes. The guide was used flexibly, allowing participants to lead the conversation into areas of personal significance.
+
+## 2.3 Interview procedures
+
+All interviews were conducted by the first author (TA) between March and August 2025. Fourteen interviews were conducted in person in a private room at the participants' workplace or at a location of their choosing. Four interviews were conducted via secure video call at participants' request. Interviews ranged from 47 to 92 minutes in length (mean: 68 minutes).
+
+Interviews were audio-recorded with participants' consent. Field notes were taken during each interview, capturing non-verbal cues, emotional tone, and the interviewer's immediate reflections. A reflexive memo was written within 24 hours of each interview.
+
+## 2.4 Transcription
+
+Audio recordings were transcribed verbatim by a professional transcription service with experience in health research. All transcripts were checked against audio recordings by the first author for accuracy. Paralinguistic features (pauses, laughter, emotional breaks) were noted using standardised conventions. Identifying information was removed at the point of transcription and replaced with pseudonymised identifiers.
+
+## 2.5 Data saturation
+
+We assessed informational saturation using both theme-level and code-level tracking. As documented in the theme saturation diagram (Figure 2), all six overarching themes were present by interview 11, and no new themes emerged after interview 13. Code-level saturation was reached at interview 15, after which no new codes were generated. Interviews 14 through 18 served as confirmatory cases, enriching existing themes with additional illustrative data.

--- a/qualitative-study/content/sections/3-findings.md
+++ b/qualitative-study/content/sections/3-findings.md
@@ -1,0 +1,114 @@
++++
+title = "3. Findings"
+description = "The six themes with participant quotes, thematic interpretations, and code-level detail from reflexive thematic analysis."
+weight = 3
+template = "post"
+tags = ["qualitative", "findings", "thematic-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+Six themes were constructed from the data, together encompassing 14 sub-themes and 42 codes. Each theme is presented below with illustrative participant quotations and interpretive commentary.
+
+## 3.1 <span class="theme-label t1">Theme 1: The Weight of Accumulated Distress</span>
+
+This theme captures the compounding nature of pandemic-related exhaustion, which participants described not as a single breaking point but as a slow accumulation that eventually overwhelmed their capacity to cope. Two sub-themes were identified: *compounding fatigue* and *delayed grief processing*.
+
+Participants consistently described a pattern in which each successive wave of pandemic demand was layered onto unresolved distress from the previous one, without adequate time or space for recovery between surges.
+
+<div class="participant-quote">
+  <p>It was not one thing. It was everything, stacked on top of everything else. You think you have recovered, and then the next wave hits, and you realise you never actually dealt with the last one. By the third wave, I was running on something that was not energy -- it was just momentum.</p>
+  <span class="quote-id">-- P02, Registered Nurse, General Ward, 7 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>I did not cry when my patients died. I did not cry for months. And then one day, eighteen months later, I was in the supermarket and I just started sobbing. It all came out at once, in the cereal aisle. That was when I knew something was deeply wrong.</p>
+  <span class="quote-id">-- P07, Physician, Internal Medicine, 22 years experience</span>
+</div>
+
+The delayed nature of grief processing was particularly pronounced among participants who had maintained high levels of clinical functioning during the acute phase. Several described a dissociative quality to their pandemic experience, as though they had compartmentalised their emotional responses in order to continue working.
+
+## 3.2 <span class="theme-label t2">Theme 2: Institutional Silence and Moral Injury</span>
+
+This theme addresses the perceived failure of healthcare institutions to acknowledge the extraordinary nature of the pandemic experience and to provide adequate structural support for recovery. Sub-themes included *betrayal by leadership* and *forced silence about suffering*.
+
+Moral injury -- the distress arising from actions or inactions that violate one's moral code -- was a recurring concern. Participants described being placed in situations where they were forced to make resource allocation decisions that contradicted their professional values, and then receiving no institutional acknowledgement or debriefing afterward.
+
+<div class="participant-quote">
+  <p>We were told we were heroes, but heroes do not need better staffing ratios, apparently. The hero language was a way of shutting us up. If you are a hero, you do not complain. You do not ask for help. You just keep going.</p>
+  <span class="quote-id">-- P11, Physician, Emergency Department, 19 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>There was never a debrief. Not one. We lost six patients in a single shift and the next morning we were expected to do it again. No one from management came to the ward to ask how we were. Not once. That silence told us everything about how much we actually mattered.</p>
+  <span class="quote-id">-- P03, Registered Nurse, ICU, 15 years experience</span>
+</div>
+
+The absence of institutional acknowledgement was interpreted by many participants as a form of gaslighting, in which the severity of their experience was implicitly minimised through organisational silence.
+
+## 3.3 <span class="theme-label t3">Theme 3: Permission to Not Be Okay</span>
+
+This theme captures the significance of moments in which participants felt permitted -- by peers, supervisors, or themselves -- to acknowledge their distress without professional penalty. Sub-themes included *vulnerability as strength* and *breaking the stoic norm*.
+
+Healthcare culture's emphasis on resilience and stoicism was identified as a significant barrier to recovery. Participants described a professional culture in which admitting to burnout was perceived as weakness, creating a double bind: they could not recover from distress that they were not permitted to acknowledge.
+
+<div class="participant-quote">
+  <p>The turning point for me was when my clinical lead, someone I really respected, said in a team meeting: I am not okay, and I do not think any of us are. That one sentence changed everything. It gave me permission to stop pretending.</p>
+  <span class="quote-id">-- P09, Registered Nurse, ED, 9 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>I reduced my hours to 0.6 and I felt so guilty about it. Like I was abandoning the team. But my psychologist said something that stuck with me: you cannot pour from an empty cup, and right now your cup is not just empty -- it has a hole in it. That reframing helped.</p>
+  <span class="quote-id">-- P15, Allied Health (Physiotherapist), 12 years experience</span>
+</div>
+
+## 3.4 <span class="theme-label t4">Theme 4: Rebuilding Professional Identity</span>
+
+This theme describes the process through which participants renegotiated their relationship to clinical work following burnout. Three sub-themes were identified: *role renegotiation*, *clinical confidence shifts*, and *boundary setting*.
+
+For many participants, the pandemic fundamentally altered their professional self-concept. The clinician they had been before the pandemic no longer existed, and recovery involved constructing a new professional identity that incorporated the lessons of the crisis.
+
+<div class="participant-quote">
+  <p>I used to define myself entirely by my work. I was a nurse, full stop. After the pandemic, I had to learn to be a person who also happens to be a nurse. That distinction sounds small, but it was everything.</p>
+  <span class="quote-id">-- P01, Registered Nurse, ICU, 24 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>I moved from emergency medicine to a teaching role. Some of my colleagues saw it as a step down. But for me, it was survival. I could not go back to that environment and remain the kind of clinician -- the kind of person -- I wanted to be.</p>
+  <span class="quote-id">-- P14, Physician, Emergency Department, 16 years experience</span>
+</div>
+
+Boundary setting emerged as a critical recovery behaviour. Participants who had previously been unable to decline additional shifts or clinical responsibilities described learning to say no as a necessary act of professional self-preservation.
+
+## 3.5 <span class="theme-label t5">Theme 5: Relational Anchoring</span>
+
+This theme captures the role of interpersonal relationships -- both professional and personal -- as stabilising forces during the recovery process. Sub-themes included *peer solidarity and witness* and *family and home anchors*.
+
+Participants consistently identified peer relationships as the single most important resource in their recovery. The sense of being understood by colleagues who had shared the same experience was described as qualitatively different from -- and more therapeutically powerful than -- formal psychological support.
+
+<div class="participant-quote">
+  <p>My colleagues saved me. Not the EAP, not the wellness webinars. My colleagues. Because they were there. They saw what I saw. They did not need me to explain why I was broken, because they were broken too. There is something profoundly healing about being witnessed.</p>
+  <span class="quote-id">-- P06, Registered Nurse, ICU, 6 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>My wife would just hold me when I came home. She did not try to fix it. She did not offer advice. She just held me and said: I am here. That was the anchor. Without that, I do not know where I would be.</p>
+  <span class="quote-id">-- P18, Physician, Internal Medicine, 28 years experience</span>
+</div>
+
+## 3.6 <span class="theme-label t6">Theme 6: Finding Meaning After Crisis</span>
+
+This theme describes participants' efforts to construct meaning from their pandemic experience and to integrate it into a coherent narrative of professional and personal growth. Sub-themes included *post-traumatic growth* and *purpose reaffirmation*.
+
+Not all participants experienced growth. Several described being stuck in a liminal space between exhaustion and renewal, unable to find meaning in what they had endured. However, those who did articulate growth typically framed it in terms of clarified values, altered priorities, and a deepened sense of purpose.
+
+<div class="participant-quote">
+  <p>I would never wish this on anyone. But I will say this: I know who I am now in a way that I did not before. I know what matters. I know what I will tolerate and what I will not. The pandemic stripped everything away, and what was left -- that is who I actually am.</p>
+  <span class="quote-id">-- P08, Allied Health (Social Worker), 10 years experience</span>
+</div>
+
+<div class="participant-quote">
+  <p>I started volunteering with a healthcare advocacy group. I figured, if the system will not fix itself, maybe we can push it. That work gave me back something the pandemic took -- a sense of agency. I am not just surviving anymore. I am doing something about it.</p>
+  <span class="quote-id">-- P12, Registered Nurse, General Ward, 5 years experience</span>
+</div>

--- a/qualitative-study/content/sections/4-theme-analysis.md
+++ b/qualitative-study/content/sections/4-theme-analysis.md
@@ -1,0 +1,50 @@
++++
+title = "4. Theme Analysis"
+description = "Theme development process, coding decisions, analytical memos, and the evolution of the thematic framework."
+weight = 4
+template = "post"
+tags = ["qualitative", "coding", "theme-development"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Coding process
+
+Initial coding was conducted inductively by the first author (TA) using line-by-line analysis of the first five transcripts. This generated 67 preliminary codes, which were refined through discussion with the research team and collapsed into 42 final codes during the second coding pass. Codes were applied to data segments ranging from single sentences to extended passages of narrative.
+
+The coding framework was maintained in a structured spreadsheet that tracked each code's definition, exemplar quotes, frequency across participants, and analytical notes. This framework was shared with all team members and served as the primary audit trail for the analysis.
+
+## 4.2 Theme development
+
+The transition from codes to themes was the most interpretive phase of the analysis. We moved through three iterations of the thematic map before arriving at the final six-theme structure. Key decisions included:
+
+- **Merging "Exhaustion" and "Grief"** into a single theme (*The Weight of Accumulated Distress*). These were initially separate themes but were collapsed because participants consistently described them as inseparable aspects of the same compounding experience.
+- **Separating "Institutional Failure" into two components.** What began as a broad theme about organisational factors was split into *Institutional Silence and Moral Injury* (Theme 2) and aspects of *Permission to Not Be Okay* (Theme 3), because the data revealed that institutional silence operated differently from the personal, relational moments of permission-granting.
+- **Elevating "Boundary Setting"** from a code to a sub-theme within *Rebuilding Professional Identity*. This decision was made after recognising that boundary setting was not merely a coping strategy but a fundamental component of how participants reconstructed their professional selves.
+
+## 4.3 Analytical memos
+
+Reflexive memos were maintained throughout the analysis. Below is an excerpt from a memo written during Phase 4 (reviewing and developing themes):
+
+*Memo, 12 June 2025: I am struck by the tension between Themes 2 and 3. Institutional silence creates the conditions that make personal permission so powerful. If institutions had acknowledged the crisis, would participants have needed that one courageous colleague to say "I am not okay" in a meeting? The themes are not independent -- they are in dialogue with each other. The absence described in Theme 2 is what makes the presence described in Theme 3 so meaningful. I need to reflect this relational quality in the write-up without collapsing the distinction.*
+
+## 4.4 Cross-theme patterns
+
+Three patterns cut across the six themes and warrant explicit acknowledgement:
+
+**Non-linearity of recovery.** Participants did not describe recovery as a progressive movement from distress to wellness. Instead, they described oscillation -- periods of improvement followed by regression, often triggered by institutional decisions or anniversaries of pandemic events. This pattern was evident in all six themes.
+
+**The centrality of relationships.** While Theme 5 (*Relational Anchoring*) explicitly addresses interpersonal relationships, relational dynamics appeared in every theme. Institutional silence is a relational failure; permission to be vulnerable is a relational gift; professional identity is negotiated through relational contexts.
+
+**Agency and structure.** The tension between individual agency and structural conditions was a persistent undercurrent. Participants simultaneously described their recovery in terms of personal choices (reducing hours, seeking therapy, setting boundaries) and structural enablers or barriers (workload reform, staffing levels, institutional culture). Recovery could not be reduced to either dimension alone.
+
+## 4.5 Rigour and trustworthiness
+
+We adopted the following strategies to support the trustworthiness of the analysis:
+
+- **Reflexive journaling** by the first author throughout data collection and analysis
+- **Team-based coding review** at three key analytical decision points
+- **External audit** of the coding framework by an independent qualitative methodologist
+- **Participant checking** with five participants (P01, P06, P09, P14, P18) who reviewed a summary of the findings and confirmed that the themes resonated with their experience
+- **Thick description** in the findings section to support transferability judgements by readers

--- a/qualitative-study/content/sections/5-discussion.md
+++ b/qualitative-study/content/sections/5-discussion.md
@@ -1,0 +1,54 @@
++++
+title = "5. Discussion"
+description = "Interpretation, comparison with existing literature, implications for policy and practice, reflexive considerations, and limitations."
+weight = 5
+template = "post"
+tags = ["qualitative", "discussion", "implications"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of findings
+
+This study constructed six themes from interviews with 18 healthcare workers who experienced burnout during the pandemic: the compounding nature of distress, the role of institutional silence in deepening moral injury, the significance of permission to be vulnerable, the process of rebuilding professional identity, the anchoring function of relationships, and the variable emergence of meaning and growth. These themes collectively suggest that burnout recovery is a relational, non-linear, and structurally mediated process that cannot be adequately addressed through individual-level interventions alone.
+
+## 5.2 Relationship to existing literature
+
+Our findings extend the growing body of qualitative research on pandemic-related healthcare worker distress (Billings et al., 2021; Maben and Bridges, 2020) by focusing specifically on the recovery phase rather than the acute crisis. The theme of *Institutional Silence and Moral Injury* resonates with Shay's (2014) original concept of moral injury as arising not only from the traumatic event itself but from the perceived betrayal by those in authority. Participants in our study consistently located the source of their deepest distress not in the clinical demands of the pandemic but in the institutional failure to acknowledge those demands.
+
+The theme of *Permission to Not Be Okay* adds to the emerging literature on psychological safety in healthcare settings (Edmondson and Lei, 2014). Our data suggest that permission to be vulnerable operates differently in post-crisis contexts than in routine clinical practice: it requires active, visible modelling by respected colleagues or leaders, rather than simply the absence of punitive responses to help-seeking.
+
+The identification of *Relational Anchoring* as central to recovery is consistent with Maslach and Leiter's (2016) updated model of burnout, which identifies community as one of six key organisational domains. However, our participants drew a sharp distinction between the therapeutic value of peer solidarity -- grounded in shared experience and mutual witnessing -- and the perceived inadequacy of formal support programmes (employee assistance, wellness webinars) that lacked this relational foundation.
+
+## 5.3 Implications for policy and practice
+
+Our findings suggest several implications for healthcare organisations seeking to support burnout recovery:
+
+**Structural acknowledgement.** Institutions must move beyond generic wellness messaging to provide specific, sustained acknowledgement of the pandemic experience. This includes formal debriefing processes, institutional memorials, and leadership communication that names the moral and emotional toll of the crisis.
+
+**Protected recovery time.** Burnout recovery cannot occur within the same conditions that produced burnout. Participants identified workload reduction, protected non-clinical time, and flexible scheduling as necessary structural preconditions for recovery.
+
+**Peer support programmes.** The relational nature of recovery suggests that peer support models -- particularly those that create space for shared storytelling and mutual witnessing -- may be more effective than individualised psychological interventions for many healthcare workers.
+
+**Identity-sensitive transitions.** Organisations should support career transitions (from clinical to teaching, from acute to community settings) without framing them as failures or demotions. For many participants, such transitions were essential acts of professional renewal.
+
+## 5.4 Reflexive considerations
+
+The first author's insider position as a healthcare worker and qualitative researcher shaped this study in ways that must be transparently acknowledged. Insider positionality likely facilitated rapport and enabled access to emotionally sensitive material that participants might not have shared with an outsider. At the same time, shared experience may have led to assumptions of understanding that foreclosed deeper probing of taken-for-granted meanings.
+
+We attempted to mitigate these risks through team diversity (including non-clinical researchers), external audit, and sustained reflexive practice. However, we recognise that no methodological strategy can fully eliminate the influence of researcher positionality; rather, reflexive thematic analysis treats this influence as an inherent and productive feature of qualitative inquiry.
+
+## 5.5 Limitations
+
+Several limitations should be considered when interpreting these findings:
+
+- **Sample composition.** All participants were recruited from two metropolitan teaching hospitals in a single Australian city. The experiences of healthcare workers in rural, regional, or resource-constrained settings may differ substantially.
+- **Self-selection bias.** Participants who volunteered for the study may represent those who were most willing or able to reflect on their burnout experience. Healthcare workers who had left the profession entirely, or who were in acute distress, may be underrepresented.
+- **Temporal context.** Interviews were conducted approximately two to three years after the peak pandemic period. Participants' accounts are retrospective constructions shaped by the passage of time and ongoing recovery processes. Longitudinal designs capturing the recovery trajectory in real time would complement these findings.
+- **Single-country context.** Australia's pandemic experience, while severe, differed from that of many other countries in terms of timing, policy responses, and healthcare system structure. Transferability to other national contexts should be assessed with caution.
+- **Gender imbalance.** The sample included 12 women and 6 men. While this broadly reflects the gender distribution of the healthcare workforce, the experiences of male healthcare workers may be underrepresented, particularly given gendered norms around emotional expression and help-seeking.
+
+## 5.6 Future research directions
+
+Future research should examine burnout recovery longitudinally, tracking the same participants over multiple years to capture the non-linear trajectories described in our findings. Comparative qualitative studies across different healthcare systems and national contexts would help to distinguish universal features of burnout recovery from those that are context-dependent. Research on the effectiveness of peer support models informed by the relational principles identified in this study is also warranted.

--- a/qualitative-study/content/sections/_index.md
+++ b/qualitative-study/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The manuscript is organised into five sections following conventions for reporting qualitative research using reflexive thematic analysis.

--- a/qualitative-study/static/css/style.css
+++ b/qualitative-study/static/css/style.css
@@ -1,0 +1,659 @@
+/* ============================================================================
+   Qualitative Study - Interview Analysis Paper
+   Light background, serif display headings, thematic analysis.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #faf8f4;
+  --bg-2: #f0ede6;
+  --bg-3: #e6e2d8;
+  --rule: #ccc6b8;
+  --ink: #2a2420;
+  --ink-2: #3e3830;
+  --ink-3: #7a7268;
+  --ink-4: #a09888;
+  --accent: #6b3a5c;
+  --accent-2: #522c47;
+  --theme-1: #6b3a5c;
+  --theme-2: #3a5c6b;
+  --theme-3: #5c6b3a;
+  --theme-4: #8a5c3a;
+  --theme-5: #3a3a6b;
+  --theme-6: #6b5c3a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Lora", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 56px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 700; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Lora", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "Crimson Pro", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", "Lora", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.12rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Lora", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--accent);
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Lora", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Participant quote blocks ---------------- */
+
+.participant-quote {
+  margin: 1.6rem 0;
+  padding: 1.2rem 1.6rem 1.2rem 1.8rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  font-family: "Lora", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.98rem;
+  line-height: 1.7;
+  color: var(--ink-2);
+}
+
+.participant-quote p {
+  margin: 0.4rem 0;
+  text-align: left;
+}
+
+.quote-id {
+  display: block;
+  margin-top: 0.6rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+}
+
+/* ---------------- Theme labels ---------------- */
+
+.theme-label {
+  display: inline;
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1em;
+  letter-spacing: 0.01em;
+}
+
+.theme-label.t1 { color: var(--theme-1); }
+.theme-label.t2 { color: var(--theme-2); }
+.theme-label.t3 { color: var(--theme-3); }
+.theme-label.t4 { color: var(--theme-4); }
+.theme-label.t5 { color: var(--theme-5); }
+.theme-label.t6 { color: var(--theme-6); }
+
+/* ---------------- Demographic grid ---------------- */
+
+.demographic-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.demographic-grid .demo-card {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1rem 1.2rem;
+  text-align: center;
+}
+
+.demographic-grid .demo-card .demo-value {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.demographic-grid .demo-card .demo-label {
+  font-family: "Crimson Pro", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------------- Model callout ---------------- */
+
+.model-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 2.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.model-callout .callout-stat {
+  text-align: center;
+}
+
+.model-callout .callout-value {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--accent);
+  display: block;
+  line-height: 1.1;
+}
+
+.model-callout .callout-label {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.15em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.3rem;
+}
+
+.model-callout .callout-sep {
+  width: 1px;
+  height: 2.4rem;
+  background: var(--rule);
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #ffffff;
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons / Footer ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+.error-page { text-align: center; padding: 3rem 0; }
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "Crimson Pro", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Interview guide list ---------------- */
+
+.interview-guide {
+  margin: 1.4rem 0;
+  padding-left: 1.4rem;
+}
+
+.interview-guide li {
+  margin: 0.5rem 0;
+  font-family: "Lora", "Crimson Pro", serif;
+  font-style: italic;
+  color: var(--ink-2);
+}
+
+/* ---------------- Theme summary cards ---------------- */
+
+.theme-summary {
+  margin: 1.5rem 0;
+  padding: 1rem 1.4rem;
+  border-left: 3px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.theme-summary.ts1 { border-left-color: var(--theme-1); }
+.theme-summary.ts2 { border-left-color: var(--theme-2); }
+.theme-summary.ts3 { border-left-color: var(--theme-3); }
+.theme-summary.ts4 { border-left-color: var(--theme-4); }
+.theme-summary.ts5 { border-left-color: var(--theme-5); }
+.theme-summary.ts6 { border-left-color: var(--theme-6); }
+
+.theme-summary h4 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin: 0 0 0.4rem;
+  font-style: normal;
+}
+
+.theme-summary p {
+  margin: 0.3rem 0;
+  font-size: 0.95rem;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .model-callout { flex-direction: column; gap: 1rem; }
+  .model-callout .callout-sep { width: 3rem; height: 1px; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .demographic-grid { grid-template-columns: 1fr 1fr; }
+  .participant-quote { padding: 1rem 1.2rem 1rem 1.4rem; }
+}

--- a/qualitative-study/templates/404.html
+++ b/qualitative-study/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/qualitative-study/templates/footer.html
+++ b/qualitative-study/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#ccc6b8" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#ccc6b8" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Adeyemi T, Johansson K, Reyes-Mendoza L, Okonkwo N, Hartmann S, Takahashi M. Navigating Recovery: Healthcare Workers' Lived Experiences of Pandemic Burnout and the Pathways to Professional Renewal. <em>Qual. Health Res. Lett.</em> 2026;28(6):312-348. doi:10.48127/qhrl.2026.28.06.312</p>
+        <p class="footer-note">ISSN 1049-7323 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/qualitative-study/templates/header.html
+++ b/qualitative-study/templates/header.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant:wght@400;700&family=EB+Garamond:wght@400;700&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Lora:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Abstract qualitative interview icon: converging speech bubbles -->
+          <rect x="4" y="6" width="22" height="16" rx="3" fill="none" stroke="#6b3a5c" stroke-width="1.5"/>
+          <polygon points="12,22 16,28 20,22" fill="none" stroke="#6b3a5c" stroke-width="1.5"/>
+          <line x1="9" y1="11" x2="21" y2="11" stroke="#6b3a5c" stroke-width="1" opacity="0.5"/>
+          <line x1="9" y1="15" x2="18" y2="15" stroke="#6b3a5c" stroke-width="1" opacity="0.5"/>
+          <rect x="30" y="10" width="22" height="16" rx="3" fill="none" stroke="#3a5c6b" stroke-width="1.5"/>
+          <polygon points="38,26 42,32 46,26" fill="none" stroke="#3a5c6b" stroke-width="1.5"/>
+          <line x1="35" y1="15" x2="47" y2="15" stroke="#3a5c6b" stroke-width="1" opacity="0.5"/>
+          <line x1="35" y1="19" x2="44" y2="19" stroke="#3a5c6b" stroke-width="1" opacity="0.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Qualitative Health Research Letters</span>
+          <span class="journal-sub">Vol. 28 &middot; Issue 06 &middot; Jun 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/participants/">PARTICIPANTS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/qualitative-study/templates/page.html
+++ b/qualitative-study/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/qualitative-study/templates/post.html
+++ b/qualitative-study/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/qualitative-study/templates/section.html
+++ b/qualitative-study/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/qualitative-study/templates/shortcodes/alert.html
+++ b/qualitative-study/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/qualitative-study/templates/taxonomy.html
+++ b/qualitative-study/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/qualitative-study/templates/taxonomy_term.html
+++ b/qualitative-study/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4063,5 +4063,12 @@
     "rct",
     "clinical-trial",
     "rigorous"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
   ]
 }


### PR DESCRIPTION
## Summary
- Add new `qualitative-study` example site: an interview analysis paper with light theme
- Features SVG code tree diagrams showing theme hierarchy (6 themes with sub-themes and codes), participant demographic summary displays, and theme saturation diagrams showing when new themes stopped emerging
- Typography: Cormorant Bold / EB Garamond Bold for theme headers, Crimson Pro / Lora for body text
- Participant quotes presented in indented italic blocks with ID codes (P01-P18)
- Theme names displayed in colored bold with six distinct theme colors
- Five content sections covering methodology, data collection, findings, theme analysis, and discussion
- Tags: paper, light, qualitative, thematic, interpretive

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check SVG code tree diagram renders with proper theme colors
- [ ] Confirm participant quotes display in indented italic blocks
- [ ] Verify theme saturation diagram shows plateau
- [ ] Check tags.json entry is valid JSON

Closes #1626