### PR TITLE
feat: add editorial-letter example site (closes #1606)

### DIFF
--- a/editorial-letter/AGENTS.md
+++ b/editorial-letter/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/editorial-letter/config.toml
+++ b/editorial-letter/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Editorial Letter - Journal Editorial Paper
+# Issue #1606 | Tags: paper, light, editorial, authority, statement
+# =============================================================================
+
+title = "Editorial: The Reproducibility Imperative"
+description = "A journal editorial letter addressing the reproducibility crisis in computational sciences, with masthead decorations, editorial column rules, and editor signature facsimile in traditional newspaper style."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/editorial-letter/content/index.md
+++ b/editorial-letter/content/index.md
@@ -1,0 +1,96 @@
++++
+title = "Editorial"
+description = "A journal editorial letter addressing the reproducibility crisis in computational sciences, calling for mandatory open-data policies and transparent peer review."
+tags = ["paper", "light", "editorial", "authority", "statement"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Editorial &middot; Vol. 59, No. 4 &middot; April 2026</p>
+  <h1 class="paper-title">The Reproducibility Imperative: A Call for Structural Reform in Computational Sciences</h1>
+  <p class="paper-subtitle">Why we can no longer afford to treat reproducibility as optional -- and what this journal intends to do about it.</p>
+  <p class="paper-author-line">Eleanor Whitfield, Editor-in-Chief</p>
+</header>
+
+<!-- Column rule decoration -->
+<svg viewBox="0 0 740 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:100%;height:24px;display:block;margin:0 auto 1.5rem;">
+  <line x1="0" y1="8" x2="320" y2="8" stroke="#c8c0b0" stroke-width="0.5"/>
+  <circle cx="340" cy="8" r="2" fill="#8b1a1a"/>
+  <circle cx="360" cy="8" r="1.2" fill="#c8c0b0"/>
+  <circle cx="380" cy="8" r="2" fill="#8b1a1a"/>
+  <line x1="400" y1="8" x2="740" y2="8" stroke="#c8c0b0" stroke-width="0.5"/>
+</svg>
+
+<div class="editorial-columns">
+<p class="drop-cap">In the spring of 2024, a consortium of researchers from four continents attempted to reproduce the results of 127 highly cited computational studies published between 2018 and 2023. The outcome was sobering: fewer than 38 percent of the studies could be reproduced using the methods described in the original manuscripts. Of the remaining 62 percent, roughly half failed due to incomplete methodological descriptions, while the other half could not be verified because the underlying code or data had never been made available.</p>
+
+<p>These findings, published last autumn by the International Reproducibility Consortium, did not surprise those of us who have watched this crisis unfold over the past decade. But they did provide the kind of systematic evidence that makes inaction unconscionable. The credibility of computational science rests on the assumption that our methods are transparent, our data are accessible, and our results can withstand independent scrutiny. When that assumption fails, the entire enterprise is diminished.</p>
+
+<p>This editorial sets out our position, which is not merely an opinion but a declaration of editorial policy. Beginning with the next volume, this journal will require all submissions to include complete, executable code repositories, raw data deposits in certified archives, and structured reproducibility checklists verified by independent reviewers. These requirements are not optional and will not be waived.</p>
+
+<p>We recognise that these demands impose real costs on authors. Preparing code for public release, anonymising sensitive data, and documenting computational environments all require time and resources that the current incentive structure does not adequately reward. But the alternative -- a literature that cannot be trusted -- is far more costly to science and to society.</p>
+
+<p>The sections that follow elaborate on the scope of the crisis, our responsibilities as gatekeepers, the new standards we intend to enforce, and the support structures we are building to help authors meet these expectations. We also include a call to action directed at funding agencies, institutional leaders, and fellow editors.</p>
+
+<p>This is not a conversation we can continue to defer. The integrity of the record demands that we act now.</p>
+</div>
+
+<div class="pull-quote">
+"A literature that cannot be reproduced is not a literature at all -- it is a collection of claims."
+</div>
+
+## The Scale of the Problem
+
+The reproducibility crisis is not confined to a single discipline or methodology. A 2025 meta-analysis spanning computational biology, climate modelling, materials science, and computational fluid dynamics found that irreproducibility rates varied from 42 percent in well-funded collaborative fields to 71 percent in smaller sub-disciplines where data-sharing norms had not yet taken hold.
+
+The causes are structural, not merely individual. Among the most common barriers to reproduction identified by the International Reproducibility Consortium:
+
+- **Incomplete method descriptions** in 61% of irreproducible studies
+- **Unavailable source code** in 54% of cases
+- **Missing or restricted raw data** in 48% of cases
+- **Undocumented software dependencies** in 39% of cases
+- **Hardware-specific optimisations** not disclosed in 22% of cases
+
+These are not occasional oversights; they are systemic failures of scientific communication. And they are failures that journals -- as the primary gatekeepers of the published record -- have a particular responsibility to address.
+
+<!-- Editorial column rule SVG divider -->
+<svg viewBox="0 0 740 30" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:100%;height:30px;display:block;margin:2rem auto;">
+  <line x1="0" y1="12" x2="250" y2="12" stroke="#c8c0b0" stroke-width="0.5"/>
+  <line x1="260" y1="6" x2="260" y2="18" stroke="#1a1612" stroke-width="0.5"/>
+  <line x1="270" y1="4" x2="270" y2="20" stroke="#1a1612" stroke-width="1"/>
+  <line x1="280" y1="6" x2="280" y2="18" stroke="#1a1612" stroke-width="0.5"/>
+  <line x1="290" y1="12" x2="740" y2="12" stroke="#c8c0b0" stroke-width="0.5"/>
+</svg>
+
+## Our New Requirements
+
+Effective with Volume 60 (January 2027), the following will be mandatory for all research articles:
+
+| Requirement | Standard | Verification |
+|---|---|---|
+| Code deposit | Zenodo or institutional repo with DOI | Automated build check |
+| Data archive | Domain-certified repository | Reviewer spot-check |
+| Environment spec | Container image or lockfile | Independent rebuild |
+| Reproducibility checklist | Structured 22-item form | Editorial verification |
+| Methods appendix | Step-by-step computational protocol | Peer review |
+
+We are committed to supporting authors through this transition with dedicated reproducibility editors, template repositories, and a grace period during which feedback will be formative rather than exclusionary.
+
+<!-- Editor signature with SVG facsimile -->
+<div class="editor-signature">
+  <svg viewBox="0 0 280 80" xmlns="http://www.w3.org/2000/svg" aria-label="Editor signature" style="width:280px;height:80px;display:block;margin-left:auto;">
+    <!-- Signature facsimile: stylised cursive strokes -->
+    <path d="M20,55 C25,20 35,18 40,35 C45,52 50,58 55,40 C60,22 65,20 70,38" fill="none" stroke="#1a1612" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M75,42 C80,30 90,25 100,32 C105,35 108,42 105,48" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M108,28 L108,52" fill="none" stroke="#1a1612" stroke-width="1" stroke-linecap="round"/>
+    <path d="M115,35 C120,25 135,22 145,30 C150,33 148,42 140,45 C132,48 120,44 118,38" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M150,30 C155,25 160,28 162,35 L165,50" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M170,32 C172,28 178,26 185,30 C190,33 192,40 188,45 C184,50 175,48 172,42" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M195,28 C198,22 205,20 210,25 C215,30 218,40 220,50" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M225,38 C228,32 235,30 240,34 C245,38 248,45 250,50" fill="none" stroke="#1a1612" stroke-width="1" stroke-linecap="round"/>
+    <!-- Underline flourish -->
+    <path d="M20,62 C80,60 180,58 260,62" fill="none" stroke="#1a1612" stroke-width="0.5" stroke-linecap="round"/>
+  </svg>
+  <p class="sig-name">Prof. Eleanor Whitfield, FRS</p>
+  <p class="sig-title">Editor-in-Chief, Journal of Computational Sciences</p>
+  <p class="sig-title">April 2026</p>
+</div>

--- a/editorial-letter/content/policy.md
+++ b/editorial-letter/content/policy.md
@@ -1,0 +1,114 @@
++++
+title = "Editorial Policy"
+description = "New editorial policy on reproducibility requirements, effective Volume 60 (January 2027)."
+tags = ["paper", "light", "editorial", "authority", "statement"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Policy Statement &middot; Effective January 2027</p>
+  <h1 class="paper-title">Reproducibility Policy for Research Articles</h1>
+  <p class="paper-subtitle">Approved by the Editorial Board, 28 March 2026. Effective for all submissions to Volume 60 onwards.</p>
+</header>
+
+<!-- Policy document header rule -->
+<svg viewBox="0 0 740 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:100%;height:20px;display:block;margin:0 auto 2rem;">
+  <line x1="0" y1="4" x2="740" y2="4" stroke="#1a1612" stroke-width="1.5"/>
+  <line x1="0" y1="8" x2="740" y2="8" stroke="#1a1612" stroke-width="0.5"/>
+  <line x1="0" y1="16" x2="740" y2="16" stroke="#c8c0b0" stroke-width="0.5"/>
+</svg>
+
+## 1. Scope
+
+This policy applies to all original research articles, review articles with computational components, and methods papers submitted to the Journal of Computational Sciences beginning with Volume 60, Issue 1 (January 2027). Editorials, letters, and purely theoretical contributions are exempt.
+
+## 2. Code Availability
+
+All source code necessary to reproduce the computational results reported in a manuscript must be deposited in a publicly accessible, persistent repository with a digital object identifier (DOI) prior to acceptance. Acceptable repositories include Zenodo, Figshare, institutional repositories with DOI minting capability, and language-specific archives (e.g., CRAN, PyPI) when accompanied by a version-pinned DOI.
+
+Code must be accompanied by:
+
+- A README describing the purpose, dependencies, and execution instructions
+- A licence file (open-source licences strongly preferred)
+- A test suite demonstrating expected outputs
+
+## 3. Data Availability
+
+Raw data and processed datasets necessary for reproduction must be deposited in a domain-appropriate certified repository. Where data cannot be shared due to ethical, legal, or proprietary constraints, authors must provide:
+
+- A data availability statement explaining the restriction
+- Synthetic or simulated datasets that enable methodological reproduction
+- Contact information for data access requests
+- Ethics board documentation authorising the data sharing arrangement chosen
+
+## 4. Computational Environment
+
+Authors must specify the computational environment used to generate results. Acceptable approaches include, in order of preference:
+
+1. **Container images** (Docker, Singularity) deposited with the code repository
+2. **Environment lockfiles** (conda environment.yml, pip requirements.txt with pinned versions, Nix flake.lock)
+3. **Virtual machine images** for hardware-specific computations
+4. **Detailed environment documentation** as a last resort, including OS version, compiler versions, library versions, and hardware specifications
+
+## 5. Reproducibility Checklist
+
+All submissions must include a completed Reproducibility Checklist (available on the journal website) covering 22 items across five categories:
+
+| Category | Items | Description |
+|---|---|---|
+| Code completeness | 5 | All scripts, build files, and dependencies documented |
+| Data provenance | 4 | Data sources, processing steps, and access methods |
+| Environment specification | 4 | Hardware, software, and configuration details |
+| Results verification | 5 | Expected outputs, tolerance thresholds, and test cases |
+| Documentation quality | 4 | README, comments, method description alignment |
+
+## 6. Review Process
+
+Manuscripts will undergo a two-track review process:
+
+**Track A (Scientific Merit):** Traditional peer review evaluating the contribution, methodology, and conclusions.
+
+**Track B (Reproducibility):** Independent assessment by a dedicated Reproducibility Editor who will:
+
+- Verify that code executes without errors in the specified environment
+- Confirm that deposited data matches the descriptions in the manuscript
+- Spot-check at least two key computational results
+- Evaluate the completeness and clarity of documentation
+
+Both tracks must pass for acceptance. Track B reviewers will receive explicit credit and compensation through the journal's reviewer recognition programme.
+
+## 7. Transition Period
+
+To support the transition, the journal will offer:
+
+- Template repositories for common languages and frameworks
+- A reproducibility helpdesk staffed by editorial assistants
+- Formative feedback (without rejection) during the first two issues (Vol. 60, Issues 1-2)
+- Fee waivers for archival costs incurred by authors from low-income institutions
+
+## 8. Enforcement
+
+Non-compliance discovered after publication will be addressed through the following escalation:
+
+1. Author notification and 90-day remediation period
+2. Editorial expression of concern
+3. Formal correction or retraction if remediation is not completed
+
+This policy will be reviewed annually by the Editorial Board.
+
+<!-- Policy signature block -->
+<div class="editor-signature">
+  <svg viewBox="0 0 280 80" xmlns="http://www.w3.org/2000/svg" aria-label="Editor signature" style="width:280px;height:80px;display:block;margin-left:auto;">
+    <path d="M20,55 C25,20 35,18 40,35 C45,52 50,58 55,40 C60,22 65,20 70,38" fill="none" stroke="#1a1612" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M75,42 C80,30 90,25 100,32 C105,35 108,42 105,48" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M108,28 L108,52" fill="none" stroke="#1a1612" stroke-width="1" stroke-linecap="round"/>
+    <path d="M115,35 C120,25 135,22 145,30 C150,33 148,42 140,45 C132,48 120,44 118,38" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M150,30 C155,25 160,28 162,35 L165,50" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M170,32 C172,28 178,26 185,30 C190,33 192,40 188,45 C184,50 175,48 172,42" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M195,28 C198,22 205,20 210,25 C215,30 218,40 220,50" fill="none" stroke="#1a1612" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M225,38 C228,32 235,30 240,34 C245,38 248,45 250,50" fill="none" stroke="#1a1612" stroke-width="1" stroke-linecap="round"/>
+    <path d="M20,62 C80,60 180,58 260,62" fill="none" stroke="#1a1612" stroke-width="0.5" stroke-linecap="round"/>
+  </svg>
+  <p class="sig-name">Prof. Eleanor Whitfield, FRS</p>
+  <p class="sig-title">Editor-in-Chief</p>
+  <p class="sig-title">On behalf of the Editorial Board</p>
+</div>

--- a/editorial-letter/content/response.md
+++ b/editorial-letter/content/response.md
@@ -1,0 +1,85 @@
++++
+title = "Letters in Response"
+description = "Selected letters from the scientific community responding to the editorial on reproducibility reform."
+tags = ["paper", "light", "editorial", "authority", "statement"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Correspondence &middot; Letters to the Editor</p>
+  <h1 class="paper-title">Letters in Response</h1>
+  <p class="paper-subtitle">Selected correspondence regarding "The Reproducibility Imperative" editorial, received March -- April 2026.</p>
+</header>
+
+<!-- Decorative column rule -->
+<svg viewBox="0 0 740 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:100%;height:16px;display:block;margin:0 auto 2rem;">
+  <line x1="0" y1="8" x2="740" y2="8" stroke="#c8c0b0" stroke-width="0.5"/>
+  <rect x="355" y="4" width="30" height="8" fill="none" stroke="#1a1612" stroke-width="0.5"/>
+  <line x1="363" y1="4" x2="363" y2="12" stroke="#1a1612" stroke-width="0.3"/>
+  <line x1="377" y1="4" x2="377" y2="12" stroke="#1a1612" stroke-width="0.3"/>
+</svg>
+
+## Supporting the Mandate, Questioning the Timeline
+
+**From: Dr. Kenji Murakami, Department of Computational Physics, University of Kyoto**
+
+Dear Editor,
+
+I write in strong support of the new reproducibility requirements outlined in your April editorial. The evidence presented by the International Reproducibility Consortium leaves no room for equivocation: we must do better.
+
+However, I wish to raise a concern about the proposed timeline. Requiring full compliance by Volume 60 (January 2027) gives authors approximately eight months to restructure their workflows, adopt containerisation technologies, and prepare legacy code for public release. For well-resourced laboratories, this is ambitious but achievable. For early-career researchers in underfunded institutions -- particularly in the Global South -- this timeline may effectively exclude a generation of scholars from publication in leading venues.
+
+I urge the editorial board to consider a phased implementation with tiered requirements, beginning with code availability and methods documentation in 2027, and extending to full environmental reproducibility by 2028.
+
+Yours sincerely,
+*K. Murakami*
+
+---
+
+## The Hidden Cost of Open Data
+
+**From: Prof. Amara Osei-Bonsu, Centre for Biomedical Computing, University of Cape Town**
+
+Dear Editor,
+
+Your editorial rightly identifies the reproducibility crisis as a systemic failure. Yet it does not sufficiently address the asymmetric burden that mandatory open-data policies place on researchers working with sensitive data, particularly in clinical and population health computing.
+
+The requirement for "raw data deposits in certified archives" presupposes that raw data can be shared. In many of our studies, participant consent agreements explicitly prohibit broad data sharing. National data protection legislation in South Africa, the EU's GDPR, and similar frameworks in Brazil and India create legal barriers that no editorial policy can override.
+
+I would welcome guidance from the journal on how authors working under such constraints can satisfy the new requirements -- perhaps through synthetic data generation, federated analysis protocols, or controlled-access repositories with ethics board oversight.
+
+With respect,
+*A. Osei-Bonsu*
+
+---
+
+## A Practitioner's Perspective
+
+**From: Dr. Sofia Lindqvist, Senior Research Engineer, European Space Agency**
+
+Dear Editor,
+
+As someone who sits between academic research and operational deployment, I offer a perspective that your editorial did not address: the gap between research code and production code is not merely a reproducibility problem; it is a safety problem.
+
+In aerospace computing, every line of code that informs a design decision must be traceable, tested, and version-controlled. The standards your journal now proposes for academic publications are, frankly, the baseline we have expected in industry for decades. That they are only now being adopted by the academic community speaks to a troubling disconnection between the rigour we demand of ourselves in practice and the rigour we accept in the published literature.
+
+I commend this editorial and hope it signals a broader cultural shift.
+
+Yours,
+*S. Lindqvist*
+
+---
+
+## The Reviewer Burden
+
+**From: Prof. Carlos Mendes da Silva, Institute of Mathematical Sciences, University of Lisbon**
+
+Dear Editor,
+
+While I applaud the ambition of these reforms, I note with concern that the editorial does not address who will perform the independent verification of computational environments and reproducibility checklists.
+
+Peer reviewers are already overburdened. Adding the requirement to rebuild Docker containers, verify data checksums, and execute computational pipelines will dramatically increase the time and technical skill required for each review. Unless the journal commits substantial resources to dedicated reproducibility editors -- as distinct from traditional peer reviewers -- these requirements risk becoming box-ticking exercises that create an illusion of rigour without delivering the reality.
+
+I hope the editorial board will clarify the operational model in a subsequent communication.
+
+Respectfully,
+*C. Mendes da Silva*

--- a/editorial-letter/content/sections/1-the-crisis.md
+++ b/editorial-letter/content/sections/1-the-crisis.md
@@ -1,0 +1,63 @@
++++
+title = "I. The Crisis in Context"
+description = "A historical and empirical account of the reproducibility crisis in computational sciences, from early warnings to systematic evidence."
+weight = 1
+template = "post"
+tags = ["editorial", "reproducibility", "methodology"]
+categories = ["sections"]
+[extra]
+section_number = "I"
++++
+
+## Early Warnings
+
+The first systematic warnings about computational irreproducibility appeared not in the literature of any single discipline but in the proceedings of software engineering conferences. As early as 2011, researchers noted that the culture of "code as supplementary material" -- unreviewed, undocumented, and often unavailable -- was creating a growing gap between what papers claimed and what could be independently verified.
+
+These warnings were largely ignored by the broader scientific community. The prevailing view was that reproducibility was a concern for experimental sciences, where physical measurements could vary, but that computational results -- being deterministic -- were inherently reproducible provided the methods were correctly described. This assumption proved catastrophically wrong.
+
+## The Consortium Findings
+
+The International Reproducibility Consortium (IRC) was established in 2022 as a cross-disciplinary initiative funded by the Wellcome Trust, the National Science Foundation, and the European Research Council. Its mandate was simple: attempt to reproduce the computational results of a stratified random sample of highly cited papers.
+
+The IRC's final report, published in September 2025, documented:
+
+- **127 studies** attempted across four disciplines
+- **48 studies (38%)** fully reproduced within tolerance
+- **41 studies (32%)** partially reproduced with discrepancies
+- **38 studies (30%)** could not be reproduced at all
+
+Among the 79 studies that could not be fully reproduced, the IRC identified the following primary barriers:
+
+<!-- Barrier breakdown SVG -->
+<figure>
+<svg viewBox="0 0 700 200" xmlns="http://www.w3.org/2000/svg" aria-label="Bar chart showing barriers to reproducibility" style="width:100%;max-width:700px;display:block;margin:1rem auto;">
+  <!-- Axes -->
+  <line x1="180" y1="20" x2="180" y2="180" stroke="#1a1612" stroke-width="1"/>
+  <line x1="180" y1="180" x2="680" y2="180" stroke="#1a1612" stroke-width="1"/>
+  <!-- Bars -->
+  <rect x="182" y="28" width="305" height="22" fill="#8b1a1a" opacity="0.85"/>
+  <rect x="182" y="62" width="270" height="22" fill="#8b1a1a" opacity="0.7"/>
+  <rect x="182" y="96" width="240" height="22" fill="#8b1a1a" opacity="0.6"/>
+  <rect x="182" y="130" width="195" height="22" fill="#8b1a1a" opacity="0.5"/>
+  <rect x="182" y="164" width="110" height="22" fill="#8b1a1a" opacity="0.4"/>
+  <!-- Labels -->
+  <text x="175" y="44" text-anchor="end" font-family="'Cormorant','EB Garamond',serif" font-size="11" fill="#1a1612">Incomplete methods</text>
+  <text x="175" y="78" text-anchor="end" font-family="'Cormorant','EB Garamond',serif" font-size="11" fill="#1a1612">Unavailable code</text>
+  <text x="175" y="112" text-anchor="end" font-family="'Cormorant','EB Garamond',serif" font-size="11" fill="#1a1612">Missing raw data</text>
+  <text x="175" y="146" text-anchor="end" font-family="'Cormorant','EB Garamond',serif" font-size="11" fill="#1a1612">Undocumented deps</text>
+  <text x="175" y="180" text-anchor="end" font-family="'Cormorant','EB Garamond',serif" font-size="11" fill="#1a1612">Hardware-specific</text>
+  <!-- Values -->
+  <text x="492" y="44" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#faf8f2">61%</text>
+  <text x="457" y="78" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#faf8f2">54%</text>
+  <text x="427" y="112" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#faf8f2">48%</text>
+  <text x="382" y="146" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#faf8f2">39%</text>
+  <text x="297" y="180" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#faf8f2">22%</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6258;font-style:italic;">Fig. 1. Primary barriers to reproduction identified across 79 irreproducible studies (IRC, 2025). Categories are not mutually exclusive.</figcaption>
+</figure>
+
+## Disciplinary Variation
+
+The crisis does not affect all fields equally. Climate modelling and computational fluid dynamics, where long-standing community standards require model intercomparison, showed the highest reproducibility rates (52% and 49% respectively). Computational biology and machine learning, where rapid publication cycles and complex software stacks are the norm, fared worst (28% and 31% respectively).
+
+This variation suggests that reproducibility is not simply a matter of individual diligence but of community infrastructure. Fields that have invested in shared benchmarks, standard datasets, and interoperability frameworks produce more reproducible work -- not because their researchers are more careful, but because the systems in which they operate make reproducibility the path of least resistance.

--- a/editorial-letter/content/sections/2-editorial-responsibility.md
+++ b/editorial-letter/content/sections/2-editorial-responsibility.md
@@ -1,0 +1,57 @@
++++
+title = "II. Our Responsibility as Gatekeepers"
+description = "The role of journals and editors in enabling -- and now confronting -- the reproducibility crisis."
+weight = 2
+template = "post"
+tags = ["editorial", "peer-review", "governance"]
+categories = ["sections"]
+[extra]
+section_number = "II"
++++
+
+## The Journal's Complicity
+
+It would be dishonest to frame the reproducibility crisis as a problem created solely by authors. Journals have been complicit. For decades, we have accepted manuscripts with vague methodological descriptions, treated code as an optional afterthought, and placed no meaningful requirements on data availability. We have prioritised novelty over rigour and speed over completeness.
+
+This journal is no exception. A review of our own publication records from the past five years reveals that only 23 percent of research articles deposited code in a public repository, and fewer than 15 percent provided raw data. We published the remaining 77 percent without objection.
+
+## Why Peer Review Alone Is Insufficient
+
+Traditional peer review was designed to evaluate the intellectual merit of a contribution, not to verify its computational correctness. Reviewers are asked to assess whether the methodology is sound, whether the conclusions follow from the evidence, and whether the work advances the field. They are not asked -- and are rarely equipped -- to download code, install dependencies, and re-run analyses.
+
+<!-- Peer review gap diagram -->
+<figure>
+<svg viewBox="0 0 700 140" xmlns="http://www.w3.org/2000/svg" aria-label="Diagram showing the peer review verification gap" style="width:100%;max-width:700px;display:block;margin:1.5rem auto;">
+  <!-- What reviewers assess -->
+  <rect x="20" y="10" width="200" height="120" rx="4" fill="none" stroke="#1a1612" stroke-width="1.5"/>
+  <text x="120" y="32" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#1a1612">WHAT REVIEWERS ASSESS</text>
+  <line x1="40" y1="40" x2="200" y2="40" stroke="#c8c0b0" stroke-width="0.5"/>
+  <text x="40" y="58" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Scientific novelty</text>
+  <text x="40" y="74" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Methodological logic</text>
+  <text x="40" y="90" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Statistical analysis</text>
+  <text x="40" y="106" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Writing quality</text>
+  <text x="40" y="122" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Literature engagement</text>
+  <!-- Gap arrow -->
+  <line x1="240" y1="70" x2="330" y2="70" stroke="#8b1a1a" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <polygon points="330,65 340,70 330,75" fill="#8b1a1a"/>
+  <text x="290" y="60" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="9" fill="#8b1a1a" letter-spacing="1">GAP</text>
+  <!-- What reproducibility requires -->
+  <rect x="350" y="10" width="230" height="120" rx="4" fill="none" stroke="#8b1a1a" stroke-width="1.5"/>
+  <text x="465" y="32" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="11" font-weight="700" fill="#8b1a1a">WHAT REPRODUCTION NEEDS</text>
+  <line x1="370" y1="40" x2="560" y2="40" stroke="#c8c0b0" stroke-width="0.5"/>
+  <text x="370" y="58" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Executable source code</text>
+  <text x="370" y="74" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Raw and processed data</text>
+  <text x="370" y="90" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Environment specification</text>
+  <text x="370" y="106" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Dependency documentation</text>
+  <text x="370" y="122" font-family="'Cormorant',serif" font-size="11" fill="#3a3428">Automated test suites</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6258;font-style:italic;">Fig. 2. The verification gap between traditional peer review and computational reproducibility requirements.</figcaption>
+</figure>
+
+## The Cost of Inaction
+
+The cost of a non-reproducible literature is not merely academic. Computational models inform drug design, climate policy, infrastructure engineering, and financial regulation. When these models cannot be independently verified, the decisions they inform rest on unexamined foundations.
+
+A 2025 report by the U.S. National Academies estimated that irreproducible computational research costs the global research enterprise between $12 billion and $28 billion annually in wasted effort -- studies that build on unreliable foundations, failed replication attempts, and redundant work undertaken because existing results could not be verified.
+
+For a journal that aspires to influence the practice of computational science, continuing to publish unverifiable claims is not neutrality; it is negligence.

--- a/editorial-letter/content/sections/3-new-standards.md
+++ b/editorial-letter/content/sections/3-new-standards.md
@@ -1,0 +1,95 @@
++++
+title = "III. The New Standards"
+description = "Detailed description of the reproducibility requirements that will take effect with Volume 60."
+weight = 3
+template = "post"
+tags = ["editorial", "policy", "standards"]
+categories = ["sections"]
+[extra]
+section_number = "III"
++++
+
+## Five Pillars of Reproducibility
+
+The new requirements are organised around five pillars, each addressing a distinct component of the computational research workflow. Together, they establish a minimum standard for what we believe a trustworthy computational paper should provide.
+
+<!-- Five pillars diagram -->
+<figure>
+<svg viewBox="0 0 700 180" xmlns="http://www.w3.org/2000/svg" aria-label="Five pillars of reproducibility" style="width:100%;max-width:700px;display:block;margin:1.5rem auto;">
+  <!-- Base line -->
+  <line x1="30" y1="160" x2="670" y2="160" stroke="#1a1612" stroke-width="2"/>
+  <text x="350" y="178" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" fill="#6a6258" letter-spacing="2">REPRODUCIBILITY FOUNDATION</text>
+  <!-- Pillar 1 -->
+  <rect x="42" y="40" width="108" height="120" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <line x1="42" y1="65" x2="150" y2="65" stroke="#1a1612" stroke-width="0.5"/>
+  <text x="96" y="56" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" font-weight="700" fill="#8b1a1a">CODE</text>
+  <text x="96" y="82" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Public repo</text>
+  <text x="96" y="96" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">DOI assigned</text>
+  <text x="96" y="110" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Test suite</text>
+  <text x="96" y="124" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">README</text>
+  <text x="96" y="138" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Licence</text>
+  <!-- Pillar 2 -->
+  <rect x="168" y="40" width="108" height="120" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <line x1="168" y1="65" x2="276" y2="65" stroke="#1a1612" stroke-width="0.5"/>
+  <text x="222" y="56" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" font-weight="700" fill="#8b1a1a">DATA</text>
+  <text x="222" y="82" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Certified archive</text>
+  <text x="222" y="96" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Provenance log</text>
+  <text x="222" y="110" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Format docs</text>
+  <text x="222" y="124" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Access policy</text>
+  <text x="222" y="138" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Checksums</text>
+  <!-- Pillar 3 -->
+  <rect x="294" y="40" width="108" height="120" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <line x1="294" y1="65" x2="402" y2="65" stroke="#1a1612" stroke-width="0.5"/>
+  <text x="348" y="56" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" font-weight="700" fill="#8b1a1a">ENVIRONMENT</text>
+  <text x="348" y="82" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Container image</text>
+  <text x="348" y="96" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Lockfile</text>
+  <text x="348" y="110" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">OS + compiler</text>
+  <text x="348" y="124" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Hardware spec</text>
+  <text x="348" y="138" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Build script</text>
+  <!-- Pillar 4 -->
+  <rect x="420" y="40" width="108" height="120" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <line x1="420" y1="65" x2="528" y2="65" stroke="#1a1612" stroke-width="0.5"/>
+  <text x="474" y="56" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" font-weight="700" fill="#8b1a1a">CHECKLIST</text>
+  <text x="474" y="82" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">22 items</text>
+  <text x="474" y="96" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">5 categories</text>
+  <text x="474" y="110" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Self-assessed</text>
+  <text x="474" y="124" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Editor-verified</text>
+  <text x="474" y="138" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Published</text>
+  <!-- Pillar 5 -->
+  <rect x="546" y="40" width="108" height="120" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <line x1="546" y1="65" x2="654" y2="65" stroke="#1a1612" stroke-width="0.5"/>
+  <text x="600" y="56" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" font-weight="700" fill="#8b1a1a">METHODS</text>
+  <text x="600" y="82" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Step-by-step</text>
+  <text x="600" y="96" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Parameters</text>
+  <text x="600" y="110" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Tolerances</text>
+  <text x="600" y="124" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Expected output</text>
+  <text x="600" y="138" text-anchor="middle" font-family="'Cormorant',serif" font-size="9" fill="#3a3428">Runtime est.</text>
+  <!-- Top cap -->
+  <line x1="30" y1="35" x2="670" y2="35" stroke="#1a1612" stroke-width="1"/>
+  <text x="350" y="28" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="10" fill="#1a1612" letter-spacing="2">THE FIVE PILLARS</text>
+  <line x1="30" y1="18" x2="670" y2="18" stroke="#1a1612" stroke-width="0.5"/>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6258;font-style:italic;">Fig. 3. The five pillars of the journal's new reproducibility framework.</figcaption>
+</figure>
+
+## Pillar 1: Code Deposit
+
+All source code must be deposited prior to acceptance. We do not accept GitHub links alone, as repositories can be modified or deleted after publication. A DOI-bearing snapshot in Zenodo, Figshare, or an equivalent service is required.
+
+Code quality is not assessed -- we are not asking for production-grade software. We are asking for code that runs, is documented, and can be examined by others.
+
+## Pillar 2: Data Archive
+
+Raw data must be deposited in a domain-certified repository. For fields with established archives (GenBank, CMIP, Materials Cloud), we expect authors to use those resources. For others, Zenodo or institutional repositories with long-term preservation commitments are acceptable.
+
+## Pillar 3: Environment Specification
+
+The most common silent failure mode in computational reproduction is environmental: the same code produces different results on different systems due to library version changes, compiler differences, or floating-point behaviour. Container images eliminate this problem entirely and are our preferred approach.
+
+## Pillar 4: Reproducibility Checklist
+
+The 22-item checklist serves two purposes. First, it forces authors to explicitly confirm that each component of their computational workflow has been documented. Second, it provides reviewers and readers with a structured summary of what is available and how to access it.
+
+## Pillar 5: Methods Appendix
+
+The methods section of a paper describes the scientific approach. The methods appendix describes the computational execution in sufficient detail that a competent practitioner could reproduce the work without reference to the code. This includes parameter values, convergence criteria, random seeds, and expected wall-clock times.

--- a/editorial-letter/content/sections/4-support-structures.md
+++ b/editorial-letter/content/sections/4-support-structures.md
@@ -1,0 +1,73 @@
++++
+title = "IV. Support Structures"
+description = "Resources and infrastructure the journal is providing to help authors meet the new reproducibility requirements."
+weight = 4
+template = "post"
+tags = ["editorial", "infrastructure", "support"]
+categories = ["sections"]
+[extra]
+section_number = "IV"
++++
+
+## Recognising the Burden
+
+We are acutely aware that these requirements impose significant additional work on authors. Preparing code for public release is not the same as writing code for personal use. Documenting a computational environment requires technical skills that many researchers have not been trained in. Depositing data in certified archives involves navigating institutional policies, ethics approvals, and archival workflows.
+
+We do not believe it is sufficient to announce new requirements and then leave authors to navigate these challenges alone. The journal is committing resources to the following support structures.
+
+## Reproducibility Editors
+
+Beginning with Volume 60, we will appoint a dedicated panel of Reproducibility Editors (REs) distinct from the traditional editorial board. REs will be recruited from the research software engineering community and will bring expertise in containerisation, version control, data management, and automated testing.
+
+Each submission undergoing Track B review will be assigned to an RE who will:
+
+- Attempt to build and run the deposited code
+- Verify that at least two key results can be reproduced
+- Provide constructive feedback to authors on documentation quality
+- Certify the reproducibility status of the accepted paper
+
+REs will be compensated at a rate commensurate with the technical expertise and time required.
+
+## Template Repositories
+
+We are preparing template repositories for the five most common computational frameworks used by our authors:
+
+| Framework | Language | Template Contents |
+|---|---|---|
+| Numerical simulation | Python / NumPy | Dockerfile, Makefile, test harness, CI config |
+| Machine learning | Python / PyTorch | Environment lockfile, data loader template, training script template |
+| Finite element analysis | C++ / deal.II | CMake build system, container spec, validation suite |
+| Statistical analysis | R / tidyverse | renv lockfile, Makefile, knitr template |
+| Climate modelling | Fortran / MPI | Singularity container, batch script templates, model comparison tools |
+
+These templates will be published as open-source repositories under the journal's GitHub organisation, with detailed guides and worked examples.
+
+## Reproducibility Helpdesk
+
+A dedicated helpdesk, staffed by research software engineers, will be available to authors during the submission process. The helpdesk will provide:
+
+- Guidance on choosing appropriate repositories for code and data
+- Technical assistance with containerisation
+- Review of reproducibility checklists prior to submission
+- Advice on data anonymisation and controlled-access arrangements
+
+The helpdesk will operate during standard business hours (GMT) and will respond to queries within 48 hours.
+
+## Fee Waivers and Institutional Support
+
+We recognise that archival costs, container registry fees, and the time required to prepare reproducibility materials represent a financial burden that falls disproportionately on researchers in low-income institutions. The journal will offer:
+
+- Full fee waivers for archival costs incurred by authors from institutions classified as low-income by the World Bank
+- Partial fee waivers for authors from lower-middle-income institutions
+- Letters of support for researchers seeking reproducibility-related funding from their institutions or funders
+
+## Training Programme
+
+In partnership with the Software Sustainability Institute and The Carpentries, we will offer a series of online workshops covering:
+
+- Git and version control for researchers
+- Docker and Singularity for computational reproducibility
+- Data management plans and FAIR principles
+- Writing reproducibility documentation
+
+These workshops will be free for authors who have submitted or plan to submit to the journal.

--- a/editorial-letter/content/sections/5-call-to-action.md
+++ b/editorial-letter/content/sections/5-call-to-action.md
@@ -1,0 +1,83 @@
++++
+title = "V. A Call to the Community"
+description = "An appeal to funding agencies, institutions, and fellow editors to join the reproducibility reform effort."
+weight = 5
+template = "post"
+tags = ["editorial", "community", "reform"]
+categories = ["sections"]
+[extra]
+section_number = "V"
++++
+
+## Beyond This Journal
+
+The reforms described in this editorial will be meaningless if they remain confined to a single journal. Reproducibility is a systemic challenge that requires systemic responses. We therefore direct this call to three constituencies whose participation is essential.
+
+## To Funding Agencies
+
+The most powerful lever for changing research behaviour is funding. We urge national and international funding bodies to:
+
+- **Require reproducibility plans** as a component of grant applications, alongside data management plans
+- **Fund research software engineering positions** as core infrastructure, not as project-specific costs
+- **Recognise reproducibility contributions** in grant evaluation criteria -- researchers who make their work reproducible should be rewarded, not penalised for the time invested
+- **Support community infrastructure** such as public container registries, domain-specific data archives, and reproducibility verification services
+
+## To Institutional Leaders
+
+Universities and research institutes set the incentive structures within which researchers operate. We urge institutional leaders to:
+
+- **Value reproducibility in hiring and promotion** by explicitly including open science practices in evaluation criteria
+- **Invest in research software engineering** as a professional career path, with appropriate titles, salaries, and advancement opportunities
+- **Provide institutional data repositories** with long-term preservation commitments
+- **Offer training** in computational reproducibility as part of doctoral programmes
+
+## To Fellow Editors
+
+We are not the first journal to adopt reproducibility requirements, and we will not be the last. Journals across computational sciences are moving in this direction, but progress is uneven and standards vary. We urge our fellow editors to:
+
+- **Adopt minimum reproducibility standards** appropriate to their disciplines
+- **Collaborate on shared infrastructure** such as common checklist frameworks, reviewer training materials, and reproducibility badges
+- **Share experiences** through the newly established Editors' Forum on Reproducibility
+- **Resist the pressure** to prioritise speed over rigour in the review process
+
+<!-- Community network diagram SVG -->
+<figure>
+<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg" aria-label="Diagram of stakeholders in reproducibility reform" style="width:100%;max-width:600px;display:block;margin:1.5rem auto;">
+  <!-- Central node -->
+  <circle cx="300" cy="100" r="35" fill="none" stroke="#8b1a1a" stroke-width="2"/>
+  <text x="300" y="96" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="9" font-weight="700" fill="#8b1a1a">REPRODUCIBLE</text>
+  <text x="300" y="110" text-anchor="middle" font-family="'Bodoni Moda',serif" font-size="9" font-weight="700" fill="#8b1a1a">SCIENCE</text>
+  <!-- Funders -->
+  <line x1="265" y1="100" x2="120" y2="45" stroke="#c8c0b0" stroke-width="1"/>
+  <circle cx="100" cy="38" r="28" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <text x="100" y="35" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Funding</text>
+  <text x="100" y="47" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Agencies</text>
+  <!-- Institutions -->
+  <line x1="265" y1="100" x2="120" y2="155" stroke="#c8c0b0" stroke-width="1"/>
+  <circle cx="100" cy="162" r="28" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <text x="100" y="159" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Research</text>
+  <text x="100" y="171" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Institutions</text>
+  <!-- Journals -->
+  <line x1="335" y1="100" x2="480" y2="45" stroke="#c8c0b0" stroke-width="1"/>
+  <circle cx="500" cy="38" r="28" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <text x="500" y="35" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Journal</text>
+  <text x="500" y="47" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Editors</text>
+  <!-- Researchers -->
+  <line x1="335" y1="100" x2="480" y2="155" stroke="#c8c0b0" stroke-width="1"/>
+  <circle cx="500" cy="162" r="28" fill="none" stroke="#1a1612" stroke-width="1"/>
+  <text x="500" y="159" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Research</text>
+  <text x="500" y="171" text-anchor="middle" font-family="'Cormorant',serif" font-size="10" fill="#1a1612">Community</text>
+  <!-- Cross connections (dashed) -->
+  <line x1="128" y1="38" x2="472" y2="38" stroke="#c8c0b0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="128" y1="162" x2="472" y2="162" stroke="#c8c0b0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="100" y1="66" x2="100" y2="134" stroke="#c8c0b0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="500" y1="66" x2="500" y2="134" stroke="#c8c0b0" stroke-width="0.5" stroke-dasharray="4,3"/>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6258;font-style:italic;">Fig. 4. Stakeholder network required for systemic reproducibility reform. All actors must contribute; no single actor can solve this alone.</figcaption>
+</figure>
+
+## The Imperative
+
+We do not use the word "imperative" lightly. The reproducibility of computational science is not a nice-to-have, not a quality-of-life improvement, not a box to tick for compliance purposes. It is a foundational requirement for the credibility of the scientific enterprise. Without it, we are building on sand.
+
+This journal intends to build on rock. We invite the community to join us.

--- a/editorial-letter/content/sections/_index.md
+++ b/editorial-letter/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The editorial is structured into five sections, each addressing a distinct dimension of the reproducibility crisis and the journal's response.

--- a/editorial-letter/static/css/style.css
+++ b/editorial-letter/static/css/style.css
@@ -1,0 +1,449 @@
+/* ============================================================================
+   Editorial Letter - Journal Editorial Paper
+   Light background, Didone display headings, Garamond editorial prose.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #faf8f2;
+  --bg-2: #f2efe6;
+  --bg-3: #e8e4d8;
+  --rule: #c8c0b0;
+  --ink: #1a1612;
+  --ink-2: #3a3428;
+  --ink-3: #6a6258;
+  --ink-4: #9a9288;
+  --accent: #8b1a1a;
+  --accent-2: #6a1010;
+  --column-rule: #d0c8b8;
+  --drop-cap: #8b1a1a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Cormorant", "EB Garamond", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.78;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Masthead & Header ---------------- */
+
+.site-header {
+  padding: 1.5rem 0 0;
+}
+
+.masthead {
+  text-align: center;
+}
+
+.masthead-svg {
+  width: 100%;
+  max-width: 800px;
+  height: auto;
+}
+
+.site-nav {
+  display: flex;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--rule);
+  margin-top: 0.5rem;
+}
+
+.site-nav a {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--ink-2);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+}
+
+/* ---------------- Main Content Area ---------------- */
+
+.site-main {
+  padding: 2rem 0;
+}
+
+.paper-article {
+  max-width: 740px;
+  margin: 0 auto;
+}
+
+/* ---------------- Editorial Header (index) ---------------- */
+
+.paper-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-eyebrow {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 900;
+  font-size: 2.2rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.8rem;
+  letter-spacing: -0.01em;
+}
+
+.paper-subtitle {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.15rem;
+  font-style: italic;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.paper-author-line {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--ink-2);
+  margin: 0;
+}
+
+/* ---------------- Editorial Column Rules ---------------- */
+
+.editorial-columns {
+  column-count: 2;
+  column-gap: 2.5rem;
+  column-rule: 1px solid var(--column-rule);
+  margin: 2rem 0;
+}
+
+.editorial-columns p {
+  text-align: justify;
+  text-indent: 1.5em;
+  margin: 0 0 0.8em;
+}
+
+.editorial-columns p:first-child {
+  text-indent: 0;
+}
+
+/* ---------------- Drop Cap ---------------- */
+
+.drop-cap::first-letter {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 900;
+  font-size: 4.2em;
+  line-height: 0.8;
+  float: left;
+  margin: 0.05em 0.12em 0 0;
+  color: var(--drop-cap);
+}
+
+/* ---------------- Headings ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+h1 { font-size: 1.8rem; margin: 2rem 0 0.8rem; }
+h2 { font-size: 1.4rem; margin: 2rem 0 0.6rem; }
+h3 { font-size: 1.15rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 1rem; margin: 1.5rem 0 0.5rem; font-style: italic; }
+
+/* ---------------- Body Text ---------------- */
+
+p { margin: 1em 0; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.5em;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  font-style: italic;
+  color: var(--ink-2);
+}
+
+blockquote p { margin: 0.4em 0; }
+
+/* ---------------- Editorial Pull Quotes ---------------- */
+
+.pull-quote {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 1.5rem;
+  font-style: italic;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--accent);
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+}
+
+/* ---------------- Section Header (post.html) ---------------- */
+
+.paper-section-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-section-eyebrow {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.5rem;
+}
+
+.paper-section-title {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 900;
+  font-size: 1.8rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.5rem;
+}
+
+.paper-lede {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.paper-content p {
+  text-align: justify;
+}
+
+.paper-section-footer {
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  margin-bottom: 0;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+.section-list li a {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Editor Signature ---------------- */
+
+.editor-signature {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  text-align: right;
+}
+
+.editor-signature .sig-name {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 0.5rem 0 0;
+}
+
+.editor-signature .sig-title {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.92rem;
+}
+
+th, td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+th {
+  font-family: "Bodoni Moda", "Didot", serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  border-bottom: 2px solid var(--ink);
+}
+
+/* ---------------- Code ---------------- */
+
+code {
+  font-family: "IBM Plex Mono", Consolas, monospace;
+  font-size: 0.85em;
+  background: var(--bg-2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: var(--bg-2);
+  padding: 1rem;
+  overflow-x: auto;
+  border: 1px solid var(--bg-3);
+  border-radius: 2px;
+}
+
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy ---------------- */
+
+.taxonomy-desc {
+  font-style: italic;
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+
+/* ---------------- Pagination ---------------- */
+
+nav.pagination { margin: 1.5rem 0; }
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid var(--rule);
+  color: var(--ink-3);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------------- Shortcode Alert ---------------- */
+
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--accent);
+  background: var(--bg-2);
+  margin: 1rem 0;
+}
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem;
+  padding-bottom: 2rem;
+}
+
+.footer-rule {
+  margin-bottom: 1rem;
+}
+
+.footer-rule svg {
+  width: 100%;
+  height: 6px;
+  display: block;
+}
+
+.footer-content {
+  text-align: center;
+}
+
+.footer-meta {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  margin: 0 0 0.3rem;
+}
+
+.footer-note {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.6rem; }
+  .editorial-columns { column-count: 1; }
+  .masthead-svg { height: auto; }
+  .site-nav { gap: 1.5rem; flex-wrap: wrap; justify-content: center; }
+  .pull-quote { font-size: 1.2rem; padding: 1rem 1.2rem; }
+}

--- a/editorial-letter/templates/404.html
+++ b/editorial-letter/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this volume.</p>
+      <p><a href="{{ base_url }}/">Return to Editorial</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/editorial-letter/templates/footer.html
+++ b/editorial-letter/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#1a1612" stroke-width="0.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a1612" stroke-width="1.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Journal of Computational Sciences &middot; Vol. 59, No. 4 &middot; April 2026 &middot; pp. i-viii</p>
+        <p class="footer-note">ISSN 0021-9991 &middot; Copyright 2026 The Editorial Board. All rights reserved. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/editorial-letter/templates/header.html
+++ b/editorial-letter/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:ital,wght@0,400;0,700;0,900;1,400&family=Cormorant:ital,wght@0,400;0,600;0,700;1,400&family=EB+Garamond:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <div class="masthead" aria-label="Journal masthead">
+        <svg viewBox="0 0 800 120" xmlns="http://www.w3.org/2000/svg" class="masthead-svg" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
+          <!-- Top rule -->
+          <line x1="0" y1="2" x2="800" y2="2" stroke="#1a1612" stroke-width="2"/>
+          <line x1="0" y1="6" x2="800" y2="6" stroke="#1a1612" stroke-width="0.5"/>
+          <!-- Journal title -->
+          <text x="400" y="48" text-anchor="middle" font-family="'Bodoni Moda', 'Didot', serif" font-size="30" font-weight="900" fill="#1a1612" letter-spacing="6">JOURNAL OF COMPUTATIONAL SCIENCES</text>
+          <!-- Thin separator -->
+          <line x1="200" y1="58" x2="600" y2="58" stroke="#1a1612" stroke-width="0.5"/>
+          <!-- Publication details -->
+          <text x="400" y="76" text-anchor="middle" font-family="'Cormorant', 'EB Garamond', serif" font-size="12" fill="#5a5248" letter-spacing="3">ESTABLISHED 1967 &middot; VOLUME 59 &middot; NUMBER 4 &middot; APRIL 2026</text>
+          <!-- Editor line -->
+          <text x="400" y="96" text-anchor="middle" font-family="'Cormorant', 'EB Garamond', serif" font-size="11" fill="#7a7268" letter-spacing="2">EDITOR-IN-CHIEF: PROF. ELEANOR WHITFIELD, FRS</text>
+          <!-- Bottom rules -->
+          <line x1="0" y1="108" x2="800" y2="108" stroke="#1a1612" stroke-width="0.5"/>
+          <line x1="0" y1="112" x2="800" y2="112" stroke="#1a1612" stroke-width="2"/>
+        </svg>
+      </div>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">EDITORIAL</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/response/">RESPONSE</a>
+        <a href="{{ base_url }}/policy/">POLICY</a>
+      </nav>
+    </header>

--- a/editorial-letter/templates/page.html
+++ b/editorial-letter/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/editorial-letter/templates/post.html
+++ b/editorial-letter/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/editorial-letter/templates/section.html
+++ b/editorial-letter/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/editorial-letter/templates/shortcodes/alert.html
+++ b/editorial-letter/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/editorial-letter/templates/taxonomy.html
+++ b/editorial-letter/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/editorial-letter/templates/taxonomy_term.html
+++ b/editorial-letter/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4070,5 +4070,12 @@
     "qualitative",
     "thematic",
     "interpretive"
+  ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
   ]
 }


### PR DESCRIPTION
## Summary
- Journal editorial paper with traditional newspaper-style layout
- SVG masthead decorations with publication details, editorial column rules, and editor signature facsimile
- Bodoni Moda (Didone) for display headings, Cormorant/EB Garamond for editorial prose
- Five editorial sections addressing reproducibility crisis, letters in response, and editorial policy statement
- Tags: paper, light, editorial, authority, statement

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check masthead SVG renders at all viewport sizes
- [ ] Confirm editorial column rules display on desktop
- [ ] Verify editor signature SVG appears at letter conclusion
- [ ] Check tags.json entry is valid JSON