### PR TITLE
feat: add null-result example site (closes #1611)

### DIFF
--- a/null-result/AGENTS.md
+++ b/null-result/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/null-result/config.toml
+++ b/null-result/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Null Result - Negative Finding Paper with Full Transparency
+# Issue #1611 | Tags: paper, light, null, negative, honest
+# =============================================================================
+
+title = "No Effect of Omega-3 Supplementation on Cognitive Decline"
+description = "A negative finding paper reporting null results with flat-line effect size plots, equivalence testing TOST diagrams, power analysis curves, and honest transparent reporting of non-significant outcomes."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/null-result/content/appendix.md
+++ b/null-result/content/appendix.md
@@ -1,0 +1,55 @@
++++
+title = "Appendix"
+description = "Supplementary materials including sensitivity analyses, subgroup breakdowns, and protocol deviations."
+template = "page"
++++
+
+<div class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</div>
+
+<div class="paper-content">
+
+## A. Pre-Registration Details
+
+The trial protocol was registered on OSF Registries (10.17605/OSF.IO/X8K2P) on 12 January 2024, prior to enrollment of the first participant. The pre-registration specified:
+
+- Primary outcome: change in MoCA score at 24 months
+- Secondary outcomes: ADAS-Cog, TMT-B, Omega-3 Index
+- Sample size: N = 1,206 (603 per arm)
+- Equivalence margin: +/- 1.5 MoCA points
+- Analysis: mixed-effects model for repeated measures (MMRM)
+- Bayesian stopping rule: BF01 > 10 at interim analysis (12 months)
+
+No deviations from the pre-registered analysis plan occurred.
+
+## B. Sensitivity Analyses
+
+| Analysis | Difference (95% CI) | p-value | Consistent with ITT? |
+|----------|---------------------|---------|---------------------|
+| Per-protocol (compliance > 80%) | -0.08 (-0.62, 0.46) | 0.77 | Yes |
+| CACE (complier average) | -0.06 (-0.68, 0.56) | 0.85 | Yes |
+| Multiple imputation (m=50) | -0.03 (-0.54, 0.48) | 0.91 | Yes |
+| Bayesian MMRM (weakly informative prior) | -0.05 (95% CrI: -0.56, 0.46) | BF01 = 14.2 | Yes |
+
+All sensitivity analyses confirm the null finding. The Bayesian analysis yields a Bayes Factor of 14.2 in favor of the null hypothesis, constituting strong evidence for no effect.
+
+## C. Subgroup Analyses
+
+No pre-registered subgroup analyses reached significance after Bonferroni correction (alpha = 0.05/6 = 0.0083):
+
+| Subgroup | n | Difference (95% CI) | p-interaction |
+|----------|---|---------------------|---------------|
+| Age 65-72 | 682 | 0.12 (-0.58, 0.82) | 0.44 |
+| Age 73-80 | 524 | -0.22 (-0.98, 0.54) | 0.44 |
+| Female | 654 | 0.08 (-0.56, 0.72) | 0.62 |
+| Male | 552 | -0.18 (-0.92, 0.56) | 0.62 |
+| APOE e4 carrier | 312 | -0.34 (-1.32, 0.64) | 0.28 |
+| APOE e4 non-carrier | 894 | 0.06 (-0.52, 0.64) | 0.28 |
+
+## D. Protocol Deviations
+
+A total of 18 protocol deviations were recorded across all four sites (1.5% of participants). None were classified as major. The most common deviation was a missed visit window (n = 12), followed by temporary interruption of supplementation due to unrelated illness (n = 4) and incorrect dose dispensing corrected within 48 hours (n = 2).
+
+</div>

--- a/null-result/content/index.md
+++ b/null-result/content/index.md
@@ -1,0 +1,168 @@
++++
+title = "Abstract"
+description = "No Effect of Omega-3 Fatty Acid Supplementation on Age-Related Cognitive Decline: A 24-Month Randomized Controlled Trial with Equivalence Testing"
+tags = ["paper", "light", "null", "negative", "honest"]
+template = "page"
++++
+
+<div class="paper-header">
+  <p class="paper-eyebrow">Negative Result &middot; Registered Report</p>
+  <h1 class="paper-title">No Effect of Omega-3 Fatty Acid Supplementation on Age-Related Cognitive Decline: A 24-Month Randomized Controlled Trial</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Elsa Lindqvist</span><sup>1*</sup>,
+    Chukwuemeka Okafor<sup>2</sup>,
+    Mitsuki Hayashi<sup>3</sup>,
+    Anneliese De Vries<sup>4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup> Department of Neuroscience, Karolinska Institutet, Stockholm, Sweden;
+    <sup>2</sup> Centre for Ageing Research, University of Ibadan, Nigeria;
+    <sup>3</sup> Graduate School of Medicine, Kyoto University, Japan;
+    <sup>4</sup> Department of Psychology, University of Amsterdam, Netherlands
+  </p>
+  <p class="paper-doi">
+    doi: <a href="#">10.41093/jcn.2026.34.04.312</a> &middot;
+    Pre-registered: <a href="#">OSF Registries 10.17605/OSF.IO/X8K2P</a>
+  </p>
+  <div class="null-badge-row">
+    <span class="null-badge">NULL RESULT</span>
+    <span class="null-badge preregistered">PRE-REGISTERED</span>
+  </div>
+</div>
+
+<div class="dates-box">
+  <div class="dates-row">
+    <div class="date-item">
+      <span class="date-label">Protocol registered</span>
+      <span class="date-value">12 Jan 2024</span>
+    </div>
+    <div class="date-item">
+      <span class="date-label">Trial completed</span>
+      <span class="date-value">08 Feb 2026</span>
+    </div>
+    <div class="date-item">
+      <span class="date-label">Published</span>
+      <span class="date-value">15 Apr 2026</span>
+    </div>
+  </div>
+</div>
+
+<div class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Omega-3 polyunsaturated fatty acids (n-3 PUFAs) have been hypothesized to protect against age-related cognitive decline through anti-inflammatory and neuroprotective mechanisms. However, prior evidence from observational studies and small trials has been inconsistent, and adequately powered confirmatory trials with pre-registered analysis plans are lacking.</dd>
+    <dt>Objectives</dt>
+    <dd>To determine whether daily high-dose omega-3 supplementation (2.4 g EPA + DHA) slows cognitive decline in community-dwelling older adults aged 65-80, compared with placebo, over a 24-month period.</dd>
+    <dt>Methods</dt>
+    <dd>Multi-center, double-blind, placebo-controlled randomized trial across four sites (Stockholm, Ibadan, Kyoto, Amsterdam). N = 1,206 participants randomized 1:1. Primary outcome: change in Montreal Cognitive Assessment (MoCA) score at 24 months. Secondary outcomes: ADAS-Cog, Trail Making Test B, and erythrocyte membrane EPA + DHA (Omega-3 Index). Pre-registered equivalence margins and Bayesian stopping rules.</dd>
+    <dt>Results</dt>
+    <dd>At 24 months, the mean MoCA change was -1.42 (95% CI: -1.78 to -1.06) in the omega-3 group vs. -1.38 (95% CI: -1.74 to -1.02) in placebo. The between-group difference was -0.04 points (95% CI: -0.55 to 0.47; p = 0.88). TOST equivalence testing confirmed the effect lies within the pre-registered equivalence margin of +/- 1.5 MoCA points (p_TOST = 0.002). All secondary endpoints were similarly non-significant. Post-hoc power exceeded 0.92 for all primary analyses.</dd>
+    <dt>Conclusions</dt>
+    <dd>High-dose omega-3 supplementation for 24 months had no detectable effect on cognitive decline in older adults. Equivalence testing confirms the treatment effect, if any, is smaller than the minimally clinically important difference. These null results contribute to the evidence base by ruling out effects of meaningful magnitude and illustrating the value of transparent reporting of negative findings.</dd>
+    <dt>Keywords</dt>
+    <dd>omega-3, cognitive decline, null result, equivalence testing, TOST, negative finding, randomized controlled trial, pre-registration, MoCA</dd>
+  </dl>
+</div>
+
+## Effect Size Plot: Primary Outcome
+
+<div class="figure">
+  <svg viewBox="0 0 700 320" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="Cormorant" font-size="14" font-weight="500" fill="#1a2030">Between-Group Difference in MoCA Change Score (24 Months)</text>
+    <line x1="80" y1="50" x2="80" y2="240" stroke="#ccc8ba" stroke-width="1"/>
+    <line x1="80" y1="240" x2="650" y2="240" stroke="#ccc8ba" stroke-width="1"/>
+    <text x="75" y="75" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#5b6272">Primary (MoCA)</text>
+    <text x="75" y="115" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#5b6272">ADAS-Cog</text>
+    <text x="75" y="155" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#5b6272">TMT-B (sec)</text>
+    <text x="75" y="195" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#5b6272">Omega-3 Index</text>
+    <line x1="365" y1="50" x2="365" y2="240" stroke="#1a2030" stroke-width="1.5" stroke-dasharray="6 3"/>
+    <text x="365" y="262" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a2030">0</text>
+    <text x="175" y="262" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#8a8e9a">-1.0</text>
+    <text x="555" y="262" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#8a8e9a">1.0</text>
+    <text x="80" y="262" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#8a8e9a">-1.5</text>
+    <text x="650" y="262" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#8a8e9a">1.5</text>
+    <text x="365" y="280" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272">Standardized Mean Difference (SMD)</text>
+    <rect x="80" y="55" width="570" height="180" fill="none" stroke="none"/>
+    <rect x="80" y="55" width="570" height="180" fill="#f0efe8" opacity="0.3"/>
+    <line x1="340" y1="75" x2="390" y2="75" stroke="#8a8e9a" stroke-width="2"/>
+    <circle cx="362" cy="75" r="4" fill="#8a8e9a" stroke="#1a2030" stroke-width="1"/>
+    <line x1="345" y1="115" x2="405" y2="115" stroke="#8a8e9a" stroke-width="2"/>
+    <circle cx="372" cy="115" r="4" fill="#8a8e9a" stroke="#1a2030" stroke-width="1"/>
+    <line x1="330" y1="155" x2="400" y2="155" stroke="#8a8e9a" stroke-width="2"/>
+    <circle cx="358" cy="155" r="4" fill="#8a8e9a" stroke="#1a2030" stroke-width="1"/>
+    <line x1="450" y1="195" x2="560" y2="195" stroke="#2a7a4a" stroke-width="2"/>
+    <circle cx="505" cy="195" r="4" fill="#2a7a4a" stroke="#1a2030" stroke-width="1"/>
+    <text x="395" y="79" font-family="JetBrains Mono" font-size="9" fill="#5b6272">-0.02 [-0.13, 0.09]</text>
+    <text x="410" y="119" font-family="JetBrains Mono" font-size="9" fill="#5b6272">0.04 [-0.08, 0.16]</text>
+    <text x="405" y="159" font-family="JetBrains Mono" font-size="9" fill="#5b6272">-0.04 [-0.18, 0.10]</text>
+    <text x="565" y="199" font-family="JetBrains Mono" font-size="9" fill="#2a7a4a">0.74 [0.61, 0.87]</text>
+    <text x="365" y="304" text-anchor="middle" font-family="Crimson Pro" font-size="11" font-style="italic" fill="#8a8e9a">Favours placebo &larr; | &rarr; Favours omega-3</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 1.</span> Forest plot of between-group standardized mean differences for primary and secondary cognitive outcomes at 24 months. All cognitive endpoints cluster tightly around the null line (SMD = 0), with narrow confidence intervals excluding clinically meaningful effects. The Omega-3 Index (biomarker) confirms supplementation compliance.</p>
+</div>
+
+## Key Findings
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Primary and secondary outcomes at 24 months (intention-to-treat analysis, N = 1,206)</caption>
+  <thead>
+    <tr>
+      <th>Outcome</th>
+      <th>Omega-3 (n=603)</th>
+      <th>Placebo (n=603)</th>
+      <th>Difference (95% CI)</th>
+      <th>p-value</th>
+      <th>Verdict</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MoCA change</td>
+      <td class="num">-1.42</td>
+      <td class="num">-1.38</td>
+      <td class="num">-0.04 (-0.55, 0.47)</td>
+      <td class="num">0.88</td>
+      <td class="null-cell">NULL</td>
+    </tr>
+    <tr>
+      <td>ADAS-Cog change</td>
+      <td class="num">+1.86</td>
+      <td class="num">+1.72</td>
+      <td class="num">0.14 (-0.52, 0.80)</td>
+      <td class="num">0.68</td>
+      <td class="null-cell">NULL</td>
+    </tr>
+    <tr>
+      <td>TMT-B change (sec)</td>
+      <td class="num">+4.2</td>
+      <td class="num">+5.0</td>
+      <td class="num">-0.8 (-3.6, 2.0)</td>
+      <td class="num">0.57</td>
+      <td class="null-cell">NULL</td>
+    </tr>
+    <tr>
+      <td>Omega-3 Index (%)</td>
+      <td class="num">11.8</td>
+      <td class="num">5.2</td>
+      <td class="num">6.6 (5.9, 7.3)</td>
+      <td class="num">&lt;0.001</td>
+      <td class="positive-cell">CONFIRMED</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">MoCA = Montreal Cognitive Assessment; ADAS-Cog = Alzheimer's Disease Assessment Scale -- Cognitive; TMT-B = Trail Making Test Part B. Omega-3 Index serves as a compliance biomarker, not a cognitive endpoint.</td>
+    </tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+This paper is organized into five sections detailing the methods, results, equivalence testing, power analysis, and implications of these null findings:
+
+1. **Methods** -- Trial design, randomization, blinding, and pre-registered analysis plan
+2. **Primary Results** -- Effect size estimates and null significance tests across all endpoints
+3. **Equivalence Testing** -- Two One-Sided Tests (TOST) confirming practical equivalence
+4. **Power Analysis** -- Post-hoc and sensitivity power curves demonstrating adequate sample size
+5. **Discussion** -- Interpretation of null findings in context and publication bias implications

--- a/null-result/content/power.md
+++ b/null-result/content/power.md
@@ -1,0 +1,72 @@
++++
+title = "Statistical Power"
+description = "Pre-registered power analysis and post-hoc power calculations confirming adequate sample size for detecting clinically meaningful effects."
+template = "page"
++++
+
+<div class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY ANALYSIS</p>
+  <h1 class="paper-section-title">Statistical Power</h1>
+</div>
+
+<div class="paper-content">
+
+## Pre-Registered Power Calculation
+
+The sample size of N = 1,206 was determined a priori to detect a minimally clinically important difference (MCID) of 1.5 MoCA points with 90% power at alpha = 0.05 (two-sided), assuming a pooled standard deviation of 4.2 points and 15% attrition. The calculation was pre-registered on OSF prior to enrollment.
+
+<div class="figure">
+  <svg viewBox="0 0 700 380" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="Cormorant" font-size="14" font-weight="500" fill="#1a2030">Power Curve: Detectable Effect Size by Sample Size</text>
+    <line x1="80" y1="40" x2="80" y2="310" stroke="#ccc8ba" stroke-width="1"/>
+    <line x1="80" y1="310" x2="660" y2="310" stroke="#ccc8ba" stroke-width="1"/>
+    <text x="35" y="180" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272" transform="rotate(-90,35,180)">Statistical Power</text>
+    <text x="370" y="345" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272">Effect Size (MoCA points)</text>
+    <text x="75" y="60" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">1.00</text>
+    <text x="75" y="114" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.80</text>
+    <text x="75" y="168" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.60</text>
+    <text x="75" y="222" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.40</text>
+    <text x="75" y="276" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.20</text>
+    <line x1="80" y1="60" x2="660" y2="60" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <line x1="80" y1="114" x2="660" y2="114" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <line x1="80" y1="168" x2="660" y2="168" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <text x="176" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.5</text>
+    <text x="273" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">1.0</text>
+    <text x="370" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">1.5</text>
+    <text x="466" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">2.0</text>
+    <text x="563" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">2.5</text>
+    <text x="660" y="325" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">3.0</text>
+    <line x1="80" y1="114" x2="660" y2="114" stroke="#5a7a8a" stroke-width="1" stroke-dasharray="4 2" opacity="0.6"/>
+    <text x="665" y="118" font-family="JetBrains Mono" font-size="8" fill="#5a7a8a">80%</text>
+    <polyline points="80,305 118,302 157,296 196,285 234,268 273,240 312,200 350,155 389,110 427,78 466,60 505,52 543,48 582,46 620,45 660,44" fill="none" stroke="#5a7a8a" stroke-width="2"/>
+    <polyline points="80,298 118,294 157,284 196,267 234,242 273,205 312,160 350,112 389,76 427,56 466,46 505,42 543,40 582,40 620,40 660,40" fill="none" stroke="#1a2030" stroke-width="2.5"/>
+    <line x1="370" y1="310" x2="370" y2="40" stroke="#c44a3a" stroke-width="1" stroke-dasharray="4 2" opacity="0.6"/>
+    <text x="375" y="300" font-family="JetBrains Mono" font-size="8" fill="#c44a3a">MCID</text>
+    <circle cx="370" cy="112" r="5" fill="#1a2030" stroke="white" stroke-width="1.5"/>
+    <text x="380" y="108" font-family="JetBrains Mono" font-size="9" fill="#1a2030">N=1,206 (0.92)</text>
+    <circle cx="370" cy="155" r="4" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <text x="380" y="152" font-family="JetBrains Mono" font-size="9" fill="#5a7a8a">N=800 (0.80)</text>
+    <rect x="450" y="55" width="12" height="2" fill="#1a2030"/>
+    <text x="467" y="59" font-family="Crimson Pro" font-size="10" fill="#5b6272">Actual (N=1,206)</text>
+    <rect x="450" y="70" width="12" height="2" fill="#5a7a8a"/>
+    <text x="467" y="74" font-family="Crimson Pro" font-size="10" fill="#5b6272">Minimum (N=800)</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure S1.</span> Statistical power as a function of true effect size for two sample sizes. At the pre-registered MCID of 1.5 MoCA points, the actual sample (N = 1,206) achieved 0.92 power, exceeding the target of 0.80. The study was adequately powered to detect clinically meaningful effects had they existed.</p>
+</div>
+
+## Post-Hoc Power Assessment
+
+| Parameter | Pre-registered | Observed |
+|-----------|---------------|----------|
+| Target effect (MCID) | 1.5 MoCA points | -- |
+| Observed effect | -- | -0.04 MoCA points |
+| Pooled SD | 4.2 (assumed) | 3.9 (observed) |
+| Alpha | 0.05 (two-sided) | 0.05 |
+| Target power | 0.90 | -- |
+| Achieved power at MCID | 0.90 | 0.92 |
+| Attrition assumed | 15% | 11.2% (actual) |
+| Final analyzable N | 1,024 (expected) | 1,071 (actual) |
+
+The observed pooled standard deviation (3.9) was smaller than assumed (4.2), and attrition (11.2%) was lower than planned (15%), resulting in slightly higher realized power (0.92) than targeted (0.90).
+
+</div>

--- a/null-result/content/sections/1-methods.md
+++ b/null-result/content/sections/1-methods.md
@@ -1,0 +1,44 @@
++++
+title = "1. Methods"
+weight = 1
+template = "post"
+description = "Multi-center trial design, randomization, blinding, and pre-registered statistical analysis plan."
+[extra]
+section_number = "1"
++++
+
+## Trial Design
+
+This was a multi-center, double-blind, placebo-controlled, parallel-group randomized trial conducted at four academic medical centers: Karolinska University Hospital (Stockholm), University College Hospital Ibadan, Kyoto University Hospital, and Amsterdam University Medical Centre. The trial was registered prospectively on OSF Registries and received ethics approval from each site's institutional review board.
+
+## Participants
+
+Community-dwelling adults aged 65-80 years were recruited between March 2024 and September 2024. Inclusion criteria: (1) age 65-80, (2) MoCA baseline score of 22-28 (normal to mild impairment), (3) ability to attend follow-up visits. Exclusion criteria: (1) diagnosed dementia or MoCA < 22, (2) current fish oil supplementation, (3) fish allergy, (4) anticoagulant therapy, (5) major psychiatric disorder.
+
+## Randomization and Blinding
+
+Participants were randomized 1:1 to omega-3 or placebo using computer-generated block randomization (block size 4-8), stratified by site and baseline MoCA category (22-25 vs. 26-28). Allocation was concealed using sequentially numbered opaque sealed envelopes prepared by an independent statistician. Both participants and all study personnel were blinded to allocation throughout the trial.
+
+## Intervention
+
+The omega-3 group received 2.4 g/day of combined EPA and DHA (1.6 g EPA + 0.8 g DHA) as soft gel capsules. The placebo group received identical capsules containing olive oil. Capsules were dispensed every 3 months at clinic visits.
+
+## Outcomes
+
+**Primary outcome:** Change from baseline in MoCA score at 24 months.
+
+**Secondary outcomes:**
+- ADAS-Cog change at 24 months
+- Trail Making Test Part B (TMT-B) change at 24 months
+- Erythrocyte membrane Omega-3 Index at 12 and 24 months
+
+## Statistical Analysis
+
+The pre-registered analysis plan specified:
+
+1. **Primary analysis:** Mixed-effects model for repeated measures (MMRM) with treatment, visit, treatment-by-visit interaction, site, baseline MoCA, age, and sex as covariates. Unstructured covariance matrix.
+2. **Equivalence testing:** Two One-Sided Tests (TOST) with pre-registered equivalence margins of +/- 1.5 MoCA points (the established MCID).
+3. **Bayesian analysis:** Bayesian MMRM with weakly informative priors. Pre-registered stopping rule at interim (12 months) if BF01 > 10.
+4. **Multiplicity:** Secondary outcomes reported with 95% CIs without p-value adjustment, following the pre-registered hierarchy.
+
+All analyses followed the intention-to-treat principle using all randomized participants with at least one post-baseline assessment.

--- a/null-result/content/sections/2-results.md
+++ b/null-result/content/sections/2-results.md
@@ -1,0 +1,70 @@
++++
+title = "2. Primary Results"
+weight = 2
+template = "post"
+description = "Effect size estimates showing null findings across all cognitive endpoints."
+[extra]
+section_number = "2"
++++
+
+## Participant Flow
+
+Of 2,418 individuals screened, 1,206 were randomized (603 omega-3, 603 placebo). At 24 months, 537 (89.1%) in the omega-3 group and 534 (88.6%) in the placebo group completed the primary endpoint assessment. Attrition did not differ between groups (p = 0.82) and was lower than the 15% assumed in power calculations.
+
+## Baseline Characteristics
+
+Groups were well balanced at baseline. Mean age was 72.4 (SD 4.1) years; 54.2% were female. Mean baseline MoCA was 25.8 (SD 1.9). The proportion of APOE e4 carriers was 25.9% (omega-3) vs. 25.7% (placebo).
+
+## Primary Outcome
+
+<div class="figure">
+  <svg viewBox="0 0 700 300" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="Cormorant" font-size="14" font-weight="500" fill="#1a2030">MoCA Score Trajectories Over 24 Months</text>
+    <line x1="100" y1="40" x2="100" y2="240" stroke="#ccc8ba" stroke-width="1"/>
+    <line x1="100" y1="240" x2="640" y2="240" stroke="#ccc8ba" stroke-width="1"/>
+    <text x="45" y="150" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272" transform="rotate(-90,45,150)">MoCA Score</text>
+    <text x="370" y="275" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272">Months</text>
+    <text x="95" y="60" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">27</text>
+    <text x="95" y="100" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">26</text>
+    <text x="95" y="140" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">25</text>
+    <text x="95" y="180" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">24</text>
+    <text x="95" y="220" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">23</text>
+    <text x="100" y="255" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0</text>
+    <text x="280" y="255" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">6</text>
+    <text x="460" y="255" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">12</text>
+    <text x="640" y="255" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">24</text>
+    <line x1="100" y1="100" x2="640" y2="100" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <line x1="100" y1="140" x2="640" y2="140" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <line x1="100" y1="180" x2="640" y2="180" stroke="#ccc8ba" stroke-width="0.5" stroke-dasharray="2 4"/>
+    <polyline points="100,92 280,108 460,126 640,148" fill="none" stroke="#5a7a8a" stroke-width="2.5"/>
+    <circle cx="100" cy="92" r="4" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <circle cx="280" cy="108" r="4" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <circle cx="460" cy="126" r="4" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <circle cx="640" cy="148" r="4" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <polyline points="100,94 280,110 460,128 640,150" fill="none" stroke="#8a8e9a" stroke-width="2.5" stroke-dasharray="6 3"/>
+    <circle cx="100" cy="94" r="4" fill="#8a8e9a" stroke="white" stroke-width="1.5"/>
+    <circle cx="280" cy="110" r="4" fill="#8a8e9a" stroke="white" stroke-width="1.5"/>
+    <circle cx="460" cy="128" r="4" fill="#8a8e9a" stroke="white" stroke-width="1.5"/>
+    <circle cx="640" cy="150" r="4" fill="#8a8e9a" stroke="white" stroke-width="1.5"/>
+    <rect x="440" y="46" width="12" height="2" fill="#5a7a8a"/>
+    <text x="457" y="50" font-family="Crimson Pro" font-size="10" fill="#5b6272">Omega-3 (n=603)</text>
+    <rect x="440" y="60" width="12" height="2" fill="#8a8e9a"/>
+    <text x="457" y="64" font-family="Crimson Pro" font-size="10" fill="#5b6272">Placebo (n=603)</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 2.</span> Mean MoCA score trajectories over 24 months. Both groups show nearly identical rates of cognitive decline, with overlapping trajectories at every assessment point. The parallel decline reflects normal age-related change with no treatment effect.</p>
+</div>
+
+At 24 months, the mean MoCA change was -1.42 (95% CI: -1.78 to -1.06) in the omega-3 group and -1.38 (95% CI: -1.74 to -1.02) in the placebo group. The between-group difference from the MMRM was -0.04 MoCA points (95% CI: -0.55 to 0.47; p = 0.88). The effect was indistinguishable from zero, with the confidence interval comfortably excluding the pre-registered MCID of 1.5 points in both directions.
+
+## Secondary Outcomes
+
+All secondary cognitive endpoints were non-significant:
+
+- **ADAS-Cog change:** omega-3 +1.86 vs. placebo +1.72; difference 0.14 (95% CI: -0.52 to 0.80; p = 0.68)
+- **TMT-B change:** omega-3 +4.2 sec vs. placebo +5.0 sec; difference -0.8 sec (95% CI: -3.6 to 2.0; p = 0.57)
+
+The Omega-3 Index (compliance biomarker) increased significantly in the treatment group (11.8% vs. 5.2%; p < 0.001), confirming that the supplementation protocol successfully raised tissue omega-3 levels despite the absence of cognitive effects.
+
+## Interpretation
+
+The flat-line pattern across all cognitive endpoints is unambiguous. Both groups declined at equivalent rates, and the supplementation biomarker confirms compliance was adequate. These results cannot be attributed to poor adherence or insufficient dosing.

--- a/null-result/content/sections/3-equivalence-testing.md
+++ b/null-result/content/sections/3-equivalence-testing.md
@@ -1,0 +1,100 @@
++++
+title = "3. Equivalence Testing"
+weight = 3
+template = "post"
+description = "Two One-Sided Tests (TOST) confirming that the treatment effect falls within pre-registered equivalence bounds."
+[extra]
+section_number = "3"
++++
+
+## Rationale for Equivalence Testing
+
+A non-significant p-value does not prove the absence of an effect -- it merely fails to reject the null. To provide affirmative evidence that omega-3 supplementation is practically equivalent to placebo, we conducted Two One-Sided Tests (TOST) with pre-registered equivalence margins of +/- 1.5 MoCA points, corresponding to the established minimally clinically important difference.
+
+## TOST Results
+
+<div class="figure">
+  <svg viewBox="0 0 700 280" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="Cormorant" font-size="14" font-weight="500" fill="#1a2030">Equivalence Testing: TOST Procedure for Primary Outcome</text>
+    <rect x="80" y="80" width="540" height="120" fill="#f5f4ef" stroke="none"/>
+    <rect x="80" y="100" width="540" height="80" fill="#eceadf" stroke="none"/>
+    <line x1="80" y1="140" x2="620" y2="140" stroke="#ccc8ba" stroke-width="0.5"/>
+    <line x1="350" y1="50" x2="350" y2="220" stroke="#1a2030" stroke-width="1.5" stroke-dasharray="6 3"/>
+    <text x="350" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#1a2030">0</text>
+    <line x1="125" y1="50" x2="125" y2="220" stroke="#c44a3a" stroke-width="2"/>
+    <text x="125" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#c44a3a">-1.5</text>
+    <text x="125" y="255" text-anchor="middle" font-family="Crimson Pro" font-size="9" font-style="italic" fill="#c44a3a">Lower bound</text>
+    <line x1="575" y1="50" x2="575" y2="220" stroke="#c44a3a" stroke-width="2"/>
+    <text x="575" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#c44a3a">+1.5</text>
+    <text x="575" y="255" text-anchor="middle" font-family="Crimson Pro" font-size="9" font-style="italic" fill="#c44a3a">Upper bound</text>
+    <text x="80" y="75" font-family="Crimson Pro" font-size="11" fill="#5b6272">MoCA (primary)</text>
+    <line x1="268" y1="100" x2="420" y2="100" stroke="#5a7a8a" stroke-width="2.5"/>
+    <circle cx="347" cy="100" r="5" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <text x="425" y="104" font-family="JetBrains Mono" font-size="9" fill="#5a7a8a">-0.04 [-0.55, 0.47]</text>
+    <text x="80" y="145" font-family="Crimson Pro" font-size="11" fill="#5b6272">ADAS-Cog</text>
+    <line x1="286" y1="140" x2="440" y2="140" stroke="#5a7a8a" stroke-width="2.5"/>
+    <circle cx="360" cy="140" r="5" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <text x="445" y="144" font-family="JetBrains Mono" font-size="9" fill="#5a7a8a">0.14 [-0.52, 0.80]</text>
+    <text x="80" y="185" font-family="Crimson Pro" font-size="11" fill="#5b6272">TMT-B</text>
+    <line x1="256" y1="180" x2="410" y2="180" stroke="#5a7a8a" stroke-width="2.5"/>
+    <circle cx="340" cy="180" r="5" fill="#5a7a8a" stroke="white" stroke-width="1.5"/>
+    <text x="415" y="184" font-family="JetBrains Mono" font-size="9" fill="#5a7a8a">-0.8 [-3.6, 2.0]</text>
+    <text x="350" y="270" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272">Between-Group Difference (MoCA points or equivalent scale)</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 3.</span> Equivalence testing diagram. Red vertical lines mark the pre-registered equivalence bounds (+/- 1.5 MoCA points). For equivalence to be established, the entire 90% confidence interval must fall within the bounds. All three cognitive endpoints meet this criterion, confirming practical equivalence between omega-3 and placebo. The shaded region represents the zone of equivalence.</p>
+</div>
+
+## Formal TOST Results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Two One-Sided Tests (TOST) for equivalence at the pre-registered margin of +/- 1.5 MoCA points</caption>
+  <thead>
+    <tr>
+      <th>Outcome</th>
+      <th>Observed difference</th>
+      <th>90% CI</th>
+      <th>t_lower</th>
+      <th>t_upper</th>
+      <th>p_TOST</th>
+      <th>Equivalence?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MoCA (primary)</td>
+      <td class="num">-0.04</td>
+      <td class="num">(-0.46, 0.38)</td>
+      <td class="num">5.61</td>
+      <td class="num">5.66</td>
+      <td class="num">0.002</td>
+      <td class="equiv-cell">EQUIVALENT</td>
+    </tr>
+    <tr>
+      <td>ADAS-Cog</td>
+      <td class="num">0.14</td>
+      <td class="num">(-0.40, 0.68)</td>
+      <td class="num">4.88</td>
+      <td class="num">4.20</td>
+      <td class="num">0.006</td>
+      <td class="equiv-cell">EQUIVALENT</td>
+    </tr>
+    <tr>
+      <td>TMT-B</td>
+      <td class="num">-0.8</td>
+      <td class="num">(-3.1, 1.5)</td>
+      <td class="num">3.42</td>
+      <td class="num">4.12</td>
+      <td class="num">0.011</td>
+      <td class="equiv-cell">EQUIVALENT</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="7">TOST p-values use the larger of the two one-sided p-values. Equivalence is declared when p_TOST < 0.05, indicating the 90% CI lies entirely within the equivalence bounds.</td>
+    </tr>
+  </tfoot>
+</table>
+
+## Interpretation
+
+All three cognitive endpoints achieved statistical equivalence with the pre-registered bounds. This means we can affirmatively state that the effect of omega-3 supplementation on cognitive decline, if any exists, is smaller than the minimally clinically important difference. The TOST procedure transforms the null finding from an absence of evidence into evidence of absence (within the specified margins).

--- a/null-result/content/sections/4-power-analysis.md
+++ b/null-result/content/sections/4-power-analysis.md
@@ -1,0 +1,73 @@
++++
+title = "4. Power Analysis"
+weight = 4
+template = "post"
+description = "Demonstration that the study had adequate statistical power to detect meaningful effects."
+[extra]
+section_number = "4"
++++
+
+## Why Power Matters for Null Results
+
+A null finding is only informative if the study had sufficient power to detect effects of clinically relevant magnitude. An underpowered study that fails to reject the null tells us little -- the absence of significance may reflect insufficient sample size rather than a true null effect. We therefore present both our a priori power calculation and post-hoc power assessment.
+
+## A Priori Power Calculation
+
+The sample size was determined before the trial began and documented in the pre-registration:
+
+- **Target effect:** 1.5 MoCA points (MCID from established literature)
+- **Assumed SD:** 4.2 MoCA points (from pooled prior studies)
+- **Alpha:** 0.05 (two-sided)
+- **Target power:** 0.90
+- **Attrition allowance:** 15%
+- **Required N per group:** 520 (analyzable) / 603 (enrolled with attrition buffer)
+- **Total N:** 1,206
+
+<div class="figure">
+  <svg viewBox="0 0 700 340" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="Cormorant" font-size="14" font-weight="500" fill="#1a2030">Minimum Detectable Effect by Power Level</text>
+    <line x1="100" y1="40" x2="100" y2="280" stroke="#ccc8ba" stroke-width="1"/>
+    <line x1="100" y1="280" x2="640" y2="280" stroke="#ccc8ba" stroke-width="1"/>
+    <text x="45" y="165" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272" transform="rotate(-90,45,165)">Minimum Detectable Effect (MoCA pts)</text>
+    <text x="370" y="315" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#5b6272">Statistical Power (1 - beta)</text>
+    <text x="95" y="55" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">3.0</text>
+    <text x="95" y="95" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">2.5</text>
+    <text x="95" y="135" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">2.0</text>
+    <text x="95" y="175" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">1.5</text>
+    <text x="95" y="215" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">1.0</text>
+    <text x="95" y="255" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.5</text>
+    <line x1="100" y1="175" x2="640" y2="175" stroke="#c44a3a" stroke-width="1" stroke-dasharray="4 2" opacity="0.6"/>
+    <text x="645" y="179" font-family="JetBrains Mono" font-size="8" fill="#c44a3a">MCID</text>
+    <text x="152" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.60</text>
+    <text x="235" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.70</text>
+    <text x="316" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.80</text>
+    <text x="397" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.85</text>
+    <text x="478" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.90</text>
+    <text x="559" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.95</text>
+    <text x="640" y="295" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#8a8e9a">0.99</text>
+    <polyline points="152,215 235,195 316,182 397,178 478,172 559,164 640,150" fill="none" stroke="#8a8e9a" stroke-width="2"/>
+    <circle cx="152" cy="215" r="3.5" fill="#8a8e9a"/>
+    <circle cx="235" cy="195" r="3.5" fill="#8a8e9a"/>
+    <circle cx="316" cy="182" r="3.5" fill="#8a8e9a"/>
+    <circle cx="397" cy="178" r="3.5" fill="#8a8e9a"/>
+    <circle cx="478" cy="172" r="5" fill="#1a2030" stroke="white" stroke-width="1.5"/>
+    <circle cx="559" cy="164" r="3.5" fill="#8a8e9a"/>
+    <circle cx="640" cy="150" r="3.5" fill="#8a8e9a"/>
+    <text x="488" y="166" font-family="JetBrains Mono" font-size="9" fill="#1a2030">Target: 0.90</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 4.</span> Minimum detectable effect (MDE) at N = 1,206 (603 per arm) across different power levels. At the target power of 0.90, the MDE is 1.3 MoCA points, which is below the pre-registered MCID of 1.5 points (red dashed line), confirming the study was adequately powered.</p>
+</div>
+
+## Post-Hoc Power Assessment
+
+The observed pooled standard deviation (3.9 MoCA points) was slightly smaller than assumed (4.2), and final attrition (11.2%) was lower than budgeted (15%). Together, these yield:
+
+- **Post-hoc power at MCID of 1.5 points:** 0.92 (exceeds target of 0.90)
+- **Smallest detectable effect at 80% power:** 0.89 MoCA points
+- **Smallest detectable effect at 90% power:** 1.06 MoCA points
+
+This means the study could reliably detect effects as small as approximately 1 MoCA point -- well below the threshold considered clinically meaningful.
+
+## Ruling Out Meaningful Effects
+
+The combination of (1) a near-zero point estimate, (2) narrow confidence intervals excluding the MCID, (3) confirmed equivalence via TOST, and (4) power exceeding 90% at the MCID provides strong, convergent evidence that omega-3 supplementation does not meaningfully slow cognitive decline. This is not a failure to detect an effect -- it is successful detection of its absence.

--- a/null-result/content/sections/5-discussion.md
+++ b/null-result/content/sections/5-discussion.md
@@ -1,0 +1,43 @@
++++
+title = "5. Discussion"
+weight = 5
+template = "post"
+description = "Interpretation of null findings, comparison with prior literature, and implications for publication bias."
+[extra]
+section_number = "5"
++++
+
+## Summary of Findings
+
+This pre-registered, multi-center, double-blind randomized controlled trial found no evidence that 24 months of high-dose omega-3 supplementation (2.4 g/day EPA + DHA) slows age-related cognitive decline in community-dwelling older adults. The treatment effect was indistinguishable from zero across all cognitive endpoints. Equivalence testing confirmed the effect lies within the zone of practical irrelevance, and post-hoc power analyses verified the study was adequately powered.
+
+## Comparison with Prior Literature
+
+Our findings are consistent with two previous large RCTs:
+
+- **MAPT Trial** (Andrieu et al., 2017): N = 1,680 older adults, 3-year supplementation. No cognitive benefit of omega-3 alone (HR = 0.98, 95% CI: 0.83-1.16).
+- **VITAL-Cog** (Manson et al., 2023): N = 2,525 adults aged 50+, 5.3-year supplementation. No effect on global cognition composite (difference = 0.01 SD, 95% CI: -0.04 to 0.06).
+
+Our study adds to this evidence by (a) using pre-registered equivalence testing to provide affirmative evidence of no meaningful effect, (b) enrolling a more geographically and ethnically diverse sample, and (c) confirming compliance through biomarker verification.
+
+The persistent disconnect between observational studies (which consistently show positive associations between fish intake and cognitive health) and randomized trials (which consistently show null effects) likely reflects residual confounding in observational designs -- higher fish intake correlates with education, physical activity, and overall dietary quality.
+
+## The Value of Null Results
+
+This paper is published as an explicit null result. We believe negative findings deserve the same rigorous reporting and peer review as positive findings, for several reasons:
+
+1. **Reducing publication bias.** The systematic suppression of null results inflates the published literature's apparent effect sizes and contributes to the replication crisis.
+2. **Informing meta-analyses.** Inclusion of well-powered null results in future meta-analyses will produce more accurate pooled estimates.
+3. **Guiding clinical practice.** Clinicians recommending omega-3 for cognitive protection need to know that the best available evidence shows no benefit.
+4. **Respecting participant contributions.** Over 1,200 individuals contributed two years of their time to this trial. Their data deserve to be published regardless of the outcome.
+
+## Limitations
+
+- The study enrolled cognitively normal to mildly impaired older adults. Results may not generalize to populations with established dementia or to younger adults.
+- Twenty-four months may be insufficient to detect very slow neuroprotective effects, though longer trials (VITAL-Cog, 5.3 years) also found no effect.
+- We tested a single dose regimen. Different EPA:DHA ratios or formulations cannot be excluded.
+- Despite multi-site recruitment, the sample was predominantly from high-income countries (the Ibadan site enrolled 18% of participants).
+
+## Conclusions
+
+High-dose omega-3 fatty acid supplementation for 24 months has no detectable effect on age-related cognitive decline. This is not an ambiguous or underpowered finding: equivalence testing and power analysis confirm that we can rule out effects of clinically meaningful magnitude. We encourage journals and researchers to prioritize transparent reporting of null results as essential contributions to cumulative science.

--- a/null-result/content/sections/_index.md
+++ b/null-result/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Full paper sections detailing the methods, results, equivalence testing, power analysis, and implications of the null findings from this 24-month omega-3 supplementation trial.

--- a/null-result/static/css/style.css
+++ b/null-result/static/css/style.css
@@ -1,0 +1,584 @@
+/* ============================================================================
+   Null Result - Negative Finding Paper with Full Transparency
+   Light background. Cormorant Light / Crimson Pro Light display.
+   Noto Serif / STIX Two body. No gradients, no emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #fafaf7;
+  --paper-2: #f0efe8;
+  --rule: #ccc8ba;
+  --ink: #1a2030;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #5a7a8a;
+  --accent-2: #4a6a7a;
+  --null-color: #8a8e9a;
+  --null-bg: #f0efe8;
+  --equiv-color: #5a7a8a;
+  --equiv-bg: #edf2f4;
+  --positive-color: #2a7a4a;
+  --positive-bg: #edf7f0;
+  --warning-color: #c44a3a;
+  --warning-bg: #fdf0ee;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Noto Serif", "STIX Two Text", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 400;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Null / Equivalence badges ---------------- */
+
+.null-badge-row {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.null-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--null-bg);
+  border: 1.5px solid var(--null-color);
+  padding: 0.25rem 0.7rem;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--null-color);
+  text-transform: uppercase;
+}
+
+.null-badge.preregistered {
+  background: var(--equiv-bg);
+  border-color: var(--equiv-color);
+  color: var(--equiv-color);
+}
+
+/* ---------------- Dates box ---------------- */
+
+.dates-box {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 1rem 1.4rem;
+  margin: 1.5rem 0;
+}
+
+.dates-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.date-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.date-label {
+  font-family: "Cormorant", serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+}
+
+.date-value {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  color: var(--ink);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 300;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 500;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 500;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 300;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Null / Equivalence result cells ---------------- */
+
+.null-cell {
+  background: var(--null-bg);
+  color: var(--null-color);
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+}
+
+.equiv-cell {
+  background: var(--equiv-bg);
+  color: var(--equiv-color);
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+}
+
+.positive-cell {
+  background: var(--positive-bg);
+  color: var(--positive-color);
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure .caption {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Cormorant", "Crimson Pro", serif;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Noto Serif", serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "Cormorant", serif;
+  font-weight: 500;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Noto Serif", "STIX Two Text", serif;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Cormorant", serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Cormorant", serif;
+  font-weight: 500;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Noto Serif", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .dates-row { flex-direction: column; gap: 0.8rem; }
+}

--- a/null-result/templates/404.html
+++ b/null-result/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 - Page Not Found</h1>
+      <p>The requested page does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/null-result/templates/footer.html
+++ b/null-result/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2030" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2030" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Lindqvist E, Okafor C, Hayashi M, De Vries A. No Effect of Omega-3 Fatty Acid Supplementation on Age-Related Cognitive Decline: A 24-Month Randomized Controlled Trial. <em>J Cogn Neurosci.</em> 2026;34(4):312-328. doi:10.41093/jcn.2026.34.04.312</p>
+        <p class="footer-note">ISSN 2891-7734 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/null-result/templates/header.html
+++ b/null-result/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Crimson+Pro:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#1a2030" stroke-width="1.5"/>
+          <line x1="10" y1="20" x2="54" y2="20" stroke="#8a8e9a" stroke-width="1.5"/>
+          <line x1="10" y1="14" x2="54" y2="14" stroke="#ccc8ba" stroke-width="0.75" stroke-dasharray="2 3"/>
+          <line x1="10" y1="26" x2="54" y2="26" stroke="#ccc8ba" stroke-width="0.75" stroke-dasharray="2 3"/>
+          <text x="32" y="34" font-family="Cormorant" font-size="7" font-weight="300" fill="#8a8e9a" text-anchor="middle">p = n.s.</text>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Cognitive Neuroscience</span>
+          <span class="journal-sub">Negative Result &middot; Vol. 34 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/power/">POWER</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/null-result/templates/page.html
+++ b/null-result/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/null-result/templates/post.html
+++ b/null-result/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/null-result/templates/section.html
+++ b/null-result/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/null-result/templates/shortcodes/alert.html
+++ b/null-result/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/null-result/templates/taxonomy.html
+++ b/null-result/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/null-result/templates/taxonomy_term.html
+++ b/null-result/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Posts tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2484,6 +2484,13 @@
     "blog",
     "journal"
   ],
+  "null-result": [
+    "paper",
+    "light",
+    "null",
+    "negative",
+    "honest"
+  ],
   "oasis": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Adds negative finding paper example site reporting null results from a 24-month omega-3 supplementation RCT
- Features flat-line effect size forest plots, TOST equivalence testing diagrams, and power analysis curves as inline SVG
- Uses Cormorant Light/Crimson Pro Light for display typography and Noto Serif/STIX Two for body text
- Includes 5 paper sections: Methods, Primary Results, Equivalence Testing, Power Analysis, and Discussion

## Test plan
- [ ] Verify `hwaro build` completes successfully in the `null-result/` directory
- [ ] Verify all SVG diagrams render correctly with no CSS gradients
- [ ] Verify tags.json entry is valid JSON and sorted alphabetically
- [ ] Verify no emojis are present in any files

Closes #1611