### PR TITLE
feat: add perspective-piece example site (closes #1616)

### DIFF
--- a/perspective-piece/AGENTS.md
+++ b/perspective-piece/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/perspective-piece/config.toml
+++ b/perspective-piece/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Perspective Piece - Viewpoint Paper
+# Issue #1616 | Tags: paper, dark, opinion, viewpoint, argumentative
+# =============================================================================
+
+title = "Perspective Piece"
+description = "A viewpoint paper with argument structure tree diagrams, thesis-antithesis-synthesis dialectic flow patterns, and claim confidence gauges for persuasive academic writing."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/perspective-piece/content/appendix.md
+++ b/perspective-piece/content/appendix.md
@@ -1,0 +1,111 @@
++++
+title = "Appendix"
+description = "Supplementary data, methodology notes, and extended references for the perspective on algorithmic monoculture."
+tags = ["opinion", "appendix", "methodology"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">APPENDIX</p>
+  <h1 class="paper-section-title">Supplementary Materials</h1>
+</header>
+
+## A. Bibliometric methodology
+
+Our bibliometric analysis covered 14,200 papers accepted at six venues (NeurIPS, ICML, ICLR, AAAI, ACL, CVPR) across the years 2018 to 2025. Papers were classified by primary architecture type using a combination of automated keyword extraction and manual verification by two independent annotators. Inter-annotator agreement (Cohen's kappa) was 0.89.
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Architecture prevalence by venue and year (percentage of accepted papers).</caption>
+  <thead>
+    <tr>
+      <th>Venue</th>
+      <th>2018</th>
+      <th>2020</th>
+      <th>2022</th>
+      <th>2024</th>
+      <th>2025</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>NeurIPS</td>
+      <td class="num">14</td>
+      <td class="num">38</td>
+      <td class="num">62</td>
+      <td class="num">81</td>
+      <td class="num">86</td>
+    </tr>
+    <tr>
+      <td>ICML</td>
+      <td class="num">11</td>
+      <td class="num">35</td>
+      <td class="num">58</td>
+      <td class="num">78</td>
+      <td class="num">84</td>
+    </tr>
+    <tr>
+      <td>ICLR</td>
+      <td class="num">18</td>
+      <td class="num">45</td>
+      <td class="num">71</td>
+      <td class="num">88</td>
+      <td class="num">92</td>
+    </tr>
+    <tr>
+      <td>ACL</td>
+      <td class="num">22</td>
+      <td class="num">55</td>
+      <td class="num">78</td>
+      <td class="num">91</td>
+      <td class="num">94</td>
+    </tr>
+    <tr>
+      <td>CVPR</td>
+      <td class="num">6</td>
+      <td class="num">22</td>
+      <td class="num">48</td>
+      <td class="num">72</td>
+      <td class="num">82</td>
+    </tr>
+    <tr>
+      <td>AAAI</td>
+      <td class="num">8</td>
+      <td class="num">28</td>
+      <td class="num">52</td>
+      <td class="num">74</td>
+      <td class="num">80</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">Percentage indicates Transformer-based or Transformer-variant architectures among all accepted papers. Classification based on primary architecture; hybrid models counted as Transformer if attention was the primary mechanism.</td>
+    </tr>
+  </tfoot>
+</table>
+
+## B. Confidence assessment methodology
+
+The confidence scores reported in Figures 2 and 3 were determined through a three-round modified Delphi process:
+
+1. **Round 1 (independent):** Each of the five authors independently scored each claim on a 0.0-1.0 scale based on the strength of available evidence.
+2. **Round 2 (deliberation):** Authors discussed their scores in a structured 90-minute session, identifying points of agreement and disagreement.
+3. **Round 3 (revision):** Authors independently revised their scores in light of the discussion. The reported score is the median of the five revised scores.
+
+Inter-rater reliability (ICC, two-way mixed, absolute agreement) was 0.78, indicating good agreement. The largest disagreements concerned Premises P8 (compute barrier, range 0.45-0.80) and the feasibility of Recommendation 2 (peer review reform, range 0.50-0.85).
+
+## C. Disclosure and competing interests
+
+EO and SFV have previously published work proposing alternative architectures and therefore have a professional interest in the promotion of methodological diversity. We have attempted to address this conflict transparently by (a) assigning confidence scores through a structured process that includes authors without such interests, and (b) presenting the strongest counterarguments to our thesis in the Counterpoint section.
+
+No author received funding specifically for the preparation of this perspective. The bibliometric analysis was conducted using publicly available data and tools.
+
+## D. Extended references
+
+The argument draws on work across multiple disciplines. Key references by area:
+
+**Philosophy of science:** Kuhn (1962), Feyerabend (1975), Lakatos (1978), Longino (1990), Kitcher (1993), Hull (1988), Campbell (1960).
+
+**Monoculture and systemic risk:** Scott (1998), Haldane and May (2011), Li (2000), MacKenzie (2006), Taleb (2007).
+
+**Machine learning methodology:** Vaswani et al. (2017), Hooker (2021), Lipton and Steinhardt (2019), Sculley et al. (2015), Birhane et al. (2022).
+
+**Bibliometrics and scientometrics:** Clauset et al. (2017), Way et al. (2019), Sugimoto and Lariviere (2018).

--- a/perspective-piece/content/counterpoint.md
+++ b/perspective-piece/content/counterpoint.md
@@ -1,0 +1,47 @@
++++
+title = "Counterpoint"
+description = "A structured summary of the strongest objections to the monoculture thesis and the authors' responses."
+tags = ["opinion", "counterpoint", "rebuttal"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">COUNTERPOINT</p>
+  <h1 class="paper-section-title">Objections and Responses</h1>
+</header>
+
+We believe that strong arguments are strengthened, not weakened, by honest engagement with their best objections. Below we present the five strongest counterarguments to our thesis and our responses to each.
+
+<div class="strength-summary str-antithesis">
+  <h4>Objection 1: The Transformer earned its dominance</h4>
+  <p>Transformers did not become dominant through fashion or inertia but through consistent, measurable superiority across an unprecedented range of tasks. Demanding diversity in the face of genuine superiority is like demanding that some physicists abandon general relativity to maintain "paradigmatic diversity."</p>
+</div>
+
+**Response:** We do not dispute the Transformer's empirical superiority on current benchmarks. Our argument is that benchmark performance on today's tasks is an insufficient basis for concluding that the architecture is globally optimal. General relativity has been tested against genuinely different predictions (gravitational lensing, time dilation, gravitational waves); the Transformer has not been tested against tasks specifically designed to probe its architectural limitations.
+
+<div class="strength-summary str-antithesis">
+  <h4>Objection 2: The market will self-correct</h4>
+  <p>If Transformers truly have blind spots, someone will eventually discover them and profit from developing alternatives. The history of technology is a history of disruption; no dominant technology lasts forever. Intervention is unnecessary and potentially counterproductive.</p>
+</div>
+
+**Response:** The market self-correction argument assumes low switching costs and a level playing field for challengers. In practice, the compute, data, and ecosystem advantages of the incumbent paradigm mean that market correction, when it comes, will be slower and more costly than it needs to be. Our recommendations aim to reduce the cost of exploring alternatives, not to mandate outcomes.
+
+<div class="strength-summary str-antithesis">
+  <h4>Objection 3: Diversity for its own sake is wasteful</h4>
+  <p>Research resources are finite. Spreading them across multiple paradigms means less depth in each. A focused community, all pushing on the same frontier, makes faster progress than a fragmented one exploring dead ends.</p>
+</div>
+
+**Response:** This objection treats research as hill-climbing on a known landscape. In a landscape with many peaks (and the true landscape of computational approaches is certainly multi-modal), focused climbing on a single peak guarantees missing higher ones. The question is not whether to diversify but how much diversification is optimal given our uncertainty about the landscape's topology.
+
+<div class="strength-summary str-antithesis">
+  <h4>Objection 4: Alternatives have been tried and found wanting</h4>
+  <p>Recurrent networks, convolutional networks, graph networks, and symbolic approaches have all been explored and found inferior to Transformers for most practical tasks. The monoculture is a rational response to empirical evidence.</p>
+</div>
+
+**Response:** That specific alternatives have underperformed on specific benchmarks under specific resource constraints does not demonstrate that the space of non-Transformer approaches has been exhausted. Many of the cited alternatives were developed with orders of magnitude less compute than Transformers have received. The comparison is between a mature, heavily-resourced paradigm and under-resourced challengers -- exactly the structural disadvantage our recommendations aim to address.
+
+<div class="strength-summary str-antithesis">
+  <h4>Objection 5: The analogy to agriculture is misleading</h4>
+  <p>Agricultural monocultures fail because biological pathogens evolve to exploit uniform hosts. Software architectures do not face evolutionary adversaries in the same way. The analogy, while vivid, is structurally flawed.</p>
+</div>
+
+**Response:** The analogy holds at the level of systemic risk, not biological mechanism. The relevant parallel is not pathogens but environmental change. When the computing environment shifts -- through hardware changes, new task requirements, energy constraints, or regulatory demands -- a monocultural field is poorly positioned to adapt. The source of disruption is different; the vulnerability to it is structurally identical.

--- a/perspective-piece/content/index.md
+++ b/perspective-piece/content/index.md
@@ -1,0 +1,305 @@
++++
+title = "Thesis"
+description = "A perspective on the epistemic costs of algorithmic monoculture in machine learning research, arguing for methodological pluralism."
+tags = ["paper", "dark", "opinion", "viewpoint", "argumentative"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Perspective &middot; Open Access</p>
+  <h1 class="paper-title">The Epistemic Cost of Algorithmic Monoculture: A Perspective on Homogenisation in Machine Learning Research</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Emeka Okafor</span><sup>1</sup>,
+    Astrid Lindqvist<sup>2</sup>,
+    Rohan Patel<sup>3</sup>,
+    Keiko Yamamoto<sup>4</sup>,
+    Sofia Fernandez-Vidal<sup>1,5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Philosophy of Science, University of Edinburgh &middot;
+    <sup>2</sup>AI Ethics Laboratory, KTH Royal Institute of Technology &middot;
+    <sup>3</sup>Centre for Responsible Computing, Indian Institute of Science &middot;
+    <sup>4</sup>Graduate School of Informatics, Kyoto University &middot;
+    <sup>5</sup>Santa Fe Institute
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48127/pci.2026.14.02.088</a> &middot; <strong>Received:</strong> 22 Oct 2025 &middot; <strong>Accepted:</strong> 11 Feb 2026</p>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Thesis</dt>
+    <dd>We argue that the rapid convergence of machine learning research toward a narrow set of architectural paradigms -- principally the Transformer and its variants -- constitutes an epistemic monoculture that systematically undervalues alternative computational approaches and limits the field's capacity for fundamental innovation.</dd>
+    <dt>Approach</dt>
+    <dd>Drawing on philosophy of science, evolutionary epistemology, and bibliometric analysis, we construct a multi-premise argument that monoculture in ML mirrors patterns observed in agricultural and financial systems where homogeneity amplified systemic risk.</dd>
+    <dt>Central Claim</dt>
+    <dd>Methodological pluralism is not merely desirable but epistemically necessary. The concentration of research effort on a single paradigm creates blind spots that cannot be detected from within that paradigm, producing a field that is locally optimised but globally fragile.</dd>
+    <dt>Implication</dt>
+    <dd>We call for structural changes in funding, peer review, and research culture that incentivise architectural diversity, including dedicated funding streams for non-dominant paradigms and revised evaluation criteria that reward novelty alongside benchmark performance.</dd>
+    <dt>Keywords</dt>
+    <dd><em>algorithmic monoculture; epistemic diversity; machine learning; methodological pluralism; philosophy of science; Transformer hegemony; research incentives</em></dd>
+  </dl>
+</section>
+
+## Argument Structure
+
+<figure class="figure">
+  <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Argument structure tree showing how premises lead through inference to the central conclusion about algorithmic monoculture">
+    <!-- Title -->
+    <text x="360" y="18" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="11" fill="#e8e2d8">ARGUMENT STRUCTURE: PREMISES TO CONCLUSION</text>
+
+    <!-- Conclusion (top) -->
+    <rect x="210" y="30" width="300" height="40" fill="none" stroke="#c9a84c" stroke-width="2" rx="3"/>
+    <text x="360" y="48" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="9" fill="#c9a84c">CONCLUSION</text>
+    <text x="360" y="62" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">Methodological pluralism is epistemically necessary</text>
+
+    <!-- Inference arrows -->
+    <line x1="280" y1="70" x2="160" y2="100" stroke="#b07a4a" stroke-width="1.2" stroke-dasharray="4 3"/>
+    <line x1="360" y1="70" x2="360" y2="100" stroke="#b07a4a" stroke-width="1.2" stroke-dasharray="4 3"/>
+    <line x1="440" y1="70" x2="560" y2="100" stroke="#b07a4a" stroke-width="1.2" stroke-dasharray="4 3"/>
+
+    <!-- Inference label -->
+    <text x="360" y="90" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#b07a4a">INFERENCE</text>
+
+    <!-- Intermediate claims -->
+    <rect x="60" y="100" width="200" height="36" fill="#b07a4a" fill-opacity="0.08" stroke="#b07a4a" stroke-width="1.2" rx="2"/>
+    <text x="160" y="116" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#b07a4a">I1: Monoculture creates</text>
+    <text x="160" y="128" text-anchor="middle" font-family="Cormorant, serif" font-size="7.5" fill="#d0c8b8">undetectable blind spots</text>
+
+    <rect x="270" y="100" width="180" height="36" fill="#b07a4a" fill-opacity="0.08" stroke="#b07a4a" stroke-width="1.2" rx="2"/>
+    <text x="360" y="116" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#b07a4a">I2: Historical precedent</text>
+    <text x="360" y="128" text-anchor="middle" font-family="Cormorant, serif" font-size="7.5" fill="#d0c8b8">shows systemic risk</text>
+
+    <rect x="460" y="100" width="200" height="36" fill="#b07a4a" fill-opacity="0.08" stroke="#b07a4a" stroke-width="1.2" rx="2"/>
+    <text x="560" y="116" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#b07a4a">I3: Incentive structures</text>
+    <text x="560" y="128" text-anchor="middle" font-family="Cormorant, serif" font-size="7.5" fill="#d0c8b8">reinforce convergence</text>
+
+    <!-- Premise lines -->
+    <line x1="120" y1="136" x2="80" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+    <line x1="160" y1="136" x2="160" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+    <line x1="200" y1="136" x2="240" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+
+    <line x1="330" y1="136" x2="300" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+    <line x1="390" y1="136" x2="420" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+
+    <line x1="520" y1="136" x2="490" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+    <line x1="560" y1="136" x2="560" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+    <line x1="600" y1="136" x2="630" y2="160" stroke="#6a8ab0" stroke-width="0.8"/>
+
+    <!-- Premises row 1 -->
+    <rect x="40" y="160" width="80" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="80" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P1: Paradigm</text>
+    <text x="80" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">lock-in observed</text>
+
+    <rect x="125" y="160" width="70" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="160" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P2: 87% of</text>
+    <text x="160" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">top venues use T</text>
+
+    <rect x="200" y="160" width="80" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="240" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P3: Kuhnian</text>
+    <text x="240" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">normal science</text>
+
+    <rect x="265" y="160" width="70" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="300" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P4: Agriculture</text>
+    <text x="300" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">monoculture risk</text>
+
+    <rect x="385" y="160" width="70" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="420" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P5: Financial</text>
+    <text x="420" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">crisis parallel</text>
+
+    <rect x="455" y="160" width="70" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="490" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P6: Benchmark</text>
+    <text x="490" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">culture narrows</text>
+
+    <rect x="525" y="160" width="70" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="560" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P7: Peer review</text>
+    <text x="560" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">favours familiar</text>
+
+    <rect x="595" y="160" width="80" height="30" fill="#6a8ab0" fill-opacity="0.08" stroke="#6a8ab0" stroke-width="0.8" rx="2"/>
+    <text x="635" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#6a8ab0">P8: Compute</text>
+    <text x="635" y="184" text-anchor="middle" font-family="Cormorant, serif" font-size="6" fill="#a09888">cost barrier</text>
+
+    <!-- Evidence layer -->
+    <text x="360" y="210" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#a09888">SUPPORTING EVIDENCE</text>
+    <line x1="100" y1="215" x2="620" y2="215" stroke="#3a3632" stroke-width="0.5"/>
+
+    <!-- Evidence boxes -->
+    <rect x="40" y="220" width="130" height="24" fill="none" stroke="#3a3632" stroke-width="0.5" rx="1"/>
+    <text x="105" y="235" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#7a7268">Bibliometric data 2018-2025</text>
+
+    <rect x="180" y="220" width="130" height="24" fill="none" stroke="#3a3632" stroke-width="0.5" rx="1"/>
+    <text x="245" y="235" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#7a7268">Feyerabend 1975, Kuhn 1962</text>
+
+    <rect x="320" y="220" width="130" height="24" fill="none" stroke="#3a3632" stroke-width="0.5" rx="1"/>
+    <text x="385" y="235" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#7a7268">Irish famine, 2008 crisis</text>
+
+    <rect x="460" y="220" width="130" height="24" fill="none" stroke="#3a3632" stroke-width="0.5" rx="1"/>
+    <text x="525" y="235" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#7a7268">NeurIPS/ICML review data</text>
+
+    <!-- Legend -->
+    <rect x="200" y="260" width="10" height="10" fill="#c9a84c" fill-opacity="0.3" stroke="#c9a84c" stroke-width="0.8"/>
+    <text x="215" y="269" font-family="Cormorant, serif" font-size="7" fill="#a09888">Conclusion</text>
+    <rect x="280" y="260" width="10" height="10" fill="#b07a4a" fill-opacity="0.3" stroke="#b07a4a" stroke-width="0.8"/>
+    <text x="295" y="269" font-family="Cormorant, serif" font-size="7" fill="#a09888">Inference</text>
+    <rect x="350" y="260" width="10" height="10" fill="#6a8ab0" fill-opacity="0.3" stroke="#6a8ab0" stroke-width="0.8"/>
+    <text x="365" y="269" font-family="Cormorant, serif" font-size="7" fill="#a09888">Premise</text>
+    <rect x="420" y="260" width="10" height="10" fill="none" stroke="#3a3632" stroke-width="0.5"/>
+    <text x="435" y="269" font-family="Cormorant, serif" font-size="7" fill="#a09888">Evidence</text>
+  </svg>
+  <figcaption><span class="fig-num">Figure 1.</span> Argument structure tree showing the logical chain from eight empirical premises, through three inferential steps, to the central conclusion that methodological pluralism is epistemically necessary for machine learning research.</figcaption>
+</figure>
+
+## Thesis-Antithesis-Synthesis
+
+<figure class="figure">
+  <svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dialectic flow diagram showing thesis, antithesis, and synthesis positions on algorithmic monoculture">
+    <!-- Title -->
+    <text x="360" y="18" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="11" fill="#e8e2d8">DIALECTIC FLOW: MONOCULTURE DEBATE</text>
+
+    <!-- Thesis box -->
+    <rect x="30" y="40" width="200" height="100" fill="#c9a84c" fill-opacity="0.06" stroke="#c9a84c" stroke-width="1.5" rx="3"/>
+    <text x="130" y="58" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="10" fill="#c9a84c">THESIS</text>
+    <line x1="60" y1="64" x2="200" y2="64" stroke="#c9a84c" stroke-width="0.5" opacity="0.4"/>
+    <text x="130" y="78" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">Convergence on Transformers</text>
+    <text x="130" y="90" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">represents harmful monoculture</text>
+    <text x="130" y="102" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">that limits discovery and</text>
+    <text x="130" y="114" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">amplifies systemic risk.</text>
+    <text x="130" y="132" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#a09888">Confidence: 0.82</text>
+
+    <!-- Arrow thesis to antithesis -->
+    <line x1="230" y1="90" x2="260" y2="90" stroke="#e8e2d8" stroke-width="1" marker-end="url(#arrowhead)"/>
+    <text x="245" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#a09888">challenges</text>
+
+    <!-- Antithesis box -->
+    <rect x="260" y="40" width="200" height="100" fill="#a05050" fill-opacity="0.06" stroke="#a05050" stroke-width="1.5" rx="3"/>
+    <text x="360" y="58" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="10" fill="#a05050">ANTITHESIS</text>
+    <line x1="290" y1="64" x2="430" y2="64" stroke="#a05050" stroke-width="0.5" opacity="0.4"/>
+    <text x="360" y="78" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">Convergence reflects genuine</text>
+    <text x="360" y="90" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">superiority. Transformers won</text>
+    <text x="360" y="102" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">on merit; diversity for its</text>
+    <text x="360" y="114" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">own sake is wasteful.</text>
+    <text x="360" y="132" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#a09888">Confidence: 0.58</text>
+
+    <!-- Arrow antithesis to synthesis -->
+    <line x1="460" y1="90" x2="490" y2="90" stroke="#e8e2d8" stroke-width="1" marker-end="url(#arrowhead)"/>
+    <text x="475" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5" fill="#a09888">resolves</text>
+
+    <!-- Synthesis box -->
+    <rect x="490" y="40" width="200" height="100" fill="#5a8a6a" fill-opacity="0.06" stroke="#5a8a6a" stroke-width="1.5" rx="3"/>
+    <text x="590" y="58" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="10" fill="#5a8a6a">SYNTHESIS</text>
+    <line x1="520" y1="64" x2="660" y2="64" stroke="#5a8a6a" stroke-width="0.5" opacity="0.4"/>
+    <text x="590" y="78" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">Transformer success is real</text>
+    <text x="590" y="90" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">but does not justify excluding</text>
+    <text x="590" y="102" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">alternatives. Structured pluralism</text>
+    <text x="590" y="114" text-anchor="middle" font-family="Cormorant, serif" font-size="8" fill="#e8e2d8">reduces risk without waste.</text>
+    <text x="590" y="132" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#a09888">Confidence: 0.91</text>
+
+    <!-- Arrowhead definition -->
+    <defs>
+      <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <polygon points="0 0, 8 3, 0 6" fill="#e8e2d8"/>
+      </marker>
+    </defs>
+
+    <!-- Feedback loop -->
+    <path d="M 590 140 L 590 170 Q 590 185 575 185 L 145 185 Q 130 185 130 170 L 130 140" fill="none" stroke="#a09888" stroke-width="0.8" stroke-dasharray="4 3"/>
+    <text x="360" y="195" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7268">dialectic refinement loop</text>
+
+    <!-- Legend -->
+    <rect x="220" y="220" width="10" height="10" fill="#c9a84c" fill-opacity="0.15" stroke="#c9a84c" stroke-width="0.8"/>
+    <text x="236" y="229" font-family="Cormorant, serif" font-size="7" fill="#a09888">Thesis</text>
+    <rect x="290" y="220" width="10" height="10" fill="#a05050" fill-opacity="0.15" stroke="#a05050" stroke-width="0.8"/>
+    <text x="306" y="229" font-family="Cormorant, serif" font-size="7" fill="#a09888">Antithesis</text>
+    <rect x="370" y="220" width="10" height="10" fill="#5a8a6a" fill-opacity="0.15" stroke="#5a8a6a" stroke-width="0.8"/>
+    <text x="386" y="229" font-family="Cormorant, serif" font-size="7" fill="#a09888">Synthesis</text>
+  </svg>
+  <figcaption><span class="fig-num">Figure 2.</span> Dialectic flow diagram illustrating the thesis (monoculture is harmful), antithesis (convergence reflects merit), and synthesis (structured pluralism) positions, with confidence scores assigned through structured deliberation among the authoring team.</figcaption>
+</figure>
+
+## Claim Confidence Assessment
+
+<figure class="figure">
+  <svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Viewpoint strength gauge displays showing confidence levels for key claims in the argument">
+    <!-- Title -->
+    <text x="360" y="18" text-anchor="middle" font-family="Playfair Display, serif" font-weight="700" font-size="11" fill="#e8e2d8">CLAIM CONFIDENCE GAUGES</text>
+
+    <!-- Gauge 1: Monoculture exists -->
+    <text x="120" y="50" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Monoculture exists</text>
+    <!-- Background track -->
+    <rect x="40" y="58" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <!-- Fill bar (95%) -->
+    <rect x="41" y="59" width="150" height="10" fill="#c9a84c" fill-opacity="0.7" rx="1"/>
+    <text x="120" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c9a84c">0.95 -- Very High</text>
+    <text x="120" y="94" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Bibliometric evidence unambiguous</text>
+
+    <!-- Gauge 2: Monoculture is harmful -->
+    <text x="360" y="50" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Monoculture is harmful</text>
+    <rect x="280" y="58" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <rect x="281" y="59" width="131" height="10" fill="#c9a84c" fill-opacity="0.7" rx="1"/>
+    <text x="360" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c9a84c">0.82 -- High</text>
+    <text x="360" y="94" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Strong analogy, limited direct evidence</text>
+
+    <!-- Gauge 3: Alternatives viable -->
+    <text x="600" y="50" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Alternatives are viable</text>
+    <rect x="520" y="58" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <rect x="521" y="59" width="112" height="10" fill="#b07a4a" fill-opacity="0.7" rx="1"/>
+    <text x="600" y="82" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#b07a4a">0.70 -- Moderate-High</text>
+    <text x="600" y="94" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Emerging results but not yet at scale</text>
+
+    <!-- Gauge 4: Incentives fixable -->
+    <text x="120" y="130" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Incentives are fixable</text>
+    <rect x="40" y="138" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <rect x="41" y="139" width="96" height="10" fill="#b07a4a" fill-opacity="0.7" rx="1"/>
+    <text x="120" y="162" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#b07a4a">0.60 -- Moderate</text>
+    <text x="120" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Institutional inertia is significant</text>
+
+    <!-- Gauge 5: Pluralism reduces risk -->
+    <text x="360" y="130" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Pluralism reduces risk</text>
+    <rect x="280" y="138" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <rect x="281" y="139" width="144" height="10" fill="#5a8a6a" fill-opacity="0.7" rx="1"/>
+    <text x="360" y="162" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#5a8a6a">0.91 -- Very High</text>
+    <text x="360" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Cross-domain evidence robust</text>
+
+    <!-- Gauge 6: Convergence reflects merit -->
+    <text x="600" y="130" text-anchor="middle" font-family="Cormorant, serif" font-weight="700" font-size="8" fill="#e8e2d8">Convergence = merit</text>
+    <rect x="520" y="138" width="160" height="12" fill="none" stroke="#3a3632" stroke-width="1" rx="2"/>
+    <rect x="521" y="139" width="93" height="10" fill="#a05050" fill-opacity="0.7" rx="1"/>
+    <text x="600" y="162" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#a05050">0.58 -- Moderate</text>
+    <text x="600" y="174" text-anchor="middle" font-family="Cormorant, serif" font-size="6.5" fill="#a09888">Partly true but overstated</text>
+
+    <!-- Scale legend -->
+    <text x="360" y="210" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7268">CONFIDENCE SCALE</text>
+    <rect x="160" y="218" width="400" height="8" fill="none" stroke="#3a3632" stroke-width="0.5" rx="1"/>
+    <rect x="160" y="218" width="80" height="8" fill="#a05050" fill-opacity="0.3" rx="1"/>
+    <rect x="240" y="218" width="80" height="8" fill="#b07a4a" fill-opacity="0.3"/>
+    <rect x="320" y="218" width="80" height="8" fill="#c9a84c" fill-opacity="0.3"/>
+    <rect x="400" y="218" width="80" height="8" fill="#5a8a6a" fill-opacity="0.3"/>
+    <rect x="480" y="218" width="80" height="8" fill="#5a8a6a" fill-opacity="0.5" rx="1"/>
+    <text x="200" y="238" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#a09888">0.0 - 0.4 Low</text>
+    <text x="320" y="238" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#a09888">0.4 - 0.6 Moderate</text>
+    <text x="440" y="238" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#a09888">0.6 - 0.8 High</text>
+    <text x="540" y="238" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#a09888">0.8 - 1.0 Very High</text>
+  </svg>
+  <figcaption><span class="fig-num">Figure 3.</span> Viewpoint strength gauges displaying the authors' collectively assessed confidence levels for each major claim in the argument. Scores were determined through structured deliberation using a modified Delphi process among the five co-authors.</figcaption>
+</figure>
+
+<div class="dialectic-callout">
+  <div class="callout-stat">
+    <span class="callout-value">8</span>
+    <span class="callout-label">Premises</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">3</span>
+    <span class="callout-label">Inferences</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">0.91</span>
+    <span class="callout-label">Synthesis Confidence</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">5</span>
+    <span class="callout-label">Policy Recommendations</span>
+  </div>
+</div>

--- a/perspective-piece/content/sections/1-the-monoculture-thesis.md
+++ b/perspective-piece/content/sections/1-the-monoculture-thesis.md
@@ -1,0 +1,36 @@
++++
+title = "1. The Monoculture Thesis"
+description = "Documenting the empirical case for architectural convergence in machine learning and defining what we mean by algorithmic monoculture."
+weight = 1
+template = "post"
+tags = ["opinion", "monoculture", "bibliometrics"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Defining algorithmic monoculture
+
+We use the term *algorithmic monoculture* to describe a state in which the overwhelming majority of published research, deployed systems, and funded projects within a scientific field rely on a single architectural paradigm or a narrow family of closely related architectures. Monoculture is not merely popularity; it is a structural condition in which alternatives become progressively harder to pursue, evaluate, and publish.
+
+The concept borrows deliberately from agricultural science, where monoculture refers to the cultivation of a single crop species across large areas. The analogy is not ornamental. In both domains, monoculture emerges because a dominant variety demonstrably outperforms alternatives on the metrics that matter most to practitioners in the short term. And in both domains, the long-term cost of that dominance is a loss of resilience and adaptability that only becomes visible when the environment changes.
+
+## 1.2 The bibliometric evidence
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P2</span>
+  <p>Our analysis of 14,200 papers accepted at the six leading ML venues (NeurIPS, ICML, ICLR, AAAI, ACL, CVPR) between 2018 and 2025 reveals a striking pattern: the proportion of papers using Transformer-based architectures rose from 12% in 2018 to 87% in 2025. Over the same period, papers proposing genuinely novel (non-Transformer) architectures fell from 34% to under 6%.</p>
+</div>
+
+This is not an argument against the Transformer itself. The architecture has earned its dominance through genuine empirical superiority on many tasks. Our concern is with what happens to the broader research landscape when a single approach becomes so dominant that alternatives are not merely less popular but structurally disadvantaged in the competition for attention, funding, and publication.
+
+## 1.3 The narrowing of the search space
+
+The pattern extends beyond architecture choice. We observe convergence in training methodology (pre-train then fine-tune), data strategy (ever-larger web-scraped corpora), and evaluation paradigm (benchmark leaderboards). Each of these convergences may individually reflect rational choices, but their combination produces a research ecosystem that explores a diminishing fraction of the possible design space.
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P1</span>
+  <p>Paradigm lock-in is observable not only in what researchers build but in what reviewers accept. Analysis of 3,200 review reports from ICLR 2023-2025 shows that papers proposing non-Transformer architectures received, on average, 0.8 points lower initial scores (on a 1-10 scale) than Transformer-based papers of comparable empirical rigour, controlling for author reputation and institutional affiliation.</p>
+</div>
+
+The feedback loop is self-reinforcing: fewer non-Transformer papers are published, producing fewer reference points for reviewers, making subsequent non-Transformer submissions seem more unusual and therefore riskier to accept. This is not a conspiracy but a structural dynamic that produces convergence without any individual actor intending it.

--- a/perspective-piece/content/sections/2-historical-parallels.md
+++ b/perspective-piece/content/sections/2-historical-parallels.md
@@ -1,0 +1,44 @@
++++
+title = "2. Historical Parallels"
+description = "Drawing on agricultural science, financial systems, and evolutionary biology to illustrate the systemic risks of monoculture."
+weight = 2
+template = "post"
+tags = ["opinion", "history", "analogy"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 The agricultural analogy
+
+The Irish Potato Famine of 1845-1852 is the canonical example of monoculture catastrophe. Ireland's reliance on a single potato variety (the Irish Lumper) meant that when *Phytophthora infestans* arrived, there was no genetic diversity to buffer the shock. The result was not merely a bad harvest but a systemic collapse that killed approximately one million people and drove another million to emigrate.
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P4</span>
+  <p>Agricultural monoculture demonstrates a recurring pattern: short-term efficiency gains from standardisation mask long-term fragility. The same pattern is observable in the Gros Michel banana crisis (1950s), the Southern Corn Leaf Blight epidemic (1970), and the ongoing vulnerability of Cavendish banana plantations to Tropical Race 4.</p>
+</div>
+
+The parallel to machine learning is structural, not metaphorical. In each case, monoculture emerges because a single variety outperforms alternatives on the metrics that matter most to producers. In each case, the risk is invisible until an environmental change exposes the brittleness of the system.
+
+## 2.2 The financial parallel
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P5</span>
+  <p>The 2008 global financial crisis demonstrated how methodological monoculture amplifies systemic risk. The near-universal adoption of Gaussian copula models for pricing collateralised debt obligations created a system in which every major institution had the same blind spot: the models systematically underestimated tail risk because they were calibrated on the same historically benign data.</p>
+</div>
+
+The financial case is particularly instructive because the convergence was not mandated by any central authority. Individual banks adopted Gaussian copula models because they were the standard, and the standard existed because individual banks adopted them. The circularity is identical to what we observe in machine learning's relationship with Transformers.
+
+## 2.3 Evolutionary epistemology
+
+<div class="argument-block antithesis">
+  <span class="argument-label antithesis-label">Counterpoint</span>
+  <p>One might object that convergence in science is different from convergence in agriculture or finance because scientific paradigms are selected for truth-tracking ability, not merely for market efficiency. The Transformer may simply be the right architecture in the way that natural selection is the right explanation for adaptation -- there is no virtue in maintaining alternatives that have been refuted.</p>
+</div>
+
+<div class="argument-block synthesis">
+  <span class="argument-label synthesis-label">Response</span>
+  <p>This objection confuses local performance with global adequacy. Evolutionary epistemology, as articulated by Campbell (1960) and developed by Hull (1988), holds that the reliability of scientific progress depends on maintaining variation in approaches. A field that prematurely converges on a single approach has not found the truth; it has narrowed its capacity to detect its own errors.</p>
+</div>
+
+Feyerabend's (1975) provocative claim that methodological anarchism is the only approach compatible with sustained scientific progress is often dismissed as rhetorical excess. But his underlying observation -- that every methodological rule, however successful, has been productive precisely because researchers were willing to violate it -- applies with uncomfortable precision to the current state of machine learning research.

--- a/perspective-piece/content/sections/3-the-mechanism-of-convergence.md
+++ b/perspective-piece/content/sections/3-the-mechanism-of-convergence.md
@@ -1,0 +1,51 @@
++++
+title = "3. The Mechanism of Convergence"
+description = "Analysing the institutional, economic, and social forces that drive methodological convergence in machine learning research."
+weight = 3
+template = "post"
+tags = ["opinion", "incentives", "peer-review"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 The benchmark trap
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P6</span>
+  <p>Benchmark culture creates a self-fulfilling prophecy of convergence. When ImageNet accuracy, GLUE scores, and perplexity on standard corpora become the primary evaluation criteria, architectures optimised for these specific benchmarks will dominate -- and since Transformers have been heavily optimised for exactly these benchmarks, the game is structurally tilted before a single experiment is run.</p>
+</div>
+
+This is not an argument that benchmarks are useless. Standardised evaluation is essential for scientific comparison. The problem arises when benchmark performance becomes the exclusive signal for publication, funding, and career advancement. Under those conditions, rational researchers will allocate their effort to improving Transformer performance on existing benchmarks rather than developing alternative architectures that might excel on tasks for which no benchmark yet exists.
+
+## 3.2 Peer review as a conserving force
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P7</span>
+  <p>The peer review system, as currently constituted at major ML venues, acts as a conserving force that penalises novelty. Reviewers are drawn from the existing research community and therefore carry the community's assumptions about what constitutes a reasonable approach. Papers that challenge these assumptions face a higher evidential bar -- they must not merely match but significantly exceed the performance of dominant approaches to be considered publishable.</p>
+</div>
+
+The asymmetry is revealing: a paper that achieves a 0.3% improvement on ImageNet using a Transformer variant is publishable at a top venue; a paper that achieves the same performance using a fundamentally different architecture faces scepticism about whether the approach is "worth pursuing." The implicit assumption is that marginal improvements to the dominant paradigm are inherently more valuable than demonstrating the viability of alternatives.
+
+## 3.3 Compute as a barrier to diversity
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Premise P8</span>
+  <p>The compute requirements of modern ML research create an economic barrier to diversity. Training a competitive large language model costs millions of dollars. This concentration of compute in the hands of a few wealthy organisations means that the architectural choices of those organisations -- which overwhelmingly favour Transformers -- set the agenda for the entire field.</p>
+</div>
+
+Academic researchers who cannot afford to train models at the frontier scale are left with two options: work on fine-tuning existing (Transformer-based) models, or pursue alternative architectures without the resources to demonstrate them at competitive scale. The first option reinforces monoculture; the second produces work that is dismissed as "not at scale" and therefore unpublishable at top venues.
+
+## 3.4 The social dynamics of paradigm adherence
+
+Kuhn's (1962) analysis of scientific revolutions describes how normal science functions within an accepted paradigm, with anomalies accumulating until a crisis triggers a paradigm shift. But Kuhn also observed that scientists have strong social incentives to work within the dominant paradigm: their careers, reputations, and professional networks are built within it. The cost of abandoning the paradigm is not merely intellectual but personal and professional.
+
+<div class="argument-block antithesis">
+  <span class="argument-label antithesis-label">Counterpoint</span>
+  <p>Perhaps convergence is efficient. If the Transformer architecture is genuinely superior to alternatives for the vast majority of tasks, then directing the field's collective effort toward improving it -- rather than scattering effort across inferior alternatives -- may be the most productive use of limited research capacity.</p>
+</div>
+
+<div class="argument-block synthesis">
+  <span class="argument-label synthesis-label">Response</span>
+  <p>The efficiency argument is valid in a world of perfect information, where we know with certainty that Transformers are globally optimal. In a world of radical uncertainty about the future of computing, efficiency in exploiting the current paradigm must be balanced against the option value of exploring alternatives that might prove essential when the paradigm's limitations become binding.</p>
+</div>

--- a/perspective-piece/content/sections/4-the-epistemic-cost.md
+++ b/perspective-piece/content/sections/4-the-epistemic-cost.md
@@ -1,0 +1,42 @@
++++
+title = "4. The Epistemic Cost"
+description = "Examining the specific intellectual losses that result from architectural monoculture in machine learning."
+weight = 4
+template = "post"
+tags = ["opinion", "epistemology", "blind-spots"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Blind spots that cannot be detected internally
+
+<div class="argument-block thesis">
+  <span class="argument-label thesis-label">Inference I1</span>
+  <p>The most dangerous consequence of monoculture is the creation of blind spots that cannot be detected from within the dominant paradigm. If every researcher uses the same architectural assumptions, then the limitations of those assumptions become invisible -- not because they do not exist, but because there is no contrasting perspective from which to observe them.</p>
+</div>
+
+Consider the analogy of stereoscopic vision. A single eye provides a detailed image but no depth perception. Depth emerges only from the parallax between two different viewpoints. Similarly, the limitations of any computational paradigm become visible only when compared with alternatives that make different assumptions. A field that has converged on a single paradigm has, in effect, closed one eye.
+
+## 4.2 The problem of unknown unknowns
+
+The distinction between known unknowns and unknown unknowns, popularised by Rumsfeld but formalised in epistemic logic, is central to our argument. Monoculture does not prevent the field from addressing known challenges within the dominant paradigm -- Transformer researchers are well aware of quadratic attention complexity, position encoding limitations, and extrapolation failures. These are known unknowns that receive abundant research attention.
+
+The concern is with unknown unknowns: failure modes, applications, and capabilities that are invisible because the dominant paradigm's assumptions make them impossible to formulate. We cannot enumerate these by definition, but we can point to historical precedents where they proved consequential.
+
+## 4.3 Historical examples of paradigmatic blind spots
+
+The behaviorist paradigm in psychology (roughly 1920-1960) provides an instructive case. By restricting the discipline to observable stimulus-response relationships, behaviorism was unable to formulate questions about internal cognitive processes that turned out to be essential for understanding language, memory, and reasoning. The cognitive revolution did not merely add new answers; it revealed questions that could not be asked within the behaviorist framework.
+
+Similarly, the dominance of frequentist statistics in the 20th century made it difficult for researchers to articulate certain kinds of uncertainty -- prior knowledge, model comparison, hierarchical structure -- that Bayesian methods later showed to be essential. The issue was not that frequentist methods were wrong but that their ubiquity made it hard to see what they could not do.
+
+## 4.4 What might we be missing?
+
+We cannot know what we are missing, but we can identify areas where Transformer assumptions may be limiting:
+
+- **Compositionality and systematic generalisation** -- architectures that learn compositional structure through explicit symbolic operations may handle distributional shift in ways that attention mechanisms cannot.
+- **Energy-efficient inference** -- neuromorphic and spiking neural architectures offer fundamentally different compute-energy tradeoffs that may prove essential as energy constraints tighten.
+- **Causal reasoning** -- architectures that build causal models rather than learning correlational patterns may be necessary for robust decision-making in novel environments.
+- **Continual learning** -- the catastrophic forgetting problem in neural networks may require architectural innovations that current paradigms are poorly suited to explore.
+
+Each of these represents a direction where monoculture may be causing the field to under-invest relative to its long-term importance.

--- a/perspective-piece/content/sections/5-toward-structured-pluralism.md
+++ b/perspective-piece/content/sections/5-toward-structured-pluralism.md
@@ -1,0 +1,62 @@
++++
+title = "5. Toward Structured Pluralism"
+description = "Proposing concrete institutional reforms to promote methodological diversity in machine learning without sacrificing rigour."
+weight = 5
+template = "post"
+tags = ["opinion", "policy", "recommendations"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 The case for intervention
+
+Our argument leads to a constructive conclusion: that the machine learning research community should adopt *structured pluralism* -- institutional mechanisms that maintain architectural diversity without mandating specific alternatives or penalising work within the dominant paradigm. The goal is not to displace Transformers but to ensure that the field retains the capacity to discover and develop approaches that may prove essential in the future.
+
+<div class="argument-block synthesis">
+  <span class="argument-label synthesis-label">Synthesis</span>
+  <p>Structured pluralism resolves the tension between the thesis (monoculture is harmful) and the antithesis (convergence reflects merit) by acknowledging that the Transformer's success is real while insisting that a healthy research ecosystem requires active cultivation of diversity. This is not diversity for its own sake but diversity as an epistemic insurance policy.</p>
+</div>
+
+## 5.2 Recommendation 1: Dedicated funding for non-dominant paradigms
+
+Funding agencies should establish dedicated streams for research on non-Transformer architectures, evaluated on criteria that do not require direct comparison with frontier Transformer models. The evaluation criteria should emphasise novelty of approach, theoretical motivation, and potential for fundamentally different capabilities.
+
+We propose that at least 15% of public ML research funding be allocated to architecturally diverse work, with a separate review process staffed by reviewers drawn from adjacent fields (computational neuroscience, programming languages, theoretical computer science) rather than exclusively from the ML mainstream.
+
+## 5.3 Recommendation 2: Revised peer review criteria
+
+Major ML venues should adopt review criteria that explicitly reward architectural novelty. Currently, a paper that demonstrates a 2% improvement using a well-known architecture is valued more highly than a paper that achieves competitive results using a fundamentally different approach. This incentive structure should be inverted: genuinely novel architectures should receive credit for demonstrating viability, not penalised for falling short of frontier performance.
+
+Concretely, we propose that venues introduce a "methodological diversity" track with modified acceptance criteria that weight novelty more heavily than state-of-the-art performance.
+
+## 5.4 Recommendation 3: Benchmark reform
+
+The benchmark ecosystem should be expanded to include tasks that probe capabilities where Transformers are known to struggle: systematic generalisation, sample-efficient learning, energy-efficient inference, and causal reasoning. Creating benchmarks where the dominant architecture does not enjoy a structural advantage would create natural incentives for architectural innovation.
+
+## 5.5 Recommendation 4: Compute equity programmes
+
+Public compute infrastructure should be made available to academic researchers pursuing non-dominant architectures, at sufficient scale to produce competitive results. The current situation, in which only well-funded industry labs can afford to demonstrate architectures at scale, systematically advantages incumbents.
+
+## 5.6 Recommendation 5: Cross-disciplinary bridge programmes
+
+Formal programmes should be established to bring insights from computational neuroscience, evolutionary computation, symbolic AI, and other traditions into contact with mainstream ML research. The goal is not to create artificial collaborations but to maintain the intellectual diversity that generates genuine innovation.
+
+<div class="confidence-display">
+  <div class="conf-card">
+    <span class="conf-value">0.91</span>
+    <span class="conf-label">Pluralism reduces risk</span>
+  </div>
+  <div class="conf-card">
+    <span class="conf-value">0.82</span>
+    <span class="conf-label">Monoculture is harmful</span>
+  </div>
+  <div class="conf-card">
+    <span class="conf-value">0.70</span>
+    <span class="conf-label">Recommendations are feasible</span>
+  </div>
+  <div class="conf-card">
+    <span class="conf-value">0.60</span>
+    <span class="conf-label">Institutional change is likely</span>
+  </div>
+</div>

--- a/perspective-piece/content/sections/_index.md
+++ b/perspective-piece/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The argument is organised into five sections, moving from the empirical observation of monoculture through historical analogy and philosophical analysis to concrete policy recommendations.

--- a/perspective-piece/static/css/style.css
+++ b/perspective-piece/static/css/style.css
@@ -1,0 +1,646 @@
+/* ============================================================================
+   Perspective Piece - Viewpoint Paper
+   Dark background, bold display headings, argumentative structure.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #1a1714;
+  --bg-2: #242018;
+  --bg-3: #2e2a22;
+  --rule: #3a3632;
+  --ink: #e8e2d8;
+  --ink-2: #d0c8b8;
+  --ink-3: #a09888;
+  --ink-4: #7a7268;
+  --accent: #c9a84c;
+  --accent-2: #e8d5a3;
+  --thesis: #c9a84c;
+  --antithesis: #a05050;
+  --synthesis: #5a8a6a;
+  --premise: #6a8ab0;
+  --inference: #b07a4a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Cormorant", "EB Garamond", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 56px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 700; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "EB Garamond", "Cormorant", serif;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "Cormorant", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--bg-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Cormorant", "EB Garamond", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 700;
+  font-size: 1.12rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "EB Garamond", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--accent);
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "EB Garamond", "Cormorant", serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Argument callout blocks ---------------- */
+
+.argument-block {
+  margin: 1.6rem 0;
+  padding: 1.2rem 1.6rem 1.2rem 1.8rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  font-family: "EB Garamond", "Cormorant", serif;
+  font-size: 0.98rem;
+  line-height: 1.7;
+  color: var(--ink-2);
+}
+
+.argument-block.thesis { border-left-color: var(--thesis); }
+.argument-block.antithesis { border-left-color: var(--antithesis); }
+.argument-block.synthesis { border-left-color: var(--synthesis); }
+
+.argument-block p {
+  margin: 0.4rem 0;
+  text-align: left;
+}
+
+.argument-label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-family: "Playfair Display", serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.argument-label.thesis-label { color: var(--thesis); }
+.argument-label.antithesis-label { color: var(--antithesis); }
+.argument-label.synthesis-label { color: var(--synthesis); }
+
+/* ---------------- Viewpoint confidence display ---------------- */
+
+.confidence-display {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.confidence-display .conf-card {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1rem 1.2rem;
+  text-align: center;
+}
+
+.confidence-display .conf-card .conf-value {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: 1.6rem;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.confidence-display .conf-card .conf-label {
+  font-family: "Cormorant", sans-serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------------- Dialectic callout ---------------- */
+
+.dialectic-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.4rem 1.8rem;
+  margin: 2rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 2.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dialectic-callout .callout-stat {
+  text-align: center;
+}
+
+.dialectic-callout .callout-value {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 900;
+  font-size: 1.8rem;
+  color: var(--accent);
+  display: block;
+  line-height: 1.1;
+}
+
+.dialectic-callout .callout-label {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.15em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.3rem;
+}
+
+.dialectic-callout .callout-sep {
+  width: 1px;
+  height: 2.4rem;
+  background: var(--rule);
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.9rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "Cormorant", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons / Footer ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Cormorant", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+.error-page { text-align: center; padding: 3rem 0; }
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "Cormorant", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Premise chain list ---------------- */
+
+.premise-chain {
+  margin: 1.4rem 0;
+  padding-left: 1.4rem;
+}
+
+.premise-chain li {
+  margin: 0.5rem 0;
+  font-family: "EB Garamond", "Cormorant", serif;
+  color: var(--ink-2);
+}
+
+/* ---------------- Argument strength cards ---------------- */
+
+.strength-summary {
+  margin: 1.5rem 0;
+  padding: 1rem 1.4rem;
+  border-left: 3px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.strength-summary.str-thesis { border-left-color: var(--thesis); }
+.strength-summary.str-antithesis { border-left-color: var(--antithesis); }
+.strength-summary.str-synthesis { border-left-color: var(--synthesis); }
+.strength-summary.str-premise { border-left-color: var(--premise); }
+.strength-summary.str-inference { border-left-color: var(--inference); }
+
+.strength-summary h4 {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin: 0 0 0.4rem;
+  font-style: normal;
+}
+
+.strength-summary p {
+  margin: 0.3rem 0;
+  font-size: 0.95rem;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 16px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .dialectic-callout { flex-direction: column; gap: 1rem; }
+  .dialectic-callout .callout-sep { width: 3rem; height: 1px; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .confidence-display { grid-template-columns: 1fr 1fr; }
+  .argument-block { padding: 1rem 1.2rem 1rem 1.4rem; }
+}

--- a/perspective-piece/templates/404.html
+++ b/perspective-piece/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to thesis</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/perspective-piece/templates/footer.html
+++ b/perspective-piece/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#3a3632" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#3a3632" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Okafor E, Lindqvist A, Patel R, Yamamoto K, Fernandez-Vidal S. The Epistemic Cost of Algorithmic Monoculture: A Perspective on Homogenisation in Machine Learning Research. <em>Perspect. Crit. Inq.</em> 2026;14(2):88-116. doi:10.48127/pci.2026.14.02.088</p>
+        <p class="footer-note">ISSN 2156-8472 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/perspective-piece/templates/header.html
+++ b/perspective-piece/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Abril+Fatface&family=Cormorant:ital,wght@0,400;0,600;0,700;1,400&family=EB+Garamond:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Abstract argument/viewpoint icon: balanced scales of reasoning -->
+          <line x1="28" y1="4" x2="28" y2="32" stroke="#c9a84c" stroke-width="1.5"/>
+          <line x1="12" y1="12" x2="44" y2="12" stroke="#c9a84c" stroke-width="1.5"/>
+          <polygon points="8,14 16,14 12,24" fill="none" stroke="#c9a84c" stroke-width="1.2"/>
+          <polygon points="40,14 48,14 44,24" fill="none" stroke="#e8d5a3" stroke-width="1.2"/>
+          <circle cx="28" cy="8" r="3" fill="none" stroke="#c9a84c" stroke-width="1.2"/>
+          <line x1="22" y1="32" x2="34" y2="32" stroke="#c9a84c" stroke-width="1.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Perspectives in Critical Inquiry</span>
+          <span class="journal-sub">Vol. 14 &middot; Issue 02 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">THESIS</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/counterpoint/">COUNTERPOINT</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/perspective-piece/templates/page.html
+++ b/perspective-piece/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/perspective-piece/templates/post.html
+++ b/perspective-piece/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/perspective-piece/templates/section.html
+++ b/perspective-piece/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/perspective-piece/templates/shortcodes/alert.html
+++ b/perspective-piece/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/perspective-piece/templates/taxonomy.html
+++ b/perspective-piece/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/perspective-piece/templates/taxonomy_term.html
+++ b/perspective-piece/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -328,6 +328,13 @@
     "clock",
     "traditional"
   ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
+  ],
   "bijou": [
     "dark",
     "elegant",
@@ -754,6 +761,13 @@
     "blog",
     "medieval"
   ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
+  ],
   "colosseum": [
     "light",
     "event",
@@ -861,6 +875,13 @@
     "portfolio",
     "agency",
     "bold"
+  ],
+  "cross-sectional": [
+    "paper",
+    "light",
+    "cross-sectional",
+    "snapshot",
+    "population"
   ],
   "crucible": [
     "light",
@@ -1082,6 +1103,13 @@
     "celestial",
     "dramatic"
   ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
+  ],
   "electric-bloom": [
     "dark",
     "blog",
@@ -1169,6 +1197,13 @@
     "magazine",
     "experimental",
     "asymmetric"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
   ],
   "etching": [
     "dark",
@@ -1407,6 +1442,13 @@
     "portfolio",
     "elegant",
     "glamorous"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
   ],
   "geodesic": [
     "light",
@@ -1953,6 +1995,13 @@
     "light",
     "docs",
     "compliance"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
   ],
   "lookbook": [
     "dark",
@@ -2717,6 +2766,13 @@
     "carpet",
     "ornate"
   ],
+  "perspective-piece": [
+    "paper",
+    "dark",
+    "opinion",
+    "viewpoint",
+    "argumentative"
+  ],
   "petrified-wood": [
     "dark",
     "blog",
@@ -2905,6 +2961,13 @@
     "docs",
     "networking"
   ],
+  "protocol-paper": [
+    "paper",
+    "light",
+    "protocol",
+    "pre-registration",
+    "rigorous"
+  ],
   "psychedelic": [
     "dark",
     "minimal",
@@ -2926,6 +2989,13 @@
     "showcase",
     "metallic",
     "luxury"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
   ],
   "quantum": [
     "dark",
@@ -2965,12 +3035,26 @@
     "blog",
     "hiking"
   ],
+  "randomized-trial": [
+    "paper",
+    "light",
+    "rct",
+    "clinical-trial",
+    "rigorous"
+  ],
   "rave": [
     "dark",
     "blog",
     "acid",
     "rave",
     "neon"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
   ],
   "reactor": [
     "dark",
@@ -3052,6 +3136,13 @@
     "military",
     "assembly",
     "urgent"
+  ],
+  "review-article": [
+    "paper",
+    "light",
+    "review",
+    "literature",
+    "synthesis"
   ],
   "ridgeline": [
     "dark",
@@ -3993,89 +4084,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "genome-paper": [
-    "paper",
-    "dark",
-    "genomics",
-    "bioinformatics",
-    "data-intensive"
-  ],
-  "longitudinal": [
-    "paper",
-    "dark",
-    "longitudinal",
-    "temporal",
-    "tracking"
-  ],
-  "protocol-paper": [
-    "paper",
-    "light",
-    "protocol",
-    "pre-registration",
-    "rigorous"
-  ],
-  "bench-report": [
-    "paper",
-    "light",
-    "laboratory",
-    "bench",
-    "experimental"
-  ],
-  "errata-sheet": [
-    "paper",
-    "light",
-    "errata",
-    "correction",
-    "transparent"
-  ],
-  "review-article": [
-    "paper",
-    "light",
-    "review",
-    "literature",
-    "synthesis"
-  ],
-  "cohort-study": [
-    "paper",
-    "light",
-    "cohort",
-    "survival",
-    "epidemiological"
-  ],
-  "raw-data": [
-    "paper",
-    "light",
-    "raw",
-    "data",
-    "tables"
-  ],
-  "cross-sectional": [
-    "paper",
-    "light",
-    "cross-sectional",
-    "snapshot",
-    "population"
-  ],
-  "randomized-trial": [
-    "paper",
-    "light",
-    "rct",
-    "clinical-trial",
-    "rigorous"
-  ],
-  "qualitative-study": [
-    "paper",
-    "light",
-    "qualitative",
-    "thematic",
-    "interpretive"
-  ],
-  "editorial-letter": [
-    "paper",
-    "light",
-    "editorial",
-    "authority",
-    "statement"
   ]
 }


### PR DESCRIPTION
## Summary
- Dark-themed viewpoint paper with argument structure tree diagrams (premise > inference > conclusion), thesis/antithesis/synthesis dialectic flow patterns, and viewpoint strength gauge displays for claim confidence levels
- Typography uses Playfair Display Black/Abril Fatface for thesis statements and Cormorant/EB Garamond for argument prose
- Content explores algorithmic monoculture in ML research with structured counterpoint section

## Test plan
- [ ] Verify `hwaro build` succeeds in perspective-piece directory
- [ ] Check dark theme renders correctly with gold accent colors
- [ ] Confirm all three SVG diagrams (argument tree, dialectic flow, confidence gauges) display properly
- [ ] Validate thesis/antithesis/synthesis argument blocks have correct border colors
- [ ] Test responsive layout at mobile breakpoint (700px)

Closes #1616