### PR TITLE
feat: add white-paper-noir example site (closes #1601)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -3919,6 +3919,13 @@
     "elegant",
     "event"
   ],
+  "white-paper-noir": [
+    "paper",
+    "dark",
+    "industry",
+    "executive",
+    "authoritative"
+  ],
   "wiki": [
     "light",
     "docs",

--- a/white-paper-noir/AGENTS.md
+++ b/white-paper-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/white-paper-noir/config.toml
+++ b/white-paper-noir/config.toml
@@ -1,0 +1,52 @@
+title = "Digital Infrastructure Resilience"
+description = "A dark industry white paper examining enterprise digital infrastructure resilience strategies, risk frameworks, and executive-level architectural recommendations for critical systems modernization."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/white-paper-noir/content/appendix.md
+++ b/white-paper-noir/content/appendix.md
@@ -1,0 +1,88 @@
++++
+title = "Appendix"
+description = "Supplementary materials including survey instrument excerpt, glossary of resilience terms, author contributions, and disclosure statements."
+tags = ["appendix", "supplementary", "glossary"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+<h1 class="paper-section-title">Appendix</h1>
+</header>
+
+<div class="paper-content">
+
+## A. Glossary of Key Terms
+
+<table class="paper-table">
+<caption>Table A1. Key resilience terminology used in this paper</caption>
+<thead>
+<tr>
+<th>Term</th>
+<th>Definition</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Blast Radius Score (BRS)</td>
+<td>Quantitative measure (0--100) of the proportion of system functionality affected by a single component failure.</td>
+</tr>
+<tr>
+<td>Composite Resilience Index (CRI)</td>
+<td>Aggregate metric combining blast radius, recovery velocity, and degradation quality into a single infrastructure resilience score.</td>
+</tr>
+<tr>
+<td>Dependency Chain Depth (DCD)</td>
+<td>Length of the longest critical path through a system's service dependency graph, measured in hops.</td>
+</tr>
+<tr>
+<td>Isolation Zone</td>
+<td>A bounded failure domain within which component failures are contained and cannot propagate to the broader system.</td>
+</tr>
+<tr>
+<td>Circuit Breaker</td>
+<td>Pattern that detects downstream degradation and short-circuits requests before they consume upstream resources.</td>
+</tr>
+<tr>
+<td>Graceful Degradation</td>
+<td>System behaviour that maintains partial functionality during component failure rather than failing entirely.</td>
+</tr>
+<tr>
+<td>MTTR</td>
+<td>Mean Time to Recovery. The average duration from incident detection to full service restoration.</td>
+</tr>
+</tbody>
+</table>
+
+## B. Survey Instrument Excerpt
+
+The following questions are representative of the 42-item survey instrument administered to infrastructure leadership:
+
+1. How many distinct services comprise your organisation's critical infrastructure path?
+2. What is the maximum dependency chain depth in your service graph?
+3. What percentage of critical services operate in two or more independent isolation zones?
+4. How frequently does your organisation conduct fault injection testing on production systems?
+5. Does your organisation track a composite resilience metric at the board level?
+6. What was the total cost of unplanned downtime for your organisation in the past 12 months?
+7. How many severity-1 incidents involved cascading failure across three or more services?
+8. What is your organisation's current mean time to recovery for severity-1 incidents?
+
+## C. Author Contributions
+
+- **Reiko Nakamura** -- Conceptualization, methodology, data analysis, writing (original draft and revision).
+- **Chidiebere Okonkwo** -- Architecture reviews, data collection (enterprise survey), writing (Sections 3 and 4).
+- **Erik Lindqvist** -- Risk framework development, statistical analysis, writing (Section 2).
+- **Sanya Patel** -- Industry landscape research, sector-specific analysis, writing (Section 1), project administration.
+
+## D. Conflict of Interest
+
+Reiko Nakamura serves as Chief Architect at Meridian Systems, which provides infrastructure consulting services. Sanya Patel is CTO of Arclight Consulting. Both organisations offer services related to the topics discussed in this paper. The analysis and recommendations presented here are based on the empirical data described in the Methodology section and were not influenced by commercial considerations.
+
+## E. Funding
+
+This research was supported by the Enterprise Architecture Research Consortium (EARC) under grant EA-2024-0187 and by in-kind contributions from the participating enterprises. The funding source had no role in study design, data collection, analysis, or manuscript preparation.
+
+## F. Data Availability
+
+De-identified summary statistics and the analytical code used in this paper are available upon request from the corresponding author (r.nakamura@meridian-systems.example). Raw survey responses and incident reports are not available due to data sharing agreement restrictions.
+
+</div>

--- a/white-paper-noir/content/index.md
+++ b/white-paper-noir/content/index.md
@@ -1,0 +1,200 @@
++++
+title = "Executive Summary"
+description = "A dark industry white paper examining enterprise digital infrastructure resilience strategies, risk frameworks, and executive-level architectural recommendations for critical systems modernization."
+tags = ["paper", "dark", "industry", "executive", "authoritative"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">WHITE PAPER</p>
+<h1 class="paper-section-title">Digital Infrastructure Resilience: Enterprise Strategies for Critical Systems Modernization</h1>
+<div class="author-grid">
+<div class="author-card">
+<span class="author-name">Reiko Nakamura</span>
+<span class="author-role">Chief Architect, Meridian Systems</span>
+</div>
+<div class="author-card">
+<span class="author-name">Chidiebere Okonkwo</span>
+<span class="author-role">VP Engineering, Helix Infrastructure</span>
+</div>
+<div class="author-card">
+<span class="author-name">Erik Lindqvist</span>
+<span class="author-role">Director of Risk, Nordic Digital</span>
+</div>
+<div class="author-card">
+<span class="author-name">Sanya Patel</span>
+<span class="author-role">CTO, Arclight Consulting</span>
+</div>
+</div>
+<p class="paper-lede" style="margin-top:1rem;">Published March 2026 &middot; doi:10.50912/ear.2026.14.3.112 &middot; Received Dec 2025 &middot; Accepted Feb 2026</p>
+</header>
+
+<div class="exec-panel">
+<p class="exec-panel-label">Executive Summary</p>
+<h3>The Case for Resilience-First Architecture</h3>
+<p><strong>Objective.</strong> This white paper presents a comprehensive framework for modernizing enterprise digital infrastructure with resilience as the primary architectural constraint, rather than an afterthought.</p>
+<p><strong>Scope.</strong> We examine 142 enterprise deployments across financial services, healthcare, logistics, and critical infrastructure sectors, analysing failure patterns, recovery architectures, and the total cost of unplanned downtime between 2022 and 2025.</p>
+<p><strong>Key Finding.</strong> Organizations that adopt resilience-first architectural patterns experience 73% fewer cascading failures and reduce mean time to recovery (MTTR) by 4.2x compared to those retrofitting resilience onto existing monolithic systems.</p>
+<p><strong>Recommendation.</strong> Enterprises should transition from availability-centric (uptime percentage) metrics to resilience-centric (recovery velocity, blast radius containment, degradation gracefullness) metrics as the primary measure of infrastructure health.</p>
+</div>
+
+<div class="metrics-bar">
+<div class="metric-item">
+<span class="metric-value">142</span>
+<span class="metric-label">Deployments Analysed</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">4.2x</span>
+<span class="metric-label">MTTR Improvement</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">73%</span>
+<span class="metric-label">Fewer Cascading Failures</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">$2.1B</span>
+<span class="metric-label">Downtime Cost Surveyed</span>
+</div>
+</div>
+
+<div class="figure" role="img" aria-label="Technical architecture diagram showing three-tier resilience framework with isolation zones, health monitors, and recovery pathways in white line art on black background">
+<svg viewBox="0 0 780 360" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="360" fill="#0a0a0a"/>
+<!-- Title -->
+<text x="390" y="28" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#888888" font-weight="600" letter-spacing="0.1em">FIGURE 1: THREE-TIER RESILIENCE ARCHITECTURE</text>
+<!-- Tier 1: Edge -->
+<rect x="40" y="50" width="700" height="70" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+<text x="60" y="70" font-family="Inter, sans-serif" font-size="9" fill="#555555" font-weight="700" letter-spacing="0.08em">TIER 1: EDGE LAYER</text>
+<rect x="60" y="78" width="120" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="120" y="97" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Load Balancer</text>
+<rect x="200" y="78" width="120" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="260" y="97" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">WAF / DDoS Shield</text>
+<rect x="340" y="78" width="120" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="400" y="97" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">CDN Cache</text>
+<rect x="480" y="78" width="120" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="540" y="97" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Health Probe</text>
+<rect x="620" y="78" width="100" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="670" y="97" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Rate Limiter</text>
+<!-- Connectors Tier 1 to Tier 2 -->
+<line x1="200" y1="120" x2="200" y2="150" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<line x1="400" y1="120" x2="400" y2="150" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<line x1="600" y1="120" x2="600" y2="150" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<!-- Tier 2: Application -->
+<rect x="40" y="150" width="700" height="90" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+<text x="60" y="170" font-family="Inter, sans-serif" font-size="9" fill="#555555" font-weight="700" letter-spacing="0.08em">TIER 2: APPLICATION LAYER</text>
+<!-- Isolation zones -->
+<rect x="60" y="178" width="200" height="50" fill="none" stroke="#888888" stroke-width="1" stroke-dasharray="6,3"/>
+<text x="80" y="193" font-family="Inter, sans-serif" font-size="7" fill="#555555">ZONE A</text>
+<rect x="80" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="115" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-01</text>
+<rect x="160" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="195" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-02</text>
+<rect x="290" y="178" width="200" height="50" fill="none" stroke="#888888" stroke-width="1" stroke-dasharray="6,3"/>
+<text x="310" y="193" font-family="Inter, sans-serif" font-size="7" fill="#555555">ZONE B</text>
+<rect x="310" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="345" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-03</text>
+<rect x="390" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="425" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-04</text>
+<rect x="520" y="178" width="200" height="50" fill="none" stroke="#888888" stroke-width="1" stroke-dasharray="6,3"/>
+<text x="540" y="193" font-family="Inter, sans-serif" font-size="7" fill="#555555">ZONE C</text>
+<rect x="540" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="575" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-05</text>
+<rect x="620" y="198" width="70" height="22" fill="none" stroke="#888888" stroke-width="0.75"/>
+<text x="655" y="212" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" fill="#d4d4d4">SVC-06</text>
+<!-- Connectors Tier 2 to Tier 3 -->
+<line x1="160" y1="240" x2="160" y2="270" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<line x1="390" y1="240" x2="390" y2="270" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<line x1="620" y1="240" x2="620" y2="270" stroke="#555555" stroke-width="1" stroke-dasharray="4,3"/>
+<!-- Tier 3: Data -->
+<rect x="40" y="270" width="700" height="70" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+<text x="60" y="290" font-family="Inter, sans-serif" font-size="9" fill="#555555" font-weight="700" letter-spacing="0.08em">TIER 3: DATA LAYER</text>
+<rect x="60" y="298" width="140" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="130" y="317" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Primary DB Cluster</text>
+<rect x="220" y="298" width="140" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="290" y="317" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Read Replicas</text>
+<rect x="380" y="298" width="140" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="450" y="317" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Event Stream</text>
+<rect x="540" y="298" width="180" height="30" fill="none" stroke="#888888" stroke-width="1"/>
+<text x="630" y="317" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Cold Storage / Archive</text>
+<!-- Recovery arrows -->
+<line x1="290" y1="298" x2="130" y2="298" stroke="#ffffff" stroke-width="0.75" marker-end="none"/>
+<text x="210" y="295" text-anchor="middle" font-family="Inter, sans-serif" font-size="6" fill="#555555">failover</text>
+</svg>
+<p class="figure-caption"><strong>Figure 1.</strong> Three-tier resilience architecture showing edge, application, and data layers with isolation zones (dashed boundaries) and inter-tier health monitoring pathways (dashed connectors).</p>
+</div>
+
+<div class="exec-panel">
+<p class="exec-panel-label">Market Context</p>
+<h3>The Rising Cost of Infrastructure Failure</h3>
+<p>Between 2022 and 2025, the average cost of a critical infrastructure outage rose from $5,600 per minute to $9,200 per minute across surveyed enterprises. The shift to distributed architectures has reduced single-point-of-failure risk but introduced new categories of cascading failure that legacy monitoring tools fail to detect.</p>
+<p>Our analysis identifies three primary failure domains that account for 84% of all cascading outages: <strong>dependency chain failures</strong> (38%), <strong>configuration drift</strong> (27%), and <strong>capacity cliff events</strong> (19%). Each domain requires distinct architectural countermeasures detailed in the sections that follow.</p>
+</div>
+
+<div class="figure" role="img" aria-label="Market trend chart showing downtime cost trends from 2022 to 2025 across four industry sectors">
+<svg viewBox="0 0 780 280" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="280" fill="#0a0a0a"/>
+<text x="390" y="24" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#888888" font-weight="600" letter-spacing="0.1em">FIGURE 2: DOWNTIME COST PER MINUTE BY SECTOR (2022-2025)</text>
+<!-- Axes -->
+<line x1="80" y1="45" x2="80" y2="230" stroke="#ffffff" stroke-width="1"/>
+<line x1="80" y1="230" x2="720" y2="230" stroke="#ffffff" stroke-width="1"/>
+<!-- Y-axis labels -->
+<text x="70" y="62" text-anchor="end" font-family="Inter, sans-serif" font-size="8" fill="#555555">$15k</text>
+<text x="70" y="108" text-anchor="end" font-family="Inter, sans-serif" font-size="8" fill="#555555">$10k</text>
+<text x="70" y="154" text-anchor="end" font-family="Inter, sans-serif" font-size="8" fill="#555555">$7.5k</text>
+<text x="70" y="200" text-anchor="end" font-family="Inter, sans-serif" font-size="8" fill="#555555">$5k</text>
+<text x="70" y="234" text-anchor="end" font-family="Inter, sans-serif" font-size="8" fill="#555555">$0</text>
+<!-- Y-axis grid -->
+<line x1="80" y1="58" x2="720" y2="58" stroke="#1a1a1a" stroke-width="0.5"/>
+<line x1="80" y1="104" x2="720" y2="104" stroke="#1a1a1a" stroke-width="0.5"/>
+<line x1="80" y1="150" x2="720" y2="150" stroke="#1a1a1a" stroke-width="0.5"/>
+<line x1="80" y1="196" x2="720" y2="196" stroke="#1a1a1a" stroke-width="0.5"/>
+<!-- X-axis labels -->
+<text x="180" y="248" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#888888">2022</text>
+<text x="340" y="248" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#888888">2023</text>
+<text x="500" y="248" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#888888">2024</text>
+<text x="660" y="248" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#888888">2025</text>
+<!-- Financial Services (white) -->
+<polyline points="180,170 340,145 500,118 660,80" fill="none" stroke="#ffffff" stroke-width="2"/>
+<circle cx="180" cy="170" r="3" fill="#ffffff"/>
+<circle cx="340" cy="145" r="3" fill="#ffffff"/>
+<circle cx="500" cy="118" r="3" fill="#ffffff"/>
+<circle cx="660" cy="80" r="3" fill="#ffffff"/>
+<!-- Healthcare (light gray) -->
+<polyline points="180,185 340,168 500,148 660,115" fill="none" stroke="#888888" stroke-width="1.5"/>
+<circle cx="180" cy="185" r="3" fill="#888888"/>
+<circle cx="340" cy="168" r="3" fill="#888888"/>
+<circle cx="500" cy="148" r="3" fill="#888888"/>
+<circle cx="660" cy="115" r="3" fill="#888888"/>
+<!-- Logistics (medium gray) -->
+<polyline points="180,198 340,188 500,172 660,152" fill="none" stroke="#555555" stroke-width="1.5" stroke-dasharray="6,3"/>
+<circle cx="180" cy="198" r="3" fill="none" stroke="#555555" stroke-width="1.5"/>
+<circle cx="340" cy="188" r="3" fill="none" stroke="#555555" stroke-width="1.5"/>
+<circle cx="500" cy="172" r="3" fill="none" stroke="#555555" stroke-width="1.5"/>
+<circle cx="660" cy="152" r="3" fill="none" stroke="#555555" stroke-width="1.5"/>
+<!-- Critical Infra (dark gray dashed) -->
+<polyline points="180,192 340,172 500,138 660,95" fill="none" stroke="#333333" stroke-width="1.5" stroke-dasharray="2,3"/>
+<circle cx="180" cy="192" r="3" fill="none" stroke="#333333" stroke-width="1.5"/>
+<circle cx="340" cy="172" r="3" fill="none" stroke="#333333" stroke-width="1.5"/>
+<circle cx="500" cy="138" r="3" fill="none" stroke="#333333" stroke-width="1.5"/>
+<circle cx="660" cy="95" r="3" fill="none" stroke="#333333" stroke-width="1.5"/>
+<!-- Legend -->
+<line x1="100" y1="268" x2="125" y2="268" stroke="#ffffff" stroke-width="2"/>
+<text x="130" y="271" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Financial Services</text>
+<line x1="260" y1="268" x2="285" y2="268" stroke="#888888" stroke-width="1.5"/>
+<text x="290" y="271" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Healthcare</text>
+<line x1="380" y1="268" x2="405" y2="268" stroke="#555555" stroke-width="1.5" stroke-dasharray="6,3"/>
+<text x="410" y="271" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Logistics</text>
+<line x1="490" y1="268" x2="515" y2="268" stroke="#333333" stroke-width="1.5" stroke-dasharray="2,3"/>
+<text x="520" y="271" font-family="Inter, sans-serif" font-size="8" fill="#d4d4d4">Critical Infrastructure</text>
+</svg>
+<p class="figure-caption"><strong>Figure 2.</strong> Per-minute downtime cost by industry sector, 2022--2025. Financial services leads at $14,200/min in 2025, followed by critical infrastructure at $11,800/min. All sectors show accelerating cost growth.</p>
+</div>
+
+## Structure of This Paper
+
+This white paper is organized into five sections, each building on the analysis presented in the executive summary:
+
+1. **Industry Landscape** -- Current state of enterprise infrastructure, failure taxonomy, and the resilience gap across sectors.
+2. **Risk Framework** -- A quantitative risk model for infrastructure resilience assessment, including blast radius scoring and dependency chain analysis.
+3. **Architecture Patterns** -- Reference architectures for resilience-first design, covering isolation zones, circuit breakers, and graceful degradation strategies.
+4. **Implementation Roadmap** -- Phased migration guidance for enterprises transitioning from legacy to resilient architectures, with cost models and timeline benchmarks.
+5. **Recommendations** -- Executive-level recommendations, governance frameworks, and metrics for ongoing resilience measurement.

--- a/white-paper-noir/content/methodology.md
+++ b/white-paper-noir/content/methodology.md
@@ -1,0 +1,46 @@
++++
+title = "Methodology"
+description = "Research methodology, data collection procedures, and analytical framework used in this white paper."
+tags = ["methodology", "research-design", "data-collection"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">RESEARCH METHODOLOGY</p>
+<h1 class="paper-section-title">Methodology</h1>
+</header>
+
+<div class="paper-content">
+
+## Data collection
+
+This white paper draws on three primary data sources collected between January 2023 and December 2025:
+
+1. **Enterprise survey** (n=142). Structured questionnaire administered to infrastructure leadership at enterprises across financial services (n=38), healthcare (n=34), logistics (n=41), and critical infrastructure (n=29). Survey covered infrastructure topology, incident history, resilience practices, and investment levels.
+
+2. **Post-incident reports** (n=847). De-identified incident reports contributed by survey participants, covering all severity-1 and severity-2 incidents during the study period. Reports were coded for failure domain, blast radius, recovery time, and root cause.
+
+3. **Architecture reviews** (n=56). In-depth architectural assessments conducted by the authoring team for a subset of survey participants. Reviews included dependency graph mapping, fault injection testing, and resilience scoring.
+
+## Analytical framework
+
+Quantitative analysis used standard statistical methods:
+
+- Descriptive statistics (median, interquartile range) for cost and recovery time distributions.
+- Pearson correlation for blast radius score vs. incident frequency.
+- Cox proportional hazards for recovery time modelling.
+- Bootstrap confidence intervals (10,000 resamples) for all reported effect sizes.
+
+Qualitative analysis of post-incident reports followed a structured coding framework with two independent coders and inter-rater reliability assessment (Cohen's kappa = 0.84).
+
+## Limitations
+
+- **Selection bias.** Survey participants were recruited through industry conferences and professional networks, which may over-represent organisations with above-average infrastructure maturity.
+- **Survivor bias.** Post-incident reports were contributed voluntarily, potentially under-representing the most severe incidents at organisations with less mature incident documentation practices.
+- **Sector coverage.** Retail, media, and government sectors are not represented in the current dataset.
+- **Geographic scope.** 78% of participants are headquartered in North America or Western Europe. Results may not generalise to other regulatory and infrastructure environments.
+
+## Ethics and data handling
+
+All survey responses and incident reports were de-identified before analysis. Participating organisations signed data sharing agreements permitting aggregated, anonymised reporting only. Raw data is not available for redistribution. Summary statistics and analytical code are available upon request from the corresponding author.
+
+</div>

--- a/white-paper-noir/content/sections/1-industry-landscape.md
+++ b/white-paper-noir/content/sections/1-industry-landscape.md
@@ -1,0 +1,91 @@
++++
+title = "1. Industry Landscape"
+description = "Current state of enterprise infrastructure, failure taxonomy, and the resilience gap across financial services, healthcare, logistics, and critical infrastructure sectors."
+weight = 1
+template = "post"
+tags = ["infrastructure", "industry-analysis", "failure-taxonomy"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 The distributed systems paradox
+
+The industry-wide migration from monolithic to distributed architectures over the past decade has delivered measurable gains in deployment velocity and horizontal scalability. However, our survey of 142 enterprise environments reveals that distributed systems introduce failure modes that are qualitatively different from those of their monolithic predecessors.
+
+Where monolithic systems fail catastrophically but predictably, distributed systems exhibit emergent failure behaviours that resist simple root-cause analysis. A single degraded node in a service mesh can trigger cascading timeouts across dozens of downstream services, producing outage patterns that bear no obvious relationship to the originating fault.
+
+## 1.2 Failure taxonomy
+
+Our analysis categorizes infrastructure failures into three primary domains based on root-cause analysis of 847 post-incident reports:
+
+<table class="paper-table">
+<caption>Table 1. Failure domain taxonomy with frequency and median impact</caption>
+<thead>
+<tr>
+<th>Domain</th>
+<th>Share of Cascading Outages</th>
+<th>Median MTTR</th>
+<th>Median Revenue Impact</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Dependency chain failures</td>
+<td>38%</td>
+<td>4.2 hours</td>
+<td>$1.8M</td>
+</tr>
+<tr>
+<td>Configuration drift</td>
+<td>27%</td>
+<td>2.8 hours</td>
+<td>$920K</td>
+</tr>
+<tr>
+<td>Capacity cliff events</td>
+<td>19%</td>
+<td>1.6 hours</td>
+<td>$540K</td>
+</tr>
+<tr>
+<td>Security-triggered isolation</td>
+<td>9%</td>
+<td>6.1 hours</td>
+<td>$2.4M</td>
+</tr>
+<tr>
+<td>Operator error (unclassified)</td>
+<td>7%</td>
+<td>1.1 hours</td>
+<td>$310K</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="4">Based on 847 post-incident reports from 142 enterprise environments, 2022--2025.</td>
+</tr>
+</tfoot>
+</table>
+
+**Dependency chain failures** represent the largest single category. These occur when a service's upstream dependency degrades below its expected SLA, causing the dependent service to exhaust connection pools, timeout budgets, or retry quotas. The resulting backpressure propagates through the service graph, converting a localised degradation into a system-wide outage.
+
+**Configuration drift** refers to the gradual divergence between declared infrastructure state (as represented in configuration management tools) and actual deployed state. Drift accumulates silently during routine operations and manifests during incident response, when operators discover that the system they are troubleshooting does not match the system they believe they are running.
+
+**Capacity cliff events** occur when a system operating near its throughput ceiling encounters a demand spike that exceeds its headroom. Unlike gradual degradation, cliff events are characterised by abrupt, non-linear performance collapse as queues saturate and garbage collection pauses compound.
+
+## 1.3 The resilience gap
+
+Despite widespread adoption of distributed architectures, our survey finds that only 23% of enterprises have formally defined resilience requirements for their critical systems. The remaining 77% continue to measure infrastructure health primarily through availability percentages (uptime SLAs), which fail to capture recovery velocity, blast radius, or degradation behaviour.
+
+This gap between architectural complexity and resilience maturity is the central challenge addressed by this white paper.
+
+## 1.4 Sector-specific observations
+
+**Financial services** exhibits the highest downtime costs ($14,200/min in 2025) but also the most mature resilience practices, driven by regulatory requirements (DORA, OCC guidance) that mandate specific recovery time objectives.
+
+**Healthcare** faces unique challenges from legacy system integration, with 62% of surveyed institutions running critical workloads on systems older than 10 years that lack modern observability instrumentation.
+
+**Logistics** demonstrates the strongest correlation between infrastructure resilience and competitive advantage, with top-quartile operators achieving 3.1x faster recovery than the sector median.
+
+**Critical infrastructure** (energy, water, telecommunications) presents the highest stakes but the slowest adoption curve, constrained by capital expenditure cycles and regulatory approval timelines that extend infrastructure refresh intervals to 15--20 years.

--- a/white-paper-noir/content/sections/2-risk-framework.md
+++ b/white-paper-noir/content/sections/2-risk-framework.md
@@ -1,0 +1,95 @@
++++
+title = "2. Risk Framework"
+description = "A quantitative risk model for infrastructure resilience assessment, including blast radius scoring, dependency chain analysis, and recovery velocity benchmarks."
+weight = 2
+template = "post"
+tags = ["risk-assessment", "blast-radius", "dependency-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Beyond availability percentages
+
+Traditional infrastructure risk assessment centres on availability targets expressed as percentages of uptime (99.9%, 99.99%, etc.). While these metrics remain useful for capacity planning, they fail to distinguish between systems that degrade gracefully under stress and systems that fail catastrophically at the same availability threshold.
+
+We propose a resilience risk model structured around three dimensions: **blast radius** (how far does a failure propagate?), **recovery velocity** (how quickly does the system return to baseline?), and **degradation quality** (what capabilities remain available during partial failure?).
+
+## 2.2 Blast radius scoring
+
+Blast radius quantifies the proportion of system functionality affected by a single component failure. We define a blast radius score (BRS) on a 0--100 scale:
+
+<div class="rec-box">
+<p class="rec-box-label">Definition</p>
+<p><strong>BRS = (Affected services / Total services) x (Affected users / Total users) x 100</strong></p>
+<p>A BRS of 0 indicates complete isolation; a BRS of 100 indicates total system failure from a single component fault. Organisations should target BRS &lt; 15 for any individual component.</p>
+</div>
+
+Our survey data shows that enterprises with mean component BRS below 15 experience 68% fewer customer-visible incidents than those with BRS above 40, even when both groups report identical availability percentages.
+
+## 2.3 Dependency chain analysis
+
+Dependency chain depth (DCD) measures the longest critical path through a system's service dependency graph. Each additional hop in the dependency chain multiplies failure probability and compounds latency during degraded operations.
+
+<table class="paper-table">
+<caption>Table 2. Dependency chain depth and cascading failure correlation</caption>
+<thead>
+<tr>
+<th>Chain Depth</th>
+<th>Cascading Failure Rate</th>
+<th>Median Recovery Time</th>
+<th>P95 Recovery Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1--3 hops</td>
+<td>4.2%</td>
+<td>18 min</td>
+<td>42 min</td>
+</tr>
+<tr>
+<td>4--6 hops</td>
+<td>17.8%</td>
+<td>54 min</td>
+<td>2.8 hrs</td>
+</tr>
+<tr>
+<td>7--10 hops</td>
+<td>41.3%</td>
+<td>2.1 hrs</td>
+<td>8.4 hrs</td>
+</tr>
+<tr>
+<td>11+ hops</td>
+<td>73.6%</td>
+<td>4.8 hrs</td>
+<td>18+ hrs</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="4">Cascading failure rate = proportion of component failures that affected 3+ downstream services.</td>
+</tr>
+</tfoot>
+</table>
+
+## 2.4 Recovery velocity benchmarks
+
+Recovery velocity captures the time-to-recovery curve shape, not merely the endpoint. We distinguish between four recovery profiles observed in our dataset:
+
+- **Snap recovery** (12% of incidents): System returns to full capacity within 5 minutes, typically through automated failover.
+- **Ramp recovery** (34%): System capacity increases linearly over 15--60 minutes as manual or semi-automated procedures execute.
+- **Step recovery** (38%): System recovers in discrete jumps as individual components are restored, often with gaps between steps.
+- **Tail recovery** (16%): System reaches 90% capacity quickly but takes hours or days to resolve the final 10%, typically due to data consistency reconciliation.
+
+## 2.5 Composite resilience index
+
+We combine blast radius, recovery velocity, and degradation quality into a Composite Resilience Index (CRI) that enables cross-sector benchmarking:
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation</p>
+<p>Adopt the Composite Resilience Index as a board-level metric alongside traditional availability SLAs. CRI provides a single number (0--100) that captures infrastructure resilience posture and enables quarter-over-quarter tracking of improvement initiatives.</p>
+</div>
+
+Across our dataset, top-quartile CRI performers (CRI > 72) experience 4.2x faster mean recovery and generate 31% fewer customer-visible incidents than bottom-quartile performers (CRI < 35), independent of infrastructure spend.

--- a/white-paper-noir/content/sections/3-architecture-patterns.md
+++ b/white-paper-noir/content/sections/3-architecture-patterns.md
@@ -1,0 +1,54 @@
++++
+title = "3. Architecture Patterns"
+description = "Reference architectures for resilience-first design, covering isolation zones, circuit breakers, graceful degradation strategies, and observability instrumentation."
+weight = 3
+template = "post"
+tags = ["architecture", "circuit-breaker", "isolation-zones"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Isolation zone design
+
+The foundation of resilience-first architecture is the isolation zone: a bounded failure domain within which component failures are contained and cannot propagate to the broader system. Our reference architecture defines three levels of isolation:
+
+**Process isolation** confines failure to a single operating system process. Container runtimes provide process isolation by default, but shared kernel resources (file descriptors, network sockets, memory) can leak failure across process boundaries if limits are not enforced.
+
+**Host isolation** confines failure to a single physical or virtual machine. This prevents kernel-level failures, hardware faults, and hypervisor issues from affecting neighbouring workloads. Host isolation requires placement constraints that prevent correlated scheduling.
+
+**Zone isolation** confines failure to a network-defined boundary (availability zone, region, or data centre). Zone isolation is the highest-cost, highest-protection tier, requiring full data replication and independent control planes in each zone.
+
+<div class="rec-box">
+<p class="rec-box-label">Architecture Principle</p>
+<p>Every critical service should operate within at least two isolation zones, with no shared fate between zones. Zone boundaries must be validated through regular fault injection testing, not assumed from vendor documentation.</p>
+</div>
+
+## 3.2 Circuit breaker patterns
+
+Circuit breakers prevent cascading failure by detecting downstream degradation and short-circuiting requests before they consume upstream resources. Our analysis identifies three circuit breaker implementations with distinct trade-off profiles:
+
+**Threshold-based** circuit breakers open when error rates exceed a configured percentage over a sliding window. These are simple to implement but require careful tuning: thresholds set too low cause false positives during normal traffic variance; thresholds set too high allow cascading failure to propagate before the breaker trips.
+
+**Latency-based** circuit breakers open when P99 latency exceeds a configured ceiling, regardless of error rate. These detect degradation earlier than threshold-based breakers because latency increases typically precede error rate increases by 30--90 seconds.
+
+**Adaptive** circuit breakers use historical baseline comparison to detect anomalous behaviour without fixed thresholds. These require more sophisticated implementation but eliminate the tuning burden and adapt automatically to changing traffic patterns.
+
+## 3.3 Graceful degradation strategies
+
+Resilient systems maintain partial functionality during component failure rather than failing entirely. We identify four degradation strategies observed in top-performing enterprises:
+
+1. **Feature shedding** -- Disable non-critical features (recommendations, analytics, personalisation) to preserve core transaction processing capacity.
+2. **Quality reduction** -- Serve cached or approximate results instead of real-time computed results, trading freshness for availability.
+3. **Rate-based admission** -- Accept a controlled subset of incoming requests at full quality rather than attempting to serve all requests at degraded quality.
+4. **Regional failover** -- Redirect traffic from a degraded region to healthy regions, accepting increased latency as a trade-off for maintained availability.
+
+## 3.4 Observability instrumentation
+
+Resilience requires observability that goes beyond traditional metrics, logs, and traces. Our framework adds three observability dimensions specific to resilience monitoring:
+
+**Dependency health maps** provide real-time visualisation of the service dependency graph with per-edge health indicators. These maps surface degradation patterns that are invisible in per-service dashboards.
+
+**Blast radius projections** continuously estimate the potential blast radius of each component based on current dependency state and traffic patterns. These projections enable proactive mitigation before failures occur.
+
+**Recovery rehearsal telemetry** captures performance data from regular failover exercises, building a statistical model of expected recovery behaviour that can be compared against actual incident recovery in real time.

--- a/white-paper-noir/content/sections/4-implementation-roadmap.md
+++ b/white-paper-noir/content/sections/4-implementation-roadmap.md
@@ -1,0 +1,92 @@
++++
+title = "4. Implementation Roadmap"
+description = "Phased migration guidance for enterprises transitioning from legacy to resilient architectures, with cost models, timeline benchmarks, and organizational change management."
+weight = 4
+template = "post"
+tags = ["implementation", "migration", "cost-model"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Phased migration approach
+
+Our data shows that enterprises attempting a single large-scale migration to resilient architectures experience a 2.3x higher failure rate than those following a phased approach. We recommend a four-phase migration spanning 18--24 months:
+
+**Phase 1: Assessment (months 1--3).** Map the complete service dependency graph, establish baseline resilience metrics (BRS, DCD, CRI), and identify the top 10 services with the highest blast radius scores. This phase requires no infrastructure changes and produces the prioritised migration backlog.
+
+**Phase 2: Foundation (months 4--9).** Implement observability instrumentation (dependency health maps, blast radius projections) and deploy circuit breakers on the top 10 highest-risk dependency edges. Establish isolation zone boundaries and begin fault injection testing.
+
+**Phase 3: Migration (months 10--18).** Migrate critical services to resilience-first architectures in priority order, beginning with the highest blast radius components. Each migration follows a strangler pattern: deploy the resilient version alongside the legacy version, shift traffic incrementally, validate resilience properties through fault injection, and decommission the legacy version.
+
+**Phase 4: Optimisation (months 19--24).** Fine-tune circuit breaker parameters based on production telemetry, implement adaptive degradation strategies, and establish ongoing resilience regression testing in CI/CD pipelines.
+
+## 4.2 Cost model
+
+Infrastructure resilience investment follows a characteristic cost curve with front-loaded capital expenditure and declining operational expenditure:
+
+<table class="paper-table">
+<caption>Table 3. Resilience investment cost model (median values, normalised per 100 services)</caption>
+<thead>
+<tr>
+<th>Phase</th>
+<th>Duration</th>
+<th>Capital Cost</th>
+<th>Operational Cost/mo</th>
+<th>Cumulative ROI</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Assessment</td>
+<td>3 months</td>
+<td>$180K</td>
+<td>$12K</td>
+<td>-$216K</td>
+</tr>
+<tr>
+<td>Foundation</td>
+<td>6 months</td>
+<td>$420K</td>
+<td>$28K</td>
+<td>-$804K</td>
+</tr>
+<tr>
+<td>Migration</td>
+<td>9 months</td>
+<td>$1.2M</td>
+<td>$45K</td>
+<td>-$1.6M</td>
+</tr>
+<tr>
+<td>Optimisation</td>
+<td>6 months</td>
+<td>$90K</td>
+<td>$18K</td>
+<td>+$420K</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">ROI calculation assumes $9,200/min downtime cost and observed 73% reduction in cascading failure incidents.</td>
+</tr>
+</tfoot>
+</table>
+
+Median payback period across our dataset is 22 months from programme initiation. Enterprises in financial services achieve payback in 14 months due to higher per-minute downtime costs; logistics enterprises average 28 months.
+
+## 4.3 Organisational change management
+
+Technical architecture changes alone are insufficient. Our data shows that 41% of resilience programme failures are attributable to organisational factors rather than technical ones:
+
+- **On-call fatigue** from increased alert volume during migration (mitigated by phased rollout and alert consolidation).
+- **Skill gaps** in distributed systems debugging (mitigated by embedded SRE coaching and incident simulation exercises).
+- **Incentive misalignment** when teams are measured on feature delivery velocity rather than system reliability (mitigated by incorporating CRI into team-level OKRs).
+
+## 4.4 Governance framework
+
+Sustained resilience requires governance structures that prevent regression:
+
+1. **Quarterly resilience reviews** at the architecture board level, examining CRI trends and blast radius scores for all critical services.
+2. **Resilience gates** in the deployment pipeline that block releases introducing new single points of failure or increasing dependency chain depth beyond thresholds.
+3. **Annual chaos engineering campaigns** that validate isolation zone boundaries and recovery procedures under realistic failure conditions.

--- a/white-paper-noir/content/sections/5-recommendations.md
+++ b/white-paper-noir/content/sections/5-recommendations.md
@@ -1,0 +1,62 @@
++++
+title = "5. Recommendations"
+description = "Executive-level recommendations, governance frameworks, and metrics for ongoing resilience measurement across enterprise infrastructure."
+weight = 5
+template = "post"
+tags = ["recommendations", "governance", "executive"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of findings
+
+This white paper's analysis of 142 enterprise deployments across four sectors demonstrates that resilience-first architectural patterns deliver measurable improvements in infrastructure reliability:
+
+- **73% reduction** in cascading failure incidents.
+- **4.2x improvement** in mean time to recovery.
+- **31% fewer** customer-visible incidents for top-quartile CRI performers.
+- **22-month median payback** on resilience investment programmes.
+
+These outcomes are not the result of increased infrastructure spending alone. The differentiating factor is architectural approach: organisations that treat resilience as a primary design constraint (not a retrofit) achieve disproportionately better outcomes at comparable cost.
+
+## 5.2 Executive recommendations
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation 1</p>
+<p><strong>Adopt resilience-centric metrics.</strong> Replace availability percentages as the primary infrastructure health metric with the Composite Resilience Index (CRI), which captures blast radius, recovery velocity, and degradation quality in a single board-reportable number.</p>
+</div>
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation 2</p>
+<p><strong>Mandate isolation zone boundaries.</strong> Require that every critical service operates within at least two independent isolation zones with validated failover. Zone boundaries must be tested through fault injection, not assumed from cloud provider documentation.</p>
+</div>
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation 3</p>
+<p><strong>Invest in dependency graph visibility.</strong> Deploy real-time dependency health maps and blast radius projection tooling before beginning architecture migration. You cannot improve what you cannot see, and most enterprises significantly underestimate their actual dependency chain depth.</p>
+</div>
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation 4</p>
+<p><strong>Follow a phased migration approach.</strong> Resist the temptation to execute a single large-scale migration. The four-phase approach (Assessment, Foundation, Migration, Optimisation) reduces programme failure risk by 2.3x while delivering incremental resilience improvements from Phase 2 onward.</p>
+</div>
+
+<div class="rec-box">
+<p class="rec-box-label">Recommendation 5</p>
+<p><strong>Align organisational incentives.</strong> Incorporate CRI into team-level OKRs alongside feature delivery velocity. Establish resilience gates in deployment pipelines and quarterly resilience reviews at the architecture board level. Technical resilience without organisational resilience is fragile.</p>
+</div>
+
+## 5.3 Sector-specific guidance
+
+**Financial services.** Leverage existing regulatory frameworks (DORA, OCC operational resilience guidance) to justify resilience investment. Map CRI components to regulatory requirements for unified compliance and resilience reporting.
+
+**Healthcare.** Prioritise legacy system isolation (containment over modernisation) for systems on 10+ year refresh cycles. Deploy protocol translation layers that isolate modern services from legacy interfaces while maintaining clinical workflow continuity.
+
+**Logistics.** Focus on edge resilience, where IoT device mesh networks and warehouse automation systems operate with intermittent connectivity. Design for partition-tolerant operation with eventual consistency reconciliation.
+
+**Critical infrastructure.** Engage regulators early in resilience programme design to align investment cycles with regulatory approval timelines. Prioritise air-gapped recovery capabilities for operational technology (OT) environments.
+
+## 5.4 Future outlook
+
+The convergence of AI-assisted operations, infrastructure-as-code maturity, and next-generation observability platforms creates an opportunity for significant advancement in infrastructure resilience over the next 3--5 years. Enterprises that establish resilience foundations now will be positioned to adopt these capabilities as they mature, while those that defer will face compounding technical debt and increasing competitive disadvantage.

--- a/white-paper-noir/content/sections/_index.md
+++ b/white-paper-noir/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+This white paper presents a structured analysis of enterprise digital infrastructure resilience, progressing from industry landscape assessment through risk frameworks and architecture patterns to actionable implementation guidance.

--- a/white-paper-noir/static/css/style.css
+++ b/white-paper-noir/static/css/style.css
@@ -1,0 +1,626 @@
+/* =========================================================
+   White Paper Noir -- Dark Industry Paper
+   ========================================================= */
+
+:root {
+  --bg: #0a0a0a;
+  --bg-2: #111111;
+  --bg-3: #1a1a1a;
+  --rule: #2a2a2a;
+  --rule-light: #333333;
+  --ink: #f0f0f0;
+  --ink-2: #d4d4d4;
+  --ink-3: #8a8a8a;
+  --ink-4: #555555;
+  --accent: #ffffff;
+  --accent-2: #cccccc;
+  --exec-border: #ffffff;
+  --chart-1: #ffffff;
+  --chart-2: #888888;
+  --chart-3: #555555;
+  --chart-4: #333333;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: "Inter", "Source Sans Pro", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink-2);
+  background: var(--bg);
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- Layout --- */
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* --- Header --- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 2px solid var(--accent);
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.logo-mark {
+  width: 56px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.journal-name {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.journal-sub {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Main content --- */
+
+.site-main {
+  min-height: calc(100vh - 200px);
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+}
+
+/* --- Paper header / eyebrow --- */
+
+.paper-section-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 0.5rem;
+}
+
+.paper-section-title {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.2;
+  margin: 0 0 0.75rem;
+}
+
+.paper-lede {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 1rem;
+  color: var(--ink-3);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Typography --- */
+
+.paper-content h2 {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-size: clamp(1.2rem, 2.5vw, 1.5rem);
+  font-weight: 700;
+  color: var(--ink);
+  margin: 2.5rem 0 1rem;
+  line-height: 1.25;
+}
+
+.paper-content h3 {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  margin: 2rem 0 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.paper-content h4 {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  margin: 1.5rem 0 0.5rem;
+}
+
+.paper-content p {
+  margin: 1em 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-content ul,
+.paper-content ol {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.paper-content li {
+  margin-bottom: 0.4rem;
+}
+
+.paper-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+.paper-content code {
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.85em;
+  background: var(--bg-3);
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--rule);
+}
+
+.paper-content pre {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* --- Executive summary panel --- */
+
+.exec-panel {
+  border: 2px solid var(--exec-border);
+  padding: 2rem;
+  margin: 2rem 0;
+  position: relative;
+}
+
+.exec-panel::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  right: -1px;
+  bottom: -1px;
+  border: 1px solid var(--rule-light);
+  pointer-events: none;
+}
+
+.exec-panel-label {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.exec-panel h3 {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 0 0 0.75rem;
+}
+
+.exec-panel p {
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+}
+
+/* --- Key metrics bar --- */
+
+.metrics-bar {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin: 2.5rem 0;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.metric-item {
+  text-align: center;
+  flex: 1;
+}
+
+.metric-item + .metric-item {
+  border-left: 1px solid var(--rule);
+}
+
+.metric-value {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--ink);
+  display: block;
+  line-height: 1;
+}
+
+.metric-label {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  display: block;
+  margin-top: 0.35rem;
+}
+
+/* --- Figures --- */
+
+.figure {
+  margin: 2.5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.figure-caption {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--rule);
+  line-height: 1.5;
+}
+
+/* --- Tables --- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+
+.paper-table caption {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: left;
+  color: var(--ink-3);
+  padding: 0 0 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+.paper-table thead th {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--accent);
+  background: var(--bg-2);
+}
+
+.paper-table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+
+.paper-table tbody tr:hover {
+  background: var(--bg-2);
+}
+
+.paper-table tfoot td {
+  padding: 0.5rem 0.75rem;
+  font-style: italic;
+  color: var(--ink-4);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* --- Recommendation boxes --- */
+
+.rec-box {
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  padding: 1.25rem 1.5rem;
+  margin: 1.5rem 0;
+  background: var(--bg-2);
+}
+
+.rec-box-label {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  margin: 0 0 0.5rem;
+}
+
+.rec-box p {
+  margin: 0.4rem 0;
+  font-size: 0.92rem;
+}
+
+/* --- Section list --- */
+
+ul.section-list {
+  list-style: decimal;
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+ul.section-list li a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* --- Section footer nav --- */
+
+.paper-section-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2px;
+}
+
+.button-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Footer --- */
+
+.site-footer {
+  margin-top: 0;
+  padding: 0;
+}
+
+.footer-rule svg {
+  display: block;
+  width: 100%;
+  height: 6px;
+}
+
+.footer-content {
+  padding: 1.5rem 0 2rem;
+  text-align: center;
+}
+
+.footer-meta {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  line-height: 1.6;
+  margin: 0 0 0.5rem;
+}
+
+.footer-meta em {
+  font-style: italic;
+}
+
+.footer-note {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* --- Error page --- */
+
+.error-page {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.error-page h1 {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-size: 2rem;
+  color: var(--ink);
+}
+
+/* --- Taxonomy pages --- */
+
+.taxonomy-desc {
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Pagination --- */
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--accent); color: var(--ink); }
+
+/* --- Author grid --- */
+
+.author-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.author-card {
+  border: 1px solid var(--rule);
+  padding: 1rem;
+  text-align: center;
+}
+
+.author-card .author-name {
+  font-family: "Playfair Display", "Cormorant", Georgia, serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+  display: block;
+}
+
+.author-card .author-role {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-4);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.25rem;
+}
+
+/* --- Alert shortcode --- */
+
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+  border-left: 4px solid var(--accent);
+  margin: 1rem 0;
+  color: var(--ink-2);
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 700px) {
+  .paper-wrap {
+    padding: 0 1rem;
+  }
+
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .paper-article {
+    padding: 2rem 0 3rem;
+  }
+
+  .metrics-bar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .metric-item + .metric-item {
+    border-left: none;
+    border-top: 1px solid var(--rule);
+    padding-top: 1rem;
+  }
+
+  .exec-panel {
+    padding: 1.25rem;
+  }
+
+  .author-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/white-paper-noir/templates/404.html
+++ b/white-paper-noir/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to executive summary</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/white-paper-noir/templates/footer.html
+++ b/white-paper-noir/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#ffffff" stroke-width="1.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#333333" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura R, Okonkwo C, Lindqvist E, Patel S. Digital Infrastructure Resilience: Enterprise Strategies for Critical Systems Modernization. <em>Enterprise Architecture Review.</em> 2026;14(3):112-148. doi:10.50912/ear.2026.14.3.112</p>
+        <p class="footer-note">ISSN 2891-4420 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/white-paper-noir/templates/header.html
+++ b/white-paper-noir/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Cormorant:wght@400;600;700&family=Inter:wght@400;500;600;700&family=Source+Sans+Pro:wght@400;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Architecture block diagram icon -->
+          <rect x="2" y="4" width="16" height="10" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+          <rect x="20" y="4" width="16" height="10" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+          <rect x="38" y="4" width="16" height="10" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+          <line x1="10" y1="14" x2="10" y2="22" stroke="#888888" stroke-width="1"/>
+          <line x1="28" y1="14" x2="28" y2="22" stroke="#888888" stroke-width="1"/>
+          <line x1="46" y1="14" x2="46" y2="22" stroke="#888888" stroke-width="1"/>
+          <rect x="2" y="22" width="52" height="10" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+          <line x1="18" y1="22" x2="18" y2="32" stroke="#555555" stroke-width="0.5" stroke-dasharray="2,2"/>
+          <line x1="38" y1="22" x2="38" y2="32" stroke="#555555" stroke-width="0.5" stroke-dasharray="2,2"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Enterprise Architecture Review</span>
+          <span class="journal-sub">Vol. 14 &middot; Issue 03 &middot; Mar 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">EXECUTIVE SUMMARY</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/methodology/">METHODOLOGY</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/white-paper-noir/templates/page.html
+++ b/white-paper-noir/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/white-paper-noir/templates/post.html
+++ b/white-paper-noir/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/white-paper-noir/templates/section.html
+++ b/white-paper-noir/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/white-paper-noir/templates/shortcodes/alert.html
+++ b/white-paper-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/white-paper-noir/templates/taxonomy.html
+++ b/white-paper-noir/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/white-paper-noir/templates/taxonomy_term.html
+++ b/white-paper-noir/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Add white-paper-noir dark industry white paper example site
- Features technical architecture diagrams in white line art on black, executive summary panels with authority borders, and market trend chart illustrations with data visualizations
- Typography: Playfair Display Bold/Cormorant Bold for display (white on black), Inter/Source Sans Pro for body (light gray on dark)
- Includes 5 content sections (Industry Landscape, Risk Framework, Architecture Patterns, Implementation Roadmap, Recommendations) plus Methodology and Appendix pages
- Updates tags.json with paper, dark, industry, executive, authoritative tags

Closes #1601

## Test plan
- [x] hwaro build completes successfully (9 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry