### PR TITLE
feat: add letter-to-editor example site (closes #1615)

### DIFF
--- a/letter-to-editor/AGENTS.md
+++ b/letter-to-editor/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/letter-to-editor/config.toml
+++ b/letter-to-editor/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Letter to the Editor - Correspondence Paper
+# Issue #1615 | Tags: paper, light, correspondence, urgent, brief
+# =============================================================================
+
+title = "Letter to the Editor"
+description = "A correspondence paper with letter/envelope frame motifs, reference link arrows pointing to the paper being responded to, and urgency level indicators."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/letter-to-editor/content/appendix.md
+++ b/letter-to-editor/content/appendix.md
@@ -1,0 +1,28 @@
++++
+title = "Appendix"
+description = "Supplementary details on the sensitivity analysis and competing interests."
+tags = ["correspondence", "appendix"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">APPENDIX</p>
+  <h1 class="paper-section-title">Supplementary Materials</h1>
+</header>
+
+## A. Sensitivity analysis for selection bias estimate
+
+Our estimate that inclusion of excluded patients would reduce the AUROC from 0.91 to 0.83-0.86 is based on the following assumptions:
+
+1. The excluded population (n = 2,847) has a higher proportion of ambiguous presentations (assumed 45% vs. 28% in the included population, based on the diagnostic uncertainty scores reported in Table S2 of the original study).
+2. Model performance on ambiguous presentations is lower by approximately 0.12 AUROC points, based on the subgroup analysis reported in Reference 6 for a comparable triage prediction model.
+3. The excluded trauma patients (n = 892) represent a high-acuity subgroup with different feature distributions from the included high-acuity patients.
+
+These assumptions are conservative; the actual impact may be larger.
+
+## B. Competing interests
+
+CN has served as a clinical advisor to two NHS trusts evaluating AI triage systems (not DeepTriage). EB has received research funding from the Swedish Research Council for work on clinical decision support systems. AC declares no competing interests.
+
+## C. Word count
+
+This letter (excluding references and appendix) comprises 842 words, within the journal's 1,000-word limit for correspondence. The brevity is deliberate: our goal is to flag specific, actionable methodological concerns, not to provide a comprehensive critique. We hope that the authors will address these points in their response and, where appropriate, provide the additional analyses we have requested.

--- a/letter-to-editor/content/index.md
+++ b/letter-to-editor/content/index.md
@@ -1,0 +1,134 @@
++++
+title = "Letter"
+description = "A letter to the editor raising methodological concerns about the validation of AI-assisted triage in emergency departments."
+tags = ["paper", "light", "correspondence", "urgent", "brief"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Correspondence &middot; Open Access</p>
+  <span class="urgency-badge high">Urgent Communication</span>
+  <h1 class="paper-title">Methodological Concerns Regarding the Validation of AI-Assisted Triage in Emergency Departments</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Chidera Nwosu</span><sup>1</sup>,
+    Erik Bergstrom<sup>2</sup>,
+    Ananya Chakraborty<sup>3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Emergency Medicine, University College London Hospitals NHS Trust &middot;
+    <sup>2</sup>Division of Clinical Informatics, Karolinska University Hospital &middot;
+    <sup>3</sup>Centre for Health Policy, Indian Institute of Technology Delhi
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.1016/S2589-7500(26)00042-7</a> &middot; <strong>Received:</strong> 18 Feb 2026 &middot; <strong>Published:</strong> 28 Mar 2026</p>
+</header>
+
+<div class="ref-target">
+  <p class="ref-label">In response to</p>
+  <p class="ref-citation">Martinez-Alvarez JC, Kim S, Osei-Bonsu K, et al. Validation of DeepTriage v3.1 for emergency department acuity prediction: a multicentre prospective cohort study. <em>Lancet Digit. Health</em> 2026;8(2):e89-e102. doi:10.1016/S2589-7500(26)00018-X</p>
+</div>
+
+## Letter/Envelope Reference Map
+
+<figure class="figure">
+  <svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Letter and envelope frame motif showing the correspondence structure and reference link arrows between this letter and the original paper">
+    <!-- Title -->
+    <text x="360" y="18" text-anchor="middle" font-family="Libre Baskerville, serif" font-weight="700" font-size="11" fill="#2c2418">CORRESPONDENCE MAP: LETTER TO ORIGINAL PAPER</text>
+
+    <!-- Original paper (envelope) -->
+    <rect x="30" y="40" width="240" height="140" rx="3" fill="none" stroke="#c8bfb0" stroke-width="1.5"/>
+    <polyline points="30,40 150,110 270,40" fill="none" stroke="#c8bfb0" stroke-width="1"/>
+    <text x="150" y="70" text-anchor="middle" font-family="Libre Baskerville, serif" font-weight="700" font-size="9" fill="#8b4513">ORIGINAL PAPER</text>
+    <text x="150" y="86" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#2c2418">Martinez-Alvarez et al. 2026</text>
+    <text x="150" y="98" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#7a7060">DeepTriage v3.1 Validation</text>
+    <line x1="60" y1="110" x2="240" y2="110" stroke="#c8bfb0" stroke-width="0.5"/>
+    <text x="150" y="124" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7060">N = 14,203 patients</text>
+    <text x="150" y="136" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7060">4 emergency departments</text>
+    <text x="150" y="148" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7060">AUROC 0.91 (claimed)</text>
+    <text x="150" y="160" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#7a7060">Lancet Digit. Health 8(2)</text>
+
+    <!-- Reference arrows -->
+    <defs>
+      <marker id="arrow-ref" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <polygon points="0 0, 8 3, 0 6" fill="#2a6496"/>
+      </marker>
+      <marker id="arrow-concern" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <polygon points="0 0, 8 3, 0 6" fill="#b83220"/>
+      </marker>
+    </defs>
+
+    <!-- This letter (envelope) -->
+    <rect x="390" y="40" width="300" height="140" rx="3" fill="none" stroke="#8b4513" stroke-width="1.5"/>
+    <polyline points="390,40 540,110 690,40" fill="none" stroke="#8b4513" stroke-width="1"/>
+    <text x="540" y="70" text-anchor="middle" font-family="Libre Baskerville, serif" font-weight="700" font-size="9" fill="#8b4513">THIS LETTER</text>
+    <text x="540" y="86" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#2c2418">Nwosu, Bergstrom, Chakraborty</text>
+    <text x="540" y="98" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#7a7060">Methodological Concerns</text>
+    <line x1="420" y1="110" x2="660" y2="110" stroke="#c8bfb0" stroke-width="0.5"/>
+    <text x="540" y="124" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#b83220">Concern 1: Selection bias</text>
+    <text x="540" y="136" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#b83220">Concern 2: Outcome leakage</text>
+    <text x="540" y="148" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#b83220">Concern 3: Subgroup analysis</text>
+    <text x="540" y="160" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="6" fill="#b83220">Concern 4: Clinical utility</text>
+
+    <!-- Reference arrows from letter to paper -->
+    <line x1="390" y1="124" x2="270" y2="124" stroke="#2a6496" stroke-width="1.2" marker-end="url(#arrow-ref)"/>
+    <text x="330" y="118" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#2a6496">references</text>
+
+    <line x1="390" y1="148" x2="270" y2="148" stroke="#b83220" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#arrow-concern)"/>
+    <text x="330" y="142" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#b83220">challenges</text>
+
+    <!-- Urgency indicators -->
+    <text x="360" y="210" text-anchor="middle" font-family="Libre Baskerville, serif" font-weight="700" font-size="9" fill="#2c2418">URGENCY LEVEL INDICATORS</text>
+
+    <!-- High urgency -->
+    <rect x="80" y="225" width="120" height="30" fill="none" stroke="#b83220" stroke-width="1.5" rx="2"/>
+    <rect x="80" y="225" width="120" height="4" fill="#b83220" rx="2"/>
+    <text x="140" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-weight="700" font-size="8" fill="#b83220">HIGH</text>
+    <text x="140" y="268" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7060">Patient safety risk</text>
+
+    <!-- Moderate urgency -->
+    <rect x="250" y="225" width="120" height="30" fill="none" stroke="#8b4513" stroke-width="1.5" rx="2"/>
+    <rect x="250" y="225" width="120" height="4" fill="#8b4513" rx="2"/>
+    <text x="310" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-weight="700" font-size="8" fill="#8b4513">MODERATE</text>
+    <text x="310" y="268" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7060">Methodological flaw</text>
+
+    <!-- Standard urgency -->
+    <rect x="420" y="225" width="120" height="30" fill="none" stroke="#7a7060" stroke-width="1.5" rx="2"/>
+    <rect x="420" y="225" width="120" height="4" fill="#7a7060" rx="2"/>
+    <text x="480" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-weight="700" font-size="8" fill="#7a7060">STANDARD</text>
+    <text x="480" y="268" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7060">Interpretive note</text>
+
+    <!-- Response pending -->
+    <rect x="590" y="225" width="100" height="30" fill="none" stroke="#3a7a4a" stroke-width="1.5" rx="2" stroke-dasharray="4 3"/>
+    <text x="640" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-weight="700" font-size="8" fill="#3a7a4a">RESPONSE</text>
+    <text x="640" y="268" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="5.5" fill="#7a7060">Author reply pending</text>
+  </svg>
+  <figcaption><span class="fig-num">Figure 1.</span> Correspondence map showing the relationship between this letter and the original publication by Martinez-Alvarez et al. (2026), with reference link arrows identifying specific points of contention and urgency level classification for each concern raised.</figcaption>
+</figure>
+
+<div class="correspondence-callout">
+  <div class="callout-stat">
+    <span class="callout-value">4</span>
+    <span class="callout-label">Concerns Raised</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">2</span>
+    <span class="callout-label">High Urgency</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">38</span>
+    <span class="callout-label">Days to Publication</span>
+  </div>
+  <div class="callout-sep" aria-hidden="true"></div>
+  <div class="callout-stat">
+    <span class="callout-value">Pending</span>
+    <span class="callout-label">Author Response</span>
+  </div>
+</div>
+
+<div class="letter-body">
+
+We read with interest the recent study by Martinez-Alvarez and colleagues reporting the multicentre validation of DeepTriage v3.1 for emergency department acuity prediction. While we acknowledge the ambition and scale of this work, we write to raise four methodological concerns that, in our view, materially affect the interpretation of the reported results and their implications for clinical deployment.
+
+These concerns are presented not as a rejection of AI-assisted triage as a concept but as a call for greater methodological rigour in validation studies whose results will directly inform deployment decisions affecting patient safety.
+
+</div>

--- a/letter-to-editor/content/references.md
+++ b/letter-to-editor/content/references.md
@@ -1,0 +1,29 @@
++++
+title = "References"
+description = "Key references cited in the correspondence."
+tags = ["correspondence", "references"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">REFERENCES</p>
+  <h1 class="paper-section-title">Cited Works</h1>
+</header>
+
+<div class="ref-target">
+  <p class="ref-label">Primary Reference</p>
+  <p class="ref-citation">1. Martinez-Alvarez JC, Kim S, Osei-Bonsu K, et al. Validation of DeepTriage v3.1 for emergency department acuity prediction: a multicentre prospective cohort study. <em>Lancet Digit. Health</em> 2026;8(2):e89-e102.</p>
+</div>
+
+2. Obermeyer Z, Powers B, Vogeli C, Mullainathan S. Dissecting racial bias in an algorithm used to manage the health of populations. *Science* 2019;366(6464):447-453.
+
+3. Vickers AJ, Elkin EB. Decision curve analysis: a novel method for evaluating prediction models. *Med Decis Making* 2006;26(6):565-574.
+
+4. Seyyed-Kalantari L, Zhang H, McDermott MBA, Chen IY, Ghassemi M. Underdiagnosis bias of artificial intelligence algorithms applied to chest radiographs in under-served patient populations. *Nat Med* 2021;27(12):2176-2182.
+
+5. Van Calster B, McLernon DJ, van Smeden M, Steyerberg EW. Calibration: the Achilles heel of predictive analytics. *BMC Med* 2019;17(1):230.
+
+6. Levin S, Toerper M, Hamrock E, et al. Machine-learning-based electronic triage more accurately differentiates patients with respect to clinical outcomes compared with the Emergency Severity Index. *Ann Emerg Med* 2018;71(5):565-574.e2.
+
+7. Collins GS, Reitsma JB, Altman DG, Moons KGM. Transparent Reporting of a multivariable prediction model for Individual Prognosis or Diagnosis (TRIPOD): the TRIPOD statement. *Ann Intern Med* 2015;162(1):55-63.
+
+8. Wynants L, Van Calster B, Collins GS, et al. Prediction models for diagnosis and prognosis of covid-19: systematic review and critical appraisal. *BMJ* 2020;369:m1328.

--- a/letter-to-editor/content/sections/1-selection-bias.md
+++ b/letter-to-editor/content/sections/1-selection-bias.md
@@ -1,0 +1,23 @@
++++
+title = "1. Selection Bias in the Study Population"
+description = "Concerns about non-random exclusion of patients from the validation cohort and its impact on reported performance."
+weight = 1
+template = "post"
+tags = ["correspondence", "methodology", "selection-bias"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+<span class="urgency-badge high">High Urgency</span>
+
+The study excluded 2,847 patients (16.7% of the initial cohort) who left before triage completion, were transferred from other facilities, or presented with trauma activation criteria. This exclusion is problematic for two reasons.
+
+First, patients who leave before triage completion are disproportionately those with conditions that present ambiguously -- precisely the patients for whom AI-assisted triage would be most clinically valuable. Their exclusion inflates the apparent accuracy of the system by removing the most diagnostically challenging cases.
+
+Second, trauma activations represent a significant proportion of high-acuity presentations. Excluding these patients from a validation study and then reporting a high AUROC for acuity prediction creates a misleading picture of the system's performance in the clinical context where accurate triage is most consequential.
+
+<div class="concern-block critical">
+  <h4>Impact Assessment</h4>
+  <p>We estimate that inclusion of the excluded population would reduce the reported AUROC from 0.91 to approximately 0.83-0.86, based on sensitivity analysis using the demographic characteristics of excluded patients reported in the study's supplementary Table S2.</p>
+</div>

--- a/letter-to-editor/content/sections/2-outcome-leakage.md
+++ b/letter-to-editor/content/sections/2-outcome-leakage.md
@@ -1,0 +1,23 @@
++++
+title = "2. Temporal Outcome Leakage"
+description = "Evidence that the model's input features may have contained information derived from the outcome being predicted."
+weight = 2
+template = "post"
+tags = ["correspondence", "methodology", "data-leakage"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+<span class="urgency-badge high">High Urgency</span>
+
+The feature set described in the study's Methods section includes "initial vital signs, chief complaint text, and nursing documentation at the time of triage." However, the supplementary materials reveal that "nursing documentation" includes fields that were populated *after* the initial triage decision was made -- specifically, the reassessment notes added during the first 30 minutes of the emergency department stay.
+
+This constitutes temporal outcome leakage: the model's inputs contain information that is causally downstream of, and correlated with, the outcome variable (final acuity classification). A model that has access to post-triage nursing observations will appear to predict acuity more accurately than a model restricted to information available at the point of triage, because the nursing observations already reflect the clinician's evolving assessment of patient acuity.
+
+We note that the original authors acknowledged this feature set in their Methods section but did not discuss the temporal relationship between feature collection and outcome determination. The distinction is clinically critical: a triage tool must predict acuity using only information available *before* the triage decision, not information that accumulates *after* it.
+
+<div class="concern-block critical">
+  <h4>Impact Assessment</h4>
+  <p>Temporal leakage through post-triage nursing documentation could account for a substantial portion of the model's apparent predictive power. Without an ablation study removing these features, the true prospective performance of the system at the point of triage remains unknown.</p>
+</div>

--- a/letter-to-editor/content/sections/3-subgroup-performance.md
+++ b/letter-to-editor/content/sections/3-subgroup-performance.md
@@ -1,0 +1,28 @@
++++
+title = "3. Inadequate Subgroup Analysis"
+description = "The absence of disaggregated performance metrics for clinically important subgroups undermines confidence in equitable deployment."
+weight = 3
+template = "post"
+tags = ["correspondence", "equity", "subgroup-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+<span class="urgency-badge moderate">Moderate Urgency</span>
+
+The study reports aggregate performance metrics across the full validation cohort but does not provide disaggregated performance by age group, sex, ethnicity, primary language, or presenting complaint category. This omission is particularly concerning given the growing evidence that clinical prediction models, including AI-based systems, may perform differently across demographic subgroups.
+
+The four participating emergency departments serve populations with substantially different demographic profiles (urban academic, suburban community, rural critical access, and paediatric specialist). Aggregate metrics across these sites may mask site-level or subgroup-level performance disparities that would be clinically and ethically unacceptable.
+
+We would urge the authors to provide, at minimum:
+
+- AUROC stratified by age decile, sex, and self-reported ethnicity
+- Sensitivity and specificity at the chosen operating threshold for each site independently
+- Performance metrics for the 10 most common presenting complaint categories
+- A formal assessment of differential calibration across subgroups
+
+<div class="concern-block methodological">
+  <h4>Impact Assessment</h4>
+  <p>Without subgroup analysis, it is impossible to determine whether the system maintains acceptable performance across the full range of patients it would encounter in deployment. A system with excellent aggregate AUROC but poor sensitivity for elderly patients presenting with atypical symptoms could cause significant harm.</p>
+</div>

--- a/letter-to-editor/content/sections/4-clinical-utility.md
+++ b/letter-to-editor/content/sections/4-clinical-utility.md
@@ -1,0 +1,25 @@
++++
+title = "4. From Discrimination to Clinical Utility"
+description = "The gap between discriminative performance (AUROC) and clinical utility, and why the study does not bridge it."
+weight = 4
+template = "post"
+tags = ["correspondence", "clinical-utility", "decision-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+<span class="urgency-badge moderate">Moderate Urgency</span>
+
+The study's primary outcome measure is the area under the receiver operating characteristic curve (AUROC), which measures the model's ability to discriminate between acuity levels. However, discrimination alone does not establish clinical utility -- the demonstration that using the model's predictions leads to better patient outcomes than the current standard of care.
+
+An AUROC of 0.91 indicates good discrimination, but it does not answer the question that matters for deployment: would patients triaged with the assistance of DeepTriage v3.1 experience better outcomes (shorter time to critical intervention, lower rates of under-triage, improved mortality) than patients triaged by experienced nurses using the Emergency Severity Index alone?
+
+The study design -- a prospective cohort with concurrent triage by both human and AI systems -- could have supported a comparison of clinical utility, but the authors chose to evaluate the model's predictions against the final clinical outcome rather than against the human triage decision. This means we know how well the model predicts acuity, but not how often it would have improved upon the human triage nurse's assessment.
+
+We believe that future validation studies should include a formal decision-analytic framework that quantifies the net clinical benefit of AI-assisted triage, accounting for the consequences of both over-triage (unnecessary resource utilisation) and under-triage (delayed critical care).
+
+<div class="concern-block interpretive">
+  <h4>Impact Assessment</h4>
+  <p>The gap between discriminative performance and clinical utility is not unique to this study, but the stakes of emergency department triage -- where under-triage can be fatal -- demand that this gap be explicitly addressed before deployment recommendations are made.</p>
+</div>

--- a/letter-to-editor/content/sections/_index.md
+++ b/letter-to-editor/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The letter is organised into four brief sections, each addressing a specific methodological concern with the original study.

--- a/letter-to-editor/static/css/style.css
+++ b/letter-to-editor/static/css/style.css
@@ -1,0 +1,571 @@
+/* ============================================================================
+   Letter to the Editor - Correspondence Paper
+   Light background, compact serif typography, letter/envelope motifs.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #faf8f5;
+  --bg-2: #f2efe8;
+  --bg-3: #e8e4da;
+  --rule: #c8bfb0;
+  --ink: #2c2418;
+  --ink-2: #3e3628;
+  --ink-3: #7a7060;
+  --ink-4: #a09480;
+  --accent: #8b4513;
+  --accent-2: #6d3410;
+  --urgent: #b83220;
+  --ref-link: #2a6496;
+  --response: #3a7a4a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 56px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-eyebrow {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.8rem;
+}
+
+.paper-title {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.8rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 700; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "Crimson Pro", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Urgency badge ---------------- */
+
+.urgency-badge {
+  display: inline-block;
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.8rem;
+  border: 1.5px solid var(--urgent);
+  color: var(--urgent);
+  margin-bottom: 1rem;
+}
+
+.urgency-badge.high { border-color: var(--urgent); color: var(--urgent); }
+.urgency-badge.moderate { border-color: var(--accent); color: var(--accent); }
+.urgency-badge.standard { border-color: var(--ink-3); color: var(--ink-3); }
+
+/* ---------------- Reference target box ---------------- */
+
+.ref-target {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--ref-link);
+  padding: 1.2rem 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.ref-target .ref-label {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ref-link);
+  margin: 0 0 0.4rem;
+}
+
+.ref-target .ref-citation {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Letter body box (envelope motif) ---------------- */
+
+.letter-body {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+  position: relative;
+}
+
+.letter-body::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--accent);
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2rem 0 0.6rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 1.5rem 0 0.4rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin: 1.2rem 0 0.3rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 0.8rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 0.8rem 0;
+  padding-left: 1.4rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.25rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--bg-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--accent);
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: clamp(1.3rem, 2.8vw, 1.8rem);
+  line-height: 1.25;
+  margin: 0 0 0.5rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Noto Serif", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.98rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Correspondence callout ---------------- */
+
+.correspondence-callout {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1.2rem 1.5rem;
+  margin: 1.5rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.correspondence-callout .callout-stat { text-align: center; }
+
+.correspondence-callout .callout-value {
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--accent);
+  display: block;
+  line-height: 1.1;
+}
+
+.correspondence-callout .callout-label {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.15em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.2rem;
+}
+
+.correspondence-callout .callout-sep {
+  width: 1px;
+  height: 2rem;
+  background: var(--rule);
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2rem 0;
+  padding: 1rem;
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #ffffff;
+  border: 1px solid var(--rule);
+  padding: 0.6rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "Libre Baskerville", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.88rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin-bottom: 0.5rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "Libre Baskerville", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  background: var(--bg-2);
+  border-bottom: 2px solid var(--ink-3);
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.84rem;
+  text-align: right;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.4rem; margin: 1.2rem 0; }
+.section-list li {
+  padding: 0.4rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "Libre Baskerville", "Crimson Text", serif;
+  font-size: 0.92rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons / Footer ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "Crimson Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.84rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 2.5rem; padding-top: 1.2rem; border-top: 1px solid var(--rule); }
+.error-page { text-align: center; padding: 3rem 0; }
+
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 0 2.5rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1rem; }
+
+.footer-content { max-width: 720px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "Crimson Pro", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin: 0.6rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Concern blocks ---------------- */
+
+.concern-block {
+  margin: 1.2rem 0;
+  padding: 1rem 1.4rem;
+  border-left: 3px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.concern-block.critical { border-left-color: var(--urgent); }
+.concern-block.methodological { border-left-color: var(--accent); }
+.concern-block.interpretive { border-left-color: var(--ref-link); }
+
+.concern-block h4 {
+  font-family: "Libre Baskerville", serif;
+  font-weight: 700;
+  font-size: 0.98rem;
+  margin: 0 0 0.3rem;
+  font-style: normal;
+}
+
+.concern-block p {
+  margin: 0.2rem 0;
+  font-size: 0.92rem;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 15px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .correspondence-callout { flex-direction: column; gap: 0.8rem; }
+  .correspondence-callout .callout-sep { width: 3rem; height: 1px; }
+  .letter-body { padding: 1rem 1.2rem; }
+}

--- a/letter-to-editor/templates/404.html
+++ b/letter-to-editor/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to letter</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/letter-to-editor/templates/footer.html
+++ b/letter-to-editor/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c8bfb0" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c8bfb0" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nwosu C, Bergstrom E, Chakraborty A. Methodological Concerns Regarding the Validation of AI-Assisted Triage in Emergency Departments (Letter). <em>Lancet Digit. Health</em> 2026;8(4):e212-e214. doi:10.1016/S2589-7500(26)00042-7</p>
+        <p class="footer-note">ISSN 2589-7500 &middot; Copyright 2026 The Authors. Published by Elsevier Ltd. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/letter-to-editor/templates/header.html
+++ b/letter-to-editor/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Crimson+Text:ital,wght@0,400;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Abstract letter/envelope icon -->
+          <rect x="6" y="8" width="44" height="28" rx="2" fill="none" stroke="#8b4513" stroke-width="1.5"/>
+          <polyline points="6,8 28,24 50,8" fill="none" stroke="#8b4513" stroke-width="1.2"/>
+          <line x1="6" y1="36" x2="20" y2="22" stroke="#8b4513" stroke-width="0.8" opacity="0.5"/>
+          <line x1="50" y1="36" x2="36" y2="22" stroke="#8b4513" stroke-width="0.8" opacity="0.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Correspondence -- Lancet Digital Health</span>
+          <span class="journal-sub">Vol. 8 &middot; Issue 04 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">LETTER</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/references/">REFERENCES</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/letter-to-editor/templates/page.html
+++ b/letter-to-editor/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/letter-to-editor/templates/post.html
+++ b/letter-to-editor/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/letter-to-editor/templates/section.html
+++ b/letter-to-editor/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/letter-to-editor/templates/shortcodes/alert.html
+++ b/letter-to-editor/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/letter-to-editor/templates/taxonomy.html
+++ b/letter-to-editor/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/letter-to-editor/templates/taxonomy_term.html
+++ b/letter-to-editor/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1947,6 +1947,13 @@
     "docs",
     "finance"
   ],
+  "letter-to-editor": [
+    "paper",
+    "light",
+    "correspondence",
+    "urgent",
+    "brief"
+  ],
   "letterbox": [
     "light",
     "blog",
@@ -2037,12 +2044,6 @@
     "portfolio",
     "minimal"
   ],
-  "lumos": [
-    "blog",
-    "elegant",
-    "light",
-    "minimal"
-  ],
   "luminary": [
     "light",
     "elegant",
@@ -2053,6 +2054,12 @@
     "blog",
     "luminescent",
     "mesh"
+  ],
+  "lumos": [
+    "blog",
+    "elegant",
+    "light",
+    "minimal"
   ],
   "lunar-base": [
     "elegant",


### PR DESCRIPTION
## Summary
- Light-themed correspondence paper with letter/envelope frame motifs, reference link arrows pointing to the paper being responded to, and urgency level indicators for communication priority
- Typography uses Libre Baskerville Bold/Crimson Text Bold for display and Crimson Pro/Noto Serif at compact leading for body
- Content models a letter raising methodological concerns about an AI-assisted triage validation study

## Test plan
- [ ] Verify `hwaro build` succeeds in letter-to-editor directory
- [ ] Check light theme renders correctly with brown accent colors
- [ ] Confirm SVG correspondence map with envelope motifs and reference arrows displays properly
- [ ] Validate urgency badges (high/moderate/standard) render with correct colors
- [ ] Test responsive layout at mobile breakpoint (700px)

Closes #1615