### PR TITLE
feat: add cold-case example site (closes #1600)

### DIFF
--- a/cold-case/AGENTS.md
+++ b/cold-case/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/cold-case/config.toml
+++ b/cold-case/config.toml
@@ -1,0 +1,52 @@
+title = "The Belmont Disappearance"
+description = "A reopened investigation paper re-examining a 1987 missing persons case with new forensic evidence, reconstructed timelines, and evidence chain diagrams connecting previously unlinked findings."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/cold-case/content/appendix.md
+++ b/cold-case/content/appendix.md
@@ -1,0 +1,50 @@
++++
+title = "Appendix"
+description = "Supplementary materials including investigator notes, witness list, legal references, and disclosure statements."
+tags = ["appendix", "supplementary", "legal"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+<h1 class="paper-section-title">Appendix</h1>
+</header>
+
+<div class="paper-content">
+
+## A. Witness Register
+
+Seven witnesses were re-interviewed during the 2024--2025 reopened investigation. Of the original 23 witnesses, 9 are deceased, 4 could not be located, and 3 declined to participate. The 7 re-interviewed witnesses include:
+
+- **W-01** (Catherine Belmont-Hayes, sister): Provided voluntary DNA sample. Confirmed last telephone contact 12 October 1987.
+- **W-07** (Neighbour, Lakeshore Drive): Revised original statement to include sounds heard on night of 14 October 1987.
+- **W-14** (Library colleague): Disclosed previously unreported statements by subject indicating fear of spouse.
+- **W-15** (Former neighbour, moved 1990): Confirmed frequent presence of a second vehicle at property.
+- **W-18** (R. Belmont's former employer): Confirmed Belmont's construction skills and access to materials.
+- **W-19** (Greyhound terminal employee, newly identified): Observed male parking vehicle matching subject's car in terminal lot.
+- **W-20** (Insurance agent): Provided records of 1995 life insurance claim and policy details.
+
+## B. Investigator Disclosures
+
+- **Lead investigator M. Torres** has 18 years of service in the Cold Case Division with no prior connection to the Belmont family or the Ridgemont County Sheriff's Department.
+- **K. Gustafsson** provided forensic analysis expertise. No conflicts of interest declared.
+- **N. Obi** conducted witness re-interviews and evidence documentation. No conflicts of interest declared.
+
+## C. Legal Framework
+
+This reopened investigation operates under the following legal authorities:
+
+- State Cold Case Review Act (2012), Section 4(a): Authorises reopening of closed cases when new physical evidence is discovered.
+- State Code of Criminal Procedure, Section 12.01(a)(1): No statute of limitations for homicide offences.
+- Interstate Compact for Fugitives, Article IV: Enables cooperation with other jurisdictions for person-of-interest interviews.
+
+## D. Author Contributions
+
+- **M. Torres** -- Case review, evidence chain analysis, timeline reconstruction, report authorship.
+- **K. Gustafsson** -- Forensic evidence coordination, laboratory liaison, evidence synthesis.
+- **N. Obi** -- Witness re-interviews, records research, chain of custody management.
+
+## E. Acknowledgements
+
+The investigators acknowledge the cooperation of Catherine Belmont-Hayes, who provided a voluntary DNA sample and participated in multiple interviews despite the personal difficulty of the subject matter. We also acknowledge the Ridgemont County Forensic Laboratory and the State Bureau of Investigation Forensic Biology Unit for analytical services.
+
+</div>

--- a/cold-case/content/evidence.md
+++ b/cold-case/content/evidence.md
@@ -1,0 +1,127 @@
++++
+title = "Evidence Log"
+description = "Complete evidence register for Case No. 87-4421-R, including chain of custody records and analysis status for all 14 items."
+tags = ["evidence", "chain-of-custody", "forensics"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">EVIDENCE REGISTER</p>
+<h1 class="paper-section-title">Evidence Log</h1>
+</header>
+
+<div class="paper-content">
+
+## Case No. 87-4421-R Evidence Register
+
+All evidence items are maintained under chain of custody per Metropolitan Bureau of Investigation standard operating procedures. Items marked with an asterisk (*) are held at the county forensic laboratory; all others are in the case evidence locker.
+
+<table class="paper-table">
+<caption>Table E1. Complete evidence register</caption>
+<thead>
+<tr>
+<th>Item</th>
+<th>Description</th>
+<th>Date Collected</th>
+<th>Analysis Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>EV-001*</td>
+<td>Skeletal remains (complete)</td>
+<td>Sep 2024</td>
+<td>Analysis complete</td>
+</tr>
+<tr>
+<td>EV-002*</td>
+<td>DNA extraction and STR profile</td>
+<td>Oct 2024</td>
+<td>Match confirmed</td>
+</tr>
+<tr>
+<td>EV-003*</td>
+<td>Bone collagen sample (C-14 dating)</td>
+<td>Oct 2024</td>
+<td>Dating complete</td>
+</tr>
+<tr>
+<td>EV-004</td>
+<td>Vehicle location report (original)</td>
+<td>Oct 1987</td>
+<td>Re-examined</td>
+</tr>
+<tr>
+<td>EV-005</td>
+<td>Personal effects inventory (original)</td>
+<td>Oct 1987</td>
+<td>Re-examined</td>
+</tr>
+<tr>
+<td>EV-006*</td>
+<td>Concrete sample from sealed cavity</td>
+<td>Sep 2024</td>
+<td>Analysis complete</td>
+</tr>
+<tr>
+<td>EV-007</td>
+<td>Building permit records</td>
+<td>Nov 2024</td>
+<td>Reviewed</td>
+</tr>
+<tr>
+<td>EV-008</td>
+<td>Hardware store purchase record</td>
+<td>Dec 2024</td>
+<td>Verified</td>
+</tr>
+<tr>
+<td>EV-009</td>
+<td>Revised witness statement, W-07</td>
+<td>Jan 2025</td>
+<td>Recorded</td>
+</tr>
+<tr>
+<td>EV-010</td>
+<td>Revised witness statement, W-14</td>
+<td>Jan 2025</td>
+<td>Recorded</td>
+</tr>
+<tr>
+<td>EV-011</td>
+<td>Handwriting note re-analysis report</td>
+<td>Feb 2025</td>
+<td>Inconclusive</td>
+</tr>
+<tr>
+<td>EV-012*</td>
+<td>Soil samples from cavity</td>
+<td>Sep 2024</td>
+<td>Analysis complete</td>
+</tr>
+<tr>
+<td>EV-013</td>
+<td>Property deed transfer records</td>
+<td>Nov 2024</td>
+<td>Verified</td>
+</tr>
+<tr>
+<td>EV-014</td>
+<td>Insurance claim records</td>
+<td>Dec 2024</td>
+<td>Verified</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="4">* Held at Ridgemont County Forensic Laboratory. All other items in Case Evidence Locker B-17.</td>
+</tr>
+</tfoot>
+</table>
+
+## Chain of Custody Notes
+
+All original evidence items (EV-004, EV-005) were retrieved from the archived case file with documented chain of custody. New evidence items (EV-001 through EV-003, EV-006 through EV-014) were collected under current department protocols with digital chain of custody tracking.
+
+Bone samples (EV-001, EV-003) were processed at an accredited forensic laboratory (ANAB ISO/IEC 17025). DNA analysis (EV-002) was performed at the State Bureau of Investigation Forensic Biology Unit.
+
+</div>

--- a/cold-case/content/index.md
+++ b/cold-case/content/index.md
@@ -1,0 +1,150 @@
++++
+title = "Case File"
+description = "A reopened investigation paper re-examining a 1987 missing persons case with new forensic evidence, reconstructed timelines, and evidence chain diagrams connecting previously unlinked findings."
+tags = ["paper", "dark", "forensic", "investigation", "reopened"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">REOPENED INVESTIGATION</p>
+<h1 class="paper-section-title">The Belmont Disappearance: A Cold Case Re-examination Using Modern Forensic Methods</h1>
+<p class="paper-lede">Case No. 87-4421 &middot; Originally filed: 14 October 1987 &middot; Reopened: 8 March 2025</p>
+<p class="paper-lede" style="margin-top:0.5rem;"><strong>Investigators:</strong> M. Torres (Lead), K. Gustafsson, N. Obi &middot; <strong>Unit:</strong> Cold Case Division, Metropolitan Bureau of Investigation</p>
+<p class="paper-lede" style="margin-top:0.5rem;">doi:10.51034/ccrq.2026.22.1.34 &middot; Published Jan 2026</p>
+</header>
+
+<div class="case-file">
+<p class="case-file-label">Case Summary</p>
+<h3>Subject: Margaret Elaine Belmont (1952--?)</h3>
+<p><strong>Status:</strong> <span class="status-badge status-reopened">REOPENED</span> <span class="status-badge status-pending">PENDING</span></p>
+<p><strong>Original finding:</strong> Voluntary disappearance. Case closed 12 February 1988 after a 4-month investigation produced no evidence of foul play. Subject's vehicle was found at the Greyhound terminal in Ridgemont with personal effects intact.</p>
+<p><strong>Basis for reopening:</strong> In September 2024, renovation of the former Belmont family property at 1140 Lakeshore Drive uncovered skeletal remains in a sealed utility space beneath the kitchen floor. DNA analysis confirmed a familial match to Margaret Belmont's surviving sister, Catherine Belmont-Hayes. Revised carbon dating places the remains within the 1985--1990 window.</p>
+<p><strong>New finding:</strong> The original investigation failed to examine the property infrastructure. Evidence now suggests the subject never left the residence. The vehicle relocation and staged personal effects constitute evidence of concealment rather than voluntary departure.</p>
+</div>
+
+<div class="metrics-bar">
+<div class="metric-item">
+<span class="metric-value">38</span>
+<span class="metric-label">Years Cold</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">14</span>
+<span class="metric-label">New Evidence Items</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">7</span>
+<span class="metric-label">Witnesses Re-interviewed</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">3</span>
+<span class="metric-label">Persons of Interest</span>
+</div>
+</div>
+
+<div class="figure" role="img" aria-label="Evidence chain diagram connecting skeletal remains discovery to vehicle staging, showing 6 linked evidence nodes with relationship arrows">
+<svg viewBox="0 0 780 320" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="320" fill="#0c0e12"/>
+<text x="390" y="24" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#7a7870" font-weight="600" letter-spacing="0.1em">FIGURE 1: EVIDENCE CHAIN -- PRIMARY LINKAGES</text>
+<!-- Node 1: Skeletal Remains -->
+<rect x="30" y="50" width="160" height="60" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+<text x="110" y="72" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-001</text>
+<text x="110" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Skeletal Remains</text>
+<text x="110" y="100" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">1140 Lakeshore Dr.</text>
+<!-- Node 2: DNA Match -->
+<rect x="310" y="50" width="160" height="60" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+<text x="390" y="72" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-002</text>
+<text x="390" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Familial DNA Match</text>
+<text x="390" y="100" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">Catherine Belmont-Hayes</text>
+<!-- Node 3: Carbon Dating -->
+<rect x="590" y="50" width="160" height="60" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+<text x="670" y="72" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-003</text>
+<text x="670" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Carbon Dating</text>
+<text x="670" y="100" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">1985-1990 window</text>
+<!-- Arrows row 1 -->
+<line x1="190" y1="80" x2="310" y2="80" stroke="#7a7870" stroke-width="1"/>
+<polygon points="307,77 313,80 307,83" fill="#7a7870"/>
+<text x="250" y="74" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">confirms identity</text>
+<line x1="470" y1="80" x2="590" y2="80" stroke="#7a7870" stroke-width="1"/>
+<polygon points="587,77 593,80 587,83" fill="#7a7870"/>
+<text x="530" y="74" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">confirms timeline</text>
+<!-- Node 4: Vehicle Location -->
+<rect x="30" y="160" width="160" height="60" fill="none" stroke="#7a7870" stroke-width="1.5"/>
+<text x="110" y="182" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-004</text>
+<text x="110" y="198" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Vehicle at Terminal</text>
+<text x="110" y="210" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">Greyhound, Ridgemont</text>
+<!-- Node 5: Staged Effects -->
+<rect x="310" y="160" width="160" height="60" fill="none" stroke="#7a7870" stroke-width="1.5"/>
+<text x="390" y="182" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-005</text>
+<text x="390" y="198" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Personal Effects</text>
+<text x="390" y="210" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">Suitcase, passport, wallet</text>
+<!-- Node 6: Utility Space -->
+<rect x="590" y="160" width="160" height="60" fill="none" stroke="#8a3a3a" stroke-width="1.5"/>
+<text x="670" y="182" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#c4a24a" font-weight="700">EV-006</text>
+<text x="670" y="198" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0">Sealed Utility Space</text>
+<text x="670" y="210" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">Concrete, post-1985 pour</text>
+<!-- Cross-links -->
+<line x1="110" y1="110" x2="110" y2="160" stroke="#4e4c46" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="100" y="138" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">contradicts</text>
+<line x1="390" y1="110" x2="390" y2="160" stroke="#4e4c46" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="380" y="138" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">staged</text>
+<line x1="670" y1="110" x2="670" y2="160" stroke="#8a3a3a" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="660" y="138" text-anchor="end" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">concealment</text>
+<!-- Conclusion box -->
+<rect x="170" y="260" width="440" height="40" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+<text x="390" y="278" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#e8e6e0" font-weight="600">CONCLUSION: Staged departure concealing on-premises death</text>
+<text x="390" y="292" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#7a7870">Evidence chain establishes concealment, not voluntary disappearance</text>
+<!-- Arrows to conclusion -->
+<line x1="110" y1="220" x2="260" y2="260" stroke="#4e4c46" stroke-width="0.75"/>
+<line x1="390" y1="220" x2="390" y2="260" stroke="#4e4c46" stroke-width="0.75"/>
+<line x1="670" y1="220" x2="520" y2="260" stroke="#4e4c46" stroke-width="0.75"/>
+</svg>
+<p class="figure-caption"><strong>Figure 1.</strong> Evidence chain diagram showing the six primary evidence items and their interconnections. Solid borders indicate new evidence (2024--2025); dashed lines indicate inferential connections. The chain establishes that evidence of voluntary departure (EV-004, EV-005) was staged to conceal on-premises death (EV-001, EV-006).</p>
+</div>
+
+<div class="figure" role="img" aria-label="Timeline reconstruction diagram showing key events from October 1987 to September 2024">
+<svg viewBox="0 0 780 200" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="200" fill="#0c0e12"/>
+<text x="390" y="24" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="10" fill="#7a7870" font-weight="600" letter-spacing="0.1em">FIGURE 2: TIMELINE RECONSTRUCTION</text>
+<!-- Timeline axis -->
+<line x1="40" y1="100" x2="740" y2="100" stroke="#2e3442" stroke-width="1.5"/>
+<!-- Event markers -->
+<circle cx="80" cy="100" r="5" fill="#c4a24a"/>
+<line x1="80" y1="105" x2="80" y2="140" stroke="#4e4c46" stroke-width="0.75"/>
+<text x="80" y="65" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c4a24a" font-weight="700">14 OCT 1987</text>
+<text x="80" y="78" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">Last confirmed</text>
+<text x="80" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">sighting</text>
+<circle cx="200" cy="100" r="5" fill="#7a7870"/>
+<line x1="200" y1="105" x2="200" y2="140" stroke="#4e4c46" stroke-width="0.75"/>
+<text x="200" y="152" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7870" font-weight="700">16 OCT 1987</text>
+<text x="200" y="164" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">Vehicle found</text>
+<text x="200" y="174" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">at terminal</text>
+<circle cx="320" cy="100" r="5" fill="#7a7870"/>
+<line x1="320" y1="95" x2="320" y2="60" stroke="#4e4c46" stroke-width="0.75"/>
+<text x="320" y="65" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7a7870" font-weight="700">12 FEB 1988</text>
+<text x="320" y="78" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">Case closed</text>
+<text x="320" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">(voluntary)</text>
+<!-- Gap marker -->
+<text x="480" y="96" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="9" fill="#4e4c46">. . .</text>
+<text x="480" y="120" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#4e4c46">36 years</text>
+<circle cx="600" cy="100" r="5" fill="#c4a24a"/>
+<line x1="600" y1="105" x2="600" y2="140" stroke="#4e4c46" stroke-width="0.75"/>
+<text x="600" y="152" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c4a24a" font-weight="700">SEP 2024</text>
+<text x="600" y="164" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">Remains</text>
+<text x="600" y="174" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">discovered</text>
+<circle cx="700" cy="100" r="5" fill="#3a8a5a"/>
+<line x1="700" y1="95" x2="700" y2="60" stroke="#4e4c46" stroke-width="0.75"/>
+<text x="700" y="65" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#3a8a5a" font-weight="700">MAR 2025</text>
+<text x="700" y="78" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">Case</text>
+<text x="700" y="88" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#c8c4ba">reopened</text>
+</svg>
+<p class="figure-caption"><strong>Figure 2.</strong> Reconstructed timeline of key events from Margaret Belmont's last confirmed sighting (October 1987) through case reopening (March 2025). Gold markers indicate new evidence events; green indicates the reopening determination.</p>
+</div>
+
+## Structure of This Paper
+
+This investigation report is organized into five sections:
+
+1. **Original Investigation** -- Summary of the 1987--1988 investigation, its methodology, findings, and the basis for the voluntary disappearance determination.
+2. **New Evidence** -- Detailed catalogue of the 14 new evidence items discovered since September 2024, including forensic analysis results and chain of custody documentation.
+3. **Timeline Reconstruction** -- Revised chronology of events incorporating new evidence, witness re-interviews, and forensic dating results.
+4. **Persons of Interest** -- Analysis of three identified persons of interest based on the re-examined evidence, including motive, means, and opportunity assessments.
+5. **Conclusions and Next Steps** -- Summary of findings, recommended investigative actions, and case status determination.

--- a/cold-case/content/sections/1-original-investigation.md
+++ b/cold-case/content/sections/1-original-investigation.md
@@ -1,0 +1,80 @@
++++
+title = "1. Original Investigation"
+description = "Summary of the 1987-1988 investigation into Margaret Belmont's disappearance, its methodology, findings, and the basis for the voluntary disappearance determination."
+weight = 1
+template = "post"
+tags = ["investigation", "original-case", "1987"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Initial report and response
+
+Margaret Elaine Belmont, age 35, was reported missing on 15 October 1987 by her employer, Ridgemont Memorial Library, after she failed to report for her scheduled shift and did not respond to telephone calls. Responding officers from Ridgemont County Sheriff's Department visited the Belmont residence at 1140 Lakeshore Drive and found the home locked and unoccupied. No signs of forced entry or disturbance were observed.
+
+## 1.2 Investigation scope
+
+The original investigation, led by Detective Raymond Hollis (now retired, deceased 2019), encompassed the following activities over a 4-month period:
+
+<table class="paper-table">
+<caption>Table 1. Original investigation activity summary</caption>
+<thead>
+<tr>
+<th>Activity</th>
+<th>Count</th>
+<th>Outcome</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Witness interviews</td>
+<td>23</td>
+<td>No evidence of foul play</td>
+</tr>
+<tr>
+<td>Property searches</td>
+<td>2</td>
+<td>No evidence recovered</td>
+</tr>
+<tr>
+<td>Vehicle forensics</td>
+<td>1</td>
+<td>Subject's fingerprints only</td>
+</tr>
+<tr>
+<td>Financial records</td>
+<td>12 months</td>
+<td>No activity post-disappearance</td>
+</tr>
+<tr>
+<td>Interstate alerts</td>
+<td>48 states</td>
+<td>No confirmed sightings</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="3">Source: Ridgemont County Sheriff's Department Case File 87-4421.</td>
+</tr>
+</tfoot>
+</table>
+
+## 1.3 Vehicle discovery
+
+On 16 October 1987, subject's vehicle (1983 Chevrolet Cavalier, licence plate RCT-4421) was located at the Greyhound bus terminal in downtown Ridgemont. Inside the vehicle: one suitcase containing clothing, a valid US passport, wallet with $47 cash and identification, and a handwritten note reading "I need to start over. Don't look for me."
+
+The note was submitted for handwriting analysis and determined to be "consistent with" the subject's known handwriting, though the analyst noted the sample was limited to three comparison documents.
+
+## 1.4 Determination
+
+On 12 February 1988, the case was closed with a finding of voluntary disappearance. The closing report cited: (a) no evidence of foul play at residence or vehicle, (b) handwritten note indicating intent to depart, (c) staged personal effects suggesting planned departure, and (d) absence of any physical evidence contradicting voluntary disappearance.
+
+## 1.5 Critical gaps in original investigation
+
+The reopened investigation has identified several deficiencies in the original case work:
+
+- **Property search was superficial.** Investigators examined visible areas of the residence but did not inspect crawl spaces, utility areas, or sub-floor infrastructure. The sealed utility space beneath the kitchen floor was not accessed.
+- **Handwriting analysis was inconclusive.** The "consistent with" determination falls below the threshold for positive identification. Modern forensic document examination standards would require additional comparison samples.
+- **No forensic processing of the residence.** Luminol testing, fingerprint dusting, and trace evidence collection were not performed at the Lakeshore Drive property. The absence of evidence of foul play reflected an absence of investigation, not an absence of evidence.
+- **Witness statements were not cross-referenced.** Two witnesses (Neighbour W-07, Colleague W-14) provided statements containing temporal inconsistencies that were not pursued.

--- a/cold-case/content/sections/2-new-evidence.md
+++ b/cold-case/content/sections/2-new-evidence.md
@@ -1,0 +1,104 @@
++++
+title = "2. New Evidence"
+description = "Detailed catalogue of the 14 new evidence items discovered since September 2024, including forensic analysis results and chain of custody documentation."
+weight = 2
+template = "post"
+tags = ["evidence", "forensics", "DNA-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Discovery circumstances
+
+In September 2024, the current owners of 1140 Lakeshore Drive commenced renovation of the kitchen and ground-floor utility spaces. During demolition of the kitchen floor, contractors discovered a sealed concrete cavity measuring approximately 2.1m x 0.8m x 0.6m beneath the original floor joists. The cavity contained skeletal remains in an advanced state of decomposition.
+
+Contractors ceased work immediately and contacted Ridgemont County Sheriff's Department. The scene was secured within 90 minutes and processed by the county forensic unit over a 5-day period.
+
+## 2.2 Primary evidence items
+
+<div class="evidence-item">
+<p class="evidence-label">EV-001 -- Skeletal Remains</p>
+<p>Complete adult female skeleton recovered from sub-floor cavity. No clothing or personal effects present. Forensic anthropological examination indicates female, approximately 30--40 years at time of death, 5'6" estimated stature. Manner of death: undetermined pending toxicology of bone samples.</p>
+</div>
+
+<div class="evidence-item">
+<p class="evidence-label">EV-002 -- Familial DNA Match</p>
+<p>DNA extracted from femoral bone. STR analysis produced a partial profile (14 of 20 loci). Comparison with voluntary sample from Catherine Belmont-Hayes (subject's sister) yields a familial match probability of 99.7%. Full sibling relationship confirmed at p &lt; 0.001.</p>
+</div>
+
+<div class="evidence-item">
+<p class="evidence-label">EV-003 -- Carbon Dating</p>
+<p>Radiocarbon analysis of bone collagen calibrated to 1985--1990 (2-sigma range). This is consistent with the 1987 disappearance date but cannot narrow the window further.</p>
+</div>
+
+<div class="evidence-item">
+<p class="evidence-label">EV-006 -- Sealed Utility Space</p>
+<p>The concrete used to seal the cavity was analysed for composition and curing characteristics. Portland cement type and aggregate composition are consistent with materials available at local building supply stores in the 1985--1990 period. The pour was performed in a single session (no layering or repair evidence).</p>
+</div>
+
+## 2.3 Secondary evidence items
+
+Re-examination of the property and re-interviews produced 10 additional evidence items (EV-007 through EV-014):
+
+<table class="paper-table">
+<caption>Table 2. Secondary evidence items summary</caption>
+<thead>
+<tr>
+<th>Item</th>
+<th>Description</th>
+<th>Significance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>EV-007</td>
+<td>Building permit records for 1140 Lakeshore Dr.</td>
+<td>No permits filed for floor work in 1985--1990</td>
+</tr>
+<tr>
+<td>EV-008</td>
+<td>Hardware store receipts (microfiche archive)</td>
+<td>Concrete purchase by R. Belmont, Oct 1987</td>
+</tr>
+<tr>
+<td>EV-009</td>
+<td>Revised witness statement, W-07 (neighbour)</td>
+<td>Heard "heavy work" sounds, night of 14 Oct 1987</td>
+</tr>
+<tr>
+<td>EV-010</td>
+<td>Revised witness statement, W-14 (colleague)</td>
+<td>Subject expressed fear of spouse in private conversation</td>
+</tr>
+<tr>
+<td>EV-011</td>
+<td>Original handwriting note re-analysis</td>
+<td>Modern analysis: "inconclusive" (insufficient basis for attribution)</td>
+</tr>
+<tr>
+<td>EV-012</td>
+<td>Soil analysis from cavity</td>
+<td>Trace chemicals consistent with cleaning agents</td>
+</tr>
+<tr>
+<td>EV-013</td>
+<td>Property deed transfer records</td>
+<td>Property sold 1991 by R. Belmont (ex-husband)</td>
+</tr>
+<tr>
+<td>EV-014</td>
+<td>Insurance records</td>
+<td>Life insurance claim filed 1995 (7-year presumption of death)</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="3">All items logged under Case No. 87-4421-R (reopened). Chain of custody maintained per department protocol.</td>
+</tr>
+</tfoot>
+</table>
+
+## 2.4 Evidence synthesis
+
+The 14 evidence items collectively establish a coherent narrative that contradicts the original voluntary disappearance determination. The subject did not leave the property. The vehicle relocation (EV-004), personal effects staging (EV-005), and handwritten note (now assessed as inconclusive, EV-011) were part of a concealment effort following the subject's death at the residence.

--- a/cold-case/content/sections/3-timeline-reconstruction.md
+++ b/cold-case/content/sections/3-timeline-reconstruction.md
@@ -1,0 +1,107 @@
++++
+title = "3. Timeline Reconstruction"
+description = "Revised chronology of events incorporating new evidence, witness re-interviews, and forensic dating results."
+weight = 3
+template = "post"
+tags = ["timeline", "reconstruction", "chronological-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Revised chronology
+
+Based on the integration of original case records with the 14 new evidence items, the following revised chronology has been established:
+
+<table class="paper-table">
+<caption>Table 3. Revised timeline of events</caption>
+<thead>
+<tr>
+<th>Date</th>
+<th>Event</th>
+<th>Evidence Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>12 Oct 1987</td>
+<td>Last verified telephone call (subject to sister, C. Belmont-Hayes)</td>
+<td>Original records, W-01</td>
+</tr>
+<tr>
+<td>13 Oct 1987</td>
+<td>Subject attended work (Ridgemont Memorial Library), departed 5:15 PM</td>
+<td>Employment records, W-14</td>
+</tr>
+<tr>
+<td>14 Oct 1987</td>
+<td>Subject did not report for scheduled 9:00 AM shift</td>
+<td>Employment records</td>
+</tr>
+<tr>
+<td>14 Oct 1987 (night)</td>
+<td>Neighbour W-07 reports hearing "heavy work sounds" from residence</td>
+<td>EV-009 (revised statement)</td>
+</tr>
+<tr>
+<td>15 Oct 1987</td>
+<td>Missing persons report filed by employer</td>
+<td>Original records</td>
+</tr>
+<tr>
+<td>16 Oct 1987</td>
+<td>Vehicle located at Greyhound terminal with staged personal effects</td>
+<td>EV-004, EV-005</td>
+</tr>
+<tr>
+<td>Late Oct 1987</td>
+<td>Concrete purchase by R. Belmont from Ridgemont Building Supply</td>
+<td>EV-008</td>
+</tr>
+<tr>
+<td>12 Feb 1988</td>
+<td>Case closed: voluntary disappearance</td>
+<td>Original records</td>
+</tr>
+<tr>
+<td>1991</td>
+<td>Property sold by R. Belmont</td>
+<td>EV-013</td>
+</tr>
+<tr>
+<td>1995</td>
+<td>Life insurance claim filed under presumption of death</td>
+<td>EV-014</td>
+</tr>
+<tr>
+<td>Sep 2024</td>
+<td>Skeletal remains discovered during renovation</td>
+<td>EV-001</td>
+</tr>
+<tr>
+<td>Mar 2025</td>
+<td>Case reopened following DNA confirmation</td>
+<td>EV-002</td>
+</tr>
+</tbody>
+</table>
+
+## 3.2 Critical window analysis
+
+The evidence establishes a critical 48-hour window between the subject's last confirmed activity (departing work, 13 October 1987, 5:15 PM) and the discovery of the staged vehicle (16 October 1987, morning). Within this window:
+
+- The subject returned home on the evening of 13 October (inferred; no contradicting evidence).
+- The subject's death occurred at the residence, likely between the evening of 13 October and the night of 14 October.
+- Concealment activities (sealing the utility space, relocating the vehicle, staging personal effects) occurred between 14 October (night sounds reported by W-07) and 16 October (vehicle discovered).
+
+## 3.3 Temporal inconsistencies resolved
+
+Two inconsistencies in the original investigation are now explained by the revised timeline:
+
+**W-07 statement discrepancy.** The original W-07 interview (23 October 1987) stated "I didn't hear anything unusual that week." The 2025 re-interview produced a different account: "I remember now -- there were sounds, like hammering or heavy lifting, late at night. I think it was the 14th because it was a Wednesday and I had my book club that day." The original investigator's notes do not record any follow-up on this statement. The revised account is consistent with concealment activities.
+
+**W-14 statement omission.** Colleague W-14 (library staff) disclosed in the 2025 re-interview that the subject had made remarks in September 1987 suggesting fear of her then-husband, Robert Belmont. These remarks were not included in the original statement because, according to W-14, "The detective seemed to have already decided she'd run off. He wasn't asking those kinds of questions."
+
+## 3.4 Events after case closure
+
+Robert Belmont sold the property in 1991 and relocated to another state. In 1995, he filed for a declaration of death under the 7-year presumption statute and collected on a life insurance policy valued at $180,000 (1987 dollars). These post-closure events are consistent with the concealment hypothesis but do not constitute direct evidence.

--- a/cold-case/content/sections/4-persons-of-interest.md
+++ b/cold-case/content/sections/4-persons-of-interest.md
@@ -1,0 +1,52 @@
++++
+title = "4. Persons of Interest"
+description = "Analysis of three identified persons of interest based on the re-examined evidence, including motive, means, and opportunity assessments."
+weight = 4
+template = "post"
+tags = ["suspects", "persons-of-interest", "motive-analysis"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Assessment methodology
+
+Persons of interest were identified through a structured analysis of motive, means, and opportunity (MMO) applied to all individuals with documented access to the subject and the property during the critical window. Three individuals met the threshold for formal person-of-interest designation.
+
+## 4.2 Person of Interest 1: Robert Belmont (ex-husband)
+
+<div class="case-file">
+<p class="case-file-label">POI-001 Assessment</p>
+<h3>Robert Belmont (b. 1949)</h3>
+<p><strong>Relationship:</strong> Husband of subject at time of disappearance. Divorce proceedings initiated by subject in August 1987, not yet finalised.</p>
+<p><strong>Motive:</strong> Pending divorce with contested property division. Life insurance policy ($180,000) with subject as insured. W-14 statement indicates subject expressed fear. Rated: HIGH.</p>
+<p><strong>Means:</strong> Sole co-occupant of residence. Construction and renovation skills (self-employed contractor). Purchased concrete materials from local supplier in October 1987 (EV-008). Rated: HIGH.</p>
+<p><strong>Opportunity:</strong> Resided at the property during the critical window. No alibi documented for the night of 13--14 October 1987. Rated: HIGH.</p>
+<p><strong>Current status:</strong> Alive, residing in another state. Has not been contacted by investigators pending completion of this review.</p>
+</div>
+
+## 4.3 Person of Interest 2: Gerald Koss (property associate)
+
+<div class="case-file">
+<p class="case-file-label">POI-002 Assessment</p>
+<h3>Gerald Koss (b. 1951)</h3>
+<p><strong>Relationship:</strong> Business associate of Robert Belmont. Worked on renovation projects together. Named in two witness statements as a frequent visitor to the Lakeshore Drive property.</p>
+<p><strong>Motive:</strong> No direct motive identified. However, potential accessory-after-the-fact if assisted with concealment activities. Rated: LOW.</p>
+<p><strong>Means:</strong> Construction skills. Vehicle access (could have driven subject's car to terminal). Rated: MODERATE.</p>
+<p><strong>Opportunity:</strong> No confirmed presence at property during critical window, but no alibi documented either. W-07 reports a second vehicle at the property on multiple occasions in October 1987. Rated: MODERATE.</p>
+<p><strong>Current status:</strong> Deceased (2018). Re-interview not possible.</p>
+</div>
+
+## 4.4 Person of Interest 3: Unknown individual at bus terminal
+
+<div class="case-file">
+<p class="case-file-label">POI-003 Assessment</p>
+<h3>Unidentified Male (est. 30--50 at time of event)</h3>
+<p><strong>Basis:</strong> A Greyhound terminal employee (W-19, identified during 2025 re-canvass) recalls a man parking a vehicle matching the subject's car description in the terminal lot on 15 or 16 October 1987. The man departed on foot. W-19 did not report this in 1987 because he was not interviewed during the original investigation.</p>
+<p><strong>Significance:</strong> If the vehicle was driven to the terminal by someone other than the subject, it confirms that the departure scene was staged. The driver would be either the perpetrator or an accessory.</p>
+<p><strong>Current status:</strong> Unidentified. Description insufficient for identification (medium build, dark jacket). No forensic evidence linking a specific individual.</p>
+</div>
+
+## 4.5 Assessment summary
+
+The evidence most strongly supports Robert Belmont (POI-001) as the primary person of interest. He demonstrates high ratings across all three MMO dimensions, had exclusive access to the property, purchased concealment materials, and benefited financially from the subject's death through insurance and property sale.

--- a/cold-case/content/sections/5-conclusions.md
+++ b/cold-case/content/sections/5-conclusions.md
@@ -1,0 +1,58 @@
++++
+title = "5. Conclusions and Next Steps"
+description = "Summary of findings, recommended investigative actions, and case status determination."
+weight = 5
+template = "post"
+tags = ["conclusions", "recommendations", "case-status"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of findings
+
+The reopened investigation of Case No. 87-4421 has established the following:
+
+1. **Margaret Belmont did not voluntarily disappear.** The discovery of her remains beneath the floor of her residence (EV-001), confirmed by familial DNA match (EV-002) and carbon dating within the disappearance window (EV-003), conclusively disproves the original voluntary disappearance determination.
+
+2. **The departure scene was staged.** The vehicle relocation (EV-004), personal effects placement (EV-005), and handwritten note (EV-011, now assessed as inconclusive) were part of a deliberate concealment effort.
+
+3. **The original investigation was deficient.** Failure to conduct forensic processing of the residence, inadequate property search scope, and insufficient witness follow-up allowed the concealment to succeed for 38 years.
+
+4. **Robert Belmont (POI-001) is the primary person of interest.** He demonstrates high motive, means, and opportunity indicators, including documented concrete purchase (EV-008), construction skills, exclusive property access, and subsequent financial benefit.
+
+## 5.2 Case reclassification
+
+Based on the evidence presented in this report, we recommend the following reclassification:
+
+<div class="evidence-item">
+<p class="evidence-label">Case Status Change</p>
+<p><strong>From:</strong> <span class="status-badge status-sealed">CLOSED -- VOLUNTARY DISAPPEARANCE</span></p>
+<p><strong>To:</strong> <span class="status-badge status-reopened">REOPENED -- SUSPECTED HOMICIDE</span></p>
+<p>The totality of evidence supports reclassification from voluntary disappearance to suspected homicide with active investigation status.</p>
+</div>
+
+## 5.3 Recommended next steps
+
+1. **Interview Robert Belmont.** Formal interview under caution. Coordinate with the jurisdiction of his current residence. Prepare detailed interview strategy based on evidence chain analysis.
+
+2. **Forensic bone toxicology.** Submit bone samples for expanded toxicology screening, including heavy metals and common 1980s-era poisons, to assist in determining manner of death.
+
+3. **Handwriting re-analysis.** Obtain additional comparison samples of both the subject's and Robert Belmont's handwriting for a definitive assessment of the departure note authorship.
+
+4. **Gerald Koss investigation.** Although deceased, review Koss's personal records, financial history, and any surviving associates for evidence of accessory involvement.
+
+5. **Insurance fraud referral.** Refer the 1995 life insurance claim to the relevant fraud investigation unit for review in light of the revised case findings.
+
+6. **Terminal witness identification.** Pursue identification of the individual described by W-19 through archival records, including Greyhound ticketing records (if preserved) and local business surveillance archives.
+
+## 5.4 Limitations
+
+This investigation faces inherent limitations typical of cold case work:
+
+- **Degraded physical evidence.** 38 years of decomposition and property modifications have eliminated many potential forensic traces.
+- **Deceased witnesses.** Lead investigator Hollis (d. 2019) and POI-002 Koss (d. 2018) are no longer available for re-interview.
+- **Memory reliability.** Witness accounts from 2025 re-interviews reflect events 38 years prior. Memory distortion and post-event information effects are acknowledged.
+- **Incomplete original records.** Some original case file materials were not preserved during the 2004 records digitisation process.
+
+Despite these limitations, the evidence chain established through modern forensic methods provides a substantially stronger evidentiary basis than was available in 1988.

--- a/cold-case/content/sections/_index.md
+++ b/cold-case/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+This investigation report follows a structured progression from the original case record through new evidence analysis, timeline reconstruction, and suspect identification to final conclusions and recommended next steps.

--- a/cold-case/static/css/style.css
+++ b/cold-case/static/css/style.css
@@ -1,0 +1,607 @@
+/* =========================================================
+   Cold Case -- Reopened Investigation Paper
+   ========================================================= */
+
+:root {
+  --bg: #0c0e12;
+  --bg-2: #12151c;
+  --bg-3: #1a1e28;
+  --rule: #252a36;
+  --rule-light: #2e3442;
+  --ink: #e8e6e0;
+  --ink-2: #c8c4ba;
+  --ink-3: #7a7870;
+  --ink-4: #4e4c46;
+  --accent: #c4a24a;
+  --accent-2: #a88a3a;
+  --evidence: #c4a24a;
+  --sealed: #8a3a3a;
+  --reopened: #3a8a5a;
+  --pending: #4a6a9a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: "IBM Plex Sans", "Noto Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink-2);
+  background: var(--bg);
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- Layout --- */
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* --- Header --- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 2px solid var(--rule-light);
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.logo-mark {
+  width: 56px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.journal-name {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Main --- */
+
+.site-main {
+  min-height: calc(100vh - 200px);
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+}
+
+/* --- Paper headers --- */
+
+.paper-section-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 0.5rem;
+}
+
+.paper-section-title {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.2;
+  margin: 0 0 0.75rem;
+}
+
+.paper-lede {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 1rem;
+  color: var(--ink-3);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Typography --- */
+
+.paper-content h2 {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: clamp(1.2rem, 2.5vw, 1.5rem);
+  font-weight: 700;
+  color: var(--ink);
+  margin: 2.5rem 0 1rem;
+  line-height: 1.25;
+}
+
+.paper-content h3 {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  margin: 2rem 0 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.paper-content h4 {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  margin: 1.5rem 0 0.5rem;
+}
+
+.paper-content p {
+  margin: 1em 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-content ul,
+.paper-content ol {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.paper-content li {
+  margin-bottom: 0.4rem;
+}
+
+.paper-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 3px solid var(--evidence);
+  background: var(--bg-2);
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+.paper-content code {
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.85em;
+  background: var(--bg-3);
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--rule);
+}
+
+.paper-content pre {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* --- Case file panel --- */
+
+.case-file {
+  border: 2px solid var(--rule-light);
+  padding: 2rem;
+  margin: 2rem 0;
+  position: relative;
+  background: var(--bg-2);
+}
+
+.case-file-label {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  margin: 0 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.case-file h3 {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 0 0 0.75rem;
+}
+
+.case-file p {
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+}
+
+/* --- Status badges --- */
+
+.status-badge {
+  display: inline-block;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid;
+  margin-right: 0.5rem;
+}
+
+.status-sealed {
+  color: var(--sealed);
+  border-color: var(--sealed);
+}
+
+.status-reopened {
+  color: var(--reopened);
+  border-color: var(--reopened);
+}
+
+.status-pending {
+  color: var(--pending);
+  border-color: var(--pending);
+}
+
+/* --- Evidence item --- */
+
+.evidence-item {
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--evidence);
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  background: var(--bg-2);
+}
+
+.evidence-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  margin: 0 0 0.5rem;
+}
+
+.evidence-item p {
+  margin: 0.4rem 0;
+  font-size: 0.92rem;
+}
+
+/* --- Key metrics bar --- */
+
+.metrics-bar {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin: 2.5rem 0;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.metric-item {
+  text-align: center;
+  flex: 1;
+}
+
+.metric-item + .metric-item {
+  border-left: 1px solid var(--rule);
+}
+
+.metric-value {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--ink);
+  display: block;
+  line-height: 1;
+}
+
+.metric-label {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  display: block;
+  margin-top: 0.35rem;
+}
+
+/* --- Figures --- */
+
+.figure {
+  margin: 2.5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.figure-caption {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--rule);
+  line-height: 1.5;
+}
+
+/* --- Tables --- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+
+.paper-table caption {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: left;
+  color: var(--ink-3);
+  padding: 0 0 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+.paper-table thead th {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--rule-light);
+  background: var(--bg-2);
+}
+
+.paper-table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+
+.paper-table tbody tr:hover {
+  background: var(--bg-2);
+}
+
+.paper-table tfoot td {
+  padding: 0.5rem 0.75rem;
+  font-style: italic;
+  color: var(--ink-4);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* --- Section list --- */
+
+ul.section-list {
+  list-style: decimal;
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+ul.section-list li a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* --- Section footer nav --- */
+
+.paper-section-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2px;
+}
+
+.button-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Footer --- */
+
+.site-footer {
+  margin-top: 0;
+  padding: 0;
+}
+
+.footer-rule svg {
+  display: block;
+  width: 100%;
+  height: 6px;
+}
+
+.footer-content {
+  padding: 1.5rem 0 2rem;
+  text-align: center;
+}
+
+.footer-meta {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  line-height: 1.6;
+  margin: 0 0 0.5rem;
+}
+
+.footer-meta em {
+  font-style: italic;
+}
+
+.footer-note {
+  font-family: "IBM Plex Sans", "Noto Sans", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* --- Error page --- */
+
+.error-page {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.error-page h1 {
+  font-family: "Roboto Condensed", "Barlow", sans-serif;
+  font-size: 2rem;
+  color: var(--ink);
+}
+
+/* --- Taxonomy --- */
+
+.taxonomy-desc {
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Pagination --- */
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--accent); color: var(--ink); }
+
+/* --- Alert shortcode --- */
+
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+  border-left: 4px solid var(--evidence);
+  margin: 1rem 0;
+  color: var(--ink-2);
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 700px) {
+  .paper-wrap {
+    padding: 0 1rem;
+  }
+
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .paper-article {
+    padding: 2rem 0 3rem;
+  }
+
+  .metrics-bar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .metric-item + .metric-item {
+    border-left: none;
+    border-top: 1px solid var(--rule);
+    padding-top: 1rem;
+  }
+
+  .case-file {
+    padding: 1.25rem;
+  }
+}

--- a/cold-case/templates/404.html
+++ b/cold-case/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to case file</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cold-case/templates/footer.html
+++ b/cold-case/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#2e3442" stroke-width="1.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#252a36" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Torres M, Gustafsson K, Obi N. Reopened Investigation: The Belmont Disappearance (Case No. 87-4421). <em>Cold Case Review Quarterly.</em> 2026;22(1):34-68. doi:10.51034/ccrq.2026.22.1.34</p>
+        <p class="footer-note">ISSN 2640-1187 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cold-case/templates/header.html
+++ b/cold-case/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&family=Barlow:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=Noto+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Case file folder icon -->
+          <rect x="4" y="8" width="48" height="30" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+          <polyline points="4,8 4,4 22,4 26,8" fill="none" stroke="#c4a24a" stroke-width="1.5"/>
+          <line x1="14" y1="18" x2="42" y2="18" stroke="#7a7870" stroke-width="1"/>
+          <line x1="14" y1="24" x2="38" y2="24" stroke="#7a7870" stroke-width="1"/>
+          <line x1="14" y1="30" x2="34" y2="30" stroke="#7a7870" stroke-width="1"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Cold Case Review Quarterly</span>
+          <span class="journal-sub">Vol. 22 &middot; Issue 01 &middot; Jan 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">CASE FILE</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/evidence/">EVIDENCE LOG</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/cold-case/templates/page.html
+++ b/cold-case/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cold-case/templates/post.html
+++ b/cold-case/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cold-case/templates/section.html
+++ b/cold-case/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cold-case/templates/shortcodes/alert.html
+++ b/cold-case/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/cold-case/templates/taxonomy.html
+++ b/cold-case/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cold-case/templates/taxonomy_term.html
+++ b/cold-case/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -766,6 +766,13 @@
     "blog",
     "medieval"
   ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
+  ],
   "cohort-study": [
     "paper",
     "light",


### PR DESCRIPTION
Closes #1600

## Summary
- Add cold-case dark reopened investigation paper example site
- Features SVG evidence chain diagrams connecting findings, case file folder illustrations as section dividers, and timeline reconstruction diagrams for chronological analysis
- Typography: Roboto Condensed Bold/Barlow Bold for display on dark; IBM Plex Sans/Noto Sans for analytical body text
- Includes 5 content sections (Original Investigation, New Evidence, Timeline Reconstruction, Persons of Interest, Conclusions) plus Evidence Log and Appendix pages
- Updates tags.json with paper, dark, forensic, investigation, reopened tags

## Test plan
- [x] hwaro build completes successfully (9 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry