### PR TITLE
feat: add bayesian-prior example site (closes #1610)

### DIFF
--- a/bayesian-prior/AGENTS.md
+++ b/bayesian-prior/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/bayesian-prior/config.toml
+++ b/bayesian-prior/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Bayesian Prior - Probabilistic Analysis Paper
+# Issue #1610 | Tags: paper, dark, bayesian, probabilistic, visualization
+# =============================================================================
+
+title = "Bayesian Hierarchical Model for Hospital Mortality Rates"
+description = "A probabilistic analysis paper featuring prior and posterior density curves, MCMC trace plots for convergence diagnostics, and DAG diagrams for model structure, with dark theme Bayesian visualization."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/bayesian-prior/content/appendix.md
+++ b/bayesian-prior/content/appendix.md
@@ -1,0 +1,76 @@
++++
+title = "Appendix"
+description = "Supplementary materials including Stan code, sensitivity analyses, and prior predictive checks."
+template = "page"
++++
+
+<div class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-section-title">Appendix</h1>
+</div>
+
+<div class="paper-content">
+
+## A. Stan Model Code (Simplified)
+
+```stan
+data {
+  int<lower=0> N;           // total patients
+  int<lower=0> J;           // number of hospitals
+  int<lower=0> K;           // number of covariates
+  array[N] int<lower=1,upper=J> hospital;
+  matrix[N, K] X;           // patient covariates
+  array[N] int<lower=0,upper=1> y;
+}
+parameters {
+  real mu;
+  real<lower=0> sigma_h;
+  vector[J] alpha_raw;
+  vector[K] beta;
+}
+transformed parameters {
+  vector[J] alpha = mu + sigma_h * alpha_raw;
+}
+model {
+  // Priors (informative from registry)
+  mu ~ normal(-3.5, 0.5);
+  sigma_h ~ cauchy(0, 0.5);
+  alpha_raw ~ std_normal();
+  beta ~ normal(beta_registry, 0.2);
+
+  // Likelihood
+  y ~ bernoulli_logit(alpha[hospital] + X * beta);
+}
+```
+
+## B. Prior Sensitivity Analysis
+
+We tested three prior specifications for sigma_h to assess sensitivity:
+
+| Prior | Posterior median sigma_h | 95% CrI | ELPD change |
+|-------|-------------------------|----------|-------------|
+| Half-Cauchy(0, 0.5) (primary) | 0.34 | (0.26, 0.44) | reference |
+| Half-Cauchy(0, 1.0) (weakly informative) | 0.35 | (0.27, 0.46) | -2.1 |
+| Half-Normal(0, 0.5) | 0.33 | (0.26, 0.42) | -0.8 |
+| Exponential(2) | 0.32 | (0.25, 0.41) | -3.4 |
+
+Results are robust to prior choice: posterior estimates change minimally across specifications. The data dominate the prior for this parameter given the large sample size.
+
+## C. Prior Predictive Check
+
+Before fitting the model to data, we simulated outcomes from the prior predictive distribution (1,000 draws from the joint prior). The prior predictive mortality rates ranged from 0.1% to 12%, which encompasses the clinically plausible range and confirms the priors are not inadvertently informative about implausible regions.
+
+## D. Posterior Predictive Check
+
+Posterior predictive p-values for key test statistics:
+
+| Statistic | Observed | Posterior predictive mean | p-value |
+|-----------|----------|--------------------------|---------|
+| Overall mortality rate | 3.2% | 3.1% | 0.48 |
+| Between-hospital variance | 0.118 | 0.112 | 0.42 |
+| Max hospital mortality | 6.8% | 7.1% | 0.55 |
+| Min hospital mortality | 0.9% | 1.0% | 0.47 |
+
+All posterior predictive p-values are near 0.5, indicating excellent model fit with no evidence of systematic misfit.
+
+</div>

--- a/bayesian-prior/content/index.md
+++ b/bayesian-prior/content/index.md
@@ -1,0 +1,193 @@
++++
+title = "Abstract"
+description = "A Bayesian hierarchical model for estimating hospital-level mortality rates using informative priors derived from national registry data, with MCMC convergence diagnostics and posterior predictive checks."
+tags = ["paper", "dark", "bayesian", "probabilistic", "visualization"]
+template = "page"
++++
+
+<div class="paper-header">
+  <p class="paper-eyebrow">Bayesian Methods &middot; Original Research</p>
+  <h1 class="paper-title">A Bayesian Hierarchical Model for Estimating Hospital-Level Mortality Rates with Informative Priors</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Takeshi Nakamura</span><sup>1*</sup>,
+    Kwame Osei-Bonsu<sup>2</sup>,
+    Linnea Eriksson<sup>3</sup>,
+    Priya Gupta<sup>4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup> Department of Biostatistics, University of Tokyo, Japan;
+    <sup>2</sup> School of Public Health, University of Ghana, Accra;
+    <sup>3</sup> Division of Clinical Epidemiology, Karolinska Institutet, Stockholm;
+    <sup>4</sup> Centre for Health Informatics, AIIMS New Delhi, India
+  </p>
+  <p class="paper-doi">
+    doi: <a href="#">10.41093/bam.2026.12.04.201</a> &middot;
+    Code: <a href="#">github.com/tnakamura/hospital-bayes</a>
+  </p>
+  <div class="badge-row">
+    <span class="bayes-badge">BAYESIAN</span>
+    <span class="bayes-badge mcmc">MCMC</span>
+    <span class="bayes-badge dag">DAG MODEL</span>
+  </div>
+</div>
+
+<div class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Comparing hospital mortality rates requires adjusting for case-mix differences. Frequentist standardized mortality ratios (SMRs) are unstable for low-volume hospitals and do not naturally incorporate external evidence. Bayesian hierarchical models address both limitations through partial pooling and informative prior specification.</dd>
+    <dt>Objectives</dt>
+    <dd>To develop a Bayesian hierarchical logistic regression model for 30-day post-surgical mortality, using informative priors derived from a national registry (N = 2.4 million admissions), and to compare its calibration and discrimination against frequentist fixed-effects and random-effects alternatives.</dd>
+    <dt>Methods</dt>
+    <dd>We fit a three-level hierarchical model (patients nested in surgeons nested in hospitals) to 186,422 surgical admissions across 47 hospitals. Priors for regression coefficients were derived from the Japanese national DPC registry. Inference was performed via Hamiltonian Monte Carlo (HMC) using Stan, with 4 chains of 4,000 iterations each. Convergence was assessed via R-hat, effective sample size, and trace plot inspection.</dd>
+    <dt>Results</dt>
+    <dd>The Bayesian hierarchical model achieved superior calibration (Brier score 0.031 vs. 0.038 frequentist) and discrimination (C-statistic 0.847 vs. 0.832). Hospital-level shrinkage was most pronounced for low-volume hospitals (median shrinkage 42% for hospitals with fewer than 200 annual cases vs. 8% for hospitals exceeding 2,000). All parameters achieved R-hat below 1.01 with effective sample sizes exceeding 3,000.</dd>
+    <dt>Conclusions</dt>
+    <dd>Bayesian hierarchical models with registry-derived informative priors produce more stable and better-calibrated hospital mortality estimates than frequentist alternatives, particularly for low-volume hospitals where data are sparse. The informative prior acts as a principled regularizer, borrowing strength from the national population.</dd>
+    <dt>Keywords</dt>
+    <dd>Bayesian hierarchical model, hospital mortality, informative prior, MCMC, Stan, partial pooling, shrinkage estimation, case-mix adjustment</dd>
+  </dl>
+</div>
+
+## Prior and Posterior Distributions
+
+<div class="figure">
+  <svg viewBox="0 0 700 320" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="STIX Two Text" font-size="14" font-weight="600" fill="#c8cad0">Prior vs. Posterior: Hospital Random Effect (sigma_h)</text>
+    <line x1="80" y1="40" x2="80" y2="260" stroke="#3a3d48" stroke-width="1"/>
+    <line x1="80" y1="260" x2="650" y2="260" stroke="#3a3d48" stroke-width="1"/>
+    <text x="35" y="155" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#8a8e9a" transform="rotate(-90,35,155)">Density</text>
+    <text x="365" y="295" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#8a8e9a">sigma_h (log-odds scale)</text>
+    <text x="80" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.0</text>
+    <text x="194" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.2</text>
+    <text x="308" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.4</text>
+    <text x="422" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.6</text>
+    <text x="536" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.8</text>
+    <text x="650" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">1.0</text>
+    <path d="M80,258 Q120,256 160,248 Q200,228 240,185 Q280,128 320,95 Q360,78 400,92 Q440,128 480,178 Q520,228 560,248 Q600,256 650,258" fill="none" stroke="#c2a07a" stroke-width="2" stroke-dasharray="6 3" opacity="0.8"/>
+    <path d="M80,258 Q130,258 180,256 Q220,250 260,228 Q290,195 310,138 Q330,78 350,55 Q370,78 390,138 Q410,195 440,228 Q470,250 510,256 Q560,258 650,258" fill="none" stroke="#7a9ec2" stroke-width="2.5"/>
+    <line x1="350" y1="55" x2="350" y2="260" stroke="#7a9ec2" stroke-width="1" stroke-dasharray="3 3" opacity="0.5"/>
+    <text x="355" y="52" font-family="JetBrains Mono" font-size="9" fill="#7a9ec2">MAP = 0.34</text>
+    <rect x="480" y="48" width="12" height="2" fill="#c2a07a"/>
+    <text x="497" y="52" font-family="Crimson Pro" font-size="11" fill="#c2a07a">Prior: Half-Cauchy(0, 0.5)</text>
+    <rect x="480" y="65" width="12" height="2" fill="#7a9ec2"/>
+    <text x="497" y="69" font-family="Crimson Pro" font-size="11" fill="#7a9ec2">Posterior (N = 186,422)</text>
+    <text x="365" y="310" text-anchor="middle" font-family="Crimson Pro" font-size="11" font-style="italic" fill="#5a5d68">Data concentrates the posterior away from the diffuse prior tail</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 1.</span> Prior and posterior density curves for the hospital-level random effect standard deviation (sigma_h). The prior (Half-Cauchy) is diffuse, reflecting uncertainty before seeing data. The posterior is concentrated around 0.34, indicating moderate between-hospital variation after accounting for case mix. The data have substantially updated the prior.</p>
+</div>
+
+## Model Structure (DAG)
+
+<div class="figure">
+  <svg viewBox="0 0 700 300" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="STIX Two Text" font-size="14" font-weight="600" fill="#c8cad0">Directed Acyclic Graph: Three-Level Hierarchical Model</text>
+    <circle cx="350" cy="70" r="28" fill="none" stroke="#c2a07a" stroke-width="2"/>
+    <text x="350" y="66" text-anchor="middle" font-family="STIX Two Text" font-size="13" fill="#c2a07a">mu</text>
+    <text x="350" y="80" text-anchor="middle" font-family="STIX Two Text" font-size="10" fill="#c2a07a">sigma_h</text>
+    <circle cx="180" cy="155" r="28" fill="none" stroke="#7a9ec2" stroke-width="2"/>
+    <text x="180" y="159" text-anchor="middle" font-family="STIX Two Text" font-size="13" fill="#7a9ec2">alpha_h</text>
+    <circle cx="350" cy="155" r="28" fill="none" stroke="#7a9ec2" stroke-width="2"/>
+    <text x="350" y="159" text-anchor="middle" font-family="STIX Two Text" font-size="13" fill="#7a9ec2">alpha_h</text>
+    <circle cx="520" cy="155" r="28" fill="none" stroke="#7a9ec2" stroke-width="2"/>
+    <text x="520" y="159" text-anchor="middle" font-family="STIX Two Text" font-size="13" fill="#7a9ec2">alpha_h</text>
+    <text x="160" y="195" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">Hospital 1</text>
+    <text x="350" y="195" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">Hospital j</text>
+    <text x="540" y="195" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">Hospital J</text>
+    <text x="265" y="155" font-family="STIX Two Text" font-size="16" fill="#5a5d68">...</text>
+    <text x="435" y="155" font-family="STIX Two Text" font-size="16" fill="#5a5d68">...</text>
+    <circle cx="290" cy="245" r="22" fill="none" stroke="#8ab87a" stroke-width="2"/>
+    <text x="290" y="249" text-anchor="middle" font-family="STIX Two Text" font-size="12" fill="#8ab87a">y_ij</text>
+    <circle cx="410" cy="245" r="22" fill="none" stroke="#8ab87a" stroke-width="2"/>
+    <text x="410" y="249" text-anchor="middle" font-family="STIX Two Text" font-size="12" fill="#8ab87a">y_ij</text>
+    <text x="350" y="249" font-family="STIX Two Text" font-size="14" fill="#5a5d68">...</text>
+    <text x="290" y="278" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">Patient i</text>
+    <text x="410" y="278" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">Patient n</text>
+    <circle cx="560" cy="245" r="22" fill="none" stroke="#c28a7a" stroke-width="2"/>
+    <text x="560" y="249" text-anchor="middle" font-family="STIX Two Text" font-size="12" fill="#c28a7a">X_ij</text>
+    <text x="560" y="278" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">Covariates</text>
+    <line x1="330" y1="94" x2="200" y2="131" stroke="#c2a07a" stroke-width="1.5" marker-end="url(#arrowGold)"/>
+    <line x1="350" y1="98" x2="350" y2="127" stroke="#c2a07a" stroke-width="1.5" marker-end="url(#arrowGold)"/>
+    <line x1="370" y1="94" x2="500" y2="131" stroke="#c2a07a" stroke-width="1.5" marker-end="url(#arrowGold)"/>
+    <line x1="340" y1="180" x2="300" y2="226" stroke="#7a9ec2" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <line x1="360" y1="180" x2="400" y2="226" stroke="#7a9ec2" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+    <line x1="545" y1="228" x2="425" y2="240" stroke="#c28a7a" stroke-width="1.5" marker-end="url(#arrowRed)"/>
+    <defs>
+      <marker id="arrowGold" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#c2a07a" stroke-width="1"/>
+      </marker>
+      <marker id="arrowBlue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#7a9ec2" stroke-width="1"/>
+      </marker>
+      <marker id="arrowRed" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#c28a7a" stroke-width="1"/>
+      </marker>
+    </defs>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 2.</span> Directed acyclic graph (DAG) of the three-level Bayesian hierarchical model. Hyperparameters mu and sigma_h (gold) govern the distribution of hospital-level random effects alpha_h (blue). Patient outcomes y_ij (green) are conditionally independent given their hospital effect and patient-level covariates X_ij (red). Arrows indicate conditional dependencies.</p>
+</div>
+
+## Key Results
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Model comparison: Bayesian hierarchical vs. frequentist alternatives</caption>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Bayesian Hierarchical</th>
+      <th>Frequentist Random Effects</th>
+      <th>Frequentist Fixed Effects</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>C-statistic</td>
+      <td class="num best-cell">0.847</td>
+      <td class="num">0.839</td>
+      <td class="num">0.832</td>
+    </tr>
+    <tr>
+      <td>Brier score</td>
+      <td class="num best-cell">0.031</td>
+      <td class="num">0.034</td>
+      <td class="num">0.038</td>
+    </tr>
+    <tr>
+      <td>ELPD (LOO-CV)</td>
+      <td class="num best-cell">-18,442</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Hospital estimates unstable (CV > 0.5)</td>
+      <td class="num best-cell">2 / 47</td>
+      <td class="num">8 / 47</td>
+      <td class="num">14 / 47</td>
+    </tr>
+    <tr>
+      <td>Max R-hat</td>
+      <td class="num">1.003</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Min ESS (bulk)</td>
+      <td class="num">3,412</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="4">ELPD = expected log pointwise predictive density; LOO-CV = leave-one-out cross-validation; ESS = effective sample size. Bold cells indicate the best-performing model for each metric.</td>
+    </tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+1. **Model Specification** -- The three-level hierarchical model, prior elicitation, and DAG structure
+2. **Prior Elicitation** -- Derivation of informative priors from the Japanese DPC national registry
+3. **MCMC Diagnostics** -- Trace plots, R-hat convergence, effective sample size assessment
+4. **Results** -- Posterior estimates, shrinkage analysis, and model comparison
+5. **Discussion** -- Interpretation, limitations, and recommendations for hospital benchmarking

--- a/bayesian-prior/content/notation.md
+++ b/bayesian-prior/content/notation.md
@@ -1,0 +1,84 @@
++++
+title = "Notation Guide"
+description = "Mathematical notation and symbol definitions used throughout the paper."
+template = "page"
++++
+
+<div class="paper-section-header">
+  <p class="paper-section-eyebrow">REFERENCE</p>
+  <h1 class="paper-section-title">Notation Guide</h1>
+</div>
+
+<div class="paper-content">
+
+## Parameters
+
+<table class="paper-table">
+  <thead>
+    <tr>
+      <th>Symbol</th>
+      <th>Description</th>
+      <th>Prior</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="math-cell">mu</td>
+      <td>Grand mean log-odds of mortality</td>
+      <td class="math-cell">N(-3.5, 0.5)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">sigma_h</td>
+      <td>Between-hospital SD of random effects</td>
+      <td class="math-cell">Half-Cauchy(0, 0.5)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">alpha_h</td>
+      <td>Hospital-specific random intercept</td>
+      <td class="math-cell">N(0, sigma_h)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">beta_k</td>
+      <td>Fixed-effect coefficient for covariate k</td>
+      <td class="math-cell">N(beta_registry, 0.2)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">y_ij</td>
+      <td>Binary outcome (0/1) for patient i in hospital j</td>
+      <td class="math-cell">Bernoulli(p_ij)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">p_ij</td>
+      <td>Probability of mortality for patient i in hospital j</td>
+      <td class="math-cell">logit^-1(eta_ij)</td>
+    </tr>
+    <tr>
+      <td class="math-cell">eta_ij</td>
+      <td>Linear predictor on log-odds scale</td>
+      <td class="math-cell">mu + alpha_h + X_ij * beta</td>
+    </tr>
+  </tbody>
+</table>
+
+## Indices
+
+| Symbol | Range | Meaning |
+|--------|-------|---------|
+| i | 1, ..., n_j | Patient within hospital j |
+| j | 1, ..., J (= 47) | Hospital |
+| k | 1, ..., K (= 12) | Covariate |
+
+## Key Metrics
+
+| Abbreviation | Full Name |
+|-------------|-----------|
+| R-hat | Potential scale reduction factor (convergence diagnostic) |
+| ESS | Effective sample size |
+| ELPD | Expected log pointwise predictive density |
+| LOO-CV | Leave-one-out cross-validation |
+| WAIC | Widely applicable information criterion |
+| SMR | Standardized mortality ratio |
+| HMC | Hamiltonian Monte Carlo |
+| NUTS | No-U-Turn Sampler |
+
+</div>

--- a/bayesian-prior/content/sections/1-model-specification.md
+++ b/bayesian-prior/content/sections/1-model-specification.md
@@ -1,0 +1,57 @@
++++
+title = "1. Model Specification"
+weight = 1
+template = "post"
+description = "The three-level Bayesian hierarchical logistic regression model for hospital mortality estimation."
+[extra]
+section_number = "1"
++++
+
+## Overview
+
+We model 30-day post-surgical mortality as a binary outcome using a three-level Bayesian hierarchical logistic regression. The three levels are: patients (level 1), surgeons (level 2, absorbed into hospital for parsimony in the primary analysis), and hospitals (level 3).
+
+## Likelihood
+
+For patient i in hospital j, the outcome y_ij (0 = survived, 1 = died within 30 days) follows:
+
+y_ij ~ Bernoulli(p_ij)
+
+where the mortality probability is linked to a linear predictor via the logit function:
+
+logit(p_ij) = mu + alpha_j + X_ij * beta
+
+## Hierarchical Structure
+
+The hospital-level random effects alpha_j are drawn from a common distribution:
+
+alpha_j ~ Normal(0, sigma_h)
+
+This induces partial pooling: hospitals with sparse data are shrunk toward the grand mean, while data-rich hospitals retain more of their individual estimate.
+
+## Prior Specification
+
+The key innovation of this work is the use of informative priors derived from external registry data:
+
+- **Grand mean mu:** Normal(-3.5, 0.5), centered on the national registry log-odds mortality rate
+- **Hospital SD sigma_h:** Half-Cauchy(0, 0.5), weakly informative for the between-hospital variation
+- **Regression coefficients beta:** Normal(beta_registry, 0.2), centered on registry-derived point estimates with moderate uncertainty
+
+The informative priors on beta are justified by the large national registry (N = 2.4 million), which provides precise estimates of covariate-outcome associations that should generalize to the study population.
+
+## Covariates
+
+Twelve patient-level covariates were included:
+
+1. Age (standardized)
+2. Sex (0/1)
+3. ASA physical status (I-V, treated as continuous)
+4. Charlson comorbidity index
+5. Emergency admission (0/1)
+6. Surgical complexity score
+7. Anesthesia duration (log-transformed)
+8. Body mass index (standardized)
+9. Preoperative albumin (standardized)
+10. Preoperative hemoglobin (standardized)
+11. Diabetes (0/1)
+12. Chronic kidney disease stage (0-5)

--- a/bayesian-prior/content/sections/2-prior-elicitation.md
+++ b/bayesian-prior/content/sections/2-prior-elicitation.md
@@ -1,0 +1,70 @@
++++
+title = "2. Prior Elicitation"
+weight = 2
+template = "post"
+description = "Derivation of informative priors from the Japanese DPC national registry database."
+[extra]
+section_number = "2"
++++
+
+## Registry Data Source
+
+The Japanese Diagnosis Procedure Combination (DPC) national registry captures administrative and clinical data for all acute-care hospital admissions in Japan. We used 2.4 million surgical admissions from fiscal years 2020-2024 to derive informative priors for model parameters.
+
+## Prior Derivation Process
+
+For each regression coefficient beta_k, we fit a standard logistic regression to the full registry dataset and used the resulting point estimates as prior means:
+
+beta_k ~ Normal(beta_hat_registry_k, 0.2)
+
+The prior standard deviation of 0.2 was chosen to be approximately twice the typical standard error from the registry fit, reflecting our belief that the study population may differ somewhat from the national population while remaining broadly similar.
+
+## Prior-Data Conflict Assessment
+
+<div class="figure">
+  <svg viewBox="0 0 700 300" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="STIX Two Text" font-size="14" font-weight="600" fill="#c8cad0">Prior-Data Conflict: Registry Prior vs. Study Likelihood for Key Covariates</text>
+    <line x1="100" y1="40" x2="100" y2="250" stroke="#3a3d48" stroke-width="1"/>
+    <line x1="100" y1="250" x2="640" y2="250" stroke="#3a3d48" stroke-width="1"/>
+    <text x="100" y="270" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">-1.0</text>
+    <text x="235" y="270" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">-0.5</text>
+    <text x="370" y="270" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.0</text>
+    <text x="505" y="270" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0.5</text>
+    <text x="640" y="270" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">1.0</text>
+    <text x="370" y="290" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#8a8e9a">Coefficient (log-odds)</text>
+    <text x="95" y="75" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">Age</text>
+    <text x="95" y="115" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">ASA status</text>
+    <text x="95" y="155" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">Emergency</text>
+    <text x="95" y="195" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">CCI</text>
+    <text x="95" y="235" text-anchor="end" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">Albumin</text>
+    <line x1="430" y1="75" x2="510" y2="75" stroke="#c2a07a" stroke-width="2" stroke-dasharray="4 2"/>
+    <circle cx="470" cy="75" r="4" fill="#c2a07a"/>
+    <line x1="440" y1="75" x2="500" y2="75" stroke="#7a9ec2" stroke-width="2.5"/>
+    <circle cx="478" cy="75" r="4" fill="#7a9ec2" stroke="#1a1c24" stroke-width="1"/>
+    <line x1="450" y1="115" x2="550" y2="115" stroke="#c2a07a" stroke-width="2" stroke-dasharray="4 2"/>
+    <circle cx="500" cy="115" r="4" fill="#c2a07a"/>
+    <line x1="460" y1="115" x2="540" y2="115" stroke="#7a9ec2" stroke-width="2.5"/>
+    <circle cx="505" cy="115" r="4" fill="#7a9ec2" stroke="#1a1c24" stroke-width="1"/>
+    <line x1="390" y1="155" x2="490" y2="155" stroke="#c2a07a" stroke-width="2" stroke-dasharray="4 2"/>
+    <circle cx="440" cy="155" r="4" fill="#c2a07a"/>
+    <line x1="410" y1="155" x2="500" y2="155" stroke="#7a9ec2" stroke-width="2.5"/>
+    <circle cx="460" cy="155" r="4" fill="#7a9ec2" stroke="#1a1c24" stroke-width="1"/>
+    <line x1="395" y1="195" x2="460" y2="195" stroke="#c2a07a" stroke-width="2" stroke-dasharray="4 2"/>
+    <circle cx="425" cy="195" r="4" fill="#c2a07a"/>
+    <line x1="400" y1="195" x2="450" y2="195" stroke="#7a9ec2" stroke-width="2.5"/>
+    <circle cx="430" cy="195" r="4" fill="#7a9ec2" stroke="#1a1c24" stroke-width="1"/>
+    <line x1="200" y1="235" x2="300" y2="235" stroke="#c2a07a" stroke-width="2" stroke-dasharray="4 2"/>
+    <circle cx="250" cy="235" r="4" fill="#c2a07a"/>
+    <line x1="210" y1="235" x2="290" y2="235" stroke="#7a9ec2" stroke-width="2.5"/>
+    <circle cx="245" cy="235" r="4" fill="#7a9ec2" stroke="#1a1c24" stroke-width="1"/>
+    <rect x="480" y="42" width="12" height="2" fill="#c2a07a"/>
+    <text x="497" y="46" font-family="Crimson Pro" font-size="10" fill="#c2a07a">Prior (registry)</text>
+    <rect x="560" y="42" width="12" height="2" fill="#7a9ec2"/>
+    <text x="577" y="46" font-family="Crimson Pro" font-size="10" fill="#7a9ec2">Posterior</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 3.</span> Comparison of registry-derived prior intervals (gold, dashed) and posterior credible intervals (blue, solid) for five key covariates. Prior and posterior intervals overlap substantially for all coefficients, indicating no prior-data conflict. The posteriors are narrower, reflecting information gain from the study data.</p>
+</div>
+
+## No Prior-Data Conflict
+
+For all twelve covariates, the posterior 95% credible interval overlapped with the prior 95% interval. Formal prior-data conflict checks using the prior predictive p-value (Box, 1980) yielded no p-values below 0.05, confirming compatibility between the registry-derived priors and the study data.

--- a/bayesian-prior/content/sections/3-mcmc-diagnostics.md
+++ b/bayesian-prior/content/sections/3-mcmc-diagnostics.md
@@ -1,0 +1,117 @@
++++
+title = "3. MCMC Diagnostics"
+weight = 3
+template = "post"
+description = "Trace plots, R-hat convergence statistics, and effective sample size assessment for all model parameters."
+[extra]
+section_number = "3"
++++
+
+## Sampling Configuration
+
+Inference was performed using Stan's No-U-Turn Sampler (NUTS), a variant of Hamiltonian Monte Carlo. We ran 4 independent chains, each with 2,000 warmup iterations and 2,000 sampling iterations, yielding 8,000 posterior draws in total.
+
+## Trace Plots
+
+<div class="figure">
+  <svg viewBox="0 0 700 260" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="20" text-anchor="middle" font-family="STIX Two Text" font-size="13" font-weight="600" fill="#c8cad0">MCMC Trace Plot: sigma_h (4 chains, 2000 post-warmup iterations each)</text>
+    <line x1="60" y1="35" x2="60" y2="200" stroke="#3a3d48" stroke-width="1"/>
+    <line x1="60" y1="200" x2="660" y2="200" stroke="#3a3d48" stroke-width="1"/>
+    <text x="55" y="50" text-anchor="end" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">0.50</text>
+    <text x="55" y="90" text-anchor="end" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">0.40</text>
+    <text x="55" y="130" text-anchor="end" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">0.30</text>
+    <text x="55" y="170" text-anchor="end" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">0.20</text>
+    <text x="60" y="215" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">0</text>
+    <text x="210" y="215" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">500</text>
+    <text x="360" y="215" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">1000</text>
+    <text x="510" y="215" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">1500</text>
+    <text x="647" y="215" font-family="JetBrains Mono" font-size="8" fill="#5a5d68">2000</text>
+    <text x="360" y="235" text-anchor="middle" font-family="Crimson Pro" font-size="11" fill="#8a8e9a">Iteration (post-warmup)</text>
+    <polyline points="60,125 90,118 120,132 150,128 180,122 210,130 240,126 270,120 300,134 330,128 360,124 390,130 420,126 450,122 480,128 510,132 540,126 570,124 600,128 630,130 660,126" fill="none" stroke="#7a9ec2" stroke-width="0.8" opacity="0.7"/>
+    <polyline points="60,130 90,122 120,128 150,134 180,126 210,120 240,132 270,128 300,124 330,130 360,126 390,122 420,130 450,128 480,124 510,126 540,132 570,128 600,124 630,126 660,130" fill="none" stroke="#c2a07a" stroke-width="0.8" opacity="0.7"/>
+    <polyline points="60,122 90,128 120,126 150,130 180,132 210,124 240,128 270,126 300,130 330,122 360,128 390,126 420,124 450,132 480,126 510,128 540,130 570,126 600,132 630,128 660,124" fill="none" stroke="#8ab87a" stroke-width="0.8" opacity="0.7"/>
+    <polyline points="60,128 90,132 120,124 150,126 180,128 210,134 240,124 270,130 300,128 330,126 360,132 390,128 420,128 450,126 480,130 510,124 540,128 570,132 600,126 630,124 660,128" fill="none" stroke="#c28a7a" stroke-width="0.8" opacity="0.7"/>
+    <rect x="490" y="36" width="10" height="2" fill="#7a9ec2"/>
+    <text x="504" y="40" font-family="JetBrains Mono" font-size="8" fill="#7a9ec2">Chain 1</text>
+    <rect x="550" y="36" width="10" height="2" fill="#c2a07a"/>
+    <text x="564" y="40" font-family="JetBrains Mono" font-size="8" fill="#c2a07a">Chain 2</text>
+    <rect x="610" y="36" width="10" height="2" fill="#8ab87a"/>
+    <text x="624" y="40" font-family="JetBrains Mono" font-size="8" fill="#8ab87a">Chain 3</text>
+    <rect x="490" y="48" width="10" height="2" fill="#c28a7a"/>
+    <text x="504" y="52" font-family="JetBrains Mono" font-size="8" fill="#c28a7a">Chain 4</text>
+    <text x="350" y="250" text-anchor="middle" font-family="Crimson Pro" font-size="11" font-style="italic" fill="#5a5d68">All four chains are well-mixed with stationary behavior -- no divergences or trending</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 4.</span> Trace plot for the hospital-level standard deviation parameter sigma_h. All four chains show excellent mixing with no visible trends, drifts, or multimodality. The chains are overlapping and stationary, consistent with convergence.</p>
+</div>
+
+## Convergence Summary
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> MCMC convergence diagnostics for selected parameters</caption>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Posterior mean</th>
+      <th>95% CrI</th>
+      <th>R-hat</th>
+      <th>ESS (bulk)</th>
+      <th>ESS (tail)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="math-cell">mu</td>
+      <td class="num">-3.42</td>
+      <td class="num">(-3.58, -3.26)</td>
+      <td class="num converged">1.001</td>
+      <td class="num">6,842</td>
+      <td class="num">5,918</td>
+    </tr>
+    <tr>
+      <td class="math-cell">sigma_h</td>
+      <td class="num">0.34</td>
+      <td class="num">(0.26, 0.44)</td>
+      <td class="num converged">1.003</td>
+      <td class="num">3,412</td>
+      <td class="num">4,128</td>
+    </tr>
+    <tr>
+      <td class="math-cell">beta[age]</td>
+      <td class="num">0.62</td>
+      <td class="num">(0.54, 0.70)</td>
+      <td class="num converged">1.001</td>
+      <td class="num">7,204</td>
+      <td class="num">6,542</td>
+    </tr>
+    <tr>
+      <td class="math-cell">beta[ASA]</td>
+      <td class="num">0.78</td>
+      <td class="num">(0.68, 0.88)</td>
+      <td class="num converged">1.001</td>
+      <td class="num">6,918</td>
+      <td class="num">6,104</td>
+    </tr>
+    <tr>
+      <td class="math-cell">beta[emergency]</td>
+      <td class="num">0.55</td>
+      <td class="num">(0.42, 0.68)</td>
+      <td class="num converged">1.002</td>
+      <td class="num">5,628</td>
+      <td class="num">5,218</td>
+    </tr>
+    <tr>
+      <td class="math-cell">beta[albumin]</td>
+      <td class="num">-0.48</td>
+      <td class="num">(-0.58, -0.38)</td>
+      <td class="num converged">1.001</td>
+      <td class="num">7,012</td>
+      <td class="num">6,328</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">All R-hat values are below 1.01, and all ESS values exceed 3,000, indicating satisfactory convergence. No divergent transitions were observed across 8,000 post-warmup iterations.</td>
+    </tr>
+  </tfoot>
+</table>

--- a/bayesian-prior/content/sections/4-results.md
+++ b/bayesian-prior/content/sections/4-results.md
@@ -1,0 +1,69 @@
++++
+title = "4. Results"
+weight = 4
+template = "post"
+description = "Posterior estimates, hospital-level shrinkage patterns, and model comparison."
+[extra]
+section_number = "4"
++++
+
+## Posterior Hospital Estimates
+
+The posterior mean mortality rates across 47 hospitals ranged from 1.1% to 5.8%, compared with raw observed rates of 0.0% to 8.4%. The Bayesian estimates show substantial shrinkage toward the overall mean, particularly for low-volume hospitals.
+
+## Shrinkage Analysis
+
+<div class="figure">
+  <svg viewBox="0 0 700 320" xmlns="http://www.w3.org/2000/svg">
+    <text x="350" y="24" text-anchor="middle" font-family="STIX Two Text" font-size="14" font-weight="600" fill="#c8cad0">Shrinkage: Raw vs. Bayesian Posterior Mortality Estimates</text>
+    <line x1="80" y1="40" x2="80" y2="260" stroke="#3a3d48" stroke-width="1"/>
+    <line x1="80" y1="260" x2="650" y2="260" stroke="#3a3d48" stroke-width="1"/>
+    <text x="35" y="155" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#8a8e9a" transform="rotate(-90,35,155)">Posterior estimate (%)</text>
+    <text x="365" y="295" text-anchor="middle" font-family="Crimson Pro" font-size="12" fill="#8a8e9a">Raw observed rate (%)</text>
+    <text x="80" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">0</text>
+    <text x="194" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">2</text>
+    <text x="308" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">4</text>
+    <text x="422" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">6</text>
+    <text x="536" y="275" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">8</text>
+    <text x="75" y="48" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">8</text>
+    <text x="75" y="103" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">6</text>
+    <text x="75" y="158" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">4</text>
+    <text x="75" y="213" text-anchor="end" font-family="JetBrains Mono" font-size="9" fill="#5a5d68">2</text>
+    <line x1="80" y1="40" x2="650" y2="260" stroke="#3a3d48" stroke-width="1" stroke-dasharray="4 2" opacity="0.4"/>
+    <text x="600" y="252" font-family="Crimson Pro" font-size="9" fill="#3a3d48" transform="rotate(-35,600,252)">y = x (no shrinkage)</text>
+    <circle cx="137" cy="208" r="6" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="194" cy="185" r="4" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="222" cy="175" r="8" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="251" cy="168" r="5" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="280" cy="155" r="7" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="308" cy="152" r="9" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="337" cy="145" r="6" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="365" cy="138" r="10" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="394" cy="132" r="5" fill="#7a9ec2" opacity="0.6" stroke="#7a9ec2" stroke-width="1"/>
+    <circle cx="451" cy="118" r="4" fill="#c2a07a" opacity="0.7" stroke="#c2a07a" stroke-width="1"/>
+    <circle cx="508" cy="112" r="3" fill="#c2a07a" opacity="0.7" stroke="#c2a07a" stroke-width="1"/>
+    <circle cx="536" cy="120" r="3" fill="#c2a07a" opacity="0.7" stroke="#c2a07a" stroke-width="1"/>
+    <circle cx="120" cy="195" r="3" fill="#c28a7a" opacity="0.7" stroke="#c28a7a" stroke-width="1"/>
+    <circle cx="100" cy="210" r="3" fill="#c28a7a" opacity="0.7" stroke="#c28a7a" stroke-width="1"/>
+    <rect x="480" y="42" width="8" height="8" rx="4" fill="#7a9ec2" opacity="0.6"/>
+    <text x="494" y="50" font-family="Crimson Pro" font-size="10" fill="#8a8e9a">Large hospital (n>500)</text>
+    <rect x="480" y="56" width="8" height="8" rx="4" fill="#c2a07a" opacity="0.7"/>
+    <text x="494" y="64" font-family="Crimson Pro" font-size="10" fill="#8a8e9a">Medium (200-500)</text>
+    <rect x="480" y="70" width="8" height="8" rx="4" fill="#c28a7a" opacity="0.7"/>
+    <text x="494" y="78" font-family="Crimson Pro" font-size="10" fill="#8a8e9a">Small (n<200)</text>
+  </svg>
+  <p class="caption"><span class="fig-num">Figure 5.</span> Shrinkage plot comparing raw observed mortality rates (x-axis) with Bayesian posterior estimates (y-axis). Points below the diagonal have been shrunk toward the grand mean. Circle size is proportional to hospital volume. Small hospitals (red) show the most shrinkage, while large hospitals (blue) retain estimates close to their raw rates.</p>
+</div>
+
+The degree of shrinkage was strongly related to hospital volume:
+
+| Volume category | Hospitals | Median shrinkage | Range |
+|----------------|-----------|-----------------|-------|
+| Low (< 200 cases/year) | 8 | 42% | 28-58% |
+| Medium (200-500) | 15 | 22% | 12-35% |
+| High (500-1000) | 14 | 12% | 6-18% |
+| Very high (> 1000) | 10 | 8% | 4-12% |
+
+## Model Comparison
+
+The Bayesian hierarchical model outperformed both frequentist alternatives on discrimination (C-statistic: 0.847 vs. 0.832-0.839) and calibration (Brier score: 0.031 vs. 0.034-0.038). The ELPD from LOO-CV was -18,442, which was 234 units higher than WAIC, confirming good out-of-sample predictive performance.

--- a/bayesian-prior/content/sections/5-discussion.md
+++ b/bayesian-prior/content/sections/5-discussion.md
@@ -1,0 +1,37 @@
++++
+title = "5. Discussion"
+weight = 5
+template = "post"
+description = "Interpretation, limitations, and recommendations for Bayesian approaches to hospital benchmarking."
+[extra]
+section_number = "5"
++++
+
+## Summary
+
+We demonstrated that a Bayesian hierarchical model with informative priors derived from a national registry produces more stable and better-calibrated hospital mortality estimates than frequentist alternatives. The key advantage is principled shrinkage: low-volume hospitals, where raw estimates are unreliable, are pulled toward the population mean by an amount determined by the data rather than by arbitrary thresholds.
+
+## The Role of Informative Priors
+
+The informative priors on regression coefficients served two functions. First, they regularized the model by incorporating external information about covariate-outcome relationships, which is especially valuable when individual hospitals have sparse data for certain patient subgroups. Second, they made the model more transparent: rather than relying solely on the study data (which may be influenced by unmeasured selection), the priors encode explicit assumptions about what we expect to see based on national patterns.
+
+Importantly, the prior-data conflict checks showed no evidence of incompatibility between the registry priors and the study data. Had conflicts been detected, we would have widened the prior standard deviations or reverted to weakly informative priors for the affected parameters.
+
+## Practical Implications for Hospital Benchmarking
+
+Current hospital quality indicators (such as the UK's Hospital Standardised Mortality Ratio) rely on frequentist methods that produce volatile estimates for small hospitals. Our Bayesian approach offers three advantages for quality monitoring:
+
+1. **Stable rankings.** Partial pooling reduces the year-to-year volatility of hospital estimates, making comparisons more reliable.
+2. **Honest uncertainty.** Posterior credible intervals naturally communicate the precision of each hospital's estimate, avoiding the false confidence of point estimates.
+3. **Incorporating evidence.** Informative priors allow formal incorporation of external evidence (registries, historical data, expert opinion) into the estimation process.
+
+## Limitations
+
+- The model assumes exchangeability of hospital effects within the hierarchical structure. Hospitals with genuinely different case mixes may require additional stratification.
+- The registry priors are specific to the Japanese healthcare system and may not transfer directly to other countries.
+- We modeled surgeons as nested within hospitals; cross-classified structures (surgeons operating at multiple hospitals) would require extensions.
+- Computational cost is higher than frequentist alternatives, though Stan's NUTS sampler makes inference tractable for models of this scale.
+
+## Conclusions
+
+Bayesian hierarchical models with registry-derived informative priors represent a principled approach to hospital mortality estimation that addresses the fundamental limitations of frequentist methods. We recommend their adoption in hospital quality monitoring programs, particularly in settings where low-volume hospitals are common and external registry data are available to inform prior specification.

--- a/bayesian-prior/content/sections/_index.md
+++ b/bayesian-prior/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Full paper sections covering model specification, prior elicitation from national registry data, MCMC convergence diagnostics, posterior results with shrinkage analysis, and implications for hospital benchmarking.

--- a/bayesian-prior/static/css/style.css
+++ b/bayesian-prior/static/css/style.css
@@ -1,0 +1,561 @@
+/* ============================================================================
+   Bayesian Prior - Probabilistic Analysis Paper
+   Dark background. STIX Two / Libertinus Serif display.
+   Crimson Pro / Noto Serif body. No gradients, no emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #14161e;
+  --paper-2: #1a1c24;
+  --paper-3: #22242e;
+  --rule: #3a3d48;
+  --ink: #c8cad0;
+  --ink-2: #a8aab2;
+  --ink-3: #8a8e9a;
+  --ink-4: #5a5d68;
+  --accent: #7a9ec2;
+  --accent-2: #9ab8d6;
+  --prior: #c2a07a;
+  --prior-bg: rgba(194,160,122,0.1);
+  --posterior: #7a9ec2;
+  --posterior-bg: rgba(122,158,194,0.1);
+  --converged: #8ab87a;
+  --converged-bg: rgba(138,184,122,0.1);
+  --best: #7a9ec2;
+  --best-bg: rgba(122,158,194,0.15);
+  --warm: #c28a7a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Badges ---------------- */
+
+.badge-row {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.bayes-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--posterior-bg);
+  border: 1.5px solid var(--posterior);
+  padding: 0.25rem 0.7rem;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--posterior);
+  text-transform: uppercase;
+}
+
+.bayes-badge.mcmc {
+  background: var(--converged-bg);
+  border-color: var(--converged);
+  color: var(--converged);
+}
+
+.bayes-badge.dag {
+  background: var(--prior-bg);
+  border-color: var(--prior);
+  color: var(--prior);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-3);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+  color: var(--prior);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--paper-3);
+  border: 1px solid var(--rule);
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+}
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Math / convergence cells ---------------- */
+
+.math-cell {
+  font-family: "STIX Two Text", serif;
+  font-style: italic;
+  color: var(--prior);
+}
+
+.converged {
+  color: var(--converged);
+  font-weight: 700;
+}
+
+.best-cell {
+  background: var(--best-bg);
+  color: var(--best);
+  font-weight: 700;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure .caption {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink-3);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", serif;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "STIX Two Text", serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 0.86rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+}

--- a/bayesian-prior/templates/404.html
+++ b/bayesian-prior/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 - Page Not Found</h1>
+      <p>The requested page does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">Return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bayesian-prior/templates/footer.html
+++ b/bayesian-prior/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#c8cad0" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#c8cad0" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura T, Osei-Bonsu K, Eriksson L, Gupta P. A Bayesian Hierarchical Model for Estimating Hospital-Level Mortality Rates with Informative Priors. <em>Bayes Anal Methods.</em> 2026;12(4):201-224. doi:10.41093/bam.2026.12.04.201</p>
+        <p class="footer-note">ISSN 3041-2288 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/bayesian-prior/templates/header.html
+++ b/bayesian-prior/templates/header.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Noto+Serif:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#c8cad0" stroke-width="1.5"/>
+          <path d="M10,32 Q18,32 22,24 Q26,10 32,10 Q38,10 42,24 Q46,32 54,32" fill="none" stroke="#7a9ec2" stroke-width="1.5" opacity="0.5"/>
+          <path d="M10,32 Q20,32 26,20 Q30,12 32,12 Q34,12 38,20 Q44,32 54,32" fill="none" stroke="#7a9ec2" stroke-width="2"/>
+          <circle cx="32" cy="12" r="2" fill="#c2a07a" stroke="none"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Bayesian Analysis &amp; Methods</span>
+          <span class="journal-sub">Vol. 12 &middot; Issue 04 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/notation/">NOTATION</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/bayesian-prior/templates/page.html
+++ b/bayesian-prior/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bayesian-prior/templates/post.html
+++ b/bayesian-prior/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bayesian-prior/templates/section.html
+++ b/bayesian-prior/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bayesian-prior/templates/shortcodes/alert.html
+++ b/bayesian-prior/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/bayesian-prior/templates/taxonomy.html
+++ b/bayesian-prior/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bayesian-prior/templates/taxonomy_term.html
+++ b/bayesian-prior/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      <p class="paper-lede">Posts tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -291,6 +291,13 @@
     "elegant",
     "batik"
   ],
+  "bayesian-prior": [
+    "paper",
+    "dark",
+    "bayesian",
+    "probabilistic",
+    "visualization"
+  ],
   "bauhaus": [
     "light",
     "portfolio",


### PR DESCRIPTION
## Summary
- Adds probabilistic analysis paper example with dark theme for Bayesian hierarchical modeling
- Features prior/posterior PDF curves, MCMC trace plots, DAG model structure diagrams, and shrinkage analysis as inline SVG
- Uses STIX Two/Libertinus Serif for mathematical display and Crimson Pro/Noto Serif for body text
- Includes 5 sections: Model Specification, Prior Elicitation, MCMC Diagnostics, Results, Discussion

## Test plan
- [ ] Verify `hwaro build` completes successfully in `bayesian-prior/`
- [ ] Verify dark theme renders correctly with no CSS gradients
- [ ] Verify tags.json entry is valid JSON and sorted alphabetically
- [ ] Verify no emojis in any files

Closes #1610