### PR TITLE
feat: add reproducibility example site (closes #1607)

### DIFF
--- a/reproducibility/AGENTS.md
+++ b/reproducibility/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/reproducibility/config.toml
+++ b/reproducibility/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Reproducibility - Replication Study Paper
+# Issue #1607 | Tags: paper, light, replication, comparison, verdict
+# =============================================================================
+
+title = "Replication Study: Attention Mechanisms in Low-Resource NLP"
+description = "A replication study paper comparing original and replicated results for attention-based models in low-resource NLP, with side-by-side comparison charts, verdict stamps, and split serif/sans-serif typography."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/reproducibility/content/index.md
+++ b/reproducibility/content/index.md
@@ -1,0 +1,136 @@
++++
+title = "Replication Report"
+description = "Replication study of attention-based models for low-resource NLP, with side-by-side comparisons of original and replicated results."
+tags = ["paper", "light", "replication", "comparison", "verdict"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Replication Report &middot; Open Access</p>
+  <h1 class="paper-title">Replication of "Attention Is Sometimes Enough: Cross-Lingual Transfer in Low-Resource Named Entity Recognition"</h1>
+  <p class="paper-authors">
+    Riku Nakamura<sup>1</sup>,
+    Adaeze Okonkwo<sup>2</sup>,
+    Sofia Lindqvist<sup>3</sup>,
+    Marco Reyes-Torres<sup>1</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Computational Linguistics Lab, University of Tokyo &middot;
+    <sup>2</sup>NLP Group, University of Edinburgh &middot;
+    <sup>3</sup>Language Technology Division, Uppsala University
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.48550/jrr.2026.12.04.201</a> &middot; <strong>Original:</strong> Park et al. (2024), ACL 2024 &middot; <strong>Submitted:</strong> 08 Jan 2026 &middot; <strong>Accepted:</strong> 22 Mar 2026</p>
+</header>
+
+## Overall Verdict
+
+<!-- Verdict stamps SVG -->
+<figure>
+<svg viewBox="0 0 750 100" xmlns="http://www.w3.org/2000/svg" aria-label="Overall replication verdicts" style="width:100%;max-width:750px;display:block;margin:1rem auto;">
+  <!-- CONFIRMED stamp -->
+  <rect x="10" y="10" width="220" height="80" rx="4" fill="#e8f4ec" stroke="#1e6e3a" stroke-width="2"/>
+  <text x="120" y="42" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" font-weight="700" fill="#1e6e3a" letter-spacing="2">MAIN CLAIM</text>
+  <line x1="40" y1="50" x2="200" y2="50" stroke="#1e6e3a" stroke-width="0.5"/>
+  <text x="120" y="72" text-anchor="middle" font-family="'Inter',sans-serif" font-size="18" font-weight="700" fill="#1e6e3a" letter-spacing="3">CONFIRMED</text>
+  <!-- Diagonal stamp lines for authenticity -->
+  <line x1="15" y1="85" x2="35" y2="15" stroke="#1e6e3a" stroke-width="0.3" opacity="0.3"/>
+  <line x1="205" y1="85" x2="225" y2="15" stroke="#1e6e3a" stroke-width="0.3" opacity="0.3"/>
+  <!-- PARTIALLY stamp -->
+  <rect x="260" y="10" width="220" height="80" rx="4" fill="#fef4e6" stroke="#a85c00" stroke-width="2"/>
+  <text x="370" y="42" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" font-weight="700" fill="#a85c00" letter-spacing="2">ABLATION CLAIMS</text>
+  <line x1="290" y1="50" x2="450" y2="50" stroke="#a85c00" stroke-width="0.5"/>
+  <text x="370" y="72" text-anchor="middle" font-family="'Inter',sans-serif" font-size="18" font-weight="700" fill="#a85c00" letter-spacing="3">PARTIALLY</text>
+  <line x1="265" y1="85" x2="285" y2="15" stroke="#a85c00" stroke-width="0.3" opacity="0.3"/>
+  <line x1="455" y1="85" x2="475" y2="15" stroke="#a85c00" stroke-width="0.3" opacity="0.3"/>
+  <!-- FAILED stamp -->
+  <rect x="510" y="10" width="220" height="80" rx="4" fill="#fce8e8" stroke="#a82020" stroke-width="2"/>
+  <text x="620" y="42" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" font-weight="700" fill="#a82020" letter-spacing="2">EFFICIENCY CLAIM</text>
+  <line x1="540" y1="50" x2="700" y2="50" stroke="#a82020" stroke-width="0.5"/>
+  <text x="620" y="72" text-anchor="middle" font-family="'Inter',sans-serif" font-size="18" font-weight="700" fill="#a82020" letter-spacing="3">FAILED</text>
+  <line x1="515" y1="85" x2="535" y2="15" stroke="#a82020" stroke-width="0.3" opacity="0.3"/>
+  <line x1="705" y1="85" x2="725" y2="15" stroke="#a82020" stroke-width="0.3" opacity="0.3"/>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6a72;font-style:italic;">Fig. 1. Overall replication verdicts for the three principal claims of Park et al. (2024).</figcaption>
+</figure>
+
+## Abstract
+
+This report presents a systematic replication of Park et al. (2024), "Attention Is Sometimes Enough: Cross-Lingual Transfer in Low-Resource Named Entity Recognition," published at ACL 2024. The original study claimed that (1) a simplified attention-only architecture achieves comparable performance to full transformer models for cross-lingual NER in low-resource settings, (2) specific attention head configurations are critical for transfer, and (3) the approach is more computationally efficient than baseline methods.
+
+We replicate all experiments using the original codebase (with corrections), identical datasets, and matched hardware. Our findings **confirm** the main performance claim (Claim 1), **partially confirm** the ablation analysis (Claim 2) with important caveats about attention head sensitivity, and **fail to confirm** the computational efficiency claim (Claim 3) due to undocumented preprocessing overhead in the original evaluation.
+
+## Key Result Comparison
+
+<!-- Side-by-side comparison chart SVG -->
+<figure>
+<svg viewBox="0 0 750 280" xmlns="http://www.w3.org/2000/svg" aria-label="Side-by-side F1 score comparison" style="width:100%;max-width:750px;display:block;margin:1rem auto;">
+  <text x="375" y="18" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="13" font-weight="700" fill="#1c1c1e">F1 SCORES: ORIGINAL vs. REPLICATED</text>
+  <!-- Axes -->
+  <line x1="120" y1="35" x2="120" y2="240" stroke="#1c1c1e" stroke-width="1"/>
+  <line x1="120" y1="240" x2="720" y2="240" stroke="#1c1c1e" stroke-width="1"/>
+  <!-- Y-axis labels -->
+  <text x="115" y="240" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">0</text>
+  <text x="115" y="199" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">20</text>
+  <text x="115" y="158" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">40</text>
+  <text x="115" y="117" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">60</text>
+  <text x="115" y="76" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">80</text>
+  <text x="115" y="42" text-anchor="end" font-family="'Inter',sans-serif" font-size="9" fill="#6a6a72">100</text>
+  <!-- Grid lines -->
+  <line x1="120" y1="195" x2="720" y2="195" stroke="#e4e2dc" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="120" y1="154" x2="720" y2="154" stroke="#e4e2dc" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="120" y1="113" x2="720" y2="113" stroke="#e4e2dc" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="120" y1="72" x2="720" y2="72" stroke="#e4e2dc" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <!-- Language pairs - grouped bars -->
+  <!-- Yoruba (yo) -->
+  <rect x="145" y="78" width="28" height="162" fill="#2c5f8a" opacity="0.85"/>
+  <rect x="175" y="82" width="28" height="158" fill="#5c3a8a" opacity="0.85"/>
+  <text x="174" y="258" text-anchor="middle" font-family="'Inter',sans-serif" font-size="9" fill="#1c1c1e">Yoruba</text>
+  <text x="159" y="73" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#2c5f8a">79.1</text>
+  <text x="189" y="77" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#5c3a8a">77.2</text>
+  <!-- Swahili (sw) -->
+  <rect x="245" y="72" width="28" height="168" fill="#2c5f8a" opacity="0.85"/>
+  <rect x="275" y="70" width="28" height="170" fill="#5c3a8a" opacity="0.85"/>
+  <text x="274" y="258" text-anchor="middle" font-family="'Inter',sans-serif" font-size="9" fill="#1c1c1e">Swahili</text>
+  <text x="259" y="67" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#2c5f8a">81.9</text>
+  <text x="289" y="65" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#5c3a8a">82.9</text>
+  <!-- Quechua (qu) -->
+  <rect x="345" y="98" width="28" height="142" fill="#2c5f8a" opacity="0.85"/>
+  <rect x="375" y="104" width="28" height="136" fill="#5c3a8a" opacity="0.85"/>
+  <text x="374" y="258" text-anchor="middle" font-family="'Inter',sans-serif" font-size="9" fill="#1c1c1e">Quechua</text>
+  <text x="359" y="93" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#2c5f8a">69.3</text>
+  <text x="389" y="99" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#5c3a8a">66.4</text>
+  <!-- Welsh (cy) -->
+  <rect x="445" y="62" width="28" height="178" fill="#2c5f8a" opacity="0.85"/>
+  <rect x="475" y="60" width="28" height="180" fill="#5c3a8a" opacity="0.85"/>
+  <text x="474" y="258" text-anchor="middle" font-family="'Inter',sans-serif" font-size="9" fill="#1c1c1e">Welsh</text>
+  <text x="459" y="57" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#2c5f8a">86.8</text>
+  <text x="489" y="55" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#5c3a8a">87.8</text>
+  <!-- Tagalog (tl) -->
+  <rect x="545" y="68" width="28" height="172" fill="#2c5f8a" opacity="0.85"/>
+  <rect x="575" y="74" width="28" height="166" fill="#5c3a8a" opacity="0.85"/>
+  <text x="574" y="258" text-anchor="middle" font-family="'Inter',sans-serif" font-size="9" fill="#1c1c1e">Tagalog</text>
+  <text x="559" y="63" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#2c5f8a">83.9</text>
+  <text x="589" y="69" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="600" fill="#5c3a8a">80.9</text>
+  <!-- Legend -->
+  <rect x="640" y="40" width="12" height="12" fill="#2c5f8a" opacity="0.85"/>
+  <text x="656" y="50" font-family="'Crimson Pro',serif" font-size="10" fill="#2c5f8a">Original</text>
+  <rect x="640" y="58" width="12" height="12" fill="#5c3a8a" opacity="0.85"/>
+  <text x="656" y="68" font-family="'Inter',sans-serif" font-size="10" fill="#5c3a8a">Replicated</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#6a6a72;font-style:italic;">Fig. 2. F1 scores for cross-lingual NER across five low-resource target languages. Left bar (blue): original results. Right bar (purple): our replication.</figcaption>
+</figure>
+
+## Claim-by-Claim Summary
+
+| Claim | Original Result | Our Result | Delta | Verdict |
+|---|---|---|---|---|
+| Cross-lingual F1 (5-lang avg) | 80.2 | 79.0 | -1.2 | <span class="verdict-confirmed">CONFIRMED</span> |
+| Attention head 3 critical | Ablation drop: 8.4 F1 | Ablation drop: 4.1 F1 | -4.3 | <span class="verdict-partial">PARTIALLY</span> |
+| Head 7 redundant | Ablation drop: 0.3 F1 | Ablation drop: 3.8 F1 | +3.5 | <span class="verdict-failed">FAILED</span> |
+| Training efficiency (2x faster) | 2.1x speedup | 1.1x speedup | -1.0x | <span class="verdict-failed">FAILED</span> |
+| Low-resource threshold (<500 sent) | Effective below 500 | Effective below 500 | 0 | <span class="verdict-confirmed">CONFIRMED</span> |
+
+## Methodology
+
+We followed the replication protocol established by the ACL 2023 Reproducibility Track. All experiments were conducted using the original authors' codebase (commit `a7f3e2d`, released January 2024) with three corrections for discovered bugs (detailed in Section 2). Hardware was matched to the original specification: NVIDIA A100 40GB GPUs, identical batch sizes, and fixed random seeds.
+
+The original datasets (WikiANN for all five target languages) were obtained from the same sources cited in the paper. We verified data integrity via SHA-256 checksums against the original data release.

--- a/reproducibility/content/methods.md
+++ b/reproducibility/content/methods.md
@@ -1,0 +1,55 @@
++++
+title = "Replication Methods"
+description = "Detailed methodology for the replication, including codebase corrections, hardware specification, and evaluation protocol."
+tags = ["paper", "light", "replication", "comparison", "verdict"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Methods &middot; Replication Protocol</p>
+  <h1 class="paper-title">Replication Methodology</h1>
+</header>
+
+## Codebase Corrections
+
+During our initial replication attempt, we identified three bugs in the original codebase that affected reproducibility:
+
+| Bug ID | File | Issue | Impact |
+|---|---|---|---|
+| B-1 | `data/loader.py` | Off-by-one in sentence boundary detection | 0.3% of sentences truncated; minor F1 impact |
+| B-2 | `model/attention.py` | Incorrect mask application in multi-head attention | Sporadic NaN in gradients; training instability |
+| B-3 | `eval/metrics.py` | Entity-level F1 computed as micro instead of macro | Inflated scores for frequent entity types |
+
+Bug B-3 is the most consequential. The original paper reports "entity-level F1" but the evaluation code computes micro-averaged F1, which weights frequent entity types (PER, LOC) more heavily than rare types (MISC). We report both micro and macro F1 in our results and note that the discrepancy is largest for languages with skewed entity distributions (Yoruba, Quechua).
+
+All bug fixes were submitted as pull requests to the original repository and have been acknowledged by the original authors.
+
+## Hardware and Environment
+
+| Component | Original | Replication |
+|---|---|---|
+| GPU | NVIDIA A100 40GB | NVIDIA A100 40GB |
+| CPU | AMD EPYC 7742 | AMD EPYC 7763 |
+| RAM | 512 GB | 512 GB |
+| CUDA | 11.7 | 11.7 |
+| PyTorch | 1.13.1 | 1.13.1 |
+| Python | 3.9.16 | 3.9.16 |
+| OS | Ubuntu 20.04 | Ubuntu 20.04 |
+| Random seed | 42 | 42 |
+
+We used Docker containers to ensure environment reproducibility. The container specification is available in our replication package.
+
+## Evaluation Protocol
+
+Each experiment was run five times with different random seeds (42, 123, 456, 789, 1024). We report the mean and standard deviation across runs. Statistical significance was assessed using paired bootstrap resampling (10,000 iterations) following the methodology of Berg-Kirkpatrick et al. (2012).
+
+A result was considered "confirmed" if:
+- The replicated mean falls within 2 percentage points of the original reported value, OR
+- The 95% confidence interval of the replicated result overlaps with the original reported value
+
+A result was considered "partially confirmed" if:
+- The direction of the effect is preserved but the magnitude differs by more than 2 percentage points
+- Qualitative conclusions remain valid but quantitative thresholds change
+
+A result was considered "failed" if:
+- The direction of the effect reverses, OR
+- The magnitude differs so substantially that the original conclusion no longer holds

--- a/reproducibility/content/sections/1-original-study.md
+++ b/reproducibility/content/sections/1-original-study.md
@@ -1,0 +1,30 @@
++++
+title = "1. Summary of the Original Study"
+description = "Overview of Park et al. (2024) and its principal claims about attention-based cross-lingual NER."
+weight = 1
+template = "post"
+tags = ["replication", "original-study", "NLP"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## Original Study Overview
+
+Park et al. (2024) proposed a simplified architecture for cross-lingual named entity recognition (NER) in low-resource languages. The core contribution was demonstrating that an attention-only model -- stripped of feed-forward layers, layer normalisation, and residual connections found in standard transformers -- could match the performance of full transformer models when transferring NER capabilities from high-resource source languages (English, Chinese) to low-resource targets.
+
+The study evaluated performance on five low-resource target languages: Yoruba, Swahili, Quechua, Welsh, and Tagalog, using the WikiANN dataset for all languages. The model was trained on English and Chinese NER data and evaluated zero-shot on the target languages.
+
+## Principal Claims
+
+The paper advanced three principal claims:
+
+**Claim 1 (Performance Parity):** The attention-only model achieves F1 scores within 2 percentage points of a full mBERT-based transformer on all five target languages, with a 5-language average of 80.2 F1.
+
+**Claim 2 (Attention Head Analysis):** Through systematic ablation, the authors identified attention head 3 as "critical" for cross-lingual transfer (removal causes 8.4 F1 drop) and head 7 as "redundant" (removal causes only 0.3 F1 drop). They interpreted this as evidence that cross-lingual transfer relies on specific, identifiable attention patterns rather than distributed representations.
+
+**Claim 3 (Computational Efficiency):** The simplified architecture trains 2.1 times faster than the full transformer baseline, making it practical for rapid deployment in low-resource settings where computational resources are limited.
+
+## Significance
+
+The paper was well-received at ACL 2024, receiving an Outstanding Paper honourable mention. Its appeal lay in the combination of practical utility (faster, simpler models for low-resource NER) and scientific insight (specific attention heads encode cross-lingual structure). If the claims hold, the work has implications for both model design and our understanding of how transformers represent cross-lingual information.

--- a/reproducibility/content/sections/2-replication-setup.md
+++ b/reproducibility/content/sections/2-replication-setup.md
@@ -1,0 +1,44 @@
++++
+title = "2. Replication Setup"
+description = "Detailed description of the replication environment, codebase corrections, and data verification."
+weight = 2
+template = "post"
+tags = ["replication", "methodology", "setup"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Codebase Acquisition
+
+The original codebase was obtained from the authors' GitHub repository at the exact commit referenced in the paper (`a7f3e2d`, tagged as `acl2024-camera-ready`). We verified the commit hash and confirmed that no post-publication modifications had been made to the tagged release.
+
+## Data Verification
+
+All datasets were re-downloaded from the original sources. SHA-256 checksums were computed and compared against values provided in the original repository's `data/checksums.txt`:
+
+| Dataset | Language | Sentences | Checksum Match |
+|---|---|---|---|
+| WikiANN-train | en | 20,000 | Verified |
+| WikiANN-train | zh | 20,000 | Verified |
+| WikiANN-test | yo | 1,196 | Verified |
+| WikiANN-test | sw | 1,000 | Verified |
+| WikiANN-test | qu | 811 | Verified |
+| WikiANN-test | cy | 1,000 | Verified |
+| WikiANN-test | tl | 1,000 | Verified |
+
+## Discovered Issues
+
+During environment setup and initial runs, we discovered three issues requiring correction before meaningful replication could proceed. These are documented in detail in the Methods page. All corrections were minimal and verifiable: two were single-line fixes, one was a two-line change to the evaluation metric.
+
+We emphasise that these bugs do not indicate carelessness by the original authors. Code bugs in research software are common and expected; their discovery during replication is precisely the value of the replication process.
+
+## Replication Protocol
+
+We pre-registered our replication plan on OSF (registration DOI: 10.17605/OSF.IO/XXXXX) before beginning experiments. The pre-registration specified:
+
+- Exact experiments to be replicated
+- Confirmation thresholds for each claim
+- Number of random seeds (5)
+- Statistical tests to be used
+- Criteria for CONFIRMED / PARTIALLY / FAILED verdicts

--- a/reproducibility/content/sections/3-results.md
+++ b/reproducibility/content/sections/3-results.md
@@ -1,0 +1,60 @@
++++
+title = "3. Replication Results"
+description = "Detailed results of the replication experiments across all three claims."
+weight = 3
+template = "post"
+tags = ["replication", "results", "comparison"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## Claim 1: Performance Parity
+
+We trained the attention-only model five times with different random seeds and evaluated on all five target languages. The following table presents our results alongside the original:
+
+| Language | Original F1 | Replicated F1 (mean) | Replicated F1 (sd) | Delta | 95% CI |
+|---|---|---|---|---|---|
+| Yoruba | 79.1 | 77.2 | 1.1 | -1.9 | [75.8, 78.6] |
+| Swahili | 81.9 | 82.9 | 0.6 | +1.0 | [82.1, 83.7] |
+| Quechua | 69.3 | 66.4 | 1.4 | -2.9 | [64.6, 68.2] |
+| Welsh | 86.8 | 87.8 | 0.5 | +1.0 | [87.1, 88.5] |
+| Tagalog | 83.9 | 80.9 | 0.9 | -3.0 | [79.7, 82.1] |
+| **Average** | **80.2** | **79.0** | **0.8** | **-1.2** | **[78.0, 80.1]** |
+
+The average F1 difference of 1.2 points is within our pre-registered confirmation threshold of 2.0 points. However, two individual languages (Quechua and Tagalog) exceed the 2-point threshold. We attribute the Quechua discrepancy primarily to bug fix B-3 (micro vs. macro F1), which disproportionately affects languages with skewed entity distributions.
+
+**Verdict: CONFIRMED.** The overall claim of performance parity holds. Per-language deviations are within the range expected from bug corrections and random seed variation.
+
+## Claim 2: Attention Head Analysis
+
+The ablation study removes individual attention heads and measures the resulting performance drop. We replicated this for all 8 heads across 5 seeds:
+
+| Head | Original Drop (F1) | Replicated Drop (mean) | Replicated Drop (sd) |
+|---|---|---|---|
+| Head 1 | -1.2 | -1.8 | 0.9 |
+| Head 2 | -2.1 | -2.4 | 1.1 |
+| **Head 3** | **-8.4** | **-4.1** | **1.2** |
+| Head 4 | -0.8 | -1.5 | 0.7 |
+| Head 5 | -1.5 | -2.0 | 1.0 |
+| Head 6 | -3.2 | -2.8 | 1.3 |
+| **Head 7** | **-0.3** | **-3.8** | **1.8** |
+| Head 8 | -1.8 | -1.6 | 0.8 |
+
+Head 3 remains the most important single head, but with roughly half the effect size (4.1 vs. 8.4). The key failure is head 7: the original paper claims it is "redundant" (0.3 F1 drop), but our replication shows a meaningful 3.8 F1 drop -- comparable to head 6 and greater than heads 1, 4, and 8.
+
+**Verdict: PARTIALLY CONFIRMED.** The qualitative finding that some heads matter more than others is replicated. The specific quantitative claims about heads 3 and 7 are not.
+
+## Claim 3: Computational Efficiency
+
+Training time measurements (mean of 5 runs, single A100 GPU):
+
+| Stage | Attention-Only | Full Transformer | Speedup |
+|---|---|---|---|
+| Preprocessing | 47 min | 0 min | -- |
+| Training | 38 min | 82 min | 2.16x |
+| Total | 85 min | 82 min | 0.96x |
+
+The original paper's 2.1x speedup figure matches our training-only measurement (2.16x). However, the attention-only model requires a preprocessing step (`align_subwords.py`) that the transformer baseline does not. This step is not included in the original timing comparison.
+
+**Verdict: FAILED.** End-to-end, the attention-only model is not faster than the baseline.

--- a/reproducibility/content/sections/4-analysis.md
+++ b/reproducibility/content/sections/4-analysis.md
@@ -1,0 +1,36 @@
++++
+title = "4. Analysis and Discussion"
+description = "Interpretation of replication outcomes, sources of discrepancy, and implications for the field."
+weight = 4
+template = "post"
+tags = ["replication", "analysis", "discussion"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Sources of Discrepancy
+
+The discrepancies we observe have three identifiable sources:
+
+**Bug corrections.** Fixes B-1 through B-3 account for approximately 0.5-1.0 F1 points of difference in the main results. Bug B-3 (micro vs. macro F1) has a larger impact on languages with skewed entity distributions, explaining the per-language variation.
+
+**Random seed sensitivity.** The original paper reports results from a single random seed. Our 5-seed analysis reveals meaningful variance (standard deviations of 0.5 to 1.8 F1 across experiments). This is particularly relevant for the attention head ablation results, where the high variance for head 7 (sd = 1.8) suggests that the original finding of redundancy may have been a seed-specific artefact.
+
+**Measurement scope.** The efficiency claim failure stems entirely from measurement scope: training-only vs. end-to-end. This is not a bug or a statistical issue but a difference in what was measured and what was reported.
+
+## Implications
+
+The partial confirmation of this paper has several implications for the broader field:
+
+**Attention head interpretability is fragile.** The sensitivity of head importance rankings to random seeds suggests that claims about specific attention heads encoding specific information should be treated with caution unless validated across multiple initialisations. This echoes concerns raised by Jain and Wallace (2019) about the reliability of attention-based explanations.
+
+**Efficiency claims need standardisation.** The community lacks a standard protocol for measuring and reporting computational efficiency. Should preprocessing be included? Data loading? Evaluation? Without standardised measurement boundaries, efficiency comparisons between methods are unreliable.
+
+**Single-seed reporting is insufficient.** This replication reinforces the argument that NLP papers should report results across multiple random seeds. The original paper's single-seed results were not wrong, but they were not representative of the distribution of outcomes.
+
+## Correspondence with Original Authors
+
+We shared our findings with the original authors prior to submission. They acknowledged all three bug fixes and agreed that the efficiency measurement excluded preprocessing time. They noted that the preprocessing step was intended as a one-time cost that could be amortised across multiple training runs, a valid point that was not communicated in the original paper.
+
+Regarding the attention head ablation discrepancy, the authors expressed surprise at the head 7 results and indicated interest in further investigation. They suggested that the discrepancy might relate to differences in the AMD EPYC CPU generation (7742 vs. 7763) affecting random number generation during data loading, though we consider this unlikely to produce effects of this magnitude.

--- a/reproducibility/content/sections/5-conclusion.md
+++ b/reproducibility/content/sections/5-conclusion.md
@@ -1,0 +1,39 @@
++++
+title = "5. Conclusion and Recommendations"
+description = "Summary of replication outcomes and recommendations for future reproducibility practices."
+weight = 5
+template = "post"
+tags = ["replication", "conclusion", "recommendations"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## Summary of Findings
+
+This replication study examined three principal claims from Park et al. (2024):
+
+1. **Performance parity (CONFIRMED):** The attention-only architecture does achieve comparable F1 scores to the full transformer baseline for cross-lingual NER in low-resource settings. The average difference of 1.2 F1 points is within expected variance.
+
+2. **Attention head importance (PARTIALLY CONFIRMED):** Some attention heads are more important than others, but the specific claims about head 3 being uniquely critical and head 7 being redundant are not robustly supported. Head importance rankings vary substantially across random seeds.
+
+3. **Computational efficiency (FAILED):** The reported 2.1x speedup reflects only the training loop, not the full pipeline. End-to-end, the attention-only model provides no meaningful efficiency advantage.
+
+## Recommendations for Authors
+
+Based on this replication experience, we offer the following recommendations:
+
+- **Report results across multiple random seeds.** At minimum, report mean and standard deviation across 3-5 seeds. Ideally, report full distributions.
+- **Include all pipeline stages in efficiency comparisons.** Measure and report wall-clock time for the complete pipeline, from raw data to final evaluation.
+- **Distinguish micro and macro averaging explicitly.** When reporting aggregate metrics, state the averaging method and consider reporting both.
+- **Release complete environments, not just code.** Docker containers or Nix flakes enable exact reproduction of the computational environment.
+
+## Recommendations for the Community
+
+- **Normalise replication as valuable scholarship.** This study required significant time and resources. Replication reports should be treated as first-class contributions worthy of publication and career credit.
+- **Establish standard efficiency measurement protocols.** The field needs consensus on what constitutes a fair efficiency comparison.
+- **Fund independent replication.** Dedicated funding for replication studies would accelerate the identification and correction of unreliable findings.
+
+## Data and Code Availability
+
+Our complete replication package, including all code, data, Docker containers, and raw results, is available at Zenodo (DOI: 10.5281/zenodo.XXXXXXX) under an MIT licence. The original codebase with our bug fixes is available as a fork with tagged releases corresponding to each experiment.

--- a/reproducibility/content/sections/_index.md
+++ b/reproducibility/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The replication report is organised into five sections following the ACL Reproducibility Track guidelines.

--- a/reproducibility/content/verdicts.md
+++ b/reproducibility/content/verdicts.md
@@ -1,0 +1,105 @@
++++
+title = "Detailed Verdicts"
+description = "Detailed verdict analysis for each claim in the original paper, with side-by-side evidence."
+tags = ["paper", "light", "replication", "comparison", "verdict"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Verdicts &middot; Claim-by-Claim Analysis</p>
+  <h1 class="paper-title">Detailed Verdict Analysis</h1>
+</header>
+
+## Claim 1: Cross-Lingual Transfer Performance
+
+<!-- Verdict stamp SVG -->
+<svg viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg" aria-label="Verdict: CONFIRMED" style="display:block;margin:1rem 0;">
+  <rect x="2" y="2" width="196" height="46" rx="4" fill="#e8f4ec" stroke="#1e6e3a" stroke-width="2"/>
+  <text x="100" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="700" fill="#1e6e3a" letter-spacing="2">CLAIM 1</text>
+  <text x="100" y="38" text-anchor="middle" font-family="'Inter',sans-serif" font-size="16" font-weight="700" fill="#1e6e3a" letter-spacing="3">CONFIRMED</text>
+</svg>
+
+**Original claim:** "The attention-only architecture achieves F1 scores within 2 points of the full transformer baseline across all five target languages."
+
+<div class="comparison-grid">
+  <div class="comparison-original">
+    <p class="comparison-label">Original (Park et al.)</p>
+    <p class="comparison-value">80.2 F1</p>
+    <p class="comparison-detail">5-language average, single seed</p>
+  </div>
+  <div class="comparison-replicated">
+    <p class="comparison-label">Replicated (This Study)</p>
+    <p class="comparison-value">79.0 F1</p>
+    <p class="comparison-detail">5-language average, mean of 5 seeds (sd = 0.8)</p>
+  </div>
+</div>
+
+The 1.2-point difference is within both our pre-registered confirmation threshold (2.0 points) and the variance observed across random seeds. On a per-language basis, the largest discrepancy was for Quechua (-2.9 F1), which we attribute to the bug fix B-3 having a disproportionate impact on languages with skewed entity distributions. Welsh and Swahili actually produced *higher* F1 scores in our replication.
+
+---
+
+## Claim 2: Attention Head Ablations
+
+<svg viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg" aria-label="Verdict: PARTIALLY CONFIRMED" style="display:block;margin:1rem 0;">
+  <rect x="2" y="2" width="196" height="46" rx="4" fill="#fef4e6" stroke="#a85c00" stroke-width="2"/>
+  <text x="100" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="700" fill="#a85c00" letter-spacing="2">CLAIM 2</text>
+  <text x="100" y="38" text-anchor="middle" font-family="'Inter',sans-serif" font-size="16" font-weight="700" fill="#a85c00" letter-spacing="3">PARTIALLY</text>
+</svg>
+
+**Original claim:** "Attention head 3 is critical for cross-lingual transfer (ablation reduces F1 by 8.4 points), while head 7 is redundant (ablation reduces F1 by only 0.3 points)."
+
+<div class="comparison-grid">
+  <div class="comparison-original">
+    <p class="comparison-label">Original: Head 3 Ablation</p>
+    <p class="comparison-value">-8.4 F1</p>
+    <p class="comparison-detail">Drop when head 3 removed</p>
+  </div>
+  <div class="comparison-replicated">
+    <p class="comparison-label">Replicated: Head 3 Ablation</p>
+    <p class="comparison-value">-4.1 F1</p>
+    <p class="comparison-detail">Drop when head 3 removed (sd = 1.2)</p>
+  </div>
+</div>
+
+<div class="comparison-grid">
+  <div class="comparison-original">
+    <p class="comparison-label">Original: Head 7 Ablation</p>
+    <p class="comparison-value">-0.3 F1</p>
+    <p class="comparison-detail">Drop when head 7 removed</p>
+  </div>
+  <div class="comparison-replicated">
+    <p class="comparison-label">Replicated: Head 7 Ablation</p>
+    <p class="comparison-value">-3.8 F1</p>
+    <p class="comparison-detail">Drop when head 7 removed (sd = 1.8)</p>
+  </div>
+</div>
+
+Head 3 is indeed more important than average, but the effect size is roughly half what was originally reported. More critically, head 7 is *not* redundant in our replication -- its removal causes a meaningful F1 drop (3.8 points). The high variance across seeds (sd = 1.8) suggests that attention head importance is more sensitive to initialisation than the original analysis implied.
+
+---
+
+## Claim 3: Computational Efficiency
+
+<svg viewBox="0 0 200 50" xmlns="http://www.w3.org/2000/svg" aria-label="Verdict: FAILED" style="display:block;margin:1rem 0;">
+  <rect x="2" y="2" width="196" height="46" rx="4" fill="#fce8e8" stroke="#a82020" stroke-width="2"/>
+  <text x="100" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="8" font-weight="700" fill="#a82020" letter-spacing="2">CLAIM 3</text>
+  <text x="100" y="38" text-anchor="middle" font-family="'Inter',sans-serif" font-size="16" font-weight="700" fill="#a82020" letter-spacing="3">FAILED</text>
+</svg>
+
+**Original claim:** "The attention-only model trains 2.1x faster than the full transformer baseline."
+
+<div class="comparison-grid">
+  <div class="comparison-original">
+    <p class="comparison-label">Original: Speedup</p>
+    <p class="comparison-value">2.1x</p>
+    <p class="comparison-detail">Reported training speedup</p>
+  </div>
+  <div class="comparison-replicated">
+    <p class="comparison-label">Replicated: Speedup</p>
+    <p class="comparison-value">1.1x</p>
+    <p class="comparison-detail">Measured end-to-end speedup</p>
+  </div>
+</div>
+
+The original speedup measurement excluded a preprocessing step (`align_subwords.py`) that is required before training the attention-only model but not the transformer baseline. This step takes approximately 45 minutes per language on our hardware. When preprocessing time is included in the total training time, the speedup drops from 2.1x to 1.1x -- effectively no meaningful efficiency gain.
+
+We confirmed this discrepancy through correspondence with the original authors, who acknowledged that the timing comparison in the paper measured only the forward/backward pass time during training, not the full end-to-end pipeline.

--- a/reproducibility/static/css/style.css
+++ b/reproducibility/static/css/style.css
@@ -1,0 +1,388 @@
+/* ============================================================================
+   Reproducibility - Replication Study Paper
+   Light background. Split display: serif (original) vs sans (replication).
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #fafaf8;
+  --bg-2: #f0eeea;
+  --bg-3: #e4e2dc;
+  --rule: #c8c4b8;
+  --ink: #1c1c1e;
+  --ink-2: #36363a;
+  --ink-3: #6a6a72;
+  --ink-4: #9a9aa2;
+  --original: #2c5f8a;
+  --original-bg: #e8f0f8;
+  --replicated: #5c3a8a;
+  --replicated-bg: #f0e8f8;
+  --confirmed: #1e6e3a;
+  --confirmed-bg: #e8f4ec;
+  --partial: #a85c00;
+  --partial-bg: #fef4e6;
+  --failed: #a82020;
+  --failed-bg: #fce8e8;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 2px solid var(--ink);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 52px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+
+.journal-name {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+}
+
+.journal-sub {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.8rem;
+}
+
+.site-nav a {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--ink-2);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover { color: var(--replicated); }
+
+/* ---------------- Main Content ---------------- */
+
+.site-main { padding: 2rem 0; }
+
+.paper-article {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ---------------- Paper Header ---------------- */
+
+.paper-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-eyebrow {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--replicated);
+  margin: 0 0 0.8rem;
+  font-weight: 600;
+}
+
+.paper-title {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 1.9rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin: 0 0 0.3rem;
+}
+
+.paper-affiliations {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+  margin: 0 0 0.5rem;
+}
+
+.paper-doi {
+  font-family: "Inter", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0;
+}
+
+/* ---------------- Split headings: serif for original, sans for replication  */
+
+h1, h2, h3, h4 {
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+h1 { font-family: "Crimson Pro", serif; font-size: 1.65rem; margin: 2rem 0 0.6rem; }
+h2 { font-family: "Crimson Pro", serif; font-size: 1.3rem; margin: 1.8rem 0 0.5rem; }
+h3 { font-family: "Crimson Pro", serif; font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 0.95rem; margin: 1.2rem 0 0.4rem; }
+
+h2.original-heading {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  color: var(--original);
+}
+
+h2.replication-heading {
+  font-family: "Inter", "Source Sans Pro", sans-serif;
+  color: var(--replicated);
+}
+
+/* ---------------- Body text ---------------- */
+
+p { margin: 0.8em 0; text-align: justify; }
+
+a { color: var(--replicated); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--original);
+  background: var(--original-bg);
+  color: var(--ink-2);
+}
+
+blockquote p { margin: 0.4em 0; }
+
+/* ---------------- Verdict Badges ---------------- */
+
+.verdict-confirmed {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--confirmed);
+  background: var(--confirmed-bg);
+  border: 1.5px solid var(--confirmed);
+  padding: 0.2rem 0.6rem;
+}
+
+.verdict-partial {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--partial);
+  background: var(--partial-bg);
+  border: 1.5px solid var(--partial);
+  padding: 0.2rem 0.6rem;
+}
+
+.verdict-failed {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--failed);
+  background: var(--failed-bg);
+  border: 1.5px solid var(--failed);
+  padding: 0.2rem 0.6rem;
+}
+
+/* ---------------- Comparison boxes ---------------- */
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.comparison-original {
+  border: 1px solid var(--original);
+  border-top: 3px solid var(--original);
+  padding: 1rem;
+  background: var(--original-bg);
+}
+
+.comparison-replicated {
+  border: 1px solid var(--replicated);
+  border-top: 3px solid var(--replicated);
+  padding: 1rem;
+  background: var(--replicated-bg);
+}
+
+.comparison-label {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0 0 0.5rem;
+}
+
+.comparison-original .comparison-label { color: var(--original); }
+.comparison-replicated .comparison-label { color: var(--replicated); }
+
+.comparison-value {
+  font-family: "Crimson Pro", serif;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.comparison-original .comparison-value { color: var(--original); }
+.comparison-replicated .comparison-value { color: var(--replicated); }
+
+.comparison-detail {
+  font-family: "Inter", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0.3rem 0 0;
+}
+
+/* ---------------- Section header (post.html) ---------------- */
+
+.paper-section-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-section-eyebrow {
+  font-family: "Inter", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--replicated);
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+.paper-section-title {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-weight: 700;
+  font-size: 1.65rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.4rem;
+}
+
+.paper-lede {
+  font-size: 0.9rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.paper-section-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Inter", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--replicated);
+  text-decoration: none;
+}
+
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+.section-list li { padding: 0.7rem 0; border-bottom: 1px solid var(--bg-3); }
+.section-list li a { font-family: "Crimson Pro", serif; font-weight: 700; font-size: 1rem; color: var(--ink); text-decoration: none; }
+.section-list li a:hover { color: var(--replicated); }
+
+/* ---------------- Tables ---------------- */
+
+table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.88rem; }
+th, td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid var(--bg-3); }
+th { font-family: "Inter", sans-serif; font-weight: 600; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-2); border-bottom: 2px solid var(--ink); }
+
+/* ---------------- Code ---------------- */
+
+code { font-family: "IBM Plex Mono", Consolas, monospace; font-size: 0.85em; background: var(--bg-2); padding: 0.1rem 0.3rem; }
+pre { background: var(--bg-2); padding: 1rem; overflow-x: auto; border: 1px solid var(--bg-3); }
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy & Pagination ---------------- */
+
+.taxonomy-desc { color: var(--ink-3); font-style: italic; margin-bottom: 1.5rem; }
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; font-size: 0.85rem; }
+nav.pagination a:hover { color: var(--replicated); border-color: var(--replicated); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer { margin-top: 3rem; padding-bottom: 2rem; }
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+.footer-content { text-align: center; }
+.footer-meta { font-family: "Crimson Pro", serif; font-size: 0.82rem; color: var(--ink-3); margin: 0 0 0.3rem; }
+.footer-note { font-family: "Inter", sans-serif; font-size: 0.72rem; color: var(--ink-4); margin: 0; }
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.5rem; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; flex-wrap: wrap; }
+  .comparison-grid { grid-template-columns: 1fr; }
+}

--- a/reproducibility/templates/404.html
+++ b/reproducibility/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this report.</p>
+      <p><a href="{{ base_url }}/">Return to Replication Report</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/reproducibility/templates/footer.html
+++ b/reproducibility/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#1c1c1e" stroke-width="0.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1c1c1e" stroke-width="1.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura R, Okonkwo A, Lindqvist S, Reyes-Torres M. Replication of Attention Mechanisms in Low-Resource NLP. <em>J. Reprod. Res.</em> 2026;12(4):201-228.</p>
+        <p class="footer-note">ISSN 2167-9843 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/reproducibility/templates/header.html
+++ b/reproducibility/templates/header.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=STIX+Two+Text:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 52 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Replication icon: two overlapping documents with check/cross -->
+          <rect x="2" y="4" width="22" height="28" rx="2" fill="none" stroke="#2c5f8a" stroke-width="1.5"/>
+          <line x1="7" y1="12" x2="19" y2="12" stroke="#2c5f8a" stroke-width="0.8" opacity="0.5"/>
+          <line x1="7" y1="17" x2="17" y2="17" stroke="#2c5f8a" stroke-width="0.8" opacity="0.5"/>
+          <line x1="7" y1="22" x2="18" y2="22" stroke="#2c5f8a" stroke-width="0.8" opacity="0.5"/>
+          <rect x="16" y="8" width="22" height="28" rx="2" fill="none" stroke="#5c3a8a" stroke-width="1.5"/>
+          <line x1="21" y1="16" x2="33" y2="16" stroke="#5c3a8a" stroke-width="0.8" opacity="0.5"/>
+          <line x1="21" y1="21" x2="31" y2="21" stroke="#5c3a8a" stroke-width="0.8" opacity="0.5"/>
+          <line x1="21" y1="26" x2="32" y2="26" stroke="#5c3a8a" stroke-width="0.8" opacity="0.5"/>
+          <!-- Small comparison arrow -->
+          <line x1="40" y1="20" x2="48" y2="20" stroke="#1c1c1e" stroke-width="1" stroke-dasharray="2,1"/>
+          <polygon points="48,17 52,20 48,23" fill="#1c1c1e"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Reproducible Research</span>
+          <span class="journal-sub">Replication Reports &middot; Vol. 12 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">REPORT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/methods/">METHODS</a>
+        <a href="{{ base_url }}/verdicts/">VERDICTS</a>
+      </nav>
+    </header>

--- a/reproducibility/templates/page.html
+++ b/reproducibility/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/reproducibility/templates/post.html
+++ b/reproducibility/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/reproducibility/templates/section.html
+++ b/reproducibility/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/reproducibility/templates/shortcodes/alert.html
+++ b/reproducibility/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/reproducibility/templates/taxonomy.html
+++ b/reproducibility/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/reproducibility/templates/taxonomy_term.html
+++ b/reproducibility/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4144,5 +4144,12 @@
     "proposal",
     "funding",
     "persuasive"
+  ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
   ]
 }


### PR DESCRIPTION
Closes #1607

## Summary
- Replication study paper with side-by-side comparison charts (original vs. replicated)
- SVG verdict stamp marks: CONFIRMED, PARTIALLY, FAILED
- Split display typography: serif headings for original study, sans-serif for replication
- Crimson Pro/STIX Two Text body, Inter for UI elements
- Five sections, methods page, and detailed verdicts page with comparison grids
- Tags: paper, light, replication, comparison, verdict

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check verdict stamps SVG renders correctly
- [ ] Confirm side-by-side comparison bar chart displays
- [ ] Verify comparison grid boxes show original vs. replicated values
- [ ] Check tags.json entry is valid JSON