### PR TITLE
feat: add field-report example site (closes #1599)

### DIFF
--- a/field-report/AGENTS.md
+++ b/field-report/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/field-report/config.toml
+++ b/field-report/config.toml
@@ -1,0 +1,52 @@
+title = "Karakoram Glacier Retreat Survey"
+description = "An expedition field report documenting glacier retreat measurements, ice-core sampling, and geomorphological observations from a 28-day survey across the Central Karakoram range."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/field-report/content/appendix.md
+++ b/field-report/content/appendix.md
@@ -1,0 +1,47 @@
++++
+title = "Appendix"
+description = "Supplementary materials including equipment list, monitoring station specifications, team credentials, and permit information."
+tags = ["appendix", "supplementary", "equipment"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+<h1 class="paper-section-title">Appendix</h1>
+</header>
+
+<div class="paper-content">
+
+## A. Key Equipment
+
+- **GPS:** 2x Trimble R12i GNSS receivers with post-processing capability
+- **Ice coring:** Kovacs Mark V, 7.5 cm diameter, rated to 15 m depth
+- **Weather station:** Campbell Scientific CR1000X with satellite telemetry
+- **Cold transport:** 4x Pelican insulated cases with phase-change cooling packs
+- **Communications:** Iridium GO satellite communicator, 2x handheld VHF radios
+- **Safety:** 3x avalanche transceivers, probe, shovel; crevasse rescue kit; inflatable raft
+
+## B. Monitoring Stations
+
+Eight permanent monitoring stations were installed during the expedition:
+
+- **MS-01 to MS-04:** Baltoro Glacier. Tilt sensors and thermistors at 200 m intervals along the centreline, 2 km from terminus. Transmitting via Iridium at 6-hour intervals.
+- **MS-05 to MS-06:** Biafo Glacier. Combined tilt/temperature stations at 1 km and 2 km from terminus.
+- **MS-07 to MS-08:** Hispar Glacier. Stations positioned on the moraine dam crest and 500 m upstream. Include water level sensors for GLOF early warning.
+
+## C. Team Credentials
+
+- **Anika Dasgupta** (Lead) -- Glaciologist, 12 years field experience in Himalayan and Karakoram systems. PhD Glaciology, ETH Zurich.
+- **Torben Olsen** -- Geomorphologist, specialist in moraine dynamics and periglacial processes. 8 years field experience.
+- **Folasade Mbeki** -- Ice-core analyst and field sampling specialist. 6 years experience in polar and alpine coring.
+
+## D. Permits and Approvals
+
+- Field permit: Geological Survey of Pakistan, No. GSP-2025-FR-041
+- National Park access: Central Karakoram National Park Authority, permit dated 15 January 2026
+- Ethics: No human subjects involvement. Environmental impact assessment filed and approved.
+
+## E. Data Availability
+
+Raw GPS data, weather station records, and field observation forms will be archived at the Pakistan National Glaciology Data Centre and the World Glacier Monitoring Service (WGMS) upon completion of laboratory analyses (estimated Q4 2026).
+
+</div>

--- a/field-report/content/index.md
+++ b/field-report/content/index.md
@@ -1,0 +1,180 @@
++++
+title = "Field Report"
+description = "An expedition field report documenting glacier retreat measurements, ice-core sampling, and geomorphological observations from a 28-day survey across the Central Karakoram range."
+tags = ["paper", "dark", "field", "expedition", "rugged"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">EXPEDITION FIELD REPORT</p>
+<h1 class="paper-section-title">Karakoram Glacier Retreat Survey</h1>
+<p class="paper-lede">Report FR-2026-017 &middot; Central Karakoram Range, Pakistan &middot; Survey Period: 1--28 February 2026</p>
+<p class="paper-lede" style="margin-top:0.5rem;"><strong>Field Team:</strong> A. Dasgupta (Lead), T. Olsen, F. Mbeki &middot; <strong>Base Camp:</strong> <span class="coord">35.8824 N, 76.5134 E</span> &middot; Elevation 4,280 m</p>
+<p class="paper-lede" style="margin-top:0.5rem;">doi:10.52401/fer.2026.017 &middot; Filed April 2026</p>
+</header>
+
+<div class="field-log">
+<p class="field-log-label">Report Summary</p>
+<p>This field report documents a 28-day glacier retreat survey across three transects in the Central Karakoram range. The expedition measured terminus positions, collected 12 ice-core samples, recorded 47 geomorphological observations, and established 8 permanent monitoring stations along the Baltoro, Biafo, and Hispar glacier systems.</p>
+<p><strong>Principal finding:</strong> All three glacier termini have retreated between 180 m and 340 m from their 2018 surveyed positions. The Baltoro Glacier shows the most pronounced retreat at 340 m (mean rate 42.5 m/yr), with accelerating loss in the final 2 years of the observation period.</p>
+</div>
+
+<div class="metrics-bar">
+<div class="metric-item">
+<span class="metric-value">28</span>
+<span class="metric-label">Days in Field</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">3</span>
+<span class="metric-label">Glacier Transects</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">12</span>
+<span class="metric-label">Ice Cores Collected</span>
+</div>
+<div class="metric-item">
+<span class="metric-value">8</span>
+<span class="metric-label">Monitoring Stations</span>
+</div>
+</div>
+
+<div class="figure" role="img" aria-label="Topographic map overlay showing three glacier transect routes with coordinate grid markers and elevation contours">
+<svg viewBox="0 0 780 380" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="380" fill="#0d100e"/>
+<text x="390" y="24" text-anchor="middle" font-family="Barlow Condensed, sans-serif" font-size="10" fill="#7a8276" font-weight="600" letter-spacing="0.1em">FIGURE 1: SURVEY AREA -- CENTRAL KARAKORAM TRANSECTS</text>
+<!-- Coordinate grid -->
+<line x1="60" y1="40" x2="60" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="200" y1="40" x2="200" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="340" y1="40" x2="340" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="480" y1="40" x2="480" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="620" y1="40" x2="620" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="60" y1="40" x2="740" y2="40" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="60" y1="115" x2="740" y2="115" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="60" y1="190" x2="740" y2="190" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="60" y1="265" x2="740" y2="265" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="60" y1="340" x2="740" y2="340" stroke="#1c241e" stroke-width="0.5"/>
+<!-- Grid labels -->
+<text x="55" y="44" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">36.2N</text>
+<text x="55" y="119" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">36.0N</text>
+<text x="55" y="194" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">35.8N</text>
+<text x="55" y="269" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">35.6N</text>
+<text x="60" y="354" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">76.0E</text>
+<text x="200" y="354" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">76.2E</text>
+<text x="340" y="354" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">76.4E</text>
+<text x="480" y="354" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">76.6E</text>
+<text x="620" y="354" font-family="IBM Plex Mono, monospace" font-size="7" fill="#4e5648">76.8E</text>
+<!-- Topographic contour lines -->
+<path d="M80,280 Q180,240 280,260 Q380,280 480,220 Q550,190 640,200" fill="none" stroke="#344038" stroke-width="1"/>
+<path d="M80,240 Q180,200 280,220 Q380,240 480,170 Q550,140 640,150" fill="none" stroke="#344038" stroke-width="1"/>
+<path d="M80,200 Q180,150 280,170 Q380,200 480,120 Q550,90 640,100" fill="none" stroke="#344038" stroke-width="1"/>
+<path d="M80,160 Q180,100 280,120 Q380,150 480,80 Q550,55 640,60" fill="none" stroke="#344038" stroke-width="0.75"/>
+<!-- Contour labels -->
+<text x="650" y="198" font-family="IBM Plex Mono, monospace" font-size="6" fill="#344038">4000m</text>
+<text x="650" y="148" font-family="IBM Plex Mono, monospace" font-size="6" fill="#344038">5000m</text>
+<text x="650" y="98" font-family="IBM Plex Mono, monospace" font-size="6" fill="#344038">6000m</text>
+<text x="650" y="58" font-family="IBM Plex Mono, monospace" font-size="6" fill="#344038">7000m</text>
+<!-- Transect 1: Baltoro -->
+<polyline points="140,230 220,190 320,160 420,130 500,110" fill="none" stroke="#5a8aa0" stroke-width="2"/>
+<circle cx="140" cy="230" r="4" fill="#5a8aa0"/>
+<circle cx="500" cy="110" r="4" fill="none" stroke="#5a8aa0" stroke-width="1.5"/>
+<text x="145" y="248" font-family="IBM Plex Mono, monospace" font-size="7" fill="#5a8aa0" font-weight="700">T1: BALTORO</text>
+<!-- Transect 2: Biafo -->
+<polyline points="100,160 180,140 260,120 340,100 400,80" fill="none" stroke="#b8a44a" stroke-width="2"/>
+<circle cx="100" cy="160" r="4" fill="#b8a44a"/>
+<circle cx="400" cy="80" r="4" fill="none" stroke="#b8a44a" stroke-width="1.5"/>
+<text x="105" y="178" font-family="IBM Plex Mono, monospace" font-size="7" fill="#b8a44a" font-weight="700">T2: BIAFO</text>
+<!-- Transect 3: Hispar -->
+<polyline points="260,280 340,250 420,220 520,180 600,160" fill="none" stroke="#c45a3a" stroke-width="2"/>
+<circle cx="260" cy="280" r="4" fill="#c45a3a"/>
+<circle cx="600" cy="160" r="4" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<text x="265" y="298" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c45a3a" font-weight="700">T3: HISPAR</text>
+<!-- Base camp marker -->
+<rect x="282" y="185" width="6" height="6" fill="#e4e8e2" transform="rotate(45,285,188)"/>
+<text x="296" y="192" font-family="IBM Plex Mono, monospace" font-size="7" fill="#e4e8e2" font-weight="700">BASE CAMP</text>
+<!-- Compass rose -->
+<circle cx="700" y="70" r="16" fill="none" stroke="#7a8276" stroke-width="0.75" cy="70"/>
+<line x1="700" y1="54" x2="700" y2="86" stroke="#7a8276" stroke-width="0.75"/>
+<line x1="684" y1="70" x2="716" y2="70" stroke="#7a8276" stroke-width="0.75"/>
+<text x="700" y="50" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c45a3a" font-weight="700">N</text>
+<!-- Legend -->
+<circle cx="90" cy="328" r="3" fill="#5a8aa0"/>
+<text x="98" y="331" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Baltoro Transect</text>
+<circle cx="220" cy="328" r="3" fill="#b8a44a"/>
+<text x="228" y="331" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Biafo Transect</text>
+<circle cx="350" cy="328" r="3" fill="#c45a3a"/>
+<text x="358" y="331" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Hispar Transect</text>
+<rect x="477" y="325" width="5" height="5" fill="#e4e8e2" transform="rotate(45,479.5,327.5)"/>
+<text x="488" y="331" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Base Camp</text>
+</svg>
+<p class="figure-caption"><strong>Figure 1.</strong> Survey area map showing three glacier transects (T1: Baltoro, T2: Biafo, T3: Hispar) overlaid on topographic contours. Filled circles mark transect start points; open circles mark terminus measurement positions. Coordinate grid in WGS84.</p>
+</div>
+
+<div class="figure" role="img" aria-label="Field sketch illustration showing glacier terminus retreat measurements with naturalist observation annotations">
+<svg viewBox="0 0 780 240" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="240" fill="#0d100e"/>
+<text x="390" y="24" text-anchor="middle" font-family="Barlow Condensed, sans-serif" font-size="10" fill="#7a8276" font-weight="600" letter-spacing="0.1em">FIGURE 2: TERMINUS RETREAT BY GLACIER (2018-2026)</text>
+<!-- Axes -->
+<line x1="100" y1="45" x2="100" y2="195" stroke="#e4e8e2" stroke-width="1"/>
+<line x1="100" y1="195" x2="700" y2="195" stroke="#e4e8e2" stroke-width="1"/>
+<!-- Y-axis labels -->
+<text x="90" y="58" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#4e5648">400m</text>
+<text x="90" y="95" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#4e5648">300m</text>
+<text x="90" y="133" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#4e5648">200m</text>
+<text x="90" y="170" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#4e5648">100m</text>
+<text x="90" y="199" text-anchor="end" font-family="IBM Plex Mono, monospace" font-size="8" fill="#4e5648">0</text>
+<!-- Y grid -->
+<line x1="100" y1="55" x2="700" y2="55" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="100" y1="92" x2="700" y2="92" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="100" y1="130" x2="700" y2="130" stroke="#1c241e" stroke-width="0.5"/>
+<line x1="100" y1="167" x2="700" y2="167" stroke="#1c241e" stroke-width="0.5"/>
+<!-- X-axis labels -->
+<text x="175" y="212" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a8276">2018</text>
+<text x="325" y="212" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a8276">2020</text>
+<text x="475" y="212" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a8276">2022</text>
+<text x="625" y="212" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a8276">2024</text>
+<text x="700" y="212" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="8" fill="#7a8276">2026</text>
+<!-- Y-axis title -->
+<text x="40" y="125" text-anchor="middle" font-family="Barlow Condensed, sans-serif" font-size="9" fill="#7a8276" transform="rotate(-90,40,125)">RETREAT (metres)</text>
+<!-- Baltoro (ice blue) -->
+<polyline points="175,195 325,170 475,138 625,95 700,68" fill="none" stroke="#5a8aa0" stroke-width="2"/>
+<circle cx="175" cy="195" r="3" fill="#5a8aa0"/>
+<circle cx="325" cy="170" r="3" fill="#5a8aa0"/>
+<circle cx="475" cy="138" r="3" fill="#5a8aa0"/>
+<circle cx="625" cy="95" r="3" fill="#5a8aa0"/>
+<circle cx="700" cy="68" r="3" fill="#5a8aa0"/>
+<text x="710" y="65" font-family="IBM Plex Mono, monospace" font-size="7" fill="#5a8aa0">340m</text>
+<!-- Biafo (gold) -->
+<polyline points="175,195 325,175 475,155 625,125 700,110" fill="none" stroke="#b8a44a" stroke-width="2"/>
+<circle cx="175" cy="195" r="3" fill="#b8a44a"/>
+<circle cx="325" cy="175" r="3" fill="#b8a44a"/>
+<circle cx="475" cy="155" r="3" fill="#b8a44a"/>
+<circle cx="625" cy="125" r="3" fill="#b8a44a"/>
+<circle cx="700" cy="110" r="3" fill="#b8a44a"/>
+<text x="710" y="107" font-family="IBM Plex Mono, monospace" font-size="7" fill="#b8a44a">230m</text>
+<!-- Hispar (red) -->
+<polyline points="175,195 325,180 475,165 625,145 700,130" fill="none" stroke="#c45a3a" stroke-width="1.5" stroke-dasharray="6,3"/>
+<circle cx="175" cy="195" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<circle cx="325" cy="180" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<circle cx="475" cy="165" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<circle cx="625" cy="145" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<circle cx="700" cy="130" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+<text x="710" y="127" font-family="IBM Plex Mono, monospace" font-size="7" fill="#c45a3a">180m</text>
+<!-- Legend -->
+<line x1="150" y1="230" x2="175" y2="230" stroke="#5a8aa0" stroke-width="2"/>
+<text x="180" y="233" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Baltoro</text>
+<line x1="270" y1="230" x2="295" y2="230" stroke="#b8a44a" stroke-width="2"/>
+<text x="300" y="233" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Biafo</text>
+<line x1="370" y1="230" x2="395" y2="230" stroke="#c45a3a" stroke-width="1.5" stroke-dasharray="6,3"/>
+<text x="400" y="233" font-family="Barlow Condensed, sans-serif" font-size="8" fill="#c4cac0">Hispar</text>
+</svg>
+<p class="figure-caption"><strong>Figure 2.</strong> Cumulative terminus retreat by glacier system relative to 2018 baseline positions. Baltoro shows the most pronounced retreat (340 m over 8 years) with accelerating loss evident in the 2024--2026 segment.</p>
+</div>
+
+## Structure of This Report
+
+This field report is organized into five sections following standard expedition documentation protocol:
+
+1. **Route and Conditions** -- Access routes, weather conditions, terrain assessment, and logistical notes for each transect.
+2. **Glacier Measurements** -- Terminus position data, retreat calculations, and surface velocity estimates from stake measurements.
+3. **Ice-Core Sampling** -- Collection procedures, core descriptions, preliminary stratigraphic observations, and storage/transport chain.
+4. **Geomorphological Observations** -- Moraine mapping, proglacial lake formation, and periglacial landform documentation.
+5. **Conclusions and Recommendations** -- Summary of findings, data quality assessment, and recommendations for follow-up surveys.

--- a/field-report/content/sections/1-route-and-conditions.md
+++ b/field-report/content/sections/1-route-and-conditions.md
@@ -1,0 +1,86 @@
++++
+title = "1. Route and Conditions"
+description = "Access routes, weather conditions, terrain assessment, and logistical notes for the three glacier transects."
+weight = 1
+template = "post"
+tags = ["route", "conditions", "logistics"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Access and staging
+
+The expedition staged from Skardu (elevation 2,228 m) on 30 January 2026. Road access to Askole (3,040 m) was maintained despite seasonal snowfall. A 3-day approach march brought the team to Base Camp at <span class="coord">35.8824 N, 76.5134 E</span>, elevation 4,280 m, on 2 February.
+
+Base Camp served as the operational hub for all three transects. Equipment cached at two forward camps (FC-1 at 4,650 m and FC-2 at 4,920 m) supported extended measurement campaigns on the Baltoro system.
+
+## 1.2 Weather conditions
+
+<table class="paper-table">
+<caption>Table 1. Weather summary by expedition phase</caption>
+<thead>
+<tr>
+<th>Phase</th>
+<th>Dates</th>
+<th>Temp Range</th>
+<th>Wind</th>
+<th>Conditions</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Approach</td>
+<td>30 Jan -- 2 Feb</td>
+<td>-8 to +4 C</td>
+<td>Light</td>
+<td>Clear, occasional cloud</td>
+</tr>
+<tr>
+<td>T1: Baltoro</td>
+<td>3 -- 12 Feb</td>
+<td>-18 to -4 C</td>
+<td>Moderate</td>
+<td>2 storm days, 8 working days</td>
+</tr>
+<tr>
+<td>T2: Biafo</td>
+<td>13 -- 19 Feb</td>
+<td>-14 to -2 C</td>
+<td>Light-moderate</td>
+<td>1 storm day, 6 working days</td>
+</tr>
+<tr>
+<td>T3: Hispar</td>
+<td>20 -- 25 Feb</td>
+<td>-16 to -6 C</td>
+<td>Moderate-strong</td>
+<td>1 storm day, 5 working days</td>
+</tr>
+<tr>
+<td>Withdrawal</td>
+<td>26 -- 28 Feb</td>
+<td>-10 to +2 C</td>
+<td>Light</td>
+<td>Clear</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">Temperatures recorded at Base Camp (4,280 m). Higher-elevation readings were 6--10 C colder.</td>
+</tr>
+</tfoot>
+</table>
+
+## 1.3 Terrain assessment
+
+<div class="field-log">
+<p class="field-log-label">Field Note -- Day 4 (6 Feb)</p>
+<p>The lateral moraine along Baltoro's south flank has become substantially more unstable since the 2018 survey. Several sections show fresh collapse scarps 3--5 m high, indicating rapid ice-core degradation within the moraine body. The established route along the moraine crest is no longer safe for loaded porters; rerouted along the glacier margin. Added 2 hours to approach time for FC-1.</p>
+</div>
+
+Access to the Hispar terminus required traversal of a newly formed proglacial lake (approx. 400 m x 180 m) that did not exist during the 2018 survey. The team used an inflatable raft for equipment transport across the lake, bearing <span class="bearing">NNW 338</span> from the approach trail terminus.
+
+## 1.4 Logistics
+
+Total expedition weight: 1,420 kg across 3 team members and 8 porters. Key equipment included differential GPS receivers (2x Trimble R12i), ice-coring drill (Kovacs Mark V), weather station (Campbell Scientific CR1000X), and specimen transport containers rated to -40 C.

--- a/field-report/content/sections/2-glacier-measurements.md
+++ b/field-report/content/sections/2-glacier-measurements.md
@@ -1,0 +1,111 @@
++++
+title = "2. Glacier Measurements"
+description = "Terminus position data, retreat calculations, and surface velocity estimates from stake measurements across the Baltoro, Biafo, and Hispar glacier systems."
+weight = 2
+template = "post"
+tags = ["glaciology", "retreat", "measurements"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Measurement methodology
+
+Terminus positions were established using differential GPS with post-processed kinematic corrections. Accuracy: horizontal +/- 2 cm, vertical +/- 4 cm. Each terminus was measured at 5 points spanning the glacier width, with the mean position reported.
+
+Surface velocity was estimated using ablation stakes drilled into the glacier surface at 200 m intervals along the centreline. Stake positions were measured at installation and again 7--10 days later to derive displacement.
+
+## 2.2 Terminus positions
+
+<table class="paper-table">
+<caption>Table 2. Terminus positions and retreat since 2018 baseline</caption>
+<thead>
+<tr>
+<th>Glacier</th>
+<th>2018 Position</th>
+<th>2026 Position</th>
+<th>Retreat</th>
+<th>Rate (m/yr)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>T1: Baltoro</td>
+<td><span class="coord">35.7342 N, 76.3018 E</span></td>
+<td><span class="coord">35.7312 N, 76.2994 E</span></td>
+<td>340 m</td>
+<td>42.5</td>
+</tr>
+<tr>
+<td>T2: Biafo</td>
+<td><span class="coord">35.9401 N, 75.8822 E</span></td>
+<td><span class="coord">35.9422 N, 75.8844 E</span></td>
+<td>230 m</td>
+<td>28.8</td>
+</tr>
+<tr>
+<td>T3: Hispar</td>
+<td><span class="coord">36.0812 N, 75.5204 E</span></td>
+<td><span class="coord">36.0828 N, 75.5228 E</span></td>
+<td>180 m</td>
+<td>22.5</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">All coordinates WGS84. Retreat measured along glacier centreline. Rate assumes linear retreat from 2018 baseline.</td>
+</tr>
+</tfoot>
+</table>
+
+## 2.3 Surface velocity
+
+<table class="paper-table">
+<caption>Table 3. Surface velocity estimates from stake displacement</caption>
+<thead>
+<tr>
+<th>Glacier</th>
+<th>Stakes</th>
+<th>Observation Period</th>
+<th>Mean Velocity (m/day)</th>
+<th>Max Velocity (m/day)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>T1: Baltoro</td>
+<td>12</td>
+<td>10 days</td>
+<td>0.38</td>
+<td>0.62</td>
+</tr>
+<tr>
+<td>T2: Biafo</td>
+<td>8</td>
+<td>7 days</td>
+<td>0.24</td>
+<td>0.41</td>
+</tr>
+<tr>
+<td>T3: Hispar</td>
+<td>6</td>
+<td>5 days</td>
+<td>0.18</td>
+<td>0.29</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">Velocities measured at centreline. Winter values; summer velocities are expected to be 1.5--2.5x higher.</td>
+</tr>
+</tfoot>
+</table>
+
+## 2.4 Field observations
+
+<div class="field-log">
+<p class="field-log-label">Field Note -- Day 8 (10 Feb) -- Baltoro Terminus</p>
+<p>Terminus face height measured at 28--35 m (mean 31 m). The calving face is notably more active than 2018 observations recorded. Observed 3 calving events in 6 hours of observation, each releasing blocks estimated at 200--500 m3 into the proglacial stream channel. Stream discharge visually assessed as 2--3x the 2018 February baseline. Bearing from stake B-07 to terminus centre: <span class="bearing">SW 224</span>.</p>
+</div>
+
+The Baltoro terminus exhibits a convex profile in plan view, which differs from the concave profile documented in 2018. This morphological change suggests that retreat is concentrated along the glacier margins, where debris cover is thinnest and ablation rates are highest.

--- a/field-report/content/sections/3-ice-core-sampling.md
+++ b/field-report/content/sections/3-ice-core-sampling.md
@@ -1,0 +1,130 @@
++++
+title = "3. Ice-Core Sampling"
+description = "Collection procedures, core descriptions, preliminary stratigraphic observations, and storage/transport chain for 12 ice-core samples."
+weight = 3
+template = "post"
+tags = ["ice-cores", "sampling", "stratigraphy"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Collection protocol
+
+Ice cores were drilled using a Kovacs Mark V coring system (7.5 cm diameter) at predetermined sites selected for minimal crevassing and consistent surface gradient. Cores were extracted in 1 m sections, photographed in the field, sealed in polyethylene sleeves, and stored in insulated transport containers maintained below -20 C.
+
+## 3.2 Core inventory
+
+<table class="paper-table">
+<caption>Table 4. Ice-core sample inventory</caption>
+<thead>
+<tr>
+<th>Core ID</th>
+<th>Glacier</th>
+<th>Location</th>
+<th>Depth (m)</th>
+<th>Sections</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>KAR-01</td>
+<td>Baltoro</td>
+<td><span class="coord">35.7944 N, 76.3812 E</span></td>
+<td>8.2</td>
+<td>9</td>
+</tr>
+<tr>
+<td>KAR-02</td>
+<td>Baltoro</td>
+<td><span class="coord">35.7988 N, 76.3654 E</span></td>
+<td>6.4</td>
+<td>7</td>
+</tr>
+<tr>
+<td>KAR-03</td>
+<td>Baltoro</td>
+<td><span class="coord">35.8012 N, 76.3498 E</span></td>
+<td>7.8</td>
+<td>8</td>
+</tr>
+<tr>
+<td>KAR-04</td>
+<td>Baltoro</td>
+<td><span class="coord">35.8102 N, 76.3340 E</span></td>
+<td>5.1</td>
+<td>6</td>
+</tr>
+<tr>
+<td>KAR-05</td>
+<td>Biafo</td>
+<td><span class="coord">35.9244 N, 75.9102 E</span></td>
+<td>7.0</td>
+<td>7</td>
+</tr>
+<tr>
+<td>KAR-06</td>
+<td>Biafo</td>
+<td><span class="coord">35.9288 N, 75.8978 E</span></td>
+<td>6.8</td>
+<td>7</td>
+</tr>
+<tr>
+<td>KAR-07</td>
+<td>Biafo</td>
+<td><span class="coord">35.9332 N, 75.8854 E</span></td>
+<td>5.5</td>
+<td>6</td>
+</tr>
+<tr>
+<td>KAR-08</td>
+<td>Biafo</td>
+<td><span class="coord">35.9376 N, 75.8730 E</span></td>
+<td>4.9</td>
+<td>5</td>
+</tr>
+<tr>
+<td>KAR-09</td>
+<td>Hispar</td>
+<td><span class="coord">36.0622 N, 75.5518 E</span></td>
+<td>6.2</td>
+<td>7</td>
+</tr>
+<tr>
+<td>KAR-10</td>
+<td>Hispar</td>
+<td><span class="coord">36.0668 N, 75.5402 E</span></td>
+<td>5.8</td>
+<td>6</td>
+</tr>
+<tr>
+<td>KAR-11</td>
+<td>Hispar</td>
+<td><span class="coord">36.0714 N, 75.5286 E</span></td>
+<td>4.4</td>
+<td>5</td>
+</tr>
+<tr>
+<td>KAR-12</td>
+<td>Hispar</td>
+<td><span class="coord">36.0760 N, 75.5170 E</span></td>
+<td>3.8</td>
+<td>4</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">All cores extracted 3--15 Feb 2026. Total recovered ice: 72.9 m in 77 sections.</td>
+</tr>
+</tfoot>
+</table>
+
+## 3.3 Preliminary stratigraphic observations
+
+Field examination of core KAR-01 (deepest: 8.2 m) revealed visible annual layering to approximately 6 m depth, with compressed and deformed layering below. A prominent dust layer at 4.1 m depth may correlate with the 2020 Central Asian dust event documented in satellite records.
+
+Cores KAR-09 through KAR-12 (Hispar) exhibited higher debris content throughout, consistent with the Hispar Glacier's greater supraglacial debris coverage.
+
+## 3.4 Transport chain
+
+All 77 core sections were transported from Base Camp to Skardu by porter train (3 days) in insulated containers with temperature loggers. Internal temperatures remained below -18 C throughout. Cores were transferred to a refrigerated vehicle in Skardu and transported to the Geological Survey of Pakistan cold storage facility in Islamabad (arrival 5 March 2026). Temperature excursion: none recorded.

--- a/field-report/content/sections/4-geomorphological-observations.md
+++ b/field-report/content/sections/4-geomorphological-observations.md
@@ -1,0 +1,42 @@
++++
+title = "4. Geomorphological Observations"
+description = "Moraine mapping, proglacial lake formation, and periglacial landform documentation across the three glacier systems."
+weight = 4
+template = "post"
+tags = ["geomorphology", "moraine", "proglacial"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Observation methodology
+
+Geomorphological features were documented using a standardised field observation form recording: GPS location, feature type, dimensions (estimated or measured), photographic documentation (with scale reference), and interpretive notes. A total of 47 observations were recorded across the three transects.
+
+## 4.2 Moraine changes
+
+The lateral and terminal moraines of all three glaciers show significant changes since the 2018 survey:
+
+**Baltoro.** The south lateral moraine has experienced extensive degradation. Seven new collapse scarps were documented, ranging from 2 to 8 m in height. Ice-cored moraine sections are actively melting, producing debris flows onto the glacier surface and into the proglacial stream system. The terminal moraine has been breached in two locations, creating new drainage channels.
+
+**Biafo.** Lateral moraine degradation is moderate, with three new collapse scarps documented. The terminal moraine remains intact but shows cracking along the crest consistent with subsurface ice-core melting. Bearing from observation point to the largest crack: <span class="bearing">ENE 068</span>.
+
+**Hispar.** The most dramatic geomorphological change is the formation of a new proglacial lake (see Section 4.3). Lateral moraines show minimal change, likely stabilised by the thick debris cover on the glacier surface.
+
+## 4.3 Proglacial lake formation
+
+The newly formed lake at the Hispar terminus represents a significant hazard development:
+
+<div class="field-log">
+<p class="field-log-label">Field Note -- Day 22 (23 Feb) -- Hispar Proglacial Lake</p>
+<p>Estimated dimensions: 400 m x 180 m. Maximum depth unknown (no sounding equipment available, recommend sonar survey for follow-up). Water colour is turbid grey-green, consistent with high suspended sediment from active calving. The calving front is approximately 15 m high where the glacier terminus meets the lake. Three icebergs were visible during our observation period, the largest approximately 8 m x 5 m at the waterline. The lake is dammed by the terminal moraine on the east side and bedrock on the west. Moraine dam freeboard: estimated 4--6 m. This lake presents a glacial lake outburst flood (GLOF) risk that should be assessed urgently.</p>
+</div>
+
+## 4.4 Periglacial features
+
+Thirty-two of the 47 geomorphological observations documented periglacial features in the areas surrounding the glacier termini:
+
+- **Thermokarst depressions** (14 observations): Circular to elongate depressions formed by melting of buried ice lenses. Most common on the Baltoro lateral moraine.
+- **Sorted stone circles** (8 observations): Active patterned ground on flat surfaces above 4,800 m elevation.
+- **Solifluction lobes** (6 observations): Downslope soil creep features on slopes of 8--15 degrees.
+- **Rock glaciers** (4 observations): Three active and one relict rock glacier identified in tributary valleys.

--- a/field-report/content/sections/5-conclusions.md
+++ b/field-report/content/sections/5-conclusions.md
@@ -1,0 +1,50 @@
++++
+title = "5. Conclusions and Recommendations"
+description = "Summary of findings, data quality assessment, and recommendations for follow-up surveys and monitoring."
+weight = 5
+template = "post"
+tags = ["conclusions", "recommendations", "monitoring"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## 5.1 Summary of findings
+
+1. **All three glaciers are retreating.** Terminus retreat since 2018 ranges from 180 m (Hispar) to 340 m (Baltoro), with all systems showing accelerating retreat rates compared to pre-2018 records.
+
+2. **Baltoro shows the most rapid change.** The 340 m retreat (42.5 m/yr) represents a 1.8x increase over the 2010--2018 retreat rate of 24 m/yr. Surface velocity measurements confirm continued dynamic flow, ruling out stagnation as a cause.
+
+3. **A new proglacial lake has formed at the Hispar terminus.** This lake did not exist in 2018 and presents a potential GLOF hazard requiring urgent assessment.
+
+4. **Moraine systems are destabilising.** Lateral moraine degradation along the Baltoro is creating access hazards and contributing to increased sediment flux in the proglacial stream system.
+
+5. **Ice-core archive secured.** Twelve cores totalling 72.9 m were successfully collected and transported to cold storage without thermal excursion.
+
+## 5.2 Data quality assessment
+
+- **GPS terminus positions:** High confidence. Post-processed differential GPS with +/- 2 cm horizontal accuracy.
+- **Surface velocity:** Moderate confidence. Short observation windows (5--10 days) during winter reduce representativeness. Summer measurements needed for annual velocity estimates.
+- **Ice cores:** High confidence for physical properties. Chemical and isotopic analysis pending laboratory processing.
+- **Geomorphological observations:** Moderate confidence. Qualitative assessments rely on comparison with 2018 photographs. Quantitative moraine change analysis requires photogrammetric processing of expedition imagery.
+
+## 5.3 Recommendations
+
+<div class="field-log">
+<p class="field-log-label">Priority 1 -- Urgent</p>
+<p><strong>Hispar GLOF hazard assessment.</strong> The new proglacial lake requires bathymetric survey, moraine dam stability analysis, and downstream hazard modelling. Recommend a dedicated assessment mission within 6 months, before monsoon season increases water input.</p>
+</div>
+
+<div class="field-log">
+<p class="field-log-label">Priority 2 -- High</p>
+<p><strong>Summer repeat measurements.</strong> Surface velocity stakes should be re-measured during the June--August ablation season to capture peak flow dynamics. GPS terminus positions should be re-surveyed to establish intra-annual variability.</p>
+</div>
+
+<div class="field-log">
+<p class="field-log-label">Priority 3 -- Standard</p>
+<p><strong>Permanent monitoring stations.</strong> The 8 installed stations (4x Baltoro, 2x Biafo, 2x Hispar) are transmitting temperature and tilt data via Iridium satellite modem. Data should be reviewed monthly and stations serviced during the summer campaign.</p>
+</div>
+
+## 5.4 Acknowledgements
+
+The field team acknowledges the assistance of Askole-based porters and guides, the logistical support of the Geological Survey of Pakistan, and the Pakistan Meteorological Department for supplementary weather data. Field permits were granted under Permit No. GSP-2025-FR-041.

--- a/field-report/content/sections/_index.md
+++ b/field-report/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+This expedition report follows standard field documentation protocol, progressing from route and conditions through measurement data, sampling records, and geomorphological observations to conclusions.

--- a/field-report/content/specimens.md
+++ b/field-report/content/specimens.md
@@ -1,0 +1,81 @@
++++
+title = "Specimens"
+description = "Complete specimen register for the Karakoram Glacier Retreat Survey, including ice cores, rock samples, and water samples."
+tags = ["specimens", "inventory", "field-collection"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">SPECIMEN REGISTER</p>
+<h1 class="paper-section-title">Specimens</h1>
+</header>
+
+<div class="paper-content">
+
+## Ice-Core Specimens
+
+See Section 3 (Ice-Core Sampling) for detailed core descriptions. All 12 cores (77 sections, 72.9 m total) are stored at the Geological Survey of Pakistan cold storage facility, Islamabad.
+
+## Rock and Sediment Samples
+
+In addition to ice cores, the expedition collected 18 rock and sediment samples for geochemical analysis:
+
+<table class="paper-table">
+<caption>Table S1. Rock and sediment sample register</caption>
+<thead>
+<tr>
+<th>Sample ID</th>
+<th>Type</th>
+<th>Location</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>RS-01</td>
+<td>Moraine debris</td>
+<td>Baltoro S. lateral</td>
+<td>Angular granodiorite clasts, fresh exposure</td>
+</tr>
+<tr>
+<td>RS-02</td>
+<td>Moraine debris</td>
+<td>Baltoro terminal</td>
+<td>Mixed lithology till, sub-angular</td>
+</tr>
+<tr>
+<td>RS-03</td>
+<td>Glacial flour</td>
+<td>Baltoro proglacial</td>
+<td>Fine-grained suspended sediment from stream</td>
+</tr>
+<tr>
+<td>RS-04 to RS-08</td>
+<td>Moraine debris</td>
+<td>Biafo system</td>
+<td>5 samples across lateral-terminal sequence</td>
+</tr>
+<tr>
+<td>RS-09 to RS-14</td>
+<td>Lake sediment</td>
+<td>Hispar proglacial lake</td>
+<td>6 surface grab samples from shoreline transect</td>
+</tr>
+<tr>
+<td>RS-15 to RS-18</td>
+<td>Rock glacier</td>
+<td>Tributary valleys</td>
+<td>4 surface clast samples from active rock glaciers</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="4">All samples bagged, labelled, and stored at GSP Petrography Laboratory, Islamabad.</td>
+</tr>
+</tfoot>
+</table>
+
+## Water Samples
+
+Eight water samples were collected from proglacial streams and the Hispar lake for hydrochemical analysis. Samples are stored at 4 C at the Pakistan Council of Research in Water Resources laboratory.
+
+</div>

--- a/field-report/static/css/style.css
+++ b/field-report/static/css/style.css
@@ -1,0 +1,542 @@
+/* =========================================================
+   Field Report -- Expedition Paper
+   ========================================================= */
+
+:root {
+  --bg: #0d100e;
+  --bg-2: #141a16;
+  --bg-3: #1c241e;
+  --rule: #2a3630;
+  --rule-light: #344038;
+  --ink: #e4e8e2;
+  --ink-2: #c4cac0;
+  --ink-3: #7a8276;
+  --ink-4: #4e5648;
+  --accent: #b8a44a;
+  --accent-2: #9a8a3a;
+  --topo: #344038;
+  --coord: #b8a44a;
+  --north: #c45a3a;
+  --ice: #5a8aa0;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: "Barlow Condensed", "Roboto Condensed", -apple-system, sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--ink-2);
+  background: var(--bg);
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- Layout --- */
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* --- Header --- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 2px solid var(--rule-light);
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.logo-mark {
+  width: 56px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.journal-name {
+  font-family: "Allerta Stencil", "Black Ops One", Impact, sans-serif;
+  font-weight: 400;
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.journal-sub {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Main --- */
+
+.site-main {
+  min-height: calc(100vh - 200px);
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+}
+
+/* --- Paper headers --- */
+
+.paper-section-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Allerta Stencil", "Black Ops One", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 0.5rem;
+}
+
+.paper-section-title {
+  font-family: "Allerta Stencil", "Black Ops One", sans-serif;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 400;
+  text-transform: uppercase;
+  color: var(--ink);
+  line-height: 1.2;
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.paper-lede {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 1rem;
+  color: var(--ink-3);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Typography --- */
+
+.paper-content h2 {
+  font-family: "Allerta Stencil", "Black Ops One", sans-serif;
+  font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  margin: 2.5rem 0 1rem;
+  line-height: 1.25;
+}
+
+.paper-content h3 {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  margin: 2rem 0 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.paper-content h4 {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  margin: 1.5rem 0 0.5rem;
+}
+
+.paper-content p {
+  margin: 1em 0;
+}
+
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-content ul,
+.paper-content ol {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.paper-content li {
+  margin-bottom: 0.4rem;
+}
+
+.paper-content blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.85em;
+  background: var(--bg-3);
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--rule);
+}
+
+.paper-content pre {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* --- Field log entry --- */
+
+.field-log {
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  padding: 1.25rem 1.5rem;
+  margin: 1.5rem 0;
+  background: var(--bg-2);
+}
+
+.field-log-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  margin: 0 0 0.5rem;
+}
+
+.field-log p {
+  margin: 0.4rem 0;
+  font-size: 0.92rem;
+}
+
+/* --- Compass bearing indicator --- */
+
+.bearing {
+  display: inline-block;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--north);
+  letter-spacing: 0.06em;
+  border: 1px solid var(--north);
+  padding: 0.15rem 0.4rem;
+  margin: 0 0.15rem;
+}
+
+/* --- Coordinate display --- */
+
+.coord {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--coord);
+  letter-spacing: 0.04em;
+}
+
+/* --- Key metrics bar --- */
+
+.metrics-bar {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin: 2.5rem 0;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.metric-item {
+  text-align: center;
+  flex: 1;
+}
+
+.metric-item + .metric-item {
+  border-left: 1px solid var(--rule);
+}
+
+.metric-value {
+  font-family: "Allerta Stencil", "Black Ops One", sans-serif;
+  font-size: 1.8rem;
+  font-weight: 400;
+  color: var(--ink);
+  display: block;
+  line-height: 1;
+}
+
+.metric-label {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  display: block;
+  margin-top: 0.35rem;
+}
+
+/* --- Figures --- */
+
+.figure {
+  margin: 2.5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.figure-caption {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--rule);
+  line-height: 1.5;
+}
+
+/* --- Tables --- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.86rem;
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+}
+
+.paper-table caption {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: left;
+  color: var(--ink-3);
+  padding: 0 0 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+.paper-table thead th {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--rule-light);
+  background: var(--bg-2);
+}
+
+.paper-table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.paper-table tbody tr:hover {
+  background: var(--bg-2);
+}
+
+.paper-table tfoot td {
+  padding: 0.5rem 0.75rem;
+  font-style: italic;
+  color: var(--ink-4);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* --- Section list --- */
+
+ul.section-list {
+  list-style: decimal;
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+ul.section-list li a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* --- Section footer nav --- */
+
+.paper-section-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2px;
+}
+
+.button-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Footer --- */
+
+.site-footer {
+  margin-top: 0;
+  padding: 0;
+}
+
+.footer-rule svg {
+  display: block;
+  width: 100%;
+  height: 6px;
+}
+
+.footer-content {
+  padding: 1.5rem 0 2rem;
+  text-align: center;
+}
+
+.footer-meta {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  line-height: 1.6;
+  margin: 0 0 0.5rem;
+}
+
+.footer-meta em {
+  font-style: italic;
+}
+
+.footer-note {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* --- Error page --- */
+
+.error-page {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.error-page h1 {
+  font-family: "Allerta Stencil", "Black Ops One", sans-serif;
+  font-size: 2rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+
+/* --- Taxonomy --- */
+
+.taxonomy-desc {
+  color: var(--ink-3);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Pagination --- */
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--accent); color: var(--ink); }
+
+/* --- Alert --- */
+
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--bg-2);
+  border-left: 4px solid var(--accent);
+  margin: 1rem 0;
+  color: var(--ink-2);
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+  .site-nav { flex-wrap: wrap; gap: 1rem; }
+  .paper-article { padding: 2rem 0 3rem; }
+  .metrics-bar { flex-direction: column; gap: 1rem; }
+  .metric-item + .metric-item { border-left: none; border-top: 1px solid var(--rule); padding-top: 1rem; }
+}

--- a/field-report/templates/404.html
+++ b/field-report/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to field report</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/field-report/templates/footer.html
+++ b/field-report/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#344038" stroke-width="1.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#2a3630" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Dasgupta A, Olsen T, Mbeki F. Karakoram Glacier Retreat Survey: Field Report FR-2026-017. <em>Field Expedition Reports.</em> 2026;FR-2026-017. doi:10.52401/fer.2026.017</p>
+        <p class="footer-note">ISSN 3104-2288 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/field-report/templates/header.html
+++ b/field-report/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Allerta+Stencil&family=Black+Ops+One&family=Barlow+Condensed:wght@400;500;600;700&family=Roboto+Condensed:wght@400;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Topographic contour icon with compass bearing -->
+          <path d="M4,32 Q14,20 28,24 Q42,28 52,16" fill="none" stroke="#7a8276" stroke-width="1"/>
+          <path d="M4,28 Q14,14 28,18 Q42,22 52,10" fill="none" stroke="#7a8276" stroke-width="1"/>
+          <path d="M4,24 Q14,8 28,12 Q42,16 52,4" fill="none" stroke="#b8a44a" stroke-width="1.5"/>
+          <circle cx="28" cy="12" r="3" fill="none" stroke="#c45a3a" stroke-width="1.5"/>
+          <line x1="28" y1="9" x2="28" y2="4" stroke="#c45a3a" stroke-width="1.5"/>
+          <text x="28" y="2" text-anchor="middle" font-family="IBM Plex Mono" font-size="4" fill="#c45a3a" font-weight="700">N</text>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Field Expedition Reports</span>
+          <span class="journal-sub">Report FR-2026-017 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">FIELD REPORT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/specimens/">SPECIMENS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/field-report/templates/page.html
+++ b/field-report/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/field-report/templates/post.html
+++ b/field-report/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/field-report/templates/section.html
+++ b/field-report/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/field-report/templates/shortcodes/alert.html
+++ b/field-report/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/field-report/templates/taxonomy.html
+++ b/field-report/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/field-report/templates/taxonomy_term.html
+++ b/field-report/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1303,6 +1303,13 @@
     "glow",
     "bold"
   ],
+  "field-report": [
+    "paper",
+    "dark",
+    "field",
+    "expedition",
+    "rugged"
+  ],
   "fiesta": [
     "light",
     "blog",


### PR DESCRIPTION
Closes #1599

## Summary
- Add field-report dark expedition paper example site
- Features SVG topographic map overlays with coordinate grid markers, field sketch illustrations in naturalist observation style, and compass bearing indicators for directional data
- Typography: Allerta Stencil/Black Ops One for rugged report headers; Barlow Condensed/Roboto Condensed for compact body text
- Includes 5 content sections (Route and Conditions, Glacier Measurements, Ice-Core Sampling, Geomorphological Observations, Conclusions) plus Specimens and Appendix pages
- Updates tags.json with paper, dark, field, expedition, rugged tags

## Test plan
- [x] hwaro build completes successfully (9 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry