### PR TITLE
feat: add corrigendum example site (closes #1602)

### DIFF
--- a/corrigendum/AGENTS.md
+++ b/corrigendum/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/corrigendum/config.toml
+++ b/corrigendum/config.toml
@@ -1,0 +1,52 @@
+title = "Corrigendum: Dopamine Receptor Binding Affinity"
+description = "A formal correction notice for a previously published paper on dopamine receptor binding affinity measurements, with detailed correction diagrams showing original versus corrected values."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/corrigendum/content/appendix.md
+++ b/corrigendum/content/appendix.md
@@ -1,0 +1,106 @@
++++
+title = "Appendix"
+description = "Supplementary information including corrected Table 2, author responsibility statement, and editorial note."
+tags = ["appendix", "supplementary", "editorial"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">SUPPLEMENTARY</p>
+<h1 class="paper-section-title">Appendix</h1>
+</header>
+
+<div class="paper-content">
+
+## A. Corrected Table 2 (Complete)
+
+For reference, the complete corrected Table 2 is reproduced below. Values that have been corrected are marked with an asterisk (*).
+
+<table class="paper-table">
+<caption>Table 2 (corrected). Binding affinities and selectivity ratios for benzazepine derivatives</caption>
+<thead>
+<tr>
+<th>Compound</th>
+<th>Ki D2 (nM)</th>
+<th>Ki D3 (nM)</th>
+<th>D3/D2 Ratio</th>
+<th>Classification</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>BZ-01</td>
+<td>12.4 +/- 1.8</td>
+<td>14.2 +/- 2.1</td>
+<td>1.1</td>
+<td>Non-selective</td>
+</tr>
+<tr>
+<td>BZ-02</td>
+<td>8.6 +/- 0.9</td>
+<td>92.4 +/- 8.8</td>
+<td>10.7</td>
+<td>D2-selective</td>
+</tr>
+<tr>
+<td>BZ-03</td>
+<td>45.2 +/- 4.4</td>
+<td>38.8 +/- 3.6</td>
+<td>0.9</td>
+<td>Non-selective</td>
+</tr>
+<tr>
+<td>BZ-04*</td>
+<td>2.8 +/- 0.3*</td>
+<td>52.4 +/- 4.8*</td>
+<td>18.7*</td>
+<td>D2-selective</td>
+</tr>
+<tr>
+<td>BZ-05</td>
+<td>6.1 +/- 0.7</td>
+<td>5.8 +/- 0.6</td>
+<td>1.0</td>
+<td>Non-selective</td>
+</tr>
+<tr>
+<td>BZ-06</td>
+<td>4.4 +/- 0.5</td>
+<td>36.2 +/- 3.2</td>
+<td>8.2</td>
+<td>D2-selective</td>
+</tr>
+<tr>
+<td>BZ-07</td>
+<td>18.8 +/- 2.2</td>
+<td>22.4 +/- 2.8</td>
+<td>1.2</td>
+<td>Non-selective</td>
+</tr>
+<tr>
+<td>BZ-08</td>
+<td>7.2 +/- 0.8</td>
+<td>68.4 +/- 6.2</td>
+<td>9.5</td>
+<td>D2-selective</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td colspan="5">* Corrected values. Ki values are mean +/- SEM from three independent experiments. D2-selective classification requires D3/D2 ratio > 5.0.</td>
+</tr>
+</tfoot>
+</table>
+
+## B. Author Responsibility Statement
+
+The errors described in this corrigendum were identified by the first author (J. Park) during preparation of a follow-up study. The unit conversion error in Table 2 originated in a spreadsheet formula that was not caught during the original manuscript preparation or peer review process. The authors have implemented additional verification procedures for future submissions.
+
+## C. Editorial Note
+
+The Editor-in-Chief confirms that this corrigendum has been reviewed and approved in accordance with the journal's correction policy. The online version of the original article (doi:10.48210/jmp.2025.88.2.412) has been updated with a linked notice directing readers to this corrigendum. The original uncorrected values remain visible in the article's version history for transparency.
+
+## D. Acknowledgements
+
+The authors thank Dr. Maria Chen (Dept. of Pharmacology, University of British Columbia) for independently verifying the corrected Ki calculations using the raw competition binding data.
+
+</div>

--- a/corrigendum/content/index.md
+++ b/corrigendum/content/index.md
@@ -1,0 +1,68 @@
++++
+title = "Corrigendum"
+description = "A formal correction notice for a previously published paper on dopamine receptor binding affinity measurements, with detailed correction diagrams showing original versus corrected values."
+tags = ["paper", "light", "correction", "errata", "formal"]
++++
+
+<header class="paper-section-header">
+<p class="paper-section-eyebrow">CORRIGENDUM</p>
+<h1 class="paper-section-title">Correction to: Selective Dopamine D2/D3 Receptor Binding Affinity of Novel Benzazepine Derivatives</h1>
+<p class="paper-lede"><strong>Original article:</strong> Park J, Lindgren S, Okafor E. <em>J. Mol. Pharmacol.</em> 2025;88(2):412-429. doi:10.48210/jmp.2025.88.2.412</p>
+<p class="paper-lede" style="margin-top:0.5rem;"><strong>Published online:</strong> 15 April 2026 &middot; doi:10.48210/jmp.2026.89.4.c01</p>
+</header>
+
+<div class="notice-panel">
+<p><strong>Notice:</strong> The authors regret that errors were identified in the published version of the above article. The corrections described below do not affect the principal conclusions of the study. The D2-selective binding profile of compound BZ-04 remains supported by the corrected data. The online version of the original article has been updated to incorporate these corrections.</p>
+</div>
+
+<div class="figure" role="img" aria-label="Correction arrow diagram showing three corrections to Table 2 binding affinity values, with original values on the left and corrected values on the right connected by arrows">
+<svg viewBox="0 0 780 260" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="260" fill="#fdfcf8"/>
+<text x="390" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#6a665e" font-weight="600" letter-spacing="0.1em">FIGURE 1: SUMMARY OF CORRECTIONS TO TABLE 2</text>
+<!-- Row 1: Ki D2 correction -->
+<rect x="40" y="48" width="260" height="48" fill="#fdf0ee" stroke="#8a2222" stroke-width="1"/>
+<text x="170" y="66" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8a2222" font-weight="700">ORIGINAL</text>
+<text x="170" y="84" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">BZ-04 Ki (D2) = 3.2 nM</text>
+<!-- Arrow -->
+<line x1="310" y1="72" x2="470" y2="72" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="467,68 477,72 467,76" fill="#6a665e"/>
+<text x="390" y="64" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">corrected</text>
+<!-- Corrected -->
+<rect x="480" y="48" width="260" height="48" fill="#edf7f0" stroke="#1a6a2a" stroke-width="1"/>
+<text x="610" y="66" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a6a2a" font-weight="700">CORRECTED</text>
+<text x="610" y="84" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">BZ-04 Ki (D2) = 2.8 nM</text>
+<!-- Row 2: Ki D3 correction -->
+<rect x="40" y="114" width="260" height="48" fill="#fdf0ee" stroke="#8a2222" stroke-width="1"/>
+<text x="170" y="132" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8a2222" font-weight="700">ORIGINAL</text>
+<text x="170" y="150" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">BZ-04 Ki (D3) = 48.1 nM</text>
+<line x1="310" y1="138" x2="470" y2="138" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="467,134 477,138 467,142" fill="#6a665e"/>
+<text x="390" y="130" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">corrected</text>
+<rect x="480" y="114" width="260" height="48" fill="#edf7f0" stroke="#1a6a2a" stroke-width="1"/>
+<text x="610" y="132" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a6a2a" font-weight="700">CORRECTED</text>
+<text x="610" y="150" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">BZ-04 Ki (D3) = 52.4 nM</text>
+<!-- Row 3: Selectivity ratio -->
+<rect x="40" y="180" width="260" height="48" fill="#fdf0ee" stroke="#8a2222" stroke-width="1"/>
+<text x="170" y="198" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8a2222" font-weight="700">ORIGINAL</text>
+<text x="170" y="216" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">D3/D2 ratio = 15.0</text>
+<line x1="310" y1="204" x2="470" y2="204" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="467,200 477,204 467,208" fill="#6a665e"/>
+<text x="390" y="196" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">corrected</text>
+<rect x="480" y="180" width="260" height="48" fill="#edf7f0" stroke="#1a6a2a" stroke-width="1"/>
+<text x="610" y="198" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a6a2a" font-weight="700">CORRECTED</text>
+<text x="610" y="216" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="11" fill="#3a3630">D3/D2 ratio = 18.7</text>
+<!-- Annotation -->
+<text x="390" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#6a665e">All corrections strengthen the reported D2-selective binding profile of BZ-04</text>
+</svg>
+<p class="figure-caption"><strong>Figure 1.</strong> Summary of the three corrections to Table 2 binding affinity values. Original (erroneous) values are shown in red-bordered boxes on the left; corrected values are shown in green-bordered boxes on the right. The corrected D3/D2 selectivity ratio (18.7) is higher than the originally reported ratio (15.0), further supporting the D2-selective binding profile.</p>
+</div>
+
+## Summary of Corrections
+
+This corrigendum addresses three categories of error identified in the original publication:
+
+1. **Table 2, Binding Affinity Values** -- A unit conversion error in the radioligand competition assay analysis for compound BZ-04 produced incorrect Ki values for both D2 and D3 receptors.
+2. **Figure 4, Dose-Response Curve** -- The curve fit for compound BZ-07 used an incorrect Hill coefficient constraint, affecting the plotted IC50 position.
+3. **Section 3.2, Statistical Reporting** -- Two p-values in the selectivity comparison were reported with insufficient decimal precision, and one confidence interval was calculated using n-1 rather than n degrees of freedom.
+
+The corrections are detailed in the sections that follow. The authors apologise for these errors.

--- a/corrigendum/content/sections/1-table-2-binding-affinity.md
+++ b/corrigendum/content/sections/1-table-2-binding-affinity.md
@@ -1,0 +1,70 @@
++++
+title = "1. Table 2: Binding Affinity Values"
+description = "Correction to Ki values for compound BZ-04 at D2 and D3 receptors due to a unit conversion error in radioligand competition assay analysis."
+weight = 1
+template = "post"
+tags = ["correction", "binding-affinity", "table"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## Source of error
+
+During preparation of Table 2 in the original manuscript, the Ki values for compound BZ-04 were calculated using the Cheng-Prusoff equation with the radioligand concentration expressed in micromolar rather than nanomolar units. This produced Ki values that were systematically offset from the correct values. The error affected only compound BZ-04; all other compounds in Table 2 were calculated correctly.
+
+## Correction to Table 2
+
+The following values in Table 2 should be corrected:
+
+<div class="correction-block">
+<p class="correction-label">Correction 1 of 3 -- Table 2, Row BZ-04, Column Ki (D2)</p>
+<div class="correction-arrow">
+<div class="correction-original">
+<span class="strike-text">Ki (D2) = 3.2 +/- 0.4 nM</span>
+</div>
+<svg class="correction-arrow-icon" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="2" y1="10" x2="34" y2="10" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="31,6 38,10 31,14" fill="#6a665e"/>
+</svg>
+<div class="correction-corrected">
+<span class="insert-text">Ki (D2) = 2.8 +/- 0.3 nM</span>
+</div>
+</div>
+</div>
+
+<div class="correction-block">
+<p class="correction-label">Correction 2 of 3 -- Table 2, Row BZ-04, Column Ki (D3)</p>
+<div class="correction-arrow">
+<div class="correction-original">
+<span class="strike-text">Ki (D3) = 48.1 +/- 5.2 nM</span>
+</div>
+<svg class="correction-arrow-icon" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="2" y1="10" x2="34" y2="10" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="31,6 38,10 31,14" fill="#6a665e"/>
+</svg>
+<div class="correction-corrected">
+<span class="insert-text">Ki (D3) = 52.4 +/- 4.8 nM</span>
+</div>
+</div>
+</div>
+
+<div class="correction-block">
+<p class="correction-label">Correction 3 of 3 -- Table 2, Row BZ-04, Column D3/D2 Selectivity</p>
+<div class="correction-arrow">
+<div class="correction-original">
+<span class="strike-text">D3/D2 = 15.0</span>
+</div>
+<svg class="correction-arrow-icon" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="2" y1="10" x2="34" y2="10" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="31,6 38,10 31,14" fill="#6a665e"/>
+</svg>
+<div class="correction-corrected">
+<span class="insert-text">D3/D2 = 18.7</span>
+</div>
+</div>
+</div>
+
+## Impact assessment
+
+The corrected Ki values result in a higher D3/D2 selectivity ratio (18.7 vs. 15.0), which strengthens rather than weakens the original conclusion that BZ-04 exhibits preferential D2 binding. No other values in Table 2, and no values in Tables 1, 3, or 4, are affected by this error.

--- a/corrigendum/content/sections/2-figure-4-dose-response.md
+++ b/corrigendum/content/sections/2-figure-4-dose-response.md
@@ -1,0 +1,89 @@
++++
+title = "2. Figure 4: Dose-Response Curve"
+description = "Correction to the BZ-07 dose-response curve fit due to an incorrect Hill coefficient constraint."
+weight = 2
+template = "post"
+tags = ["correction", "dose-response", "figure"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Source of error
+
+The dose-response curve for compound BZ-07 in Figure 4 was fitted using a four-parameter logistic model with the Hill coefficient constrained to 1.0 (standard Hill equation). However, the experimental data for BZ-07 exhibited cooperative binding behaviour, and the unconstrained fit yields a Hill coefficient of 1.34 +/- 0.08. The constrained fit shifted the apparent IC50 position.
+
+## Correction
+
+<div class="correction-block">
+<p class="correction-label">Figure 4 -- BZ-07 Curve Parameters</p>
+<p>The BZ-07 dose-response curve in Figure 4 should be replaced with the unconstrained four-parameter logistic fit. The corrected parameters are:</p>
+<div class="correction-arrow">
+<div class="correction-original">
+<span class="strike-text">IC50 = 124 nM (nH = 1.0, fixed)</span>
+</div>
+<svg class="correction-arrow-icon" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="2" y1="10" x2="34" y2="10" stroke="#6a665e" stroke-width="1.5"/>
+<polygon points="31,6 38,10 31,14" fill="#6a665e"/>
+</svg>
+<div class="correction-corrected">
+<span class="insert-text">IC50 = 108 nM (nH = 1.34 +/- 0.08)</span>
+</div>
+</div>
+</div>
+
+<div class="figure" role="img" aria-label="Correction diagram showing the original constrained curve fit versus the corrected unconstrained fit for BZ-07 dose-response data">
+<svg viewBox="0 0 780 220" xmlns="http://www.w3.org/2000/svg">
+<rect width="780" height="220" fill="#fdfcf8"/>
+<text x="390" y="20" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#6a665e" font-weight="600" letter-spacing="0.1em">FIGURE 4 (CORRECTED): BZ-07 DOSE-RESPONSE CURVE</text>
+<!-- Axes -->
+<line x1="80" y1="35" x2="80" y2="185" stroke="#1a1814" stroke-width="1"/>
+<line x1="80" y1="185" x2="720" y2="185" stroke="#1a1814" stroke-width="1"/>
+<!-- Y-axis -->
+<text x="70" y="42" text-anchor="end" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">100%</text>
+<text x="70" y="112" text-anchor="end" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">50%</text>
+<text x="70" y="189" text-anchor="end" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">0%</text>
+<text x="30" y="115" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#6a665e" transform="rotate(-90,30,115)">% Specific Binding</text>
+<!-- X-axis -->
+<text x="160" y="200" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">0.1</text>
+<text x="320" y="200" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">1</text>
+<text x="480" y="200" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">10</text>
+<text x="640" y="200" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#6a665e">100</text>
+<text x="400" y="215" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#6a665e">[BZ-07] (nM)</text>
+<!-- Grid -->
+<line x1="80" y1="110" x2="720" y2="110" stroke="#ebe8e0" stroke-width="0.5"/>
+<line x1="160" y1="35" x2="160" y2="185" stroke="#ebe8e0" stroke-width="0.5"/>
+<line x1="320" y1="35" x2="320" y2="185" stroke="#ebe8e0" stroke-width="0.5"/>
+<line x1="480" y1="35" x2="480" y2="185" stroke="#ebe8e0" stroke-width="0.5"/>
+<line x1="640" y1="35" x2="640" y2="185" stroke="#ebe8e0" stroke-width="0.5"/>
+<!-- Original fit (struck through, dashed red) -->
+<path d="M100,42 Q280,44 400,60 Q480,90 540,130 Q600,160 700,178" fill="none" stroke="#8a2222" stroke-width="1.5" stroke-dasharray="6,4"/>
+<!-- Corrected fit (solid green) -->
+<path d="M100,40 Q260,42 380,52 Q460,85 520,135 Q580,165 700,180" fill="none" stroke="#1a6a2a" stroke-width="2"/>
+<!-- Data points -->
+<circle cx="160" cy="41" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="240" cy="43" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="320" cy="48" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="400" cy="62" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="440" cy="78" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="480" cy="98" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="520" cy="132" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="560" cy="152" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<circle cx="640" cy="172" r="3" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+<!-- IC50 annotations -->
+<line x1="510" y1="110" x2="510" y2="185" stroke="#8a2222" stroke-width="0.75" stroke-dasharray="3,3"/>
+<text x="510" y="195" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#8a2222">124 nM (original)</text>
+<line x1="490" y1="110" x2="490" y2="185" stroke="#1a6a2a" stroke-width="0.75" stroke-dasharray="3,3"/>
+<text x="454" y="195" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="7" fill="#1a6a2a">108 nM (corrected)</text>
+<!-- Legend -->
+<line x1="100" y1="212" x2="130" y2="212" stroke="#8a2222" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="135" y="215" font-family="Crimson Pro, serif" font-size="8" fill="#3a3630">Original fit (nH=1.0, constrained)</text>
+<line x1="380" y1="212" x2="410" y2="212" stroke="#1a6a2a" stroke-width="2"/>
+<text x="415" y="215" font-family="Crimson Pro, serif" font-size="8" fill="#3a3630">Corrected fit (nH=1.34, unconstrained)</text>
+</svg>
+<p class="figure-caption"><strong>Figure 4 (corrected).</strong> BZ-07 dose-response curve showing both the original constrained fit (dashed red, nH=1.0) and the corrected unconstrained fit (solid green, nH=1.34). The corrected IC50 shifts from 124 nM to 108 nM.</p>
+</div>
+
+## Impact assessment
+
+The corrected IC50 for BZ-07 (108 nM vs. 124 nM) does not alter the compound's ranking within the series, nor does it affect the structure-activity relationship conclusions drawn in Section 4 of the original paper. The steeper Hill slope (nH=1.34) may indicate positive cooperativity at D2 receptors, which is noted but not further discussed in this corrigendum.

--- a/corrigendum/content/sections/3-statistical-reporting.md
+++ b/corrigendum/content/sections/3-statistical-reporting.md
@@ -1,0 +1,49 @@
++++
+title = "3. Section 3.2: Statistical Reporting"
+description = "Corrections to p-value precision and confidence interval calculation in the selectivity comparison section."
+weight = 3
+template = "post"
+tags = ["correction", "statistics", "p-values"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## Source of error
+
+Two errors were identified in the statistical reporting within Section 3.2 ("Selectivity Comparison Across the Benzazepine Series"):
+
+1. **P-value precision.** Two p-values were rounded to one decimal place (p < 0.01) where the journal's reporting standards require exact values to three decimal places when p > 0.001.
+
+2. **Confidence interval.** The 95% confidence interval for the mean D3/D2 selectivity ratio was calculated using n-1 degrees of freedom (t-distribution with df=4) when the correct calculation should have used df=3 (n=4 compounds in the selective subset, with n-1=3 degrees of freedom for the mean).
+
+## Corrections to Section 3.2
+
+<div class="correction-block">
+<p class="correction-label">Correction 1 -- Paragraph 2, Sentence 3</p>
+<p>In the sentence comparing BZ-04 and BZ-06 D2 selectivity:</p>
+<p><span class="strike-text">"The difference in D3/D2 selectivity between BZ-04 and BZ-06 was significant (p < 0.01, two-tailed t-test)."</span></p>
+<p>Should read:</p>
+<p><span class="insert-text">"The difference in D3/D2 selectivity between BZ-04 and BZ-06 was significant (p = 0.004, two-tailed t-test)."</span></p>
+</div>
+
+<div class="correction-block">
+<p class="correction-label">Correction 2 -- Paragraph 3, Sentence 1</p>
+<p>In the sentence reporting the overall series selectivity:</p>
+<p><span class="strike-text">"Across the four D2-selective compounds, the mean D3/D2 selectivity ratio was significantly greater than 1.0 (p < 0.01, one-sample t-test)."</span></p>
+<p>Should read:</p>
+<p><span class="insert-text">"Across the four D2-selective compounds, the mean D3/D2 selectivity ratio was significantly greater than 1.0 (p = 0.008, one-sample t-test)."</span></p>
+</div>
+
+<div class="correction-block">
+<p class="correction-label">Correction 3 -- Paragraph 3, Sentence 2</p>
+<p>The confidence interval for the mean D3/D2 selectivity ratio:</p>
+<p><span class="strike-text">"95% CI: [8.2, 22.4]"</span></p>
+<p>Should read:</p>
+<p><span class="insert-text">"95% CI: [7.1, 23.5]"</span></p>
+<p>The wider interval reflects the correct use of t(df=3) = 3.182 rather than t(df=4) = 2.776.</p>
+</div>
+
+## Impact assessment
+
+The corrected exact p-values (0.004 and 0.008) remain well below the significance threshold of 0.05 used throughout the paper. The corrected confidence interval is wider but still excludes 1.0, preserving the conclusion that the D2-selective subset shows significant preferential binding. These corrections affect reporting precision only and do not alter any conclusions.

--- a/corrigendum/content/sections/_index.md
+++ b/corrigendum/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Corrections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Each correction is presented with the original text, the corrected text, and a brief explanation of the source of the error.

--- a/corrigendum/static/css/style.css
+++ b/corrigendum/static/css/style.css
@@ -1,0 +1,477 @@
+/* =========================================================
+   Corrigendum -- Correction Notice Paper (Light)
+   ========================================================= */
+
+:root {
+  --paper: #fdfcf8;
+  --paper-2: #f4f2ec;
+  --paper-3: #ebe8e0;
+  --rule: #d0cdc4;
+  --rule-dark: #a8a49a;
+  --ink: #1a1814;
+  --ink-2: #3a3630;
+  --ink-3: #6a665e;
+  --ink-4: #9a968e;
+  --accent: #8a2222;
+  --accent-2: #6a1818;
+  --correct: #1a6a2a;
+  --correct-bg: #edf7f0;
+  --error: #8a2222;
+  --error-bg: #fdf0ee;
+  --strike: #8a2222;
+  --insert: #1a6a2a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  color: var(--ink-2);
+  background: var(--paper);
+  margin: 0;
+}
+
+/* --- Layout --- */
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* --- Header --- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 2px solid var(--ink);
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.logo-mark {
+  width: 56px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.journal-name {
+  font-family: "Libre Baskerville", "EB Garamond", Georgia, serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.journal-sub {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Main --- */
+
+.site-main {
+  min-height: calc(100vh - 200px);
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+}
+
+/* --- Paper headers --- */
+
+.paper-section-header {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.5rem;
+}
+
+.paper-section-title {
+  font-family: "Libre Baskerville", "EB Garamond", Georgia, serif;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.25;
+  margin: 0 0 0.75rem;
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1rem;
+  color: var(--ink-3);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Typography --- */
+
+.paper-content h2 {
+  font-family: "Libre Baskerville", "EB Garamond", Georgia, serif;
+  font-size: clamp(1.2rem, 2.5vw, 1.45rem);
+  font-weight: 700;
+  color: var(--ink);
+  margin: 2.5rem 0 1rem;
+  line-height: 1.25;
+}
+
+.paper-content h3 {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  margin: 2rem 0 0.75rem;
+}
+
+.paper-content p {
+  margin: 1em 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-content ul,
+.paper-content ol {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+.paper-content li {
+  margin-bottom: 0.4rem;
+}
+
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.85em;
+  background: var(--paper-2);
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--rule);
+}
+
+/* --- Correction markup --- */
+
+.correction-block {
+  border: 2px solid var(--accent);
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+  background: var(--paper);
+  position: relative;
+}
+
+.correction-label {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.strike-text {
+  text-decoration: line-through;
+  text-decoration-color: var(--strike);
+  color: var(--ink-3);
+  background: var(--error-bg);
+  padding: 0.1rem 0.2rem;
+}
+
+.insert-text {
+  color: var(--insert);
+  background: var(--correct-bg);
+  padding: 0.1rem 0.2rem;
+  font-weight: 600;
+}
+
+/* --- Correction arrow panel --- */
+
+.correction-arrow {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.correction-original {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--error);
+  background: var(--error-bg);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  text-align: center;
+}
+
+.correction-arrow-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.correction-corrected {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--correct);
+  background: var(--correct-bg);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  text-align: center;
+}
+
+/* --- Notice panel --- */
+
+.notice-panel {
+  border: 2px solid var(--accent);
+  border-left: 6px solid var(--accent);
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+  background: var(--error-bg);
+}
+
+.notice-panel p {
+  margin: 0.5rem 0;
+}
+
+/* --- Tables --- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+
+.paper-table caption {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: left;
+  color: var(--ink-3);
+  padding: 0 0 0.5rem;
+}
+
+.paper-table thead th {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--ink);
+  background: var(--paper-2);
+}
+
+.paper-table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+
+.paper-table tbody tr:hover {
+  background: var(--paper-2);
+}
+
+.paper-table tfoot td {
+  padding: 0.5rem 0.75rem;
+  font-style: italic;
+  color: var(--ink-4);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* --- Figures --- */
+
+.figure {
+  margin: 2.5rem 0;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.figure-caption {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--rule);
+  line-height: 1.5;
+}
+
+/* --- Section list --- */
+
+ul.section-list {
+  list-style: decimal;
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+ul.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+ul.section-list li a {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+ul.section-list li a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* --- Section footer nav --- */
+
+.paper-section-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 2px;
+}
+
+.button-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --- Footer --- */
+
+.site-footer { margin-top: 0; padding: 0; }
+
+.footer-rule svg { display: block; width: 100%; height: 6px; }
+
+.footer-content {
+  padding: 1.5rem 0 2rem;
+  text-align: center;
+}
+
+.footer-meta {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  line-height: 1.6;
+  margin: 0 0 0.5rem;
+}
+
+.footer-note {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.68rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* --- Error/taxonomy/pagination --- */
+
+.error-page { text-align: center; padding: 6rem 0; }
+.error-page h1 { font-family: "Libre Baskerville", "EB Garamond", serif; font-size: 2rem; color: var(--ink); }
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; }
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--accent); color: var(--ink); }
+
+/* --- Alert --- */
+
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+  border-left: 4px solid var(--accent);
+  margin: 1rem 0;
+  color: var(--ink-2);
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+  .site-nav { flex-wrap: wrap; gap: 1rem; }
+  .paper-article { padding: 2rem 0 3rem; }
+  .correction-arrow { flex-direction: column; }
+  .correction-block { padding: 1rem 1.25rem; }
+}

--- a/corrigendum/templates/404.html
+++ b/corrigendum/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to corrigendum</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/corrigendum/templates/footer.html
+++ b/corrigendum/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#1a1814" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#d0cdc4" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Corrigendum to: Park J, Lindgren S, Okafor E. Selective Dopamine D2/D3 Receptor Binding Affinity of Novel Benzazepine Derivatives. <em>J. Mol. Pharmacol.</em> 2025;88(2):412-429. doi:10.48210/jmp.2025.88.2.412</p>
+        <p class="footer-note">ISSN 0022-3549 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/corrigendum/templates/header.html
+++ b/corrigendum/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Correction/errata icon: document with strikethrough and checkmark -->
+          <rect x="8" y="2" width="32" height="36" fill="none" stroke="#1a1814" stroke-width="1.5"/>
+          <line x1="14" y1="12" x2="34" y2="12" stroke="#d0cdc4" stroke-width="1"/>
+          <line x1="14" y1="18" x2="34" y2="18" stroke="#d0cdc4" stroke-width="1"/>
+          <line x1="14" y1="24" x2="34" y2="24" stroke="#8a2222" stroke-width="1.5"/>
+          <line x1="12" y1="22" x2="36" y2="26" stroke="#8a2222" stroke-width="1.5"/>
+          <line x1="14" y1="30" x2="28" y2="30" stroke="#1a6a2a" stroke-width="1.5"/>
+          <polyline points="42,18 46,24 54,10" fill="none" stroke="#1a6a2a" stroke-width="2"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Molecular Pharmacology</span>
+          <span class="journal-sub">Vol. 89 &middot; Issue 04 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">CORRIGENDUM</a>
+        <a href="{{ base_url }}/sections/">CORRECTIONS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/corrigendum/templates/page.html
+++ b/corrigendum/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/corrigendum/templates/post.html
+++ b/corrigendum/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Correction {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to correction index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/corrigendum/templates/section.html
+++ b/corrigendum/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">CORRECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/corrigendum/templates/shortcodes/alert.html
+++ b/corrigendum/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/corrigendum/templates/taxonomy.html
+++ b/corrigendum/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all indexed terms.</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/corrigendum/templates/taxonomy_term.html
+++ b/corrigendum/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages indexed under this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -869,6 +869,13 @@
     "marine",
     "glamorous"
   ],
+  "corrigendum": [
+    "paper",
+    "light",
+    "correction",
+    "errata",
+    "formal"
+  ],
   "cosmos": [
     "dark",
     "magazine",


### PR DESCRIPTION
Closes #1602

## Summary
- Add corrigendum light correction notice paper example site
- Features SVG correction arrow diagrams (original -> corrected), strikethrough and insertion markup patterns, and dose-response curve comparison figures
- Typography: Libre Baskerville Bold/EB Garamond Bold for formal display; Crimson Pro/Noto Serif for standard academic body text with correction markup
- Includes 3 correction sections (Table 2 Binding Affinity, Figure 4 Dose-Response, Statistical Reporting) plus Appendix
- Updates tags.json with paper, light, correction, errata, formal tags

## Test plan
- [x] hwaro build completes successfully (6 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry