### PR TITLE
feat: add data-paper example site (closes #1609)

### DIFF
--- a/data-paper/AGENTS.md
+++ b/data-paper/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/data-paper/config.toml
+++ b/data-paper/config.toml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Data Paper - Dataset Description Paper
+# Issue #1609 | Tags: paper, light, dataset, schema, minimal-text
+# =============================================================================
+
+title = "OpenUrbanClimate: A Multi-City Microclimate Sensor Dataset"
+description = "A dataset description paper for a large-scale urban microclimate sensor network dataset, featuring database schema ER diagrams, data distribution histograms, and comprehensive data dictionaries."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/data-paper/content/distributions.md
+++ b/data-paper/content/distributions.md
@@ -1,0 +1,96 @@
++++
+title = "Data Distributions"
+description = "Visualizations of data distributions including temperature histograms and variable summary statistics."
+tags = ["paper", "light", "dataset", "schema", "minimal-text"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Data Quality &middot; Distributions</p>
+  <h1 class="paper-title">Data Distribution Analysis</h1>
+</header>
+
+## Temperature Distribution (All Cities)
+
+<!-- Histogram SVG -->
+<figure>
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" aria-label="Temperature distribution histogram across all cities" style="width:100%;max-width:720px;display:block;margin:1rem auto;">
+  <text x="360" y="18" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#1a1c22">TEMPERATURE DISTRIBUTION (ALL CITIES, N = 2.8B)</text>
+  <!-- Axes -->
+  <line x1="60" y1="30" x2="60" y2="210" stroke="#1a1c22" stroke-width="1"/>
+  <line x1="60" y1="210" x2="700" y2="210" stroke="#1a1c22" stroke-width="1"/>
+  <!-- Y axis label -->
+  <text x="15" y="120" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#5a6070" transform="rotate(-90 15 120)">Frequency (millions)</text>
+  <!-- Y axis ticks -->
+  <text x="55" y="214" text-anchor="end" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">0</text>
+  <text x="55" y="174" text-anchor="end" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">100M</text>
+  <text x="55" y="134" text-anchor="end" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">200M</text>
+  <text x="55" y="94" text-anchor="end" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">300M</text>
+  <text x="55" y="54" text-anchor="end" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">400M</text>
+  <!-- Grid -->
+  <line x1="60" y1="170" x2="700" y2="170" stroke="#e2e5ea" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="60" y1="130" x2="700" y2="130" stroke="#e2e5ea" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="60" y1="90" x2="700" y2="90" stroke="#e2e5ea" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="60" y1="50" x2="700" y2="50" stroke="#e2e5ea" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <!-- Histogram bars (temperature bins from -10 to 45C in 5C increments) -->
+  <!-- -10 to -5: 18M -->
+  <rect x="72" y="203" width="48" height="7" fill="#0a5e8a" opacity="0.8"/>
+  <!-- -5 to 0: 62M -->
+  <rect x="125" y="185" width="48" height="25" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 0 to 5: 142M -->
+  <rect x="178" y="153" width="48" height="57" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 5 to 10: 248M -->
+  <rect x="231" y="111" width="48" height="99" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 10 to 15: 362M -->
+  <rect x="284" y="65" width="48" height="145" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 15 to 20: 410M (peak) -->
+  <rect x="337" y="46" width="48" height="164" fill="#0a5e8a" opacity="0.9"/>
+  <!-- 20 to 25: 488M (highest) -->
+  <rect x="390" y="15" width="48" height="195" fill="#0a5e8a"/>
+  <!-- 25 to 30: 445M -->
+  <rect x="443" y="32" width="48" height="178" fill="#0a5e8a" opacity="0.9"/>
+  <!-- 30 to 35: 382M -->
+  <rect x="496" y="57" width="48" height="153" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 35 to 40: 198M -->
+  <rect x="549" y="131" width="48" height="79" fill="#0a5e8a" opacity="0.8"/>
+  <!-- 40 to 45: 93M -->
+  <rect x="602" y="173" width="48" height="37" fill="#0a5e8a" opacity="0.8"/>
+  <!-- X axis labels -->
+  <text x="96" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">-10</text>
+  <text x="149" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">-5</text>
+  <text x="202" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">0</text>
+  <text x="255" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">5</text>
+  <text x="308" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">10</text>
+  <text x="361" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">15</text>
+  <text x="414" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">20</text>
+  <text x="467" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">25</text>
+  <text x="520" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">30</text>
+  <text x="573" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">35</text>
+  <text x="626" y="226" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5a6070">40</text>
+  <text x="380" y="248" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#1a1c22">Temperature (C)</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#5a6070;font-style:italic;">Fig. 2. Distribution of temperature readings across all cities. Bin width = 5C. Mode at 20-25C reflecting tropical and subtropical cities.</figcaption>
+</figure>
+
+## Variable Summary Statistics
+
+| Variable | Unit | Min | P5 | P25 | Median | P75 | P95 | Max | Missing (%) |
+|---|---|---|---|---|---|---|---|---|---|
+| `temp_c` | C | -18.4 | -2.1 | 12.8 | 22.4 | 30.1 | 38.2 | 52.1 | 0.12 |
+| `humidity_pct` | % | 0.0 | 18.2 | 42.6 | 62.8 | 80.4 | 95.1 | 100.0 | 0.15 |
+| `wind_speed_ms` | m/s | 0.0 | 0.2 | 0.8 | 1.6 | 3.2 | 7.8 | 34.2 | 0.31 |
+| `solar_wm2` | W/m2 | 0.0 | 0.0 | 0.0 | 142.0 | 580.0 | 920.0 | 1,248.0 | 0.18 |
+| `pm25_ugm3` | ug/m3 | 0.0 | 2.1 | 8.4 | 18.6 | 42.8 | 112.4 | 892.0 | 2.84 |
+
+## Completeness by Year
+
+| Year | Expected Readings | Actual Readings | Completeness (%) |
+|---|---|---|---|
+| 2019 | 284,256,000 | 271,842,518 | 95.6 |
+| 2020 | 312,681,600 | 298,124,832 | 95.3 |
+| 2021 | 398,448,000 | 384,682,104 | 96.5 |
+| 2022 | 468,921,600 | 456,318,240 | 97.3 |
+| 2023 | 524,736,000 | 514,128,960 | 98.0 |
+| 2024 | 572,409,600 | 562,891,200 | 98.3 |
+| 2025 | 398,448,000 | 359,304,250 | 90.2 |
+
+The lower completeness in 2019-2020 reflects the phased sensor deployment across cities. The 2025 drop (90.2%) is due to the ongoing Lagos and Nairobi deployments, which experienced intermittent connectivity issues.

--- a/data-paper/content/index.md
+++ b/data-paper/content/index.md
@@ -1,0 +1,148 @@
++++
+title = "Dataset Overview"
+description = "OpenUrbanClimate: A multi-city microclimate sensor dataset with 2.8 billion readings from 12,400 sensors across 18 cities, featuring database schema ER diagrams and distribution visualizations."
+tags = ["paper", "light", "dataset", "schema", "minimal-text"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Data Descriptor &middot; Open Access</p>
+  <h1 class="paper-title">OpenUrbanClimate: A Multi-City Microclimate Sensor Dataset for Urban Heat Island Research</h1>
+  <p class="paper-authors">
+    Riku Nakamura<sup>1</sup>, Anika Patel<sup>2</sup>, Amara Osei-Bonsu<sup>3</sup>,
+    Carlos Mendes da Silva<sup>4</sup>, Yuki Tanaka<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Institute for Urban Systems, University of Tokyo &middot;
+    <sup>2</sup>Department of Civil Engineering, MIT &middot;
+    <sup>3</sup>Centre for Climate Computing, University of Cape Town &middot;
+    <sup>4</sup>NOVA School of Science, Universidade NOVA de Lisboa &middot;
+    <sup>5</sup>Graduate School of Environmental Studies, U. Michigan
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.1038/s41597-026-04284-2</a> &middot; <strong>Repository:</strong> <a href="#">Zenodo 10.5281/zenodo.12345678</a> &middot; <strong>Received:</strong> 05 Nov 2025 &middot; <strong>Accepted:</strong> 12 Mar 2026</p>
+</header>
+
+## Dataset Summary
+
+| Property | Value |
+|---|---|
+| Total readings | 2,847,392,104 |
+| Sensors deployed | 12,418 |
+| Cities covered | 18 |
+| Temporal range | 2019-01-01 to 2025-12-31 (7 years) |
+| Temporal resolution | 5-minute intervals |
+| Variables measured | Temperature, humidity, wind speed, solar radiation, PM2.5 |
+| Total size (compressed) | 842 GB (Parquet) |
+| Total size (raw CSV) | 4.2 TB |
+| Licence | CC BY 4.0 |
+| Format | Apache Parquet, partitioned by city and year |
+
+## Database Schema
+
+<!-- Entity-Relationship Diagram SVG -->
+<figure>
+<svg viewBox="0 0 780 340" xmlns="http://www.w3.org/2000/svg" aria-label="Entity-relationship diagram of the OpenUrbanClimate database schema" style="width:100%;max-width:780px;display:block;margin:1rem auto;">
+  <text x="390" y="18" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#1a1c22">DATABASE SCHEMA (ENTITY-RELATIONSHIP DIAGRAM)</text>
+  <!-- CITIES table -->
+  <rect x="20" y="40" width="180" height="130" rx="3" fill="none" stroke="#1a1c22" stroke-width="1.5"/>
+  <rect x="20" y="40" width="180" height="24" rx="3" fill="#0a5e8a"/>
+  <text x="110" y="56" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="11" font-weight="700" fill="#fafbfc">cities</text>
+  <text x="30" y="80" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#0a5e8a" font-weight="600">PK city_id</text>
+  <text x="155" y="80" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">INT</text>
+  <line x1="25" y1="86" x2="195" y2="86" stroke="#e2e5ea" stroke-width="0.5"/>
+  <text x="30" y="98" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">city_name</text>
+  <text x="155" y="98" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">VARCHAR</text>
+  <text x="30" y="112" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">country_code</text>
+  <text x="155" y="112" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">CHAR(2)</text>
+  <text x="30" y="126" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">latitude</text>
+  <text x="155" y="126" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">DECIMAL</text>
+  <text x="30" y="140" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">longitude</text>
+  <text x="155" y="140" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">DECIMAL</text>
+  <text x="30" y="154" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">climate_zone</text>
+  <text x="155" y="154" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">VARCHAR</text>
+  <!-- SENSORS table -->
+  <rect x="280" y="40" width="200" height="160" rx="3" fill="none" stroke="#1a1c22" stroke-width="1.5"/>
+  <rect x="280" y="40" width="200" height="24" rx="3" fill="#0a5e8a"/>
+  <text x="380" y="56" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="11" font-weight="700" fill="#fafbfc">sensors</text>
+  <text x="290" y="80" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#0a5e8a" font-weight="600">PK sensor_id</text>
+  <text x="435" y="80" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">INT</text>
+  <line x1="285" y1="86" x2="475" y2="86" stroke="#e2e5ea" stroke-width="0.5"/>
+  <text x="290" y="98" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#8a3a6a" font-weight="600">FK city_id</text>
+  <text x="435" y="98" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">INT</text>
+  <text x="290" y="112" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">site_type</text>
+  <text x="435" y="112" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">ENUM</text>
+  <text x="290" y="126" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">latitude</text>
+  <text x="435" y="126" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">DECIMAL</text>
+  <text x="290" y="140" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">longitude</text>
+  <text x="435" y="140" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">DECIMAL</text>
+  <text x="290" y="154" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">elevation_m</text>
+  <text x="435" y="154" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">FLOAT</text>
+  <text x="290" y="168" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">install_date</text>
+  <text x="435" y="168" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">DATE</text>
+  <text x="290" y="182" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">model</text>
+  <text x="435" y="182" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">VARCHAR</text>
+  <!-- READINGS table -->
+  <rect x="560" y="40" width="200" height="145" rx="3" fill="none" stroke="#1a1c22" stroke-width="1.5"/>
+  <rect x="560" y="40" width="200" height="24" rx="3" fill="#0a5e8a"/>
+  <text x="660" y="56" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="11" font-weight="700" fill="#fafbfc">readings</text>
+  <text x="570" y="80" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#0a5e8a" font-weight="600">PK reading_id</text>
+  <text x="715" y="80" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">BIGINT</text>
+  <line x1="565" y1="86" x2="755" y2="86" stroke="#e2e5ea" stroke-width="0.5"/>
+  <text x="570" y="98" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#8a3a6a" font-weight="600">FK sensor_id</text>
+  <text x="715" y="98" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">INT</text>
+  <text x="570" y="112" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">timestamp</text>
+  <text x="715" y="112" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">TIMESTAMP</text>
+  <text x="570" y="126" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">temp_c</text>
+  <text x="715" y="126" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">FLOAT</text>
+  <text x="570" y="140" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">humidity_pct</text>
+  <text x="715" y="140" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">FLOAT</text>
+  <text x="570" y="154" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">wind_speed_ms</text>
+  <text x="715" y="154" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">FLOAT</text>
+  <text x="570" y="168" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">solar_wm2</text>
+  <text x="715" y="168" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">FLOAT</text>
+  <!-- QC_FLAGS table -->
+  <rect x="340" y="240" width="200" height="90" rx="3" fill="none" stroke="#1a1c22" stroke-width="1.5"/>
+  <rect x="340" y="240" width="200" height="24" rx="3" fill="#0a5e8a"/>
+  <text x="440" y="256" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="11" font-weight="700" fill="#fafbfc">qc_flags</text>
+  <text x="350" y="280" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#8a3a6a" font-weight="600">FK reading_id</text>
+  <text x="495" y="280" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">BIGINT</text>
+  <text x="350" y="294" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">flag_code</text>
+  <text x="495" y="294" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">CHAR(2)</text>
+  <text x="350" y="308" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#2e3240">auto_flagged</text>
+  <text x="495" y="308" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">BOOLEAN</text>
+  <!-- Relationship lines -->
+  <!-- cities 1--* sensors -->
+  <line x1="200" y1="80" x2="280" y2="98" stroke="#8a3a6a" stroke-width="1.5"/>
+  <text x="240" y="82" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#8a3a6a">1:N</text>
+  <!-- sensors 1--* readings -->
+  <line x1="480" y1="80" x2="560" y2="98" stroke="#8a3a6a" stroke-width="1.5"/>
+  <text x="520" y="82" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#8a3a6a">1:N</text>
+  <!-- readings 1--* qc_flags -->
+  <line x1="660" y1="185" x2="540" y2="280" stroke="#8a3a6a" stroke-width="1.5"/>
+  <text x="610" y="228" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#8a3a6a">1:N</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#5a6070;font-style:italic;">Fig. 1. Entity-relationship diagram of the OpenUrbanClimate database schema. PK = primary key (blue), FK = foreign key (purple).</figcaption>
+</figure>
+
+## Coverage by City
+
+| City | Country | Sensors | Readings (M) | Period | Climate Zone |
+|---|---|---|---|---|---|
+| Tokyo | JP | 1,842 | 482 | 2019-2025 | Cfa |
+| Boston | US | 1,204 | 315 | 2019-2025 | Dfa |
+| Houston | US | 986 | 258 | 2020-2025 | Cfa |
+| Phoenix | US | 724 | 190 | 2020-2025 | BWh |
+| London | GB | 1,156 | 302 | 2019-2025 | Cfb |
+| Cape Town | ZA | 612 | 160 | 2021-2025 | Csb |
+| Lisbon | PT | 498 | 130 | 2021-2025 | Csa |
+| Seoul | KR | 1,380 | 362 | 2019-2025 | Dwa |
+| Singapore | SG | 428 | 112 | 2022-2025 | Af |
+| Sydney | AU | 682 | 178 | 2020-2025 | Cfa |
+| Mumbai | IN | 542 | 64 | 2023-2025 | Am |
+| Sao Paulo | BR | 498 | 58 | 2023-2025 | Cwa |
+| Lagos | NG | 312 | 36 | 2024-2025 | Aw |
+| Stockholm | SE | 386 | 52 | 2023-2025 | Dfb |
+| Dubai | AE | 268 | 31 | 2024-2025 | BWh |
+| Mexico City | MX | 356 | 42 | 2023-2025 | Cwb |
+| Helsinki | FI | 286 | 38 | 2023-2025 | Dfb |
+| Nairobi | KE | 258 | 37 | 2024-2025 | Cfb |
+| **Total** | | **12,418** | **2,847** | | |

--- a/data-paper/content/schema.md
+++ b/data-paper/content/schema.md
@@ -1,0 +1,85 @@
++++
+title = "Schema and Data Dictionary"
+description = "Complete data dictionary with field definitions, data types, constraints, and enumerated values."
+tags = ["paper", "light", "dataset", "schema", "minimal-text"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Technical Specification &middot; Schema</p>
+  <h1 class="paper-title">Data Dictionary</h1>
+</header>
+
+## Table: `cities`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `city_id` | `INT` | PK, AUTO_INCREMENT | Unique city identifier |
+| `city_name` | `VARCHAR(100)` | NOT NULL, UNIQUE | City name in English |
+| `country_code` | `CHAR(2)` | NOT NULL | ISO 3166-1 alpha-2 country code |
+| `latitude` | `DECIMAL(9,6)` | NOT NULL | City centre latitude (WGS84) |
+| `longitude` | `DECIMAL(9,6)` | NOT NULL | City centre longitude (WGS84) |
+| `climate_zone` | `VARCHAR(10)` | NOT NULL | Koppen-Geiger climate classification |
+| `population` | `INT` | | City population (most recent census) |
+| `area_km2` | `DECIMAL(10,2)` | | City administrative area in km2 |
+| `timezone` | `VARCHAR(40)` | NOT NULL | IANA timezone identifier |
+
+## Table: `sensors`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `sensor_id` | `INT` | PK, AUTO_INCREMENT | Unique sensor identifier |
+| `city_id` | `INT` | FK -> cities.city_id, NOT NULL | City where sensor is deployed |
+| `site_type` | `ENUM` | NOT NULL | Deployment site classification |
+| `latitude` | `DECIMAL(9,6)` | NOT NULL | Sensor latitude (WGS84) |
+| `longitude` | `DECIMAL(9,6)` | NOT NULL | Sensor longitude (WGS84) |
+| `elevation_m` | `FLOAT` | | Sensor elevation above sea level (metres) |
+| `height_agl_m` | `FLOAT` | NOT NULL | Height above ground level (metres) |
+| `install_date` | `DATE` | NOT NULL | Sensor installation date |
+| `decommission_date` | `DATE` | | Sensor decommission date (NULL if active) |
+| `model` | `VARCHAR(50)` | NOT NULL | Sensor hardware model identifier |
+| `lcz_class` | `VARCHAR(10)` | | Local Climate Zone classification |
+
+### `site_type` Enumeration
+
+| Value | Description | Count |
+|---|---|---|
+| `park` | Urban park or green space | 2,418 |
+| `street` | Street-level, near road | 3,842 |
+| `rooftop` | Building rooftop installation | 1,986 |
+| `courtyard` | Enclosed courtyard or plaza | 1,124 |
+| `waterfront` | Near body of water | 892 |
+| `industrial` | Industrial or commercial zone | 1,248 |
+| `residential` | Residential neighbourhood | 908 |
+
+## Table: `readings`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `reading_id` | `BIGINT` | PK, AUTO_INCREMENT | Unique reading identifier |
+| `sensor_id` | `INT` | FK -> sensors.sensor_id, NOT NULL | Source sensor |
+| `timestamp` | `TIMESTAMP` | NOT NULL | UTC timestamp of reading |
+| `temp_c` | `FLOAT` | | Air temperature (Celsius) |
+| `humidity_pct` | `FLOAT` | CHECK 0-100 | Relative humidity (%) |
+| `wind_speed_ms` | `FLOAT` | CHECK >= 0 | Wind speed (m/s) |
+| `solar_wm2` | `FLOAT` | CHECK >= 0 | Incoming solar radiation (W/m2) |
+| `pm25_ugm3` | `FLOAT` | CHECK >= 0 | PM2.5 concentration (ug/m3) |
+
+## Table: `qc_flags`
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `reading_id` | `BIGINT` | FK -> readings.reading_id | Flagged reading |
+| `flag_code` | `CHAR(2)` | NOT NULL | Quality control flag code |
+| `auto_flagged` | `BOOLEAN` | NOT NULL, DEFAULT TRUE | TRUE if flagged by automated QC |
+| `reviewer` | `VARCHAR(50)` | | Manual reviewer identifier |
+
+### QC Flag Codes
+
+| Code | Meaning | Frequency |
+|---|---|---|
+| `OK` | Passed all checks | 94.2% |
+| `SR` | Sensor range exceeded | 2.1% |
+| `SP` | Spike detected (> 3 sd from rolling mean) | 1.8% |
+| `FL` | Flat-line (> 6 hours identical value) | 0.9% |
+| `MS` | Missing (gap in time series) | 0.7% |
+| `MR` | Manual review required | 0.3% |

--- a/data-paper/content/sections/1-background.md
+++ b/data-paper/content/sections/1-background.md
@@ -1,0 +1,33 @@
++++
+title = "1. Background and Summary"
+description = "Motivation for the dataset, research context, and overview of the data collection effort."
+weight = 1
+template = "post"
+tags = ["dataset", "background", "urban-climate"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## Motivation
+
+Urban heat islands (UHIs) represent one of the most tangible manifestations of anthropogenic environmental modification. Cities are consistently warmer than their rural surroundings, with temperature differences of 2-8C common in large metropolitan areas. This temperature differential has significant implications for energy consumption, public health, air quality, and urban ecology.
+
+Despite decades of research, our understanding of intra-urban microclimate variability remains limited by data availability. Most studies rely on sparse weather station networks designed for synoptic meteorology, not urban microclimate characterisation. The spatial resolution of these networks (typically one station per 50-100 km2) is insufficient to capture the block-level variability that drives local heat exposure and energy demand.
+
+## Dataset Overview
+
+OpenUrbanClimate addresses this gap by providing high-resolution, multi-variable microclimate observations from dense sensor networks deployed across 18 cities on six continents. The dataset comprises 2.85 billion individual sensor readings collected between January 2019 and December 2025, with a temporal resolution of 5 minutes and a typical spatial density of 5-15 sensors per km2 in the instrumented areas.
+
+The dataset was collected through a consortium of 23 research institutions, coordinated by the University of Tokyo Institute for Urban Systems. Sensor deployment, calibration, maintenance, and data management followed standardised protocols developed during a 2018 pilot study in Tokyo and Boston.
+
+## Intended Uses
+
+The dataset is designed to support research in:
+
+- Urban heat island characterisation and mapping
+- Building energy demand modelling
+- Public health heat exposure assessment
+- Urban planning and green infrastructure evaluation
+- Climate model validation at the urban scale
+- Machine learning for microclimate prediction

--- a/data-paper/content/sections/2-methods.md
+++ b/data-paper/content/sections/2-methods.md
@@ -1,0 +1,55 @@
++++
+title = "2. Methods"
+description = "Sensor hardware, deployment protocol, calibration procedures, and data collection pipeline."
+weight = 2
+template = "post"
+tags = ["dataset", "methods", "sensors"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Sensor Hardware
+
+All deployments use one of two sensor models:
+
+| Property | Model A (OUC-200) | Model B (OUC-300) |
+|---|---|---|
+| Manufacturer | ClimateSense Inc. | ClimateSense Inc. |
+| Temperature range | -30 to 60C | -40 to 70C |
+| Temperature accuracy | +/- 0.2C | +/- 0.1C |
+| Humidity range | 0-100% RH | 0-100% RH |
+| Humidity accuracy | +/- 2% RH | +/- 1.5% RH |
+| Wind speed range | 0-40 m/s | 0-60 m/s |
+| Solar radiation | Pyranometer (0-1500 W/m2) | Pyranometer (0-1500 W/m2) |
+| PM2.5 | Laser scattering (0-1000 ug/m3) | Laser scattering (0-1000 ug/m3) |
+| Sampling interval | 5 minutes | 5 minutes |
+| Power | Solar + battery | Solar + battery |
+| Communication | 4G LTE | 4G LTE + LoRaWAN fallback |
+| Deployment period | 2019-2022 | 2022-present |
+
+Model B (OUC-300) was introduced in 2022 with improved accuracy and LoRaWAN fallback for areas with poor cellular coverage. Both models transmit data to a central collection server every 5 minutes.
+
+## Deployment Protocol
+
+Sensor placement follows the Local Climate Zone (LCZ) framework. Within each city, sensors are distributed across LCZ classes proportional to their areal coverage, with a minimum of 3 sensors per LCZ class per city. Specific placement requirements:
+
+- Mounted at 2.0 +/- 0.2 metres above ground level (pedestrian breathing height)
+- Minimum 2 metres from any building wall
+- Radiation shield required for temperature sensor
+- Unobstructed sky view for solar radiation sensor
+- GPS coordinates recorded at installation with sub-metre accuracy
+
+## Calibration
+
+Factory calibration is performed by ClimateSense Inc. prior to deployment. Field calibration is performed annually against reference instruments (Vaisala WXT536) at co-located sites in each city. Calibration corrections are applied retroactively to the entire time series when drift is detected.
+
+## Data Pipeline
+
+Raw sensor data flows through the following pipeline:
+
+1. **Ingestion**: 4G/LoRaWAN to central collection server (AWS eu-west-1)
+2. **Validation**: Automated range checks, duplicate detection, timestamp verification
+3. **QC Level 1**: Automated spike detection, flat-line detection, spatial consistency checks
+4. **QC Level 2**: Manual review of flagged readings (performed quarterly)
+5. **Archival**: Partitioned Parquet files (by city and year) deposited to Zenodo

--- a/data-paper/content/sections/3-records.md
+++ b/data-paper/content/sections/3-records.md
@@ -1,0 +1,84 @@
++++
+title = "3. Data Records"
+description = "File structure, partitioning scheme, and access instructions for the dataset."
+weight = 3
+template = "post"
+tags = ["dataset", "records", "access"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## File Organisation
+
+The dataset is distributed as Apache Parquet files, partitioned by city and year:
+
+```
+openurbanclimate/
+  cities.parquet              (18 rows, 1 KB)
+  sensors.parquet             (12,418 rows, 2 MB)
+  readings/
+    city=tokyo/
+      year=2019.parquet       (68M rows, 12 GB)
+      year=2020.parquet       (72M rows, 13 GB)
+      ...
+    city=boston/
+      year=2019.parquet       (44M rows, 8 GB)
+      ...
+  qc_flags/
+    city=tokyo/
+      year=2019.parquet       (3.2M rows, 180 MB)
+      ...
+  metadata/
+    calibration_log.csv       (calibration events)
+    deployment_log.csv        (sensor install/decommission)
+    checksums.sha256          (file integrity verification)
+```
+
+## Access Methods
+
+### Direct Download
+
+All files are available from Zenodo: `https://doi.org/10.5281/zenodo.12345678`
+
+Total download size: 842 GB (compressed Parquet).
+
+### Programmatic Access (Python)
+
+```python
+import pyarrow.parquet as pq
+
+# Read all Tokyo 2024 readings
+df = pq.read_table(
+    "readings/city=tokyo/year=2024.parquet"
+).to_pandas()
+
+# Filter to summer months only
+summer = df[df["timestamp"].dt.month.isin([6, 7, 8])]
+```
+
+### SQL Access (DuckDB)
+
+```sql
+SELECT city_name, AVG(temp_c) AS mean_temp,
+       COUNT(*) AS n_readings
+FROM read_parquet('readings/*/*.parquet')
+JOIN read_parquet('sensors.parquet') USING (sensor_id)
+JOIN read_parquet('cities.parquet') USING (city_id)
+WHERE timestamp >= '2024-06-01'
+  AND timestamp <  '2024-09-01'
+GROUP BY city_name
+ORDER BY mean_temp DESC;
+```
+
+## File Sizes by City
+
+| City | Readings Size | QC Flags Size | Total |
+|---|---|---|---|
+| Tokyo | 84 GB | 4.8 GB | 89 GB |
+| Seoul | 63 GB | 3.6 GB | 67 GB |
+| Boston | 55 GB | 3.1 GB | 58 GB |
+| London | 53 GB | 3.0 GB | 56 GB |
+| Houston | 45 GB | 2.5 GB | 48 GB |
+| Sydney | 31 GB | 1.8 GB | 33 GB |
+| Others (12 cities) | 511 GB | 29 GB | 540 GB |

--- a/data-paper/content/sections/4-validation.md
+++ b/data-paper/content/sections/4-validation.md
@@ -1,0 +1,44 @@
++++
+title = "4. Technical Validation"
+description = "Quality control procedures, validation against reference stations, and known limitations."
+weight = 4
+template = "post"
+tags = ["dataset", "validation", "quality"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Automated Quality Control
+
+The automated QC pipeline applies five checks to each reading:
+
+| Check | Threshold | Flag Code | Flagged (%) |
+|---|---|---|---|
+| Range check | Temp: -40 to 60C; RH: 0-100%; Wind: 0-60 m/s | `SR` | 2.1 |
+| Spike detection | > 3 sd from 1-hour rolling mean | `SP` | 1.8 |
+| Flat-line | Identical value for > 6 consecutive hours | `FL` | 0.9 |
+| Gap detection | Missing reading at expected timestamp | `MS` | 0.7 |
+| Spatial consistency | > 5 sd from 10-nearest-neighbour mean | `MR` | 0.3 |
+
+Overall, 94.2% of readings pass all automated checks. The remaining 5.8% are flagged but retained in the dataset with their QC codes, allowing users to apply their own filtering criteria.
+
+## Reference Station Comparison
+
+At 36 co-located sites (2 per city), OpenUrbanClimate sensors are deployed within 5 metres of reference-grade instruments (Vaisala WXT536). Comparison statistics for 2024:
+
+| Variable | RMSE | Bias | R2 | N pairs |
+|---|---|---|---|---|
+| Temperature | 0.31C | +0.08C | 0.998 | 3,784,320 |
+| Humidity | 2.4% | -0.6% | 0.992 | 3,784,320 |
+| Wind speed | 0.42 m/s | +0.12 m/s | 0.964 | 3,784,320 |
+| Solar radiation | 18.2 W/m2 | -4.1 W/m2 | 0.996 | 3,784,320 |
+| PM2.5 | 4.8 ug/m3 | +1.2 ug/m3 | 0.942 | 3,784,320 |
+
+## Known Limitations
+
+1. **PM2.5 accuracy at high concentrations**: The laser scattering sensors show increased positive bias above 200 ug/m3 compared to gravimetric reference methods. Users analysing high-pollution events should apply the correction equation provided in the calibration log.
+
+2. **Wind speed in street canyons**: Sensors deployed in narrow street canyons (aspect ratio > 2) underestimate free-atmosphere wind speeds due to channelling effects. The `site_type` and `lcz_class` fields can be used to filter these deployments.
+
+3. **Data gaps in 2020**: COVID-19 restrictions delayed maintenance visits in several cities during March-June 2020, resulting in elevated gap rates (up to 8% in some cities) during this period.

--- a/data-paper/content/sections/5-usage-notes.md
+++ b/data-paper/content/sections/5-usage-notes.md
@@ -1,0 +1,52 @@
++++
+title = "5. Usage Notes"
+description = "Recommended usage patterns, citation requirements, and known caveats for dataset users."
+weight = 5
+template = "post"
+tags = ["dataset", "usage", "citation"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## Recommended Workflows
+
+### Urban Heat Island Analysis
+
+For UHI studies, we recommend:
+1. Filter readings using `qc_flags` to exclude flagged data (`flag_code != 'OK'`)
+2. Join with `sensors` table to obtain `site_type` and `lcz_class`
+3. Compute spatial aggregates by LCZ class rather than by raw sensor
+4. Use the `cities` table `climate_zone` field for inter-city comparisons
+
+### Time Series Analysis
+
+For temporal analyses:
+1. Be aware of sensor model transition (OUC-200 to OUC-300) in 2022
+2. Apply the calibration corrections from `calibration_log.csv` for multi-year studies
+3. Account for the 2020 data gaps when computing annual statistics
+4. Use UTC timestamps consistently; local time conversions are the user's responsibility
+
+## Citation
+
+If you use this dataset, please cite:
+
+> Nakamura R, Patel A, Osei-Bonsu A, Mendes da Silva C, Tanaka Y. OpenUrbanClimate: A Multi-City Microclimate Sensor Dataset for Urban Heat Island Research. *Scientific Data* 13, 284 (2026). https://doi.org/10.1038/s41597-026-04284-2
+
+Additionally, cite the Zenodo data deposit:
+
+> Nakamura R, et al. (2026). OpenUrbanClimate Dataset v2.0 [Data set]. Zenodo. https://doi.org/10.5281/zenodo.12345678
+
+## Licence and Reuse
+
+The dataset is released under **Creative Commons Attribution 4.0 International (CC BY 4.0)**. You are free to share and adapt the data for any purpose, provided you give appropriate credit.
+
+## Updates
+
+The dataset is updated annually. Each annual release receives a new Zenodo DOI while the concept DOI (10.5281/zenodo.12345678) always resolves to the latest version.
+
+| Version | Release Date | Cities | Sensors | Period |
+|---|---|---|---|---|
+| v1.0 | 2023-03-15 | 8 | 6,842 | 2019-2022 |
+| v1.5 | 2024-03-20 | 14 | 10,218 | 2019-2023 |
+| v2.0 | 2026-03-10 | 18 | 12,418 | 2019-2025 |

--- a/data-paper/content/sections/_index.md
+++ b/data-paper/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The data descriptor is organised into five sections following the Scientific Data format guidelines.

--- a/data-paper/static/css/style.css
+++ b/data-paper/static/css/style.css
@@ -1,0 +1,141 @@
+/* ============================================================================
+   Data Paper - Dataset Description Paper
+   Light background, technical sans display, minimal serif body.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #fafbfc;
+  --bg-2: #f0f2f5;
+  --bg-3: #e2e5ea;
+  --rule: #c0c5cc;
+  --ink: #1a1c22;
+  --ink-2: #2e3240;
+  --ink-3: #5a6070;
+  --ink-4: #8a90a0;
+  --accent: #0a5e8a;
+  --accent-2: #084a6e;
+  --schema-pk: #0a5e8a;
+  --schema-fk: #8a3a6a;
+  --schema-field: #2a6a3a;
+  --schema-table: #1a1c22;
+  --hist-bar: #0a5e8a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.68;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap { max-width: 1000px; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.5rem 0 1.2rem; border-bottom: 2px solid var(--ink);
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.8rem; color: var(--ink); text-decoration: none; }
+.logo-mark { width: 48px; height: 40px; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.journal-name { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 700; font-size: 0.95rem; color: var(--ink); }
+.journal-sub { font-family: "IBM Plex Sans", "Inter", sans-serif; font-size: 0.68rem; color: var(--ink-3); letter-spacing: 0.08em; text-transform: uppercase; }
+
+.site-nav { display: flex; gap: 1.8rem; }
+.site-nav a { font-family: "IBM Plex Sans", "Inter", sans-serif; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.12em; color: var(--ink-2); text-decoration: none; text-transform: uppercase; }
+.site-nav a:hover { color: var(--accent); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 2rem 0; }
+.paper-article { max-width: 860px; margin: 0 auto; }
+
+/* ---------------- Paper Header ---------------- */
+
+.paper-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--rule); }
+.paper-eyebrow { font-family: "IBM Plex Sans", sans-serif; font-size: 0.7rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin: 0 0 0.8rem; font-weight: 700; }
+.paper-title { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 700; font-size: 1.75rem; line-height: 1.2; color: var(--ink); margin: 0 0 0.6rem; }
+.paper-authors { font-family: "Crimson Pro", serif; font-size: 0.95rem; color: var(--ink-2); margin: 0 0 0.3rem; }
+.paper-affiliations { font-family: "Crimson Pro", serif; font-size: 0.8rem; color: var(--ink-3); margin: 0 0 0.5rem; }
+.paper-doi { font-family: "IBM Plex Sans", sans-serif; font-size: 0.78rem; color: var(--ink-3); margin: 0; }
+
+/* ---------------- Headings (technical sans) ---------------- */
+
+h1, h2, h3, h4 { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 700; line-height: 1.25; color: var(--ink); }
+h1 { font-size: 1.5rem; margin: 2rem 0 0.6rem; }
+h2 { font-size: 1.2rem; margin: 1.8rem 0 0.5rem; }
+h3 { font-size: 1.02rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 0.9rem; margin: 1.2rem 0 0.4rem; }
+
+/* ---------------- Body text (minimal prose) ---------------- */
+
+p { margin: 0.7em 0; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+blockquote { margin: 1.5em 0; padding: 0.8em 1.2em; border-left: 3px solid var(--accent); background: var(--bg-2); color: var(--ink-2); }
+
+/* ---------------- Section header (post.html) ---------------- */
+
+.paper-section-header { margin-bottom: 1.5rem; padding-bottom: 1.2rem; border-bottom: 1px solid var(--rule); }
+.paper-section-eyebrow { font-family: "IBM Plex Sans", sans-serif; font-size: 0.7rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin: 0 0 0.4rem; font-weight: 700; }
+.paper-section-title { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 700; font-size: 1.5rem; line-height: 1.2; color: var(--ink); margin: 0 0 0.4rem; }
+.paper-lede { font-size: 0.88rem; color: var(--ink-3); margin: 0; line-height: 1.5; }
+.paper-section-footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--rule); }
+.button-link { font-family: "IBM Plex Sans", sans-serif; font-size: 0.78rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); text-decoration: none; }
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+.section-list li { padding: 0.7rem 0; border-bottom: 1px solid var(--bg-3); }
+.section-list li a { font-family: "IBM Plex Sans", sans-serif; font-weight: 700; font-size: 1rem; color: var(--ink); text-decoration: none; }
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Tables (data-heavy) ---------------- */
+
+table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.84rem; font-family: "IBM Plex Sans", "Inter", sans-serif; }
+th, td { padding: 0.45rem 0.65rem; text-align: left; border-bottom: 1px solid var(--bg-3); }
+th { font-weight: 600; font-size: 0.7rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); border-bottom: 2px solid var(--ink); }
+td code { font-family: "IBM Plex Mono", monospace; font-size: 0.82em; background: var(--bg-2); padding: 0.1rem 0.25rem; }
+
+/* ---------------- Code ---------------- */
+
+code { font-family: "IBM Plex Mono", Consolas, monospace; font-size: 0.84em; background: var(--bg-2); padding: 0.1rem 0.3rem; }
+pre { background: var(--bg-2); padding: 1rem; overflow-x: auto; border: 1px solid var(--bg-3); font-size: 0.85rem; }
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy & Pagination ---------------- */
+
+.taxonomy-desc { color: var(--ink-3); font-style: italic; margin-bottom: 1.5rem; }
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; font-size: 0.85rem; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer { margin-top: 3rem; padding-bottom: 2rem; }
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+.footer-content { text-align: center; }
+.footer-meta { font-family: "Crimson Pro", serif; font-size: 0.82rem; color: var(--ink-3); margin: 0 0 0.3rem; }
+.footer-note { font-family: "IBM Plex Sans", sans-serif; font-size: 0.72rem; color: var(--ink-4); margin: 0; }
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.4rem; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; flex-wrap: wrap; }
+  table { font-size: 0.78rem; }
+}

--- a/data-paper/templates/404.html
+++ b/data-paper/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this dataset descriptor.</p>
+      <p><a href="{{ base_url }}/">Return to Dataset Overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/data-paper/templates/footer.html
+++ b/data-paper/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#1a1c22" stroke-width="0.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a1c22" stroke-width="1.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Nakamura R, Patel A, Osei-Bonsu A, et al. OpenUrbanClimate: A Multi-City Microclimate Sensor Dataset. <em>Sci. Data</em> 2026;13:284.</p>
+        <p class="footer-note">ISSN 2052-4463 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/data-paper/templates/header.html
+++ b/data-paper/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Crimson+Pro:ital,wght@0,400;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Dataset home">
+        <svg viewBox="0 0 48 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Database/schema icon -->
+          <ellipse cx="24" cy="10" rx="18" ry="6" fill="none" stroke="#0a5e8a" stroke-width="1.5"/>
+          <path d="M6,10 L6,30" fill="none" stroke="#0a5e8a" stroke-width="1.5"/>
+          <path d="M42,10 L42,30" fill="none" stroke="#0a5e8a" stroke-width="1.5"/>
+          <ellipse cx="24" cy="30" rx="18" ry="6" fill="none" stroke="#0a5e8a" stroke-width="1.5"/>
+          <path d="M6,20 Q24,28 42,20" fill="none" stroke="#0a5e8a" stroke-width="0.8" opacity="0.4"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Scientific Data</span>
+          <span class="journal-sub">Data Descriptor &middot; Vol. 13 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">DATASET</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/schema/">SCHEMA</a>
+        <a href="{{ base_url }}/distributions/">DISTRIBUTIONS</a>
+      </nav>
+    </header>

--- a/data-paper/templates/page.html
+++ b/data-paper/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/data-paper/templates/post.html
+++ b/data-paper/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/data-paper/templates/section.html
+++ b/data-paper/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/data-paper/templates/shortcodes/alert.html
+++ b/data-paper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/data-paper/templates/taxonomy.html
+++ b/data-paper/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/data-paper/templates/taxonomy_term.html
+++ b/data-paper/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4179,5 +4179,12 @@
     "clinical",
     "case-study",
     "medical"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
   ]
 }


### PR DESCRIPTION
Closes #1609

## Summary
- Dataset description paper with urban microclimate sensor network dataset
- SVG database schema entity-relationship diagrams showing 4 tables with PK/FK relationships
- SVG data distribution histogram for temperature across 18 cities
- Comprehensive data dictionaries with field types, constraints, and enumerated values
- IBM Plex Sans Bold/Inter Bold for technical schema labels, Crimson Pro/Noto Serif for prose
- Five sections following Scientific Data format, plus schema and distributions pages
- Tags: paper, light, dataset, schema, minimal-text

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check ER diagram SVG renders with table boxes and relationship lines
- [ ] Confirm histogram SVG displays temperature distribution bars
- [ ] Verify data dictionary tables render correctly
- [ ] Check tags.json entry is valid JSON