### PR TITLE
feat: add supplementary example site (closes #1603)

### DIFF
--- a/supplementary/AGENTS.md
+++ b/supplementary/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/supplementary/config.toml
+++ b/supplementary/config.toml
@@ -1,0 +1,52 @@
+# =============================================================================
+# Supplementary - Extended Data Paper
+# Issue #1603 | Tags: paper, light, supplementary, data-heavy, exhaustive
+# =============================================================================
+
+title = "Supplementary Materials: Resistome Dynamics in Hospital Wastewater"
+description = "Extended supplementary data, figures, tables, and methods for a genomic study of antibiotic resistance gene transfer in hospital wastewater systems."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Extended supplementary materials for a genomic resistome study. Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/supplementary/content/appendix.md
+++ b/supplementary/content/appendix.md
@@ -1,0 +1,137 @@
++++
+title = "Appendix"
+description = "Author contributions, data availability statement, funding, ethics approval, and conflict of interest declarations."
+tags = ["appendix", "ethics", "contributions"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">APPENDIX</p>
+  <h1 class="paper-section-title">Author Contributions, Ethics, and Data Availability</h1>
+</header>
+
+## Author Contributions
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Author contributions following CRediT taxonomy.</caption>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>W. Chen</th>
+      <th>A. Okonkwo</th>
+      <th>S. Lindqvist</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Conceptualization</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+      <td class="num">Supporting</td>
+    </tr>
+    <tr>
+      <td>Data curation</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Formal analysis</td>
+      <td class="num">Lead</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Funding acquisition</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+      <td class="num">Supporting</td>
+    </tr>
+    <tr>
+      <td>Investigation</td>
+      <td class="num">Lead</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+    </tr>
+    <tr>
+      <td>Methodology</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+      <td class="num">Lead</td>
+    </tr>
+    <tr>
+      <td>Project administration</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Resources</td>
+      <td class="num">Supporting</td>
+      <td class="num">Supporting</td>
+      <td class="num">Lead</td>
+    </tr>
+    <tr>
+      <td>Software</td>
+      <td class="num">--</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Supervision</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Validation</td>
+      <td class="num">Supporting</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+    </tr>
+    <tr>
+      <td>Visualization</td>
+      <td class="num">Supporting</td>
+      <td class="num">Lead</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Writing -- original draft</td>
+      <td class="num">Lead</td>
+      <td class="num">Supporting</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Writing -- review and editing</td>
+      <td class="num">Lead</td>
+      <td class="num">Lead</td>
+      <td class="num">Lead</td>
+    </tr>
+  </tbody>
+</table>
+
+## Ethics Approval
+
+This study was approved by the ETH Zurich Research Ethics Committee (EK 2023-N-248) and the Oxford Tropical Research Ethics Committee (OxTREC 562-23). Wastewater sampling was conducted under facility-level agreements with the participating hospital (University Hospital Zurich). No individual patient data were collected. Environmental sampling at the WWTP and river sites was conducted under Swiss Federal Office for the Environment permit ENV-2023-1847.
+
+## Funding
+
+This work was supported by:
+
+- Swiss National Science Foundation (SNSF), grant 310030_214582 (to W.C.)
+- Wellcome Trust, grant 218205/Z/19/Z (to A.O.)
+- Swedish Research Council Formas, grant 2023-00842 (to S.L.)
+- European Joint Programme One Health (EJP), grant GA 773830
+
+The funders had no role in study design, data collection, analysis, interpretation, or the decision to publish.
+
+## Data Availability Statement
+
+All data supporting the findings of this study are available in the supplementary materials and in publicly accessible repositories as detailed in Section S5. Processed datasets are deposited on Figshare (doi:10.6084/m9.figshare.24681234). Raw sequence data are deposited in the NCBI Sequence Read Archive (BioProject PRJNA987654). Analysis code is available on GitHub (https://github.com/chen-lab/hospital-resistome-2026).
+
+## Conflicts of Interest
+
+The authors declare no competing interests. W.C. has served on advisory boards for bioMerieux (2024) and Roche Diagnostics (2025); these roles are unrelated to the present study.
+
+## Acknowledgements
+
+The authors thank the staff of the Clinical Microbiology Laboratory at University Hospital Zurich for assistance with sample collection and species identification; Dr. Marcus Keller for statistical consultation; and the ETH Zurich Genomics Facility for sequencing support. Computational resources were provided by the Swiss National Supercomputing Centre (CSCS) under project s1142.

--- a/supplementary/content/figures.md
+++ b/supplementary/content/figures.md
@@ -1,0 +1,81 @@
++++
+title = "Supplementary Figures Index"
+description = "Complete listing of all supplementary figures with descriptions and cross-references to the relevant supplementary sections."
+tags = ["figures", "index", "supplementary"]
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">FIGURE INDEX</p>
+  <h1 class="paper-section-title">Supplementary Figures</h1>
+  <p class="paper-lede">All supplementary figures accompanying the parent manuscript, listed in order of appearance.</p>
+</header>
+
+<ul class="figure-ref-list">
+  <li>
+    <span class="ref-id">Figure S1.</span>
+    Resistance gene prevalence heatmap across 12 sampling sites and 8 gene families. Color intensity represents percentage of isolates positive for each gene at each site over the 24-month study period. Located in <a href="../">Overview</a>.
+  </li>
+  <li>
+    <span class="ref-id">Figure S2.</span>
+    Multi-panel bar chart of ARG prevalence by ward type (ICU, surgical, general, outpatient). Four panels showing the consistent gradient of decreasing prevalence from ICU to outpatient for all 8 gene families. Located in <a href="../sections/2-supplementary-figures/">Section S2</a>.
+  </li>
+  <li>
+    <span class="ref-id">Figure S3.</span>
+    Temporal trend lines for the top 4 gene families (sul1, blaCTX-M, tetM, blaNDM) over 24 months of surveillance. Shows statistically significant upward trends with blaNDM exhibiting the steepest relative increase. Located in <a href="../sections/2-supplementary-figures/">Section S2</a>.
+  </li>
+</ul>
+
+## Figure Summary Statistics
+
+<table class="paper-table compact">
+  <caption><span class="tab-num">Table.</span> Key quantitative findings from supplementary figures.</caption>
+  <thead>
+    <tr>
+      <th>Figure</th>
+      <th>Key Finding</th>
+      <th>Statistic</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>S1</td>
+      <td>ICU-A mean prevalence across all gene families</td>
+      <td class="num">76.2%</td>
+    </tr>
+    <tr>
+      <td>S1</td>
+      <td>River downstream mean prevalence</td>
+      <td class="num">15.9%</td>
+    </tr>
+    <tr>
+      <td>S1</td>
+      <td>WWTP treatment reduction (influent to effluent)</td>
+      <td class="num">42.8%</td>
+    </tr>
+    <tr>
+      <td>S2</td>
+      <td>ICU vs outpatient overall prevalence ratio</td>
+      <td class="num">2.8x</td>
+    </tr>
+    <tr>
+      <td>S2</td>
+      <td>Most prevalent gene across all ward types</td>
+      <td>sul1</td>
+    </tr>
+    <tr>
+      <td>S3</td>
+      <td>blaNDM 24-month cumulative increase</td>
+      <td class="num">+26.4%</td>
+    </tr>
+    <tr>
+      <td>S3</td>
+      <td>sul1 24-month cumulative increase</td>
+      <td class="num">+15.2%</td>
+    </tr>
+    <tr>
+      <td>S3</td>
+      <td>Linear trend test significance (all 4 genes)</td>
+      <td class="num">p &lt; 0.01</td>
+    </tr>
+  </tbody>
+</table>

--- a/supplementary/content/index.md
+++ b/supplementary/content/index.md
@@ -1,0 +1,281 @@
++++
+title = "Overview"
+description = "Extended supplementary data, figures, and methods for the 24-month genomic surveillance study of antibiotic resistance gene transfer in hospital wastewater systems."
+tags = ["paper", "light", "supplementary", "data-heavy", "exhaustive"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-title">Resistome Dynamics and Horizontal Gene Transfer in Hospital Wastewater: Extended Supplementary Data</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Wei Chen</span><sup>1</sup>,
+    Adaeze Okonkwo<sup>2</sup>,
+    Sofia Lindqvist<sup>1,3</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Department of Environmental Microbiology, ETH Zurich &middot;
+    <sup>2</sup>Centre for Antimicrobial Resistance, University of Oxford &middot;
+    <sup>3</sup>Swedish University of Agricultural Sciences, Uppsala
+  </p>
+  <p class="paper-doi"><strong>Parent paper:</strong> <em>Environ. Microbiol.</em> 2026;28(3):412-438. <strong>DOI:</strong> <a href="#">10.1111/emi.2026.28.03.412</a></p>
+</header>
+
+<div class="notice-box">
+  <strong>Notice:</strong> These supplementary materials accompany the parent paper and contain extended data tables, additional figures, detailed methods, sensitivity analyses, and raw data summaries not included in the main text due to space constraints. All supplementary tables and figures are numbered with the prefix S (e.g., Table S1, Figure S1).
+</div>
+
+## Figure S1. Resistance Gene Prevalence Heatmap
+
+<figure class="figure">
+  <svg viewBox="0 0 780 520" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Heatmap showing antibiotic resistance gene prevalence across 12 sampling sites and 8 gene families">
+    <!-- Title -->
+    <text x="390" y="18" text-anchor="middle" font-family="Barlow Condensed" font-weight="700" font-size="13" fill="#1a1a18" letter-spacing="0.5">RESISTANCE GENE PREVALENCE BY SITE AND GENE FAMILY</text>
+    <!-- Y-axis: 12 sampling sites -->
+    <text x="8" y="210" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#5c5c54" transform="rotate(-90 8 210)">SAMPLING SITES</text>
+    <text x="125" y="52" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">ICU-A effluent</text>
+    <text x="125" y="88" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">ICU-B effluent</text>
+    <text x="125" y="124" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">Surgical Ward 1</text>
+    <text x="125" y="160" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">Surgical Ward 2</text>
+    <text x="125" y="196" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">General Ward A</text>
+    <text x="125" y="232" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">General Ward B</text>
+    <text x="125" y="268" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">General Ward C</text>
+    <text x="125" y="304" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">Outpatient 1</text>
+    <text x="125" y="340" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">Outpatient 2</text>
+    <text x="125" y="376" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">WWTP Influent</text>
+    <text x="125" y="412" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">WWTP Effluent</text>
+    <text x="125" y="448" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18">River Downstream</text>
+    <!-- X-axis: 8 gene families (rotated) -->
+    <text x="170" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 170 478)">blaCTX-M</text>
+    <text x="245" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 245 478)">blaKPC</text>
+    <text x="320" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 320 478)">blaNDM</text>
+    <text x="395" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 395 478)">mcr-1</text>
+    <text x="470" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 470 478)">vanA</text>
+    <text x="545" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 545 478)">qnrS</text>
+    <text x="620" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 620 478)">tetM</text>
+    <text x="695" y="478" text-anchor="end" font-family="IBM Plex Mono" font-size="8" fill="#1a1a18" transform="rotate(-45 695 478)">sul1</text>
+    <!-- Grid outline -->
+    <rect x="133" y="32" width="600" height="432" fill="none" stroke="#c8c4b8" stroke-width="1"/>
+    <!-- Grid lines (horizontal) -->
+    <line x1="133" y1="68" x2="733" y2="68" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="104" x2="733" y2="104" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="140" x2="733" y2="140" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="176" x2="733" y2="176" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="212" x2="733" y2="212" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="248" x2="733" y2="248" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="284" x2="733" y2="284" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="320" x2="733" y2="320" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="356" x2="733" y2="356" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="392" x2="733" y2="392" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="133" y1="428" x2="733" y2="428" stroke="#c8c4b8" stroke-width="0.5"/>
+    <!-- Grid lines (vertical) -->
+    <line x1="208" y1="32" x2="208" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="283" y1="32" x2="283" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="358" y1="32" x2="358" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="433" y1="32" x2="433" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="508" y1="32" x2="508" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="583" y1="32" x2="583" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="658" y1="32" x2="658" y2="464" stroke="#c8c4b8" stroke-width="0.5"/>
+    <!-- Heatmap cells: Row 1 (ICU-A) - high prevalence -->
+    <rect x="133" y="32" width="75" height="36" fill="#c45a3c" opacity="0.92"/>
+    <rect x="208" y="32" width="75" height="36" fill="#c45a3c" opacity="0.78"/>
+    <rect x="283" y="32" width="75" height="36" fill="#c45a3c" opacity="0.85"/>
+    <rect x="358" y="32" width="75" height="36" fill="#c45a3c" opacity="0.65"/>
+    <rect x="433" y="32" width="75" height="36" fill="#c45a3c" opacity="0.72"/>
+    <rect x="508" y="32" width="75" height="36" fill="#c45a3c" opacity="0.58"/>
+    <rect x="583" y="32" width="75" height="36" fill="#c45a3c" opacity="0.88"/>
+    <rect x="658" y="32" width="75" height="36" fill="#c45a3c" opacity="0.95"/>
+    <!-- Row 2 (ICU-B) -->
+    <rect x="133" y="68" width="75" height="36" fill="#c45a3c" opacity="0.88"/>
+    <rect x="208" y="68" width="75" height="36" fill="#c45a3c" opacity="0.70"/>
+    <rect x="283" y="68" width="75" height="36" fill="#c45a3c" opacity="0.80"/>
+    <rect x="358" y="68" width="75" height="36" fill="#c45a3c" opacity="0.55"/>
+    <rect x="433" y="68" width="75" height="36" fill="#c45a3c" opacity="0.68"/>
+    <rect x="508" y="68" width="75" height="36" fill="#c45a3c" opacity="0.52"/>
+    <rect x="583" y="68" width="75" height="36" fill="#c45a3c" opacity="0.82"/>
+    <rect x="658" y="68" width="75" height="36" fill="#c45a3c" opacity="0.90"/>
+    <!-- Row 3 (Surgical 1) -->
+    <rect x="133" y="104" width="75" height="36" fill="#c45a3c" opacity="0.72"/>
+    <rect x="208" y="104" width="75" height="36" fill="#c45a3c" opacity="0.48"/>
+    <rect x="283" y="104" width="75" height="36" fill="#c45a3c" opacity="0.55"/>
+    <rect x="358" y="104" width="75" height="36" fill="#c45a3c" opacity="0.38"/>
+    <rect x="433" y="104" width="75" height="36" fill="#c45a3c" opacity="0.52"/>
+    <rect x="508" y="104" width="75" height="36" fill="#c45a3c" opacity="0.42"/>
+    <rect x="583" y="104" width="75" height="36" fill="#c45a3c" opacity="0.68"/>
+    <rect x="658" y="104" width="75" height="36" fill="#c45a3c" opacity="0.75"/>
+    <!-- Row 4 (Surgical 2) -->
+    <rect x="133" y="140" width="75" height="36" fill="#c45a3c" opacity="0.68"/>
+    <rect x="208" y="140" width="75" height="36" fill="#c45a3c" opacity="0.45"/>
+    <rect x="283" y="140" width="75" height="36" fill="#c45a3c" opacity="0.50"/>
+    <rect x="358" y="140" width="75" height="36" fill="#c45a3c" opacity="0.35"/>
+    <rect x="433" y="140" width="75" height="36" fill="#c45a3c" opacity="0.48"/>
+    <rect x="508" y="140" width="75" height="36" fill="#c45a3c" opacity="0.40"/>
+    <rect x="583" y="140" width="75" height="36" fill="#c45a3c" opacity="0.62"/>
+    <rect x="658" y="140" width="75" height="36" fill="#c45a3c" opacity="0.72"/>
+    <!-- Row 5 (General A) -->
+    <rect x="133" y="176" width="75" height="36" fill="#c45a3c" opacity="0.55"/>
+    <rect x="208" y="176" width="75" height="36" fill="#c45a3c" opacity="0.30"/>
+    <rect x="283" y="176" width="75" height="36" fill="#c45a3c" opacity="0.35"/>
+    <rect x="358" y="176" width="75" height="36" fill="#c45a3c" opacity="0.22"/>
+    <rect x="433" y="176" width="75" height="36" fill="#c45a3c" opacity="0.38"/>
+    <rect x="508" y="176" width="75" height="36" fill="#c45a3c" opacity="0.28"/>
+    <rect x="583" y="176" width="75" height="36" fill="#c45a3c" opacity="0.52"/>
+    <rect x="658" y="176" width="75" height="36" fill="#c45a3c" opacity="0.60"/>
+    <!-- Row 6 (General B) -->
+    <rect x="133" y="212" width="75" height="36" fill="#c45a3c" opacity="0.50"/>
+    <rect x="208" y="212" width="75" height="36" fill="#c45a3c" opacity="0.28"/>
+    <rect x="283" y="212" width="75" height="36" fill="#c45a3c" opacity="0.32"/>
+    <rect x="358" y="212" width="75" height="36" fill="#c45a3c" opacity="0.20"/>
+    <rect x="433" y="212" width="75" height="36" fill="#c45a3c" opacity="0.35"/>
+    <rect x="508" y="212" width="75" height="36" fill="#c45a3c" opacity="0.25"/>
+    <rect x="583" y="212" width="75" height="36" fill="#c45a3c" opacity="0.48"/>
+    <rect x="658" y="212" width="75" height="36" fill="#c45a3c" opacity="0.55"/>
+    <!-- Row 7 (General C) -->
+    <rect x="133" y="248" width="75" height="36" fill="#c45a3c" opacity="0.48"/>
+    <rect x="208" y="248" width="75" height="36" fill="#c45a3c" opacity="0.25"/>
+    <rect x="283" y="248" width="75" height="36" fill="#c45a3c" opacity="0.28"/>
+    <rect x="358" y="248" width="75" height="36" fill="#c45a3c" opacity="0.18"/>
+    <rect x="433" y="248" width="75" height="36" fill="#c45a3c" opacity="0.32"/>
+    <rect x="508" y="248" width="75" height="36" fill="#c45a3c" opacity="0.22"/>
+    <rect x="583" y="248" width="75" height="36" fill="#c45a3c" opacity="0.45"/>
+    <rect x="658" y="248" width="75" height="36" fill="#c45a3c" opacity="0.52"/>
+    <!-- Row 8 (Outpatient 1) -->
+    <rect x="133" y="284" width="75" height="36" fill="#c45a3c" opacity="0.32"/>
+    <rect x="208" y="284" width="75" height="36" fill="#c45a3c" opacity="0.15"/>
+    <rect x="283" y="284" width="75" height="36" fill="#c45a3c" opacity="0.18"/>
+    <rect x="358" y="284" width="75" height="36" fill="#c45a3c" opacity="0.10"/>
+    <rect x="433" y="284" width="75" height="36" fill="#c45a3c" opacity="0.22"/>
+    <rect x="508" y="284" width="75" height="36" fill="#c45a3c" opacity="0.15"/>
+    <rect x="583" y="284" width="75" height="36" fill="#c45a3c" opacity="0.35"/>
+    <rect x="658" y="284" width="75" height="36" fill="#c45a3c" opacity="0.40"/>
+    <!-- Row 9 (Outpatient 2) -->
+    <rect x="133" y="320" width="75" height="36" fill="#c45a3c" opacity="0.28"/>
+    <rect x="208" y="320" width="75" height="36" fill="#c45a3c" opacity="0.12"/>
+    <rect x="283" y="320" width="75" height="36" fill="#c45a3c" opacity="0.15"/>
+    <rect x="358" y="320" width="75" height="36" fill="#c45a3c" opacity="0.08"/>
+    <rect x="433" y="320" width="75" height="36" fill="#c45a3c" opacity="0.18"/>
+    <rect x="508" y="320" width="75" height="36" fill="#c45a3c" opacity="0.12"/>
+    <rect x="583" y="320" width="75" height="36" fill="#c45a3c" opacity="0.30"/>
+    <rect x="658" y="320" width="75" height="36" fill="#c45a3c" opacity="0.35"/>
+    <!-- Row 10 (WWTP Influent) -->
+    <rect x="133" y="356" width="75" height="36" fill="#c45a3c" opacity="0.75"/>
+    <rect x="208" y="356" width="75" height="36" fill="#c45a3c" opacity="0.52"/>
+    <rect x="283" y="356" width="75" height="36" fill="#c45a3c" opacity="0.60"/>
+    <rect x="358" y="356" width="75" height="36" fill="#c45a3c" opacity="0.42"/>
+    <rect x="433" y="356" width="75" height="36" fill="#c45a3c" opacity="0.55"/>
+    <rect x="508" y="356" width="75" height="36" fill="#c45a3c" opacity="0.45"/>
+    <rect x="583" y="356" width="75" height="36" fill="#c45a3c" opacity="0.70"/>
+    <rect x="658" y="356" width="75" height="36" fill="#c45a3c" opacity="0.78"/>
+    <!-- Row 11 (WWTP Effluent) -->
+    <rect x="133" y="392" width="75" height="36" fill="#c45a3c" opacity="0.42"/>
+    <rect x="208" y="392" width="75" height="36" fill="#c45a3c" opacity="0.22"/>
+    <rect x="283" y="392" width="75" height="36" fill="#c45a3c" opacity="0.28"/>
+    <rect x="358" y="392" width="75" height="36" fill="#c45a3c" opacity="0.15"/>
+    <rect x="433" y="392" width="75" height="36" fill="#c45a3c" opacity="0.30"/>
+    <rect x="508" y="392" width="75" height="36" fill="#c45a3c" opacity="0.20"/>
+    <rect x="583" y="392" width="75" height="36" fill="#c45a3c" opacity="0.40"/>
+    <rect x="658" y="392" width="75" height="36" fill="#c45a3c" opacity="0.48"/>
+    <!-- Row 12 (River Downstream) -->
+    <rect x="133" y="428" width="75" height="36" fill="#c45a3c" opacity="0.22"/>
+    <rect x="208" y="428" width="75" height="36" fill="#c45a3c" opacity="0.10"/>
+    <rect x="283" y="428" width="75" height="36" fill="#c45a3c" opacity="0.12"/>
+    <rect x="358" y="428" width="75" height="36" fill="#c45a3c" opacity="0.05"/>
+    <rect x="433" y="428" width="75" height="36" fill="#c45a3c" opacity="0.15"/>
+    <rect x="508" y="428" width="75" height="36" fill="#c45a3c" opacity="0.08"/>
+    <rect x="583" y="428" width="75" height="36" fill="#c45a3c" opacity="0.25"/>
+    <rect x="658" y="428" width="75" height="36" fill="#c45a3c" opacity="0.30"/>
+    <!-- Prevalence percentage labels in each cell (selected high-value cells) -->
+    <text x="170" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">92%</text>
+    <text x="245" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">78%</text>
+    <text x="320" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">85%</text>
+    <text x="395" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">65%</text>
+    <text x="470" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">72%</text>
+    <text x="545" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">58%</text>
+    <text x="620" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">88%</text>
+    <text x="695" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">95%</text>
+    <!-- Row 2 labels -->
+    <text x="170" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">88%</text>
+    <text x="245" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">70%</text>
+    <text x="320" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">80%</text>
+    <text x="395" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">55%</text>
+    <text x="470" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">68%</text>
+    <text x="545" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">52%</text>
+    <text x="620" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">82%</text>
+    <text x="695" y="91" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">90%</text>
+    <!-- Row 5 labels (General A, mid-range) -->
+    <text x="170" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">55%</text>
+    <text x="245" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">30%</text>
+    <text x="320" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">35%</text>
+    <text x="395" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">22%</text>
+    <text x="470" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">38%</text>
+    <text x="545" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">28%</text>
+    <text x="620" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">52%</text>
+    <text x="695" y="199" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">60%</text>
+    <!-- Row 10 labels (WWTP Influent) -->
+    <text x="170" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">75%</text>
+    <text x="245" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">52%</text>
+    <text x="320" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">60%</text>
+    <text x="395" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">42%</text>
+    <text x="470" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">55%</text>
+    <text x="545" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">45%</text>
+    <text x="620" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">70%</text>
+    <text x="695" y="379" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#ffffff">78%</text>
+    <!-- Row 12 labels (River, low) -->
+    <text x="170" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">22%</text>
+    <text x="245" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">10%</text>
+    <text x="320" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">12%</text>
+    <text x="395" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">5%</text>
+    <text x="470" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">15%</text>
+    <text x="545" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">8%</text>
+    <text x="620" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">25%</text>
+    <text x="695" y="451" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">30%</text>
+    <!-- Legend -->
+    <text x="135" y="505" text-anchor="start" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="8" fill="#5c5c54">PREVALENCE:</text>
+    <rect x="215" y="497" width="30" height="10" fill="#c45a3c" opacity="0.1"/>
+    <text x="250" y="506" text-anchor="start" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">0-20%</text>
+    <rect x="295" y="497" width="30" height="10" fill="#c45a3c" opacity="0.35"/>
+    <text x="330" y="506" text-anchor="start" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">20-40%</text>
+    <rect x="375" y="497" width="30" height="10" fill="#c45a3c" opacity="0.55"/>
+    <text x="410" y="506" text-anchor="start" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">40-60%</text>
+    <rect x="455" y="497" width="30" height="10" fill="#c45a3c" opacity="0.75"/>
+    <text x="490" y="506" text-anchor="start" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">60-80%</text>
+    <rect x="535" y="497" width="30" height="10" fill="#c45a3c" opacity="0.95"/>
+    <text x="570" y="506" text-anchor="start" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">80-100%</text>
+    <!-- Annotations -->
+    <line x1="737" y1="50" x2="750" y2="50" stroke="#2c5f8a" stroke-width="1"/>
+    <text x="755" y="47" font-family="IBM Plex Sans Condensed" font-size="7" fill="#2c5f8a">ICU wards show</text>
+    <text x="755" y="56" font-family="IBM Plex Sans Condensed" font-size="7" fill="#2c5f8a">highest prevalence</text>
+    <line x1="737" y1="416" x2="750" y2="416" stroke="#2c5f8a" stroke-width="1"/>
+    <text x="755" y="413" font-family="IBM Plex Sans Condensed" font-size="7" fill="#2c5f8a">WWTP treatment</text>
+    <text x="755" y="422" font-family="IBM Plex Sans Condensed" font-size="7" fill="#2c5f8a">reduces but does</text>
+    <text x="755" y="431" font-family="IBM Plex Sans Condensed" font-size="7" fill="#2c5f8a">not eliminate ARGs</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure S1.</span> Heatmap of antibiotic resistance gene (ARG) prevalence across 12 sampling sites and 8 gene families over the 24-month surveillance period. Prevalence represents the percentage of isolates positive for each gene family at each site. ICU effluents show the highest overall prevalence (mean 76.2 pct across gene families), while the downstream river site shows the lowest (mean 15.9 pct). WWTP treatment reduced prevalence by an average of 42.8 pct between influent and effluent.</figcaption>
+</figure>
+<div class="figure-annotation">Annotation: blaCTX-M and sul1 show the highest overall prevalence across all sites. mcr-1 (colistin resistance) prevalence is comparatively lower but present at detectable levels even in outpatient wastewater, indicating community-level circulation. Hierarchical clustering of sites (not shown) groups ICU-A and ICU-B together, consistent with shared patient populations.</div>
+
+<div class="metrics-bar">
+  <div class="metric">
+    <span class="metric-value">12</span>
+    <span class="metric-label">Sampling Sites</span>
+  </div>
+  <div class="metric">
+    <span class="metric-value">847</span>
+    <span class="metric-label">Isolates Screened</span>
+  </div>
+  <div class="metric">
+    <span class="metric-value">8</span>
+    <span class="metric-label">Gene Families</span>
+  </div>
+  <div class="metric">
+    <span class="metric-value">24</span>
+    <span class="metric-label">Months Surveillance</span>
+  </div>
+</div>
+
+## Supplementary Sections
+
+1. **Section S1. Extended Tables** -- full isolate-level data and gene prevalence matrices
+2. **Section S2. Supplementary Figures** -- additional figure plates: site-type distributions, temporal trends
+3. **Section S3. Additional Methods** -- DNA extraction protocol, PCR primers, bioinformatics pipeline
+4. **Section S4. Sensitivity Analyses** -- alternative models, robustness checks, subgroup analyses
+5. **Section S5. Raw Data Summary** -- data dictionary, file formats, repository links

--- a/supplementary/content/sections/1-extended-tables.md
+++ b/supplementary/content/sections/1-extended-tables.md
@@ -1,0 +1,463 @@
++++
+title = "S1. Extended Data Tables"
+description = "Full isolate-level data, resistance gene prevalence matrices, and antibiotic susceptibility profiles across all sampling sites and time points."
+weight = 1
+template = "post"
+tags = ["data", "tables", "resistome", "isolates"]
+categories = ["sections"]
+[extra]
+section_number = "S1"
++++
+
+## Table S1. Full Isolate Characterization Data
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S1.</span> Complete isolate-level data for all 847 bacterial isolates collected across 12 sampling sites over 24 months.</caption>
+  <thead>
+    <tr>
+      <th>Isolate ID</th>
+      <th>Site</th>
+      <th>Month</th>
+      <th>Species</th>
+      <th>blaCTX-M</th>
+      <th>blaKPC</th>
+      <th>blaNDM</th>
+      <th>mcr-1</th>
+      <th>vanA</th>
+      <th>qnrS</th>
+      <th>tetM</th>
+      <th>sul1</th>
+      <th>MDR</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>WW-001</td>
+      <td>ICU-A</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-002</td>
+      <td>ICU-A</td>
+      <td class="num">1</td>
+      <td><em>K. pneumoniae</em></td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-003</td>
+      <td>ICU-A</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-004</td>
+      <td>ICU-B</td>
+      <td class="num">1</td>
+      <td><em>P. aeruginosa</em></td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-005</td>
+      <td>ICU-B</td>
+      <td class="num">1</td>
+      <td><em>A. baumannii</em></td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-006</td>
+      <td>Surg-1</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-007</td>
+      <td>Surg-1</td>
+      <td class="num">1</td>
+      <td><em>K. pneumoniae</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-008</td>
+      <td>Surg-2</td>
+      <td class="num">1</td>
+      <td><em>E. faecium</em></td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-009</td>
+      <td>Gen-A</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-010</td>
+      <td>Gen-B</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-011</td>
+      <td>Outpt-1</td>
+      <td class="num">1</td>
+      <td><em>K. pneumoniae</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-012</td>
+      <td>WWTP-In</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">Yes</td>
+    </tr>
+    <tr>
+      <td>WW-013</td>
+      <td>WWTP-Eff</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">+</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+    <tr>
+      <td>WW-014</td>
+      <td>River</td>
+      <td class="num">1</td>
+      <td><em>E. coli</em></td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">-</td>
+      <td class="num">+</td>
+      <td class="num">+</td>
+      <td class="num">No</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="13">+ = gene detected; - = gene not detected; MDR = multidrug-resistant (resistant to 3 or more antibiotic classes). Only first 14 of 847 isolates shown. Complete dataset available in supplementary file S1_isolates.csv. Species identification by MALDI-TOF MS (Bruker Biotyper, score threshold 2.0).</td></tr>
+  </tfoot>
+</table>
+
+## Table S2. Gene Family Prevalence by Site Type
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S2.</span> Resistance gene family prevalence (pct of isolates positive) stratified by ward type, aggregated across all 24 months.</caption>
+  <thead>
+    <tr>
+      <th>Gene Family</th>
+      <th>Target</th>
+      <th>ICU (n=218)</th>
+      <th>Surgical (n=165)</th>
+      <th>General (n=198)</th>
+      <th>Outpatient (n=112)</th>
+      <th>WWTP Influent (n=82)</th>
+      <th>WWTP Effluent (n=44)</th>
+      <th>River (n=28)</th>
+      <th>p-value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>blaCTX-M</strong></td>
+      <td>ESBL</td>
+      <td class="num">90.1</td>
+      <td class="num">70.3</td>
+      <td class="num">51.0</td>
+      <td class="num">30.4</td>
+      <td class="num">75.6</td>
+      <td class="num">42.1</td>
+      <td class="num">21.4</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>blaKPC</strong></td>
+      <td>Carbapenemase</td>
+      <td class="num">74.3</td>
+      <td class="num">46.7</td>
+      <td class="num">27.8</td>
+      <td class="num">13.4</td>
+      <td class="num">52.4</td>
+      <td class="num">22.7</td>
+      <td class="num">10.7</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>blaNDM</strong></td>
+      <td>Carbapenemase</td>
+      <td class="num">82.6</td>
+      <td class="num">52.7</td>
+      <td class="num">31.8</td>
+      <td class="num">16.1</td>
+      <td class="num">59.8</td>
+      <td class="num">27.3</td>
+      <td class="num">12.5</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>mcr-1</strong></td>
+      <td>Colistin</td>
+      <td class="num">60.1</td>
+      <td class="num">36.4</td>
+      <td class="num">20.7</td>
+      <td class="num">8.9</td>
+      <td class="num">42.7</td>
+      <td class="num">15.9</td>
+      <td class="num">5.4</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>vanA</strong></td>
+      <td>Vancomycin</td>
+      <td class="num">70.2</td>
+      <td class="num">50.3</td>
+      <td class="num">34.8</td>
+      <td class="num">20.5</td>
+      <td class="num">54.9</td>
+      <td class="num">29.5</td>
+      <td class="num">14.3</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>qnrS</strong></td>
+      <td>Fluoroquinolone</td>
+      <td class="num">55.0</td>
+      <td class="num">41.2</td>
+      <td class="num">25.3</td>
+      <td class="num">13.4</td>
+      <td class="num">45.1</td>
+      <td class="num">20.5</td>
+      <td class="num">8.9</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>tetM</strong></td>
+      <td>Tetracycline</td>
+      <td class="num">85.3</td>
+      <td class="num">65.5</td>
+      <td class="num">48.5</td>
+      <td class="num">32.1</td>
+      <td class="num">70.7</td>
+      <td class="num">40.9</td>
+      <td class="num">25.0</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+    <tr>
+      <td><strong>sul1</strong></td>
+      <td>Sulfonamide</td>
+      <td class="num">92.7</td>
+      <td class="num">73.9</td>
+      <td class="num">56.1</td>
+      <td class="num">37.5</td>
+      <td class="num">78.0</td>
+      <td class="num">47.7</td>
+      <td class="num">30.4</td>
+      <td class="num">&lt;0.001</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10">Prevalence in percent. p-values from chi-squared test across site types. All comparisons significant at alpha = 0.001 level after Bonferroni correction. ICU sites include ICU-A and ICU-B combined. Surgical includes Surgical Wards 1 and 2. General includes Wards A, B, and C. Outpatient includes sites 1 and 2.</td></tr>
+  </tfoot>
+</table>
+
+## Table S3. Minimum Inhibitory Concentration (MIC) Distribution
+
+<table class="paper-table compact">
+  <caption><span class="tab-num">Table S3.</span> MIC50 and MIC90 values (mg/L) for selected antibiotics among ESBL-producing <em>E. coli</em> isolates (n=312).</caption>
+  <thead>
+    <tr>
+      <th>Antibiotic</th>
+      <th>Class</th>
+      <th>MIC Range</th>
+      <th>MIC50</th>
+      <th>MIC90</th>
+      <th>Pct R</th>
+      <th>EUCAST BP</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Cefotaxime</td>
+      <td>Cephalosporin</td>
+      <td class="num">0.25-256</td>
+      <td class="num">64</td>
+      <td class="num">128</td>
+      <td class="num">94.2</td>
+      <td class="num">&gt;2</td>
+    </tr>
+    <tr>
+      <td>Ceftazidime</td>
+      <td>Cephalosporin</td>
+      <td class="num">0.5-128</td>
+      <td class="num">32</td>
+      <td class="num">64</td>
+      <td class="num">87.8</td>
+      <td class="num">&gt;4</td>
+    </tr>
+    <tr>
+      <td>Meropenem</td>
+      <td>Carbapenem</td>
+      <td class="num">0.03-64</td>
+      <td class="num">0.06</td>
+      <td class="num">4</td>
+      <td class="num">28.5</td>
+      <td class="num">&gt;8</td>
+    </tr>
+    <tr>
+      <td>Ciprofloxacin</td>
+      <td>Fluoroquinolone</td>
+      <td class="num">0.008-128</td>
+      <td class="num">8</td>
+      <td class="num">64</td>
+      <td class="num">72.4</td>
+      <td class="num">&gt;0.5</td>
+    </tr>
+    <tr>
+      <td>Gentamicin</td>
+      <td>Aminoglycoside</td>
+      <td class="num">0.25-256</td>
+      <td class="num">2</td>
+      <td class="num">64</td>
+      <td class="num">45.2</td>
+      <td class="num">&gt;4</td>
+    </tr>
+    <tr>
+      <td>Trimethoprim-sulfamethoxazole</td>
+      <td>Folate inhibitor</td>
+      <td class="num">0.25-256</td>
+      <td class="num">128</td>
+      <td class="num">256</td>
+      <td class="num">88.1</td>
+      <td class="num">&gt;4</td>
+    </tr>
+    <tr>
+      <td>Colistin</td>
+      <td>Polymyxin</td>
+      <td class="num">0.25-16</td>
+      <td class="num">0.5</td>
+      <td class="num">4</td>
+      <td class="num">18.3</td>
+      <td class="num">&gt;2</td>
+    </tr>
+    <tr>
+      <td>Tigecycline</td>
+      <td>Glycylcycline</td>
+      <td class="num">0.12-8</td>
+      <td class="num">0.5</td>
+      <td class="num">2</td>
+      <td class="num">8.0</td>
+      <td class="num">&gt;0.5</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="7">MIC50/MIC90 = concentration inhibiting 50/90 pct of isolates. Pct R = percentage resistant. EUCAST BP = EUCAST clinical breakpoint for resistance. MICs determined by broth microdilution (ISO 20776-1). ESBL production confirmed by combination disk test.</td></tr>
+  </tfoot>
+</table>

--- a/supplementary/content/sections/2-supplementary-figures.md
+++ b/supplementary/content/sections/2-supplementary-figures.md
@@ -1,0 +1,234 @@
++++
+title = "S2. Supplementary Figures"
+description = "Additional figure plates showing resistance gene distribution by site type and temporal trends across the 24-month surveillance period."
+weight = 2
+template = "post"
+tags = ["figures", "visualization", "resistome", "temporal"]
+categories = ["sections"]
+[extra]
+section_number = "S2"
++++
+
+## Figure S2. Resistance Gene Distribution by Ward Type
+
+<figure class="figure">
+  <svg viewBox="0 0 760 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Multi-panel bar chart showing resistance gene distribution across ICU, surgical ward, general ward, and outpatient sites">
+    <text x="380" y="16" text-anchor="middle" font-family="Barlow Condensed" font-weight="700" font-size="12" fill="#1a1a18" letter-spacing="0.5">ARG PREVALENCE BY WARD TYPE (MULTI-PANEL)</text>
+    <!-- Shared Y-axis label -->
+    <text x="10" y="220" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#5c5c54" transform="rotate(-90 10 220)">PREVALENCE (PCT ISOLATES POSITIVE)</text>
+    <!-- Panel A: ICU -->
+    <text x="120" y="36" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#c45a3c">A. ICU (n=218)</text>
+    <line x1="30" y1="45" x2="30" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <line x1="30" y1="195" x2="210" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <!-- Y gridlines -->
+    <line x1="30" y1="45" x2="210" y2="45" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="30" y1="82.5" x2="210" y2="82.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="30" y1="120" x2="210" y2="120" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="30" y1="157.5" x2="210" y2="157.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <!-- Y labels -->
+    <text x="26" y="48" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">100</text>
+    <text x="26" y="86" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">75</text>
+    <text x="26" y="123" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">50</text>
+    <text x="26" y="161" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">25</text>
+    <text x="26" y="198" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">0</text>
+    <!-- ICU bars (high prevalence) -->
+    <rect x="36" y="58.5" width="18" height="136.5" fill="#c45a3c" opacity="0.85"/>
+    <rect x="58" y="70.8" width="18" height="124.2" fill="#3c8a6e" opacity="0.85"/>
+    <rect x="80" y="63.9" width="18" height="131.1" fill="#6e5aad" opacity="0.85"/>
+    <rect x="102" y="105.0" width="18" height="90.0" fill="#b8862e" opacity="0.85"/>
+    <rect x="124" y="79.7" width="18" height="115.3" fill="#c45a3c" opacity="0.55"/>
+    <rect x="146" y="112.5" width="18" height="82.5" fill="#3c8a6e" opacity="0.55"/>
+    <rect x="168" y="67.1" width="18" height="127.9" fill="#6e5aad" opacity="0.55"/>
+    <rect x="190" y="50.4" width="18" height="144.6" fill="#b8862e" opacity="0.55"/>
+    <!-- Value labels -->
+    <text x="45" y="55" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">90</text>
+    <text x="67" y="67" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">74</text>
+    <text x="89" y="60" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">83</text>
+    <text x="111" y="102" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">60</text>
+    <text x="133" y="76" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">70</text>
+    <text x="155" y="109" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">55</text>
+    <text x="177" y="64" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">85</text>
+    <text x="199" y="47" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">93</text>
+    <!-- Panel B: Surgical -->
+    <text x="315" y="36" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#3c8a6e">B. SURGICAL (n=165)</text>
+    <line x1="225" y1="45" x2="225" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <line x1="225" y1="195" x2="405" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <!-- Y gridlines -->
+    <line x1="225" y1="45" x2="405" y2="45" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="225" y1="82.5" x2="405" y2="82.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="225" y1="120" x2="405" y2="120" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="225" y1="157.5" x2="405" y2="157.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <!-- Surgical bars (moderate prevalence) -->
+    <rect x="231" y="89.6" width="18" height="105.4" fill="#c45a3c" opacity="0.85"/>
+    <rect x="253" y="124.5" width="18" height="70.5" fill="#3c8a6e" opacity="0.85"/>
+    <rect x="275" y="115.4" width="18" height="79.6" fill="#6e5aad" opacity="0.85"/>
+    <rect x="297" y="140.4" width="18" height="54.6" fill="#b8862e" opacity="0.85"/>
+    <rect x="319" y="119.5" width="18" height="75.5" fill="#c45a3c" opacity="0.55"/>
+    <rect x="341" y="133.1" width="18" height="61.9" fill="#3c8a6e" opacity="0.55"/>
+    <rect x="363" y="96.7" width="18" height="98.3" fill="#6e5aad" opacity="0.55"/>
+    <rect x="385" y="84.2" width="18" height="110.8" fill="#b8862e" opacity="0.55"/>
+    <!-- Value labels -->
+    <text x="240" y="86" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">70</text>
+    <text x="262" y="121" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">47</text>
+    <text x="284" y="112" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">53</text>
+    <text x="306" y="137" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">36</text>
+    <text x="328" y="116" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">50</text>
+    <text x="350" y="130" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">41</text>
+    <text x="372" y="93" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">66</text>
+    <text x="394" y="81" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">74</text>
+    <!-- Panel C: General -->
+    <text x="510" y="36" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#6e5aad">C. GENERAL (n=198)</text>
+    <line x1="420" y1="45" x2="420" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <line x1="420" y1="195" x2="600" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <!-- Y gridlines -->
+    <line x1="420" y1="45" x2="600" y2="45" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="420" y1="82.5" x2="600" y2="82.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="420" y1="120" x2="600" y2="120" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="420" y1="157.5" x2="600" y2="157.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <!-- General bars (lower prevalence) -->
+    <rect x="426" y="118.5" width="18" height="76.5" fill="#c45a3c" opacity="0.85"/>
+    <rect x="448" y="153.3" width="18" height="41.7" fill="#3c8a6e" opacity="0.85"/>
+    <rect x="470" y="147.3" width="18" height="47.7" fill="#6e5aad" opacity="0.85"/>
+    <rect x="492" y="163.9" width="18" height="31.1" fill="#b8862e" opacity="0.85"/>
+    <rect x="514" y="142.8" width="18" height="52.2" fill="#c45a3c" opacity="0.55"/>
+    <rect x="536" y="157.1" width="18" height="37.9" fill="#3c8a6e" opacity="0.55"/>
+    <rect x="558" y="122.2" width="18" height="72.8" fill="#6e5aad" opacity="0.55"/>
+    <rect x="580" y="110.8" width="18" height="84.2" fill="#b8862e" opacity="0.55"/>
+    <!-- Value labels -->
+    <text x="435" y="115" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">51</text>
+    <text x="457" y="150" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">28</text>
+    <text x="479" y="144" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">32</text>
+    <text x="501" y="161" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">21</text>
+    <text x="523" y="140" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">35</text>
+    <text x="545" y="154" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">25</text>
+    <text x="567" y="119" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">49</text>
+    <text x="589" y="108" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">56</text>
+    <!-- Panel D: Outpatient -->
+    <text x="700" y="36" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#b8862e">D. OUTPATIENT (n=112)</text>
+    <line x1="615" y1="45" x2="615" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <line x1="615" y1="195" x2="755" y2="195" stroke="#1a1a18" stroke-width="1"/>
+    <!-- Y gridlines -->
+    <line x1="615" y1="45" x2="755" y2="45" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="615" y1="82.5" x2="755" y2="82.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="615" y1="120" x2="755" y2="120" stroke="#c8c4b8" stroke-width="0.3"/>
+    <line x1="615" y1="157.5" x2="755" y2="157.5" stroke="#c8c4b8" stroke-width="0.3"/>
+    <!-- Outpatient bars (lowest prevalence) -->
+    <rect x="619" y="149.4" width="15" height="45.6" fill="#c45a3c" opacity="0.85"/>
+    <rect x="636" y="174.9" width="15" height="20.1" fill="#3c8a6e" opacity="0.85"/>
+    <rect x="653" y="170.9" width="15" height="24.1" fill="#6e5aad" opacity="0.85"/>
+    <rect x="670" y="181.7" width="15" height="13.3" fill="#b8862e" opacity="0.85"/>
+    <rect x="687" y="164.2" width="15" height="30.8" fill="#c45a3c" opacity="0.55"/>
+    <rect x="704" y="174.9" width="15" height="20.1" fill="#3c8a6e" opacity="0.55"/>
+    <rect x="721" y="146.8" width="15" height="48.2" fill="#6e5aad" opacity="0.55"/>
+    <rect x="738" y="138.7" width="15" height="56.3" fill="#b8862e" opacity="0.55"/>
+    <!-- Value labels -->
+    <text x="627" y="146" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">30</text>
+    <text x="644" y="172" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">13</text>
+    <text x="661" y="168" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">16</text>
+    <text x="678" y="179" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">9</text>
+    <text x="695" y="161" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">21</text>
+    <text x="712" y="172" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">13</text>
+    <text x="729" y="143" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">32</text>
+    <text x="746" y="136" text-anchor="middle" font-family="IBM Plex Mono" font-size="6" fill="#1a1a18">38</text>
+    <!-- Legend -->
+    <rect x="30" y="210" width="10" height="10" fill="#c45a3c" opacity="0.85"/>
+    <text x="44" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">blaCTX-M</text>
+    <rect x="110" y="210" width="10" height="10" fill="#3c8a6e" opacity="0.85"/>
+    <text x="124" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">blaKPC</text>
+    <rect x="180" y="210" width="10" height="10" fill="#6e5aad" opacity="0.85"/>
+    <text x="194" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">blaNDM</text>
+    <rect x="250" y="210" width="10" height="10" fill="#b8862e" opacity="0.85"/>
+    <text x="264" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">mcr-1</text>
+    <rect x="320" y="210" width="10" height="10" fill="#c45a3c" opacity="0.55"/>
+    <text x="334" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">vanA</text>
+    <rect x="380" y="210" width="10" height="10" fill="#3c8a6e" opacity="0.55"/>
+    <text x="394" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">qnrS</text>
+    <rect x="440" y="210" width="10" height="10" fill="#6e5aad" opacity="0.55"/>
+    <text x="454" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">tetM</text>
+    <rect x="510" y="210" width="10" height="10" fill="#b8862e" opacity="0.55"/>
+    <text x="524" y="219" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">sul1</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure S2.</span> Multi-panel bar chart comparing antibiotic resistance gene prevalence across four ward types. Panel A: ICU effluent (n=218 isolates) shows the highest overall prevalence with sul1 at 93 pct. Panel B: surgical ward (n=165) shows moderate prevalence. Panel C: general ward (n=198) shows intermediate levels. Panel D: outpatient (n=112) has the lowest in-hospital prevalence. All eight gene families follow a consistent ICU > surgical > general > outpatient gradient (Kruskal-Wallis p &lt; 0.001 for all genes).</figcaption>
+</figure>
+
+## Figure S3. Temporal Trends in Top 4 Gene Families
+
+<figure class="figure">
+  <svg viewBox="0 0 760 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing temporal trends in resistance gene prevalence over 24 months for blaCTX-M, blaNDM, tetM, and sul1">
+    <text x="380" y="16" text-anchor="middle" font-family="Barlow Condensed" font-weight="700" font-size="12" fill="#1a1a18" letter-spacing="0.5">TEMPORAL TRENDS: TOP 4 GENE FAMILIES (ALL SITES COMBINED)</text>
+    <!-- Axes -->
+    <line x1="60" y1="30" x2="60" y2="300" stroke="#1a1a18" stroke-width="1.2"/>
+    <line x1="60" y1="300" x2="730" y2="300" stroke="#1a1a18" stroke-width="1.2"/>
+    <!-- Y-axis labels -->
+    <text x="12" y="170" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#5c5c54" transform="rotate(-90 12 170)">MEAN PREVALENCE (PCT)</text>
+    <text x="54" y="34" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">80</text>
+    <text x="54" y="71" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">70</text>
+    <text x="54" y="102" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">60</text>
+    <text x="54" y="138" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">50</text>
+    <text x="54" y="170" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">40</text>
+    <text x="54" y="205" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">30</text>
+    <text x="54" y="237" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">20</text>
+    <text x="54" y="272" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">10</text>
+    <text x="54" y="304" text-anchor="end" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">0</text>
+    <!-- Y grid -->
+    <line x1="60" y1="68" x2="730" y2="68" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="100" x2="730" y2="100" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="135" x2="730" y2="135" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="168" x2="730" y2="168" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="203" x2="730" y2="203" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="235" x2="730" y2="235" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <line x1="60" y1="270" x2="730" y2="270" stroke="#c8c4b8" stroke-width="0.3" stroke-dasharray="3 3"/>
+    <!-- X-axis labels (months) -->
+    <text x="88" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">1</text>
+    <text x="144" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">4</text>
+    <text x="200" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">7</text>
+    <text x="256" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">10</text>
+    <text x="312" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">13</text>
+    <text x="368" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">16</text>
+    <text x="424" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">19</text>
+    <text x="480" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">22</text>
+    <text x="530" y="316" text-anchor="middle" font-family="IBM Plex Mono" font-size="7" fill="#5c5c54">24</text>
+    <text x="395" y="336" text-anchor="middle" font-family="IBM Plex Sans Condensed" font-weight="700" font-size="9" fill="#5c5c54" letter-spacing="0.5">MONTH OF SURVEILLANCE</text>
+    <!-- sul1 trend line (highest, increasing) -->
+    <polyline points="88,78 144,72 200,68 256,62 312,58 368,52 424,48 480,42 530,38" fill="none" stroke="#b8862e" stroke-width="2"/>
+    <circle cx="88" cy="78" r="3" fill="#b8862e"/>
+    <circle cx="256" cy="62" r="3" fill="#b8862e"/>
+    <circle cx="530" cy="38" r="3" fill="#b8862e"/>
+    <!-- blaCTX-M trend line (second highest, gradual increase) -->
+    <polyline points="88,108 144,102 200,98 256,92 312,88 368,82 424,78 480,72 530,68" fill="none" stroke="#c45a3c" stroke-width="2"/>
+    <circle cx="88" cy="108" r="3" fill="#c45a3c"/>
+    <circle cx="256" cy="92" r="3" fill="#c45a3c"/>
+    <circle cx="530" cy="68" r="3" fill="#c45a3c"/>
+    <!-- tetM trend line (third, moderate increase) -->
+    <polyline points="88,128 144,122 200,118 256,112 312,108 368,102 424,98 480,92 530,88" fill="none" stroke="#6e5aad" stroke-width="2"/>
+    <circle cx="88" cy="128" r="3" fill="#6e5aad"/>
+    <circle cx="256" cy="112" r="3" fill="#6e5aad"/>
+    <circle cx="530" cy="88" r="3" fill="#6e5aad"/>
+    <!-- blaNDM trend line (fourth, steeper increase from lower baseline) -->
+    <polyline points="88,198 144,188 200,178 256,168 312,155 368,142 424,132 480,120 530,108" fill="none" stroke="#3c8a6e" stroke-width="2"/>
+    <circle cx="88" cy="198" r="3" fill="#3c8a6e"/>
+    <circle cx="256" cy="168" r="3" fill="#3c8a6e"/>
+    <circle cx="530" cy="108" r="3" fill="#3c8a6e"/>
+    <!-- Trend annotations -->
+    <text x="540" y="36" font-family="IBM Plex Mono" font-size="8" fill="#b8862e" font-weight="700">sul1 +15.2%</text>
+    <text x="540" y="66" font-family="IBM Plex Mono" font-size="8" fill="#c45a3c" font-weight="700">blaCTX-M +11.8%</text>
+    <text x="540" y="86" font-family="IBM Plex Mono" font-size="8" fill="#6e5aad" font-weight="700">tetM +11.1%</text>
+    <text x="540" y="106" font-family="IBM Plex Mono" font-size="8" fill="#3c8a6e" font-weight="700">blaNDM +26.4%</text>
+    <!-- Annotation: seasonal dip -->
+    <line x1="200" y1="98" x2="200" y2="285" stroke="#8a8a80" stroke-width="0.5" stroke-dasharray="2 2"/>
+    <text x="204" y="292" font-family="IBM Plex Sans Condensed" font-size="7" fill="#8a8a80">Summer dip</text>
+    <!-- Legend box -->
+    <rect x="62" y="346" width="660" height="26" fill="#f0eee8" stroke="#c8c4b8" stroke-width="0.5"/>
+    <line x1="72" y1="360" x2="92" y2="360" stroke="#c45a3c" stroke-width="2"/>
+    <text x="96" y="363" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">blaCTX-M</text>
+    <line x1="162" y1="360" x2="182" y2="360" stroke="#3c8a6e" stroke-width="2"/>
+    <text x="186" y="363" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">blaNDM</text>
+    <line x1="242" y1="360" x2="262" y2="360" stroke="#6e5aad" stroke-width="2"/>
+    <text x="266" y="363" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">tetM</text>
+    <line x1="312" y1="360" x2="332" y2="360" stroke="#b8862e" stroke-width="2"/>
+    <text x="336" y="363" font-family="IBM Plex Mono" font-size="7" fill="#1a1a18">sul1</text>
+    <text x="420" y="363" font-family="IBM Plex Sans Condensed" font-size="7" fill="#5c5c54">Percentage change is cumulative over 24 months. Linear trend test: p &lt; 0.01 for all four genes.</text>
+  </svg>
+  <figcaption class="caption"><span class="fig-num">Figure S3.</span> Temporal trends in mean prevalence across all sites for the top four gene families over the 24-month surveillance period. All four genes show statistically significant upward trends (linear trend test, p &lt; 0.01). blaNDM shows the steepest relative increase (+26.4 pct cumulative), suggesting accelerating dissemination of New Delhi metallo-beta-lactamase genes. A seasonal dip in prevalence was observed during summer months (months 5-8 and 17-20), potentially reflecting lower patient volume or reduced antibiotic prescribing.</figcaption>
+</figure>
+<div class="figure-annotation">Annotation: The accelerating blaNDM trend is of particular clinical concern given the limited treatment options for NDM-producing organisms. The seasonal pattern aligns with known variation in antibiotic consumption in European hospital settings (ECDC ESAC-Net data). Joinpoint regression analysis identified a single change point at month 12 for blaNDM (slope increase from 0.8 to 1.4 pct per month).</div>

--- a/supplementary/content/sections/3-additional-methods.md
+++ b/supplementary/content/sections/3-additional-methods.md
@@ -1,0 +1,333 @@
++++
+title = "S3. Additional Methods"
+description = "Extended methodological details including DNA extraction protocol, PCR primer sequences, bioinformatics pipeline specifications, and quality control metrics."
+weight = 3
+template = "post"
+tags = ["methods", "PCR", "bioinformatics", "QC"]
+categories = ["sections"]
+[extra]
+section_number = "S3"
++++
+
+## DNA Extraction Protocol
+
+Genomic DNA was extracted from bacterial isolates using the DNeasy Blood and Tissue Kit (Qiagen, Hilden, Germany) with the following modifications for wastewater-derived samples:
+
+1. Pre-treatment with lysozyme (10 mg/mL) at 37C for 30 min to enhance lysis of Gram-positive organisms
+2. Proteinase K digestion extended to 2 hours at 56C
+3. Additional ethanol wash step (500 uL, 80 pct) to remove humic acid co-precipitates
+4. Elution in 100 uL nuclease-free water, repeated twice
+5. DNA concentration measured by Qubit 4.0 fluorometer (dsDNA HS Assay Kit)
+6. Purity assessed by NanoDrop 2000 (A260/A280 ratio 1.8-2.0 accepted)
+
+Samples with DNA yield below 10 ng/uL or A260/A280 ratio outside 1.7-2.1 were re-extracted. Extraction blanks (n=48, one per extraction batch) were processed in parallel and screened by qPCR to monitor contamination.
+
+## Table S4. PCR Primer Sequences and Conditions
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S4.</span> Oligonucleotide primers used for resistance gene detection by multiplex PCR and qPCR.</caption>
+  <thead>
+    <tr>
+      <th>Gene Target</th>
+      <th>Primer Name</th>
+      <th>Sequence (5' to 3')</th>
+      <th>Amplicon (bp)</th>
+      <th>Tm (C)</th>
+      <th>Reference</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>blaCTX-M (group 1)</td>
+      <td>CTX-M-1F</td>
+      <td><code>AAAAATCACTGCGCCAGTTC</code></td>
+      <td class="num" rowspan="2">415</td>
+      <td class="num">58</td>
+      <td rowspan="2">Woodford et al. 2006</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>CTX-M-1R</td>
+      <td><code>AGCTTATTCATCGCCACGTT</code></td>
+      <td class="num">58</td>
+    </tr>
+    <tr>
+      <td>blaKPC</td>
+      <td>KPC-F</td>
+      <td><code>CGTCTAGTTCTGCTGTCTTG</code></td>
+      <td class="num" rowspan="2">798</td>
+      <td class="num">55</td>
+      <td rowspan="2">Bradford et al. 2004</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>KPC-R</td>
+      <td><code>CTTGTCATCCTTGTTAGGCG</code></td>
+      <td class="num">55</td>
+    </tr>
+    <tr>
+      <td>blaNDM</td>
+      <td>NDM-F</td>
+      <td><code>GGTTTGGCGATCTGGTTTTC</code></td>
+      <td class="num" rowspan="2">621</td>
+      <td class="num">56</td>
+      <td rowspan="2">Poirel et al. 2011</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>NDM-R</td>
+      <td><code>CGGAATGGCTCATCACGATC</code></td>
+      <td class="num">56</td>
+    </tr>
+    <tr>
+      <td>mcr-1</td>
+      <td>MCR1-F</td>
+      <td><code>CGGTCAGTCCGTTTGTTC</code></td>
+      <td class="num" rowspan="2">309</td>
+      <td class="num">58</td>
+      <td rowspan="2">Liu et al. 2016</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>MCR1-R</td>
+      <td><code>CTTGGTCGGTCTGTAGGG</code></td>
+      <td class="num">58</td>
+    </tr>
+    <tr>
+      <td>vanA</td>
+      <td>vanA-F</td>
+      <td><code>GGGAAAACGACAATTGC</code></td>
+      <td class="num" rowspan="2">732</td>
+      <td class="num">54</td>
+      <td rowspan="2">Dutka-Malen et al. 1995</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>vanA-R</td>
+      <td><code>GTACAATGCGGCCGTTA</code></td>
+      <td class="num">54</td>
+    </tr>
+    <tr>
+      <td>qnrS</td>
+      <td>qnrS-F</td>
+      <td><code>ACGACATTCGTCAACTGCAA</code></td>
+      <td class="num" rowspan="2">417</td>
+      <td class="num">57</td>
+      <td rowspan="2">Cattoir et al. 2007</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>qnrS-R</td>
+      <td><code>TAAATTGGCACCCTGTAGGC</code></td>
+      <td class="num">57</td>
+    </tr>
+    <tr>
+      <td>tetM</td>
+      <td>tetM-F</td>
+      <td><code>ACAGAAAGCTTATTATATAAC</code></td>
+      <td class="num" rowspan="2">171</td>
+      <td class="num">50</td>
+      <td rowspan="2">Aminov et al. 2001</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>tetM-R</td>
+      <td><code>TGGCGTGTCTATGATGTTCAC</code></td>
+      <td class="num">50</td>
+    </tr>
+    <tr>
+      <td>sul1</td>
+      <td>sul1-F</td>
+      <td><code>CGGCGTGGGCTACCTGAACG</code></td>
+      <td class="num" rowspan="2">433</td>
+      <td class="num">60</td>
+      <td rowspan="2">Pei et al. 2006</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>sul1-R</td>
+      <td><code>GCCGATCGCGTGAAGTTCCG</code></td>
+      <td class="num">60</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">All primers validated in silico against NCBI nr database. Specificity confirmed by Sanger sequencing of representative amplicons (n=5 per gene target). Multiplex grouping: Group 1 (blaCTX-M, blaKPC, blaNDM); Group 2 (mcr-1, vanA, qnrS); Group 3 (tetM, sul1). 16S rRNA internal control included in all reactions.</td></tr>
+  </tfoot>
+</table>
+
+### PCR Cycling Conditions
+
+- Initial denaturation: 95C for 5 min
+- 30 cycles of: 95C for 30 sec, annealing (see Tm above) for 30 sec, 72C for 45 sec
+- Final extension: 72C for 7 min
+- Multiplex reactions: HotStarTaq Multiplex PCR Kit (Qiagen), 25 uL total volume, 2 uL template DNA (10-50 ng)
+
+## Bioinformatics Pipeline
+
+Whole-genome sequencing was performed on a subset of 120 isolates (selected for MDR phenotype) using Illumina NovaSeq 6000 (2x150 bp paired-end reads). The bioinformatics pipeline comprised:
+
+### Table S5. Software and Databases
+
+<table class="paper-table compact">
+  <caption><span class="tab-num">Table S5.</span> Software tools and database versions used in the bioinformatics analysis pipeline.</caption>
+  <thead>
+    <tr>
+      <th>Step</th>
+      <th>Software</th>
+      <th>Version</th>
+      <th>Parameters</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Read QC</td>
+      <td>FastQC</td>
+      <td>0.12.1</td>
+      <td>Default</td>
+    </tr>
+    <tr>
+      <td>Adapter trimming</td>
+      <td>Trimmomatic</td>
+      <td>0.39</td>
+      <td>ILLUMINACLIP:2:30:10 LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15 MINLEN:36</td>
+    </tr>
+    <tr>
+      <td>Assembly</td>
+      <td>SPAdes</td>
+      <td>3.15.5</td>
+      <td>--careful --cov-cutoff auto</td>
+    </tr>
+    <tr>
+      <td>Assembly QC</td>
+      <td>QUAST</td>
+      <td>5.2.0</td>
+      <td>Default</td>
+    </tr>
+    <tr>
+      <td>ARG detection</td>
+      <td>ABRicate</td>
+      <td>1.0.1</td>
+      <td>--minid 80 --mincov 60 --db resfinder</td>
+    </tr>
+    <tr>
+      <td>ARG database</td>
+      <td>ResFinder</td>
+      <td>4.4.2</td>
+      <td>Updated 2025-11-01</td>
+    </tr>
+    <tr>
+      <td>Plasmid typing</td>
+      <td>PlasmidFinder</td>
+      <td>2.1</td>
+      <td>--threshold 0.95</td>
+    </tr>
+    <tr>
+      <td>MLST</td>
+      <td>mlst</td>
+      <td>2.23.0</td>
+      <td>Default (PubMLST)</td>
+    </tr>
+    <tr>
+      <td>Phylogenetics</td>
+      <td>IQ-TREE</td>
+      <td>2.2.6</td>
+      <td>-m GTR+G4 -bb 1000</td>
+    </tr>
+    <tr>
+      <td>Visualization</td>
+      <td>iTOL</td>
+      <td>v6</td>
+      <td>Web interface</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">Pipeline orchestrated with Snakemake v7.32.4. All software installed via Bioconda. Reproducible environment specification available in supplementary file S5_environment.yml.</td></tr>
+  </tfoot>
+</table>
+
+## Quality Control Metrics
+
+### Table S6. Sequencing QC Summary
+
+<table class="paper-table compact">
+  <caption><span class="tab-num">Table S6.</span> Summary sequencing quality metrics for 120 whole-genome-sequenced isolates.</caption>
+  <thead>
+    <tr>
+      <th>Metric</th>
+      <th>Median</th>
+      <th>IQR</th>
+      <th>Min</th>
+      <th>Max</th>
+      <th>Threshold</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Total reads (M)</td>
+      <td class="num">4.2</td>
+      <td class="num">3.6-5.1</td>
+      <td class="num">2.1</td>
+      <td class="num">8.4</td>
+      <td class="num">&gt;1.0</td>
+    </tr>
+    <tr>
+      <td>Reads after trimming (M)</td>
+      <td class="num">3.8</td>
+      <td class="num">3.2-4.6</td>
+      <td class="num">1.9</td>
+      <td class="num">7.6</td>
+      <td class="num">&gt;0.8</td>
+    </tr>
+    <tr>
+      <td>Mean read quality (Phred)</td>
+      <td class="num">35.2</td>
+      <td class="num">34.1-36.0</td>
+      <td class="num">30.4</td>
+      <td class="num">37.8</td>
+      <td class="num">&gt;30</td>
+    </tr>
+    <tr>
+      <td>GC content (pct)</td>
+      <td class="num">50.8</td>
+      <td class="num">48.2-52.4</td>
+      <td class="num">38.6</td>
+      <td class="num">66.2</td>
+      <td class="num">35-70</td>
+    </tr>
+    <tr>
+      <td>Genome coverage (x)</td>
+      <td class="num">85</td>
+      <td class="num">62-118</td>
+      <td class="num">32</td>
+      <td class="num">210</td>
+      <td class="num">&gt;30</td>
+    </tr>
+    <tr>
+      <td>Assembly N50 (kb)</td>
+      <td class="num">142</td>
+      <td class="num">98-205</td>
+      <td class="num">42</td>
+      <td class="num">512</td>
+      <td class="num">&gt;20</td>
+    </tr>
+    <tr>
+      <td>Contigs (&gt;500 bp)</td>
+      <td class="num">68</td>
+      <td class="num">45-112</td>
+      <td class="num">22</td>
+      <td class="num">248</td>
+      <td class="num">&lt;500</td>
+    </tr>
+    <tr>
+      <td>Genome size (Mb)</td>
+      <td class="num">5.12</td>
+      <td class="num">4.68-5.48</td>
+      <td class="num">3.82</td>
+      <td class="num">6.94</td>
+      <td class="num">3-8</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">All 120 isolates passed all QC thresholds. IQR = interquartile range. Two isolates with coverage below 40x were re-sequenced to achieve target depth. N50 values reflect short-read assembly quality only.</td></tr>
+  </tfoot>
+</table>

--- a/supplementary/content/sections/4-sensitivity-analyses.md
+++ b/supplementary/content/sections/4-sensitivity-analyses.md
@@ -1,0 +1,265 @@
++++
+title = "S4. Sensitivity Analyses"
+description = "Alternative statistical models, robustness checks, and subgroup analyses by site type to evaluate the stability of primary findings."
+weight = 4
+template = "post"
+tags = ["statistics", "sensitivity", "robustness", "subgroup"]
+categories = ["sections"]
+[extra]
+section_number = "S4"
++++
+
+## Alternative Statistical Models
+
+The primary analysis used logistic regression with site as a random effect. Sensitivity analyses tested alternative model specifications to assess robustness.
+
+### Table S7. Model Comparison for blaCTX-M Prevalence
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S7.</span> Comparison of estimated odds ratios (OR) for ICU vs. outpatient sites using alternative statistical models for blaCTX-M prevalence.</caption>
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>OR (ICU vs. Outpatient)</th>
+      <th>95% CI</th>
+      <th>p-value</th>
+      <th>AIC</th>
+      <th>BIC</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Primary: Mixed-effects logistic</strong></td>
+      <td class="num">20.4</td>
+      <td class="num">12.1-34.5</td>
+      <td class="num">&lt;0.001</td>
+      <td class="num">842.3</td>
+      <td class="num">868.1</td>
+    </tr>
+    <tr>
+      <td>Fixed-effects logistic</td>
+      <td class="num">22.1</td>
+      <td class="num">13.4-36.4</td>
+      <td class="num">&lt;0.001</td>
+      <td class="num">856.7</td>
+      <td class="num">874.2</td>
+    </tr>
+    <tr>
+      <td>GEE (exchangeable)</td>
+      <td class="num">19.8</td>
+      <td class="num">11.2-35.0</td>
+      <td class="num">&lt;0.001</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>GEE (autoregressive)</td>
+      <td class="num">18.6</td>
+      <td class="num">10.4-33.2</td>
+      <td class="num">&lt;0.001</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Bayesian logistic (weakly informative prior)</td>
+      <td class="num">19.2</td>
+      <td class="num">10.8-33.8</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+      <td class="num">--</td>
+    </tr>
+    <tr>
+      <td>Negative binomial (count model)</td>
+      <td class="num">IRR: 3.01</td>
+      <td class="num">2.42-3.74</td>
+      <td class="num">&lt;0.001</td>
+      <td class="num">1024.6</td>
+      <td class="num">1048.8</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">OR = odds ratio. IRR = incidence rate ratio (negative binomial model). GEE = generalized estimating equations. AIC/BIC not applicable for GEE and Bayesian models. Bayesian CI = 95 pct credible interval (4 chains, 10,000 iterations, 2,000 warmup). All models adjusted for month of sampling and species composition.</td></tr>
+  </tfoot>
+</table>
+
+## Table S8. Robustness Checks
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S8.</span> Sensitivity of primary findings to analytic decisions. Each row modifies one aspect of the primary analysis.</caption>
+  <thead>
+    <tr>
+      <th>Analysis Variant</th>
+      <th>Modification</th>
+      <th>N Isolates</th>
+      <th>OR (ICU vs. Outpt)</th>
+      <th>95% CI</th>
+      <th>Conclusion Changed?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Primary analysis</td>
+      <td>None</td>
+      <td class="num">847</td>
+      <td class="num">20.4</td>
+      <td class="num">12.1-34.5</td>
+      <td>--</td>
+    </tr>
+    <tr>
+      <td>Exclude month 1</td>
+      <td>Remove first sampling month</td>
+      <td class="num">812</td>
+      <td class="num">19.8</td>
+      <td class="num">11.6-33.8</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Exclude low-quality DNA</td>
+      <td>Remove A260/A280 &lt; 1.8</td>
+      <td class="num">831</td>
+      <td class="num">21.0</td>
+      <td class="num">12.3-35.8</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Species-stratified</td>
+      <td><em>E. coli</em> only</td>
+      <td class="num">412</td>
+      <td class="num">18.2</td>
+      <td class="num">9.4-35.2</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Species-stratified</td>
+      <td><em>K. pneumoniae</em> only</td>
+      <td class="num">198</td>
+      <td class="num">24.6</td>
+      <td class="num">10.2-59.2</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Exclude WWTP sites</td>
+      <td>Hospital sites only</td>
+      <td class="num">693</td>
+      <td class="num">21.2</td>
+      <td class="num">12.4-36.2</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Quarterly aggregation</td>
+      <td>3-month pooled samples</td>
+      <td class="num">847</td>
+      <td class="num">19.6</td>
+      <td class="num">10.8-35.5</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Bootstrap (1000 resamples)</td>
+      <td>Non-parametric CI</td>
+      <td class="num">847</td>
+      <td class="num">20.1</td>
+      <td class="num">11.4-36.8</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Multiple imputation</td>
+      <td>5 pct missing species data imputed</td>
+      <td class="num">847</td>
+      <td class="num">20.8</td>
+      <td class="num">12.0-36.0</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Stricter PCR threshold</td>
+      <td>Only strong-band positives</td>
+      <td class="num">847</td>
+      <td class="num">16.8</td>
+      <td class="num">9.8-28.8</td>
+      <td>No</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">All analyses use blaCTX-M as the outcome. OR = odds ratio for ICU vs. outpatient comparison. Conclusion changed = whether the ICU vs. outpatient comparison remains statistically significant at alpha = 0.05. All variants yield consistent results, supporting robustness of the primary finding.</td></tr>
+  </tfoot>
+</table>
+
+## Table S9. Subgroup Analyses by Site Type
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S9.</span> Within-site-type analysis of temporal trend in overall ARG burden (mean number of genes detected per isolate).</caption>
+  <thead>
+    <tr>
+      <th>Site Type</th>
+      <th>N Isolates</th>
+      <th>Mean ARG/Isolate (Month 1-6)</th>
+      <th>Mean ARG/Isolate (Month 19-24)</th>
+      <th>Change</th>
+      <th>p (trend)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>ICU</td>
+      <td class="num">218</td>
+      <td class="num">5.4</td>
+      <td class="num">6.2</td>
+      <td class="num">+0.8</td>
+      <td class="num">0.003</td>
+    </tr>
+    <tr>
+      <td>Surgical</td>
+      <td class="num">165</td>
+      <td class="num">3.8</td>
+      <td class="num">4.6</td>
+      <td class="num">+0.8</td>
+      <td class="num">0.008</td>
+    </tr>
+    <tr>
+      <td>General</td>
+      <td class="num">198</td>
+      <td class="num">2.6</td>
+      <td class="num">3.4</td>
+      <td class="num">+0.8</td>
+      <td class="num">0.012</td>
+    </tr>
+    <tr>
+      <td>Outpatient</td>
+      <td class="num">112</td>
+      <td class="num">1.4</td>
+      <td class="num">2.0</td>
+      <td class="num">+0.6</td>
+      <td class="num">0.041</td>
+    </tr>
+    <tr>
+      <td>WWTP Influent</td>
+      <td class="num">82</td>
+      <td class="num">4.2</td>
+      <td class="num">5.0</td>
+      <td class="num">+0.8</td>
+      <td class="num">0.018</td>
+    </tr>
+    <tr>
+      <td>WWTP Effluent</td>
+      <td class="num">44</td>
+      <td class="num">2.2</td>
+      <td class="num">2.8</td>
+      <td class="num">+0.6</td>
+      <td class="num">0.062</td>
+    </tr>
+    <tr>
+      <td>River Downstream</td>
+      <td class="num">28</td>
+      <td class="num">1.0</td>
+      <td class="num">1.6</td>
+      <td class="num">+0.6</td>
+      <td class="num">0.088</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">ARG/Isolate = mean number of the 8 target resistance genes detected per isolate. p (trend) from linear regression of ARG count on month. Positive trends observed across all site types, though smaller magnitude and borderline significance in WWTP effluent and river sites, consistent with dilution and treatment effects.</td></tr>
+  </tfoot>
+</table>
+
+## Interaction Analysis
+
+To test whether temporal trends differed by site type, a mixed-effects model with a site-type x month interaction term was fitted. The interaction was statistically significant (Likelihood ratio test: chi-squared = 14.8, df = 6, p = 0.022), indicating that the rate of increase in ARG burden was steeper in ICU and surgical ward effluent compared to outpatient and environmental sites. However, the direction of the trend (increasing) was consistent across all site types.

--- a/supplementary/content/sections/5-raw-data-summary.md
+++ b/supplementary/content/sections/5-raw-data-summary.md
@@ -1,0 +1,238 @@
++++
+title = "S5. Raw Data Summary"
+description = "Data availability statement, data dictionary, file format descriptions, and repository access information for all supplementary datasets."
+weight = 5
+template = "post"
+tags = ["data", "raw-data", "repository", "dictionary"]
+categories = ["sections"]
+[extra]
+section_number = "S5"
++++
+
+## Data Availability
+
+All raw data and processed datasets generated during this study have been deposited in publicly accessible repositories:
+
+- **Sequence reads:** NCBI Sequence Read Archive (SRA), BioProject PRJNA987654, 120 accessions (SRR28000001-SRR28000120)
+- **Assembled genomes:** NCBI GenBank, accessions CP150001-CP150120
+- **Isolate metadata and ARG profiles:** Figshare, doi:10.6084/m9.figshare.24681234
+- **Analysis code:** GitHub, https://github.com/chen-lab/hospital-resistome-2026
+
+Data access is unrestricted. All files are released under CC BY 4.0.
+
+## Table S10. Data Dictionary
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table S10.</span> Data dictionary for the primary supplementary dataset (S1_isolates.csv).</caption>
+  <thead>
+    <tr>
+      <th>Column</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Values / Range</th>
+      <th>Missing</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>isolate_id</code></td>
+      <td>String</td>
+      <td>Unique isolate identifier</td>
+      <td>WW-001 to WW-847</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>site_code</code></td>
+      <td>String</td>
+      <td>Sampling site code</td>
+      <td>ICU-A, ICU-B, Surg-1, Surg-2, Gen-A, Gen-B, Gen-C, Outpt-1, Outpt-2, WWTP-In, WWTP-Eff, River</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>site_type</code></td>
+      <td>String</td>
+      <td>Ward type classification</td>
+      <td>ICU, Surgical, General, Outpatient, WWTP, Environment</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>month</code></td>
+      <td>Integer</td>
+      <td>Month of surveillance (1-24)</td>
+      <td>1-24</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>date_collected</code></td>
+      <td>Date</td>
+      <td>Sampling date (ISO 8601)</td>
+      <td>2024-01-15 to 2025-12-18</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>species</code></td>
+      <td>String</td>
+      <td>Bacterial species (MALDI-TOF)</td>
+      <td>E. coli, K. pneumoniae, P. aeruginosa, A. baumannii, E. faecium, other</td>
+      <td class="num">42 (5.0%)</td>
+    </tr>
+    <tr>
+      <td><code>blaCTX_M</code></td>
+      <td>Binary</td>
+      <td>blaCTX-M gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>blaKPC</code></td>
+      <td>Binary</td>
+      <td>blaKPC gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>blaNDM</code></td>
+      <td>Binary</td>
+      <td>blaNDM gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>mcr_1</code></td>
+      <td>Binary</td>
+      <td>mcr-1 gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>vanA</code></td>
+      <td>Binary</td>
+      <td>vanA gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>qnrS</code></td>
+      <td>Binary</td>
+      <td>qnrS gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>tetM</code></td>
+      <td>Binary</td>
+      <td>tetM gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>sul1</code></td>
+      <td>Binary</td>
+      <td>sul1 gene detection</td>
+      <td>0 = negative, 1 = positive</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>arg_count</code></td>
+      <td>Integer</td>
+      <td>Total ARGs detected (0-8)</td>
+      <td>0-8</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>mdr</code></td>
+      <td>Binary</td>
+      <td>Multidrug resistant (3+ classes)</td>
+      <td>0 = no, 1 = yes</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>wgs_available</code></td>
+      <td>Binary</td>
+      <td>Whole-genome sequence available</td>
+      <td>0 = no, 1 = yes</td>
+      <td class="num">0</td>
+    </tr>
+    <tr>
+      <td><code>sra_accession</code></td>
+      <td>String</td>
+      <td>SRA accession (if WGS)</td>
+      <td>SRR28000001-SRR28000120</td>
+      <td class="num">727 (85.8%)</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="5">Missing values for species reflect isolates that failed MALDI-TOF identification (score &lt; 2.0). SRA accession is NA for isolates without whole-genome sequencing. All binary gene detection fields have zero missing values.</td></tr>
+  </tfoot>
+</table>
+
+## File Manifest
+
+<table class="paper-table compact">
+  <caption><span class="tab-num">Table S11.</span> Complete list of supplementary data files deposited on Figshare.</caption>
+  <thead>
+    <tr>
+      <th>Filename</th>
+      <th>Format</th>
+      <th>Size</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>S1_isolates.csv</code></td>
+      <td>CSV (UTF-8)</td>
+      <td class="num">142 KB</td>
+      <td>Complete isolate-level data (847 rows, 18 columns)</td>
+    </tr>
+    <tr>
+      <td><code>S2_mic_data.csv</code></td>
+      <td>CSV (UTF-8)</td>
+      <td class="num">86 KB</td>
+      <td>MIC values for ESBL-producing E. coli (312 rows, 12 columns)</td>
+    </tr>
+    <tr>
+      <td><code>S3_prevalence_matrix.csv</code></td>
+      <td>CSV (UTF-8)</td>
+      <td class="num">4 KB</td>
+      <td>Gene-by-site prevalence matrix (12 x 8)</td>
+    </tr>
+    <tr>
+      <td><code>S4_temporal_data.csv</code></td>
+      <td>CSV (UTF-8)</td>
+      <td class="num">18 KB</td>
+      <td>Monthly prevalence time series (24 months x 8 genes x 12 sites)</td>
+    </tr>
+    <tr>
+      <td><code>S5_environment.yml</code></td>
+      <td>YAML</td>
+      <td class="num">2 KB</td>
+      <td>Conda environment specification for reproducibility</td>
+    </tr>
+    <tr>
+      <td><code>S6_analysis_code.R</code></td>
+      <td>R script</td>
+      <td class="num">24 KB</td>
+      <td>Complete statistical analysis code (R 4.3.2)</td>
+    </tr>
+    <tr>
+      <td><code>S7_snakefile</code></td>
+      <td>Snakemake</td>
+      <td class="num">8 KB</td>
+      <td>Bioinformatics pipeline workflow definition</td>
+    </tr>
+    <tr>
+      <td><code>S8_phylogeny.nwk</code></td>
+      <td>Newick</td>
+      <td class="num">12 KB</td>
+      <td>Maximum-likelihood phylogenetic tree (120 isolates)</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="4">All files use UTF-8 encoding with Unix line endings. CSV files use comma delimiter with double-quote text qualifier. Missing values represented as NA. Column headers in first row.</td></tr>
+  </tfoot>
+</table>
+
+## Checksums
+
+File integrity can be verified using SHA-256 checksums provided in the accompanying `checksums.sha256` file deposited alongside the data files on Figshare.

--- a/supplementary/content/sections/_index.md
+++ b/supplementary/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Supplementary Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Extended data sections accompanying the parent manuscript. Each section contains detailed supplementary materials referenced in the main text.

--- a/supplementary/static/css/style.css
+++ b/supplementary/static/css/style.css
@@ -1,0 +1,732 @@
+/* ============================================================================
+   Supplementary Data Repository - Extended Data Paper
+   Light warm off-white background, compact dense layout for data-heavy content.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #faf9f5;
+  --paper-2: #f0eee8;
+  --paper-3: #e6e3db;
+  --ink: #1a1a18;
+  --ink-2: #2e2e2a;
+  --ink-3: #5c5c54;
+  --ink-4: #8a8a80;
+  --rule: #c8c4b8;
+  --rule-2: #d8d4c8;
+  --accent: #2c5f8a;
+  --accent-2: #1d4a6e;
+  --accent-3: #4a90c4;
+  --gene-a: #c45a3c;
+  --gene-b: #3c8a6e;
+  --gene-c: #6e5aad;
+  --gene-d: #b8862e;
+  --notice: #8a6e2c;
+  --notice-bg: #f5f0e0;
+  --code-bg: #f0eee8;
+  --white: #ffffff;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.4rem 0 1rem;
+  border-bottom: 2px solid var(--ink);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 56px; height: 36px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "Barlow Condensed", "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--ink);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.journal-sub {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.15em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.2rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 2rem 0 3rem;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.8rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-title {
+  font-family: "Barlow Condensed", "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3.2vw, 2.2rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.8rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  margin: 0 0 0.3rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 700; }
+.paper-authors sup { color: var(--accent); font-size: 0.65em; }
+
+.paper-affiliations {
+  font-family: "Noto Serif", serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  margin: 0.15rem 0 0;
+  line-height: 1.4;
+}
+
+.paper-doi {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 0.8rem;
+}
+
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Notice box (supplementary materials) ---------------- */
+
+.notice-box {
+  background: var(--notice-bg);
+  border: 1px solid var(--notice);
+  border-left: 3px solid var(--notice);
+  padding: 0.8rem 1.2rem;
+  margin: 1.4rem 0;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.82rem;
+  color: var(--ink-2);
+  line-height: 1.45;
+}
+
+.notice-box strong {
+  font-weight: 700;
+  color: var(--notice);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+}
+
+/* ---------------- Metrics bar ---------------- */
+
+.metrics-bar {
+  display: flex;
+  gap: 0;
+  margin: 1.6rem 0;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.metrics-bar .metric {
+  flex: 1;
+  text-align: center;
+  padding: 0.7rem 0.5rem;
+  border-right: 1px solid var(--rule);
+}
+
+.metrics-bar .metric:last-child { border-right: none; }
+
+.metrics-bar .metric-value {
+  display: block;
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.metrics-bar .metric-label {
+  display: block;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: 0.25rem;
+}
+
+/* ---------------- Section typography (compact) ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "Barlow Condensed", "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+  margin: 1.8rem 0 0.6rem;
+  padding-top: 0.3rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+  margin: 1.4rem 0 0.4rem;
+  letter-spacing: 0.02em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "Noto Serif", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  margin: 1rem 0 0.3rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 0.6rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover {
+  color: var(--accent-2);
+}
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 0.6rem 0;
+  padding-left: 1.4rem;
+}
+
+.paper-article li,
+.paper-content li {
+  margin: 0.2rem 0;
+  font-size: 0.92em;
+}
+
+.paper-article code,
+.paper-content code {
+  font-family: "IBM Plex Mono", monospace;
+  background: var(--code-bg);
+  padding: 0.1rem 0.3rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.82em;
+  color: var(--gene-a);
+}
+
+.paper-article pre,
+.paper-content pre {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 0.8rem 1rem;
+  overflow-x: auto;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  margin: 1rem 0;
+}
+
+.paper-article pre code,
+.paper-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+/* ---------------- Section header (for post pages) ---------------- */
+
+.paper-section-header {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.4rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin: 0 0 0.4rem;
+}
+
+.paper-section-title {
+  font-family: "Barlow Condensed", "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.3rem, 2.8vw, 1.8rem);
+  line-height: 1.15;
+  margin: 0 0 0.4rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.92rem;
+  color: var(--ink-3);
+  margin: 0.3rem 0 0;
+  line-height: 1.4;
+}
+
+/* ---------------- Figures (supplementary figure plates) ---------------- */
+
+.figure {
+  margin: 1.6rem 0;
+  padding: 0.8rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--white);
+  border: 1px solid var(--rule);
+  padding: 0.6rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.82rem;
+  color: var(--ink-2);
+  line-height: 1.45;
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num,
+.figure figcaption .fig-num {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.3em;
+}
+
+.figure-annotation {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  margin-top: 0.3rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--paper-3);
+  border-left: 2px solid var(--accent-3);
+  line-height: 1.35;
+}
+
+/* ---------------- Dense tables (supplementary data) ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.2rem 0;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-size: 0.82rem;
+  color: var(--ink-2);
+  margin-bottom: 0.4rem;
+  font-family: "Crimson Pro", serif;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-right: 0.3em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--rule-2);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink-3);
+  white-space: nowrap;
+}
+
+.paper-table td.num {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.74rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.paper-table tbody tr:nth-child(even) {
+  background: var(--paper-2);
+}
+
+.paper-table tbody tr:hover {
+  background: var(--paper-3);
+}
+
+.paper-table tfoot td {
+  font-style: italic;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  padding-top: 0.5rem;
+  border-bottom: none;
+  border-top: 1px solid var(--rule);
+}
+
+/* ---------------- Compact two-column table for data dictionaries ---------------- */
+
+.paper-table.compact th,
+.paper-table.compact td {
+  padding: 0.25rem 0.4rem;
+  font-size: 0.74rem;
+}
+
+.paper-table.compact thead th {
+  font-size: 0.68rem;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: none; padding-left: 0; margin: 1.2rem 0; }
+.section-list li {
+  padding: 0.4rem 0;
+  border-bottom: 1px dashed var(--rule);
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.section-list li::before {
+  content: "S" counter(list-item);
+  counter-increment: list-item;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  min-width: 2rem;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.86rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Pagination (disabled but styled) ---------------- */
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 0.4rem;
+  margin: 2rem 0;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.82rem;
+}
+
+.pagination a, .pagination span {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--rule);
+  color: var(--ink-3);
+  text-decoration: none;
+}
+
+.pagination a:hover { background: var(--paper-2); color: var(--accent); }
+.pagination .current { background: var(--accent); color: var(--white); border-color: var(--accent); }
+
+/* ---------------- Taxonomy pages ---------------- */
+
+.taxonomy-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 1rem 0;
+}
+
+.taxonomy-list li a {
+  display: inline-block;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-3);
+  border: 1px solid var(--rule);
+  padding: 0.2rem 0.5rem;
+  text-decoration: none;
+}
+
+.taxonomy-list li a:hover {
+  background: var(--accent);
+  color: var(--white);
+  border-color: var(--accent);
+}
+
+/* ---------------- Buttons / Links ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 0.1rem;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+/* ---------------- Section footer nav ---------------- */
+
+.paper-section-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* ---------------- Error page ---------------- */
+
+.error-page {
+  text-align: center;
+  padding: 3rem 0;
+}
+
+.error-page h1 {
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 2rem;
+  color: var(--ink);
+  margin-bottom: 0.8rem;
+}
+
+/* ---------------- Alert shortcode ---------------- */
+
+.alert {
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+  border-left: 3px solid var(--accent);
+  margin: 1rem 0;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.alert strong {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+  color: var(--accent);
+}
+
+/* ---------------- Figure reference list page ---------------- */
+
+.figure-ref-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.figure-ref-list li {
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--rule-2);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.86rem;
+}
+
+.figure-ref-list li .ref-id {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-weight: 700;
+  color: var(--accent);
+  margin-right: 0.5em;
+  font-size: 0.82rem;
+}
+
+/* ---------------- Heatmap legend / color keys ---------------- */
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.4rem 0 0.8rem;
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.68rem;
+  color: var(--ink-3);
+}
+
+.heatmap-legend .legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--rule);
+}
+
+/* ---------------- Site Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.4rem 0 2rem;
+  border-top: 2px solid var(--ink);
+}
+
+.footer-rule svg { width: 100%; height: 4px; display: block; margin-bottom: 0.8rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.78rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.footer-note {
+  font-family: "IBM Plex Sans Condensed", sans-serif;
+  font-size: 0.66rem;
+  color: var(--ink-3);
+  margin: 0.5rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 14px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .metrics-bar { flex-wrap: wrap; }
+  .metrics-bar .metric { flex: 1 1 45%; }
+  .paper-table { font-size: 0.72rem; }
+  .paper-table th, .paper-table td { padding: 0.25rem 0.35rem; }
+  .figure { padding: 0.4rem; }
+  .figure svg { padding: 0.3rem; }
+}
+
+@media (max-width: 480px) {
+  .metrics-bar .metric { flex: 1 1 100%; border-right: none; border-bottom: 1px solid var(--rule); }
+  .metrics-bar .metric:last-child { border-bottom: none; }
+  .paper-article { padding: 1.2rem 0 2rem; }
+}

--- a/supplementary/templates/404.html
+++ b/supplementary/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested supplementary resource does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; Return to overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/supplementary/templates/footer.html
+++ b/supplementary/templates/footer.html
@@ -1,0 +1,16 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 4" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#c8c4b8" stroke-width="1"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Supplementary Materials for: Chen W, Okonkwo A, Lindqvist S. Resistome Dynamics and Horizontal Gene Transfer in Hospital Wastewater: A 24-Month Genomic Surveillance Study. <em>Environ. Microbiol.</em> 2026;28(3):412-438. doi:10.1111/emi.2026.28.03.412</p>
+        <p class="footer-note">ISSN 1462-2912 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/supplementary/templates/header.html
+++ b/supplementary/templates/header.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed:wght@400;600;700&family=Barlow+Condensed:wght@400;600;700&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Supplementary data home">
+        <svg viewBox="0 0 56 36" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Data grid / chart icon -->
+          <rect x="2" y="2" width="52" height="32" fill="none" stroke="#2c5f8a" stroke-width="1.5" rx="1"/>
+          <line x1="2" y1="10" x2="54" y2="10" stroke="#2c5f8a" stroke-width="1"/>
+          <line x1="2" y1="18" x2="54" y2="18" stroke="#c8c4b8" stroke-width="0.5"/>
+          <line x1="2" y1="26" x2="54" y2="26" stroke="#c8c4b8" stroke-width="0.5"/>
+          <line x1="15" y1="2" x2="15" y2="34" stroke="#c8c4b8" stroke-width="0.5"/>
+          <line x1="28" y1="2" x2="28" y2="34" stroke="#c8c4b8" stroke-width="0.5"/>
+          <line x1="41" y1="2" x2="41" y2="34" stroke="#c8c4b8" stroke-width="0.5"/>
+          <rect x="4" y="12" width="9" height="4" fill="#c45a3c" opacity="0.7"/>
+          <rect x="17" y="12" width="9" height="4" fill="#3c8a6e" opacity="0.7"/>
+          <rect x="30" y="12" width="9" height="4" fill="#6e5aad" opacity="0.5"/>
+          <rect x="43" y="12" width="9" height="4" fill="#b8862e" opacity="0.3"/>
+          <rect x="4" y="20" width="9" height="4" fill="#c45a3c" opacity="0.5"/>
+          <rect x="17" y="20" width="9" height="4" fill="#3c8a6e" opacity="0.9"/>
+          <rect x="30" y="20" width="9" height="4" fill="#6e5aad" opacity="0.7"/>
+          <rect x="43" y="20" width="9" height="4" fill="#b8862e" opacity="0.6"/>
+          <rect x="4" y="28" width="9" height="4" fill="#c45a3c" opacity="0.3"/>
+          <rect x="17" y="28" width="9" height="4" fill="#3c8a6e" opacity="0.4"/>
+          <rect x="30" y="28" width="9" height="4" fill="#6e5aad" opacity="0.9"/>
+          <rect x="43" y="28" width="9" height="4" fill="#b8862e" opacity="0.8"/>
+          <text x="9" y="8" text-anchor="middle" font-family="IBM Plex Mono" font-size="4.5" fill="#2c5f8a">S1</text>
+          <text x="22" y="8" text-anchor="middle" font-family="IBM Plex Mono" font-size="4.5" fill="#2c5f8a">S2</text>
+          <text x="35" y="8" text-anchor="middle" font-family="IBM Plex Mono" font-size="4.5" fill="#2c5f8a">S3</text>
+          <text x="48" y="8" text-anchor="middle" font-family="IBM Plex Mono" font-size="4.5" fill="#2c5f8a">S4</text>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Supplementary Data Repository</span>
+          <span class="journal-sub">Extended Data &middot; Resistome Study &middot; 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">OVERVIEW</a>
+        <a href="{{ base_url }}/sections/">DATA</a>
+        <a href="{{ base_url }}/figures/">FIGURES</a>
+        <a href="{{ base_url }}/appendix/">METHODS</a>
+      </nav>
+    </header>

--- a/supplementary/templates/page.html
+++ b/supplementary/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content | safe }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/supplementary/templates/post.html
+++ b/supplementary/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Supplementary Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content | safe }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/supplementary/templates/section.html
+++ b/supplementary/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content | safe }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/supplementary/templates/shortcodes/alert.html
+++ b/supplementary/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/supplementary/templates/taxonomy.html
+++ b/supplementary/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Browse all indexed terms.</p>
+      {{ content | safe }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/supplementary/templates/taxonomy_term.html
+++ b/supplementary/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="paper-lede">Pages indexed under this term:</p>
+      {{ content | safe }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3622,6 +3622,13 @@
     "cosmic",
     "particles"
   ],
+  "supplementary": [
+    "paper",
+    "light",
+    "supplementary",
+    "data-heavy",
+    "exhaustive"
+  ],
   "supreme-sun": [
     "light",
     "blog",


### PR DESCRIPTION
Closes #1603

## Summary
- Add supplementary light extended data paper example site
- Features SVG extended data visualization charts filling most page space and supplementary figure plates with detailed annotations (heatmaps, multi-panel bar charts, temporal trends)
- Typography: IBM Plex Sans Condensed/Barlow Condensed Bold for compact display; Crimson Pro/Noto Serif for dense body text at compact sizes
- Includes 5 data sections (Extended Tables, Supplementary Figures, Additional Methods, Sensitivity Analyses, Raw Data Summary) plus Figures reference and Appendix
- Updates tags.json with paper, light, supplementary, data-heavy, exhaustive tags

## Test plan
- [x] hwaro build completes successfully (9 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry