### PR TITLE
feat: add systematic-review example site (closes #1613)

### DIFF
--- a/systematic-review/AGENTS.md
+++ b/systematic-review/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/systematic-review/config.toml
+++ b/systematic-review/config.toml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Systematic Review - Evidence Synthesis Paper
+# Issue #1613 | Tags: paper, light, systematic, evidence, methodology
+# =============================================================================
+
+title = "Exercise Interventions for Adolescent Depression: A Systematic Review"
+description = "An evidence synthesis paper with PRISMA flow diagrams, risk of bias traffic-light tables, forest plots, and GRADE evidence tables for exercise-based depression interventions in adolescents."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png

--- a/systematic-review/content/appendix.md
+++ b/systematic-review/content/appendix.md
@@ -1,0 +1,139 @@
++++
+title = "Appendix"
+description = "Supplementary materials including full search strings, excluded study list, sensitivity analyses, and PRISMA checklist."
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+template = "page"
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">SUPPLEMENTARY MATERIALS</p>
+  <h1 class="paper-section-title">Appendix</h1>
+  <p class="paper-lede">Supplementary tables, full search strategies, list of excluded studies with reasons, and additional sensitivity analyses.</p>
+</header>
+
+## A1. Full Search Strategy (MEDLINE via PubMed)
+
+<div class="search-block">
+  <p class="search-block-label">MEDLINE Search String (Executed 30 September 2025)</p>
+  <p class="search-terms">(("adolescent"[MeSH] OR "adolescen*"[tiab] OR "teen*"[tiab] OR "youth"[tiab] OR "young people"[tiab]) AND ("exercise"[MeSH] OR "exercise therapy"[MeSH] OR "physical activity"[tiab] OR "aerobic exercise"[tiab] OR "resistance training"[tiab] OR "yoga"[tiab] OR "running"[tiab] OR "swimming"[tiab] OR "cycling"[tiab]) AND ("depression"[MeSH] OR "depressive disorder"[MeSH] OR "depressive symptoms"[tiab] OR "mood"[tiab] OR "mental health"[tiab]) AND ("randomized controlled trial"[pt] OR "randomized"[tiab] OR "RCT"[tiab]))</p>
+</div>
+
+Results: 1,842 records retrieved.
+
+## A2. Characteristics of Included Studies
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A1.</span> Summary characteristics of the 34 included randomized controlled trials.</caption>
+  <thead>
+    <tr>
+      <th>Study</th>
+      <th>Country</th>
+      <th>N</th>
+      <th>Age (mean)</th>
+      <th>Exercise Type</th>
+      <th>Duration</th>
+      <th>Outcome</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Andersson 2022</td><td>Sweden</td><td class="num">86</td><td class="num">15.4</td><td>Aerobic (running)</td><td>12 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Chen 2021</td><td>China</td><td class="num">124</td><td class="num">14.8</td><td>Aerobic (mixed)</td><td>10 weeks</td><td>CDI</td></tr>
+    <tr><td>Da Silva 2023</td><td>Brazil</td><td class="num">62</td><td class="num">16.1</td><td>Resistance</td><td>8 weeks</td><td>PHQ-A</td></tr>
+    <tr><td>Ekblom 2020</td><td>Sweden</td><td class="num">148</td><td class="num">15.2</td><td>Aerobic (cycling)</td><td>16 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Farahmand 2021</td><td>Iran</td><td class="num">44</td><td class="num">14.6</td><td>Aerobic (dance)</td><td>8 weeks</td><td>CES-D</td></tr>
+    <tr><td>Gupta 2023</td><td>India</td><td class="num">98</td><td class="num">15.8</td><td>Yoga</td><td>12 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Hayashi 2022</td><td>Japan</td><td class="num">72</td><td class="num">14.4</td><td>Aerobic (swimming)</td><td>10 weeks</td><td>CDI</td></tr>
+    <tr><td>Ibrahim 2023</td><td>Egypt</td><td class="num">56</td><td class="num">16.3</td><td>Aerobic (running)</td><td>8 weeks</td><td>PHQ-A</td></tr>
+    <tr><td>Johansson 2024</td><td>Norway</td><td class="num">186</td><td class="num">15.6</td><td>Aerobic (mixed)</td><td>16 weeks</td><td>SMFQ</td></tr>
+    <tr><td>Kim 2021</td><td>South Korea</td><td class="num">54</td><td class="num">15.0</td><td>Resistance</td><td>8 weeks</td><td>CES-D</td></tr>
+    <tr><td>Larsson 2023</td><td>Sweden</td><td class="num">110</td><td class="num">14.9</td><td>Aerobic (running)</td><td>12 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Mendez 2022</td><td>Mexico</td><td class="num">76</td><td class="num">15.7</td><td>Aerobic (dance)</td><td>10 weeks</td><td>CDI</td></tr>
+    <tr><td>Nakamura 2024</td><td>Japan</td><td class="num">132</td><td class="num">15.1</td><td>Aerobic (cycling)</td><td>12 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Okonkwo 2022</td><td>Nigeria</td><td class="num">64</td><td class="num">16.0</td><td>Aerobic (football)</td><td>8 weeks</td><td>PHQ-A</td></tr>
+    <tr><td>Park 2023</td><td>South Korea</td><td class="num">48</td><td class="num">14.5</td><td>Tai chi</td><td>10 weeks</td><td>CES-D</td></tr>
+    <tr><td>Ramirez 2024</td><td>Chile</td><td class="num">164</td><td class="num">15.3</td><td>Aerobic (running)</td><td>16 weeks</td><td>BDI-II</td></tr>
+    <tr><td>Santos 2020</td><td>Portugal</td><td class="num">48</td><td class="num">15.9</td><td>Resistance</td><td>6 weeks</td><td>PHQ-A</td></tr>
+    <tr><td>Tanaka 2022</td><td>Japan</td><td class="num">92</td><td class="num">14.7</td><td>Aerobic (swimming)</td><td>10 weeks</td><td>CDI</td></tr>
+    <tr><td>Weber 2023</td><td>Germany</td><td class="num">82</td><td class="num">15.5</td><td>Aerobic (mixed)</td><td>12 weeks</td><td>BDI-II</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="7">BDI-II = Beck Depression Inventory II; CDI = Children's Depression Inventory; PHQ-A = Patient Health Questionnaire for Adolescents; CES-D = Center for Epidemiologic Studies Depression Scale; SMFQ = Short Mood and Feelings Questionnaire. Showing 19 of 34 included studies.</td></tr>
+  </tfoot>
+</table>
+
+## A3. Excluded Studies with Reasons
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table A2.</span> Studies excluded at full-text stage with primary reasons for exclusion (selected examples).</caption>
+  <thead>
+    <tr>
+      <th>Study</th>
+      <th>Reason for Exclusion</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Adams 2021</td><td>Non-randomized design (pre-post without control)</td></tr>
+    <tr><td>Bjork 2022</td><td>Participants aged 20-25 (outside age range)</td></tr>
+    <tr><td>Carvalho 2020</td><td>Exercise combined with medication change (confounded)</td></tr>
+    <tr><td>Deng 2023</td><td>Intervention duration 3 weeks (below minimum)</td></tr>
+    <tr><td>Eriksson 2021</td><td>No validated depression outcome measure</td></tr>
+    <tr><td>Fernandez 2022</td><td>n = 8 per arm (below minimum sample size)</td></tr>
+    <tr><td>Gao 2023</td><td>Primary diagnosis: anxiety disorder (not depression)</td></tr>
+    <tr><td>Hoffman 2020</td><td>Insufficient outcome data (contacted authors, no response)</td></tr>
+    <tr><td>Ivanova 2022</td><td>Cluster RCT with only 2 clusters (design limitation)</td></tr>
+    <tr><td>Jensen 2021</td><td>Exercise incidental to broader lifestyle program</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="2">Showing 10 of 124 excluded studies. Full list available from corresponding author.</td></tr>
+  </tfoot>
+</table>
+
+## A4. Leave-One-Out Sensitivity Analysis
+
+A leave-one-out sensitivity analysis was performed by sequentially removing each study from the meta-analysis and recalculating the pooled estimate. The pooled SMD ranged from -0.53 (when the largest study, Johansson 2024, was removed) to -0.59 (when the smallest-effect study, Santos 2020, was removed), confirming that no single study had undue influence on the overall result.
+
+## A5. Funnel Plot Assessment
+
+Visual inspection of the funnel plot revealed approximate symmetry around the pooled effect estimate. The Egger's regression intercept was -0.42 (95% CI: -1.18 to 0.34, p = 0.27), providing no statistical evidence of small-study effects or publication bias. The Begg and Mazumdar rank correlation test also showed no significant asymmetry (p = 0.34).
+
+## A6. PRISMA 2020 Checklist
+
+<table class="paper-table checklist-table">
+  <caption><span class="tab-num">Table A3.</span> PRISMA 2020 checklist with section references.</caption>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>Checklist Item</th>
+      <th>Location</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td class="num">1</td><td>Title: Identify the report as a systematic review</td><td>Title page</td></tr>
+    <tr><td class="num">2</td><td>Abstract: Structured summary</td><td>Abstract</td></tr>
+    <tr><td class="num">3</td><td>Rationale: Describe the rationale</td><td>Section 5</td></tr>
+    <tr><td class="num">4</td><td>Objectives: PICO statement</td><td>Section 1</td></tr>
+    <tr><td class="num">5</td><td>Eligibility criteria</td><td>Section 1</td></tr>
+    <tr><td class="num">6</td><td>Information sources</td><td>Section 1</td></tr>
+    <tr><td class="num">7</td><td>Search strategy</td><td>Section 1, Appendix A1</td></tr>
+    <tr><td class="num">8</td><td>Selection process</td><td>Section 1</td></tr>
+    <tr><td class="num">9</td><td>Data collection process</td><td>Section 1</td></tr>
+    <tr><td class="num">10</td><td>Data items</td><td>Section 1</td></tr>
+    <tr><td class="num">11</td><td>Study risk of bias assessment</td><td>Section 2</td></tr>
+    <tr><td class="num">12</td><td>Effect measures</td><td>Section 3</td></tr>
+    <tr><td class="num">13</td><td>Synthesis methods</td><td>Section 3</td></tr>
+    <tr><td class="num">14</td><td>Certainty assessment</td><td>Section 4</td></tr>
+    <tr><td class="num">15</td><td>Study selection: Flow diagram</td><td>PRISMA page</td></tr>
+    <tr><td class="num">16</td><td>Study characteristics</td><td>Appendix A2</td></tr>
+    <tr><td class="num">17</td><td>Risk of bias in studies</td><td>Section 2</td></tr>
+    <tr><td class="num">18</td><td>Results of individual studies</td><td>Section 3</td></tr>
+    <tr><td class="num">19</td><td>Results of syntheses</td><td>Section 3</td></tr>
+    <tr><td class="num">20</td><td>Reporting biases</td><td>Section 3</td></tr>
+    <tr><td class="num">21</td><td>Certainty of evidence</td><td>Section 4</td></tr>
+    <tr><td class="num">22</td><td>Discussion: interpretation</td><td>Section 5</td></tr>
+    <tr><td class="num">23</td><td>Registration and protocol</td><td>Abstract, Section 1</td></tr>
+  </tbody>
+</table>
+
+## A7. Data Availability
+
+All extracted data, analysis scripts (R code using the `metafor` package), and the complete PRISMA checklist are available at the study's Open Science Framework repository. Individual participant data were not available. Requests for additional analyses should be directed to the corresponding author (K.A.-M.) at the University of Ghana School of Public Health.

--- a/systematic-review/content/index.md
+++ b/systematic-review/content/index.md
@@ -1,0 +1,226 @@
++++
+title = "Abstract"
+description = "A systematic review and meta-analysis of exercise interventions for reducing depression symptoms in adolescents, PRISMA 2020 compliant."
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+template = "page"
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Systematic Review &middot; Meta-Analysis &middot; PRISMA 2020 &middot; Open Access</p>
+  <h1 class="paper-title">Exercise Interventions for Reducing Depression Symptoms in Adolescents: A Systematic Review and Meta-Analysis</h1>
+  <p class="paper-authors">
+    <span class="author-corresponding">Kwame Asante-Mensah</span><sup>1</sup>,
+    Sofia Ramirez-Cruz<sup>2</sup>,
+    Yuki Tanaka-Ito<sup>3</sup>,
+    Ingrid Holmberg<sup>4</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>University of Ghana School of Public Health, Accra &middot;
+    <sup>2</sup>Faculty of Medicine, Universidad de Chile, Santiago &middot;
+    <sup>3</sup>National Center of Neurology and Psychiatry, Tokyo &middot;
+    <sup>4</sup>Department of Clinical Neuroscience, Karolinska Institutet, Stockholm
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.41093/jahp.2026.12.02.084</a> &middot; <strong>PROSPERO:</strong> CRD42025012847 &middot; <strong>Submitted:</strong> 18 Nov 2025 &middot; <strong>Accepted:</strong> 02 Apr 2026</p>
+
+  <div class="badge-row">
+    <span class="badge badge-prisma">
+      <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="1" y="1" width="14" height="3" fill="none" stroke="#2a5a8a" stroke-width="1"/>
+        <rect x="3" y="6" width="10" height="3" fill="none" stroke="#2a5a8a" stroke-width="1"/>
+        <rect x="5" y="11" width="6" height="3" fill="none" stroke="#2a5a8a" stroke-width="1"/>
+      </svg>
+      PRISMA 2020
+    </span>
+    <span class="badge badge-grade">
+      <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="8" cy="8" r="7" fill="none" stroke="#2a6a4a" stroke-width="1.2"/>
+        <path d="M 4.5 8 L 7 10.5 L 11.5 5.5" fill="none" stroke="#2a6a4a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      GRADE
+    </span>
+  </div>
+</header>
+
+<section class="abstract-box">
+  <h2>Abstract</h2>
+  <dl>
+    <dt>Background</dt>
+    <dd>Adolescent depression is a leading cause of disability worldwide, yet pharmacological treatments carry significant side-effect profiles in young populations. Exercise has been proposed as a low-risk adjunctive or standalone intervention, but the evidence base remains fragmented across heterogeneous study designs.</dd>
+    <dt>Objectives</dt>
+    <dd>To systematically identify, appraise, and synthesize randomized controlled trials (RCTs) evaluating the effect of structured exercise interventions on depressive symptoms in adolescents aged 12-19 years, and to assess the certainty of evidence using the GRADE framework.</dd>
+    <dt>Methods</dt>
+    <dd>We searched MEDLINE, PsycINFO, CENTRAL, Embase, CINAHL, and SPORTDiscus from inception to September 2025. Two reviewers independently screened 4,218 records, extracted data from 34 eligible RCTs (N = 2,847 participants), and assessed risk of bias using the Cochrane RoB 2.0 tool. Random-effects meta-analysis was performed using restricted maximum likelihood estimation. Heterogeneity was assessed via I-squared and prediction intervals.</dd>
+    <dt>Results</dt>
+    <dd>Exercise interventions produced a moderate reduction in depressive symptoms compared with control conditions (pooled SMD = -0.56, 95% CI: -0.72 to -0.40, p &lt; 0.001). Substantial heterogeneity was observed (I-squared = 68.4%). Subgroup analyses showed larger effects for aerobic exercise (SMD = -0.64) than resistance training (SMD = -0.38), and for supervised interventions (SMD = -0.62) compared with unsupervised programs (SMD = -0.41). GRADE assessment rated the overall certainty of evidence as moderate.</dd>
+    <dt>Conclusions</dt>
+    <dd>Structured exercise interventions, particularly supervised aerobic programs of at least 8 weeks' duration, are associated with clinically meaningful reductions in adolescent depressive symptoms. These findings support the integration of exercise prescriptions into multimodal depression management for adolescents.</dd>
+    <dt>Keywords</dt>
+    <dd><em>systematic review; meta-analysis; exercise; physical activity; depression; adolescents; PRISMA; GRADE; randomized controlled trial</em></dd>
+  </dl>
+</section>
+
+## PRISMA Flow Diagram (Summary)
+
+<figure class="figure">
+  <svg viewBox="0 0 680 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="PRISMA 2020 flow diagram showing study identification, screening, eligibility, and inclusion">
+    <rect x="0" y="0" width="680" height="440" fill="#fafaf7"/>
+    <text x="340" y="22" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="12" fill="#1a2030" letter-spacing="0.5">PRISMA 2020 Flow Diagram</text>
+    <!-- Phase labels -->
+    <text x="14" y="72" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a" letter-spacing="0.1em" transform="rotate(-90,14,72)">IDENTIFICATION</text>
+    <text x="14" y="182" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#6a4a8a" letter-spacing="0.1em" transform="rotate(-90,14,182)">SCREENING</text>
+    <text x="14" y="290" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#8a6a2a" letter-spacing="0.1em" transform="rotate(-90,14,290)">ELIGIBILITY</text>
+    <text x="14" y="395" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a6a4a" letter-spacing="0.1em" transform="rotate(-90,14,395)">INCLUDED</text>
+    <!-- Identification -->
+    <rect x="60" y="38" width="240" height="44" fill="#eaf0f7" stroke="#2a5a8a" stroke-width="1.5"/>
+    <text x="180" y="56" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a5a8a">Records from databases</text>
+    <text x="180" y="72" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 4,218)</text>
+    <rect x="360" y="38" width="240" height="44" fill="#eaf0f7" stroke="#2a5a8a" stroke-width="1.5"/>
+    <text x="480" y="56" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a5a8a">Other sources</text>
+    <text x="480" y="72" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 127)</text>
+    <!-- Arrow down from both to duplicates removed -->
+    <line x1="180" y1="82" x2="180" y2="100" stroke="#1a2030" stroke-width="1"/>
+    <line x1="480" y1="82" x2="480" y2="100" stroke="#1a2030" stroke-width="1"/>
+    <line x1="180" y1="100" x2="480" y2="100" stroke="#1a2030" stroke-width="1"/>
+    <line x1="330" y1="100" x2="330" y2="110" stroke="#1a2030" stroke-width="1"/>
+    <polygon points="330,116 325,110 335,110" fill="#1a2030"/>
+    <!-- Duplicates removed -->
+    <rect x="200" y="116" width="260" height="36" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1.5"/>
+    <text x="330" y="132" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#6a4a8a">After duplicates removed</text>
+    <text x="330" y="146" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 3,041)</text>
+    <!-- Arrow down -->
+    <line x1="330" y1="152" x2="330" y2="170" stroke="#1a2030" stroke-width="1"/>
+    <polygon points="330,176 325,170 335,170" fill="#1a2030"/>
+    <!-- Title/abstract screening -->
+    <rect x="200" y="176" width="260" height="36" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1.5"/>
+    <text x="330" y="192" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#6a4a8a">Title/abstract screened</text>
+    <text x="330" y="206" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 3,041)</text>
+    <!-- Excluded right -->
+    <line x1="460" y1="194" x2="520" y2="194" stroke="#6a4a8a" stroke-width="1"/>
+    <polygon points="520,194 514,189 514,199" fill="#6a4a8a"/>
+    <rect x="520" y="180" width="140" height="28" fill="#f7f0fa" stroke="#6a4a8a" stroke-width="1"/>
+    <text x="590" y="198" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#6a4a8a">Excluded (n = 2,879)</text>
+    <!-- Arrow down -->
+    <line x1="330" y1="212" x2="330" y2="240" stroke="#1a2030" stroke-width="1"/>
+    <polygon points="330,246 325,240 335,240" fill="#1a2030"/>
+    <!-- Full-text eligibility -->
+    <rect x="200" y="246" width="260" height="36" fill="#faf3e6" stroke="#8a6a2a" stroke-width="1.5"/>
+    <text x="330" y="262" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#8a6a2a">Full-text assessed</text>
+    <text x="330" y="276" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 162)</text>
+    <!-- Excluded right -->
+    <line x1="460" y1="264" x2="520" y2="264" stroke="#8a6a2a" stroke-width="1"/>
+    <polygon points="520,264 514,259 514,269" fill="#8a6a2a"/>
+    <rect x="520" y="246" width="140" height="44" fill="#faf8f0" stroke="#8a6a2a" stroke-width="1"/>
+    <text x="590" y="262" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8a6a2a">Excluded (n = 128)</text>
+    <text x="590" y="278" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8a6a2a">reasons documented</text>
+    <!-- Arrow down -->
+    <line x1="330" y1="282" x2="330" y2="310" stroke="#1a2030" stroke-width="1"/>
+    <polygon points="330,316 325,310 335,310" fill="#1a2030"/>
+    <!-- Included -->
+    <rect x="160" y="316" width="340" height="36" fill="#e8f5ee" stroke="#2a6a4a" stroke-width="2"/>
+    <text x="330" y="332" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a6a4a">Studies included in qualitative synthesis</text>
+    <text x="330" y="346" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(n = 34 RCTs, N = 2,847 participants)</text>
+    <!-- Arrow down -->
+    <line x1="330" y1="352" x2="330" y2="370" stroke="#1a2030" stroke-width="1"/>
+    <polygon points="330,376 325,370 335,370" fill="#1a2030"/>
+    <!-- Meta-analysis -->
+    <rect x="200" y="376" width="260" height="36" fill="#e8f5ee" stroke="#2a6a4a" stroke-width="2"/>
+    <text x="330" y="392" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a6a4a">Studies in meta-analysis</text>
+    <text x="330" y="406" text-anchor="middle" font-family="Crimson Pro, serif" font-size="11" fill="#1a2030">(k = 31)</text>
+    <!-- Note -->
+    <text x="330" y="432" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="9" fill="#5b6272">3 studies excluded from quantitative synthesis due to insufficient data reporting</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 1.</span> PRISMA 2020 flow diagram summarizing the systematic identification, screening, eligibility assessment, and inclusion of studies. A total of 34 RCTs met all inclusion criteria, with 31 contributing to the quantitative meta-analysis.</div>
+</figure>
+
+## Key Findings
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 1.</span> Summary of pooled effect estimates for exercise interventions on adolescent depressive symptoms.</caption>
+  <thead>
+    <tr>
+      <th>Outcome / Subgroup</th>
+      <th>Studies (k)</th>
+      <th>SMD</th>
+      <th>95% CI</th>
+      <th>I<sup>2</sup></th>
+      <th>GRADE</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Overall effect</strong></td>
+      <td class="num">31</td>
+      <td class="num">-0.56</td>
+      <td class="num">-0.72, -0.40</td>
+      <td class="num">68.4%</td>
+      <td><span class="grade-moderate">Moderate</span></td>
+    </tr>
+    <tr>
+      <td>Aerobic exercise</td>
+      <td class="num">22</td>
+      <td class="num">-0.64</td>
+      <td class="num">-0.82, -0.46</td>
+      <td class="num">62.1%</td>
+      <td><span class="grade-moderate">Moderate</span></td>
+    </tr>
+    <tr>
+      <td>Resistance training</td>
+      <td class="num">6</td>
+      <td class="num">-0.38</td>
+      <td class="num">-0.62, -0.14</td>
+      <td class="num">44.7%</td>
+      <td><span class="grade-low">Low</span></td>
+    </tr>
+    <tr>
+      <td>Mind-body (yoga, tai chi)</td>
+      <td class="num">5</td>
+      <td class="num">-0.51</td>
+      <td class="num">-0.78, -0.24</td>
+      <td class="num">51.2%</td>
+      <td><span class="grade-low">Low</span></td>
+    </tr>
+    <tr>
+      <td>Supervised programs</td>
+      <td class="num">24</td>
+      <td class="num">-0.62</td>
+      <td class="num">-0.79, -0.45</td>
+      <td class="num">61.8%</td>
+      <td><span class="grade-moderate">Moderate</span></td>
+    </tr>
+    <tr>
+      <td>Unsupervised programs</td>
+      <td class="num">7</td>
+      <td class="num">-0.41</td>
+      <td class="num">-0.68, -0.14</td>
+      <td class="num">58.3%</td>
+      <td><span class="grade-low">Low</span></td>
+    </tr>
+    <tr>
+      <td>Duration 8+ weeks</td>
+      <td class="num">26</td>
+      <td class="num">-0.61</td>
+      <td class="num">-0.78, -0.44</td>
+      <td class="num">65.2%</td>
+      <td><span class="grade-moderate">Moderate</span></td>
+    </tr>
+    <tr>
+      <td>Duration &lt;8 weeks</td>
+      <td class="num">5</td>
+      <td class="num">-0.32</td>
+      <td class="num">-0.58, -0.06</td>
+      <td class="num">42.1%</td>
+      <td><span class="grade-low">Low</span></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">SMD = standardized mean difference (negative values favor exercise). GRADE: High / Moderate / Low / Very Low. CI = confidence interval. I<sup>2</sup> = percentage of variability due to heterogeneity.</td></tr>
+  </tfoot>
+</table>
+
+## Structure of the Paper
+
+1. **Section 1. Search Strategy** -- database selection, search terms, PICO framework, and inclusion/exclusion criteria
+2. **Section 2. Risk of Bias** -- Cochrane RoB 2.0 assessment with traffic-light visualization of domain-level judgments
+3. **Section 3. Meta-Analysis** -- pooled effect sizes, forest plot, heterogeneity assessment, and sensitivity analyses
+4. **Section 4. GRADE Evidence** -- certainty of evidence assessment across outcomes using the GRADE framework
+5. **Section 5. Discussion** -- synthesis of findings, clinical implications, heterogeneity interpretation, and limitations

--- a/systematic-review/content/prisma.md
+++ b/systematic-review/content/prisma.md
@@ -1,0 +1,161 @@
++++
+title = "PRISMA 2020 Flow Diagram"
+description = "Full PRISMA 2020 flow diagram with detailed study counts at each stage of identification, screening, eligibility, and inclusion."
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+template = "page"
++++
+
+<header class="paper-section-header">
+  <p class="paper-section-eyebrow">PRISMA 2020 Compliant</p>
+  <h1 class="paper-section-title">PRISMA Flow Diagram</h1>
+  <p class="paper-lede">Complete study selection flowchart following the PRISMA 2020 statement for systematic reviews and meta-analyses.</p>
+</header>
+
+<figure class="figure figure-wide">
+  <svg viewBox="0 0 880 760" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Complete PRISMA 2020 flow diagram showing all stages of study identification, screening, eligibility assessment, and inclusion with detailed exclusion reasons">
+    <rect x="0" y="0" width="880" height="760" fill="#fafaf7"/>
+    <text x="440" y="24" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="14" fill="#1a2030" letter-spacing="0.5">PRISMA 2020 Flow Diagram</text>
+    <!-- Phase labels (left column) -->
+    <rect x="16" y="48" width="18" height="120" fill="#eaf0f7" stroke="#2a5a8a" stroke-width="1"/>
+    <text x="25" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a" letter-spacing="0.08em" transform="rotate(-90,25,116)">IDENTIFICATION</text>
+    <rect x="16" y="188" width="18" height="180" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1"/>
+    <text x="25" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#6a4a8a" letter-spacing="0.08em" transform="rotate(-90,25,286)">SCREENING</text>
+    <rect x="16" y="388" width="18" height="200" fill="#faf3e6" stroke="#8a6a2a" stroke-width="1"/>
+    <text x="25" y="496" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#8a6a2a" letter-spacing="0.08em" transform="rotate(-90,25,496)">ELIGIBILITY</text>
+    <rect x="16" y="608" width="18" height="130" fill="#e8f5ee" stroke="#2a6a4a" stroke-width="1"/>
+    <text x="25" y="678" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a6a4a" letter-spacing="0.08em" transform="rotate(-90,25,678)">INCLUDED</text>
+    <!-- ===== IDENTIFICATION ===== -->
+    <!-- Database records -->
+    <rect x="56" y="48" width="300" height="50" fill="#eaf0f7" stroke="#2a5a8a" stroke-width="1.5"/>
+    <text x="206" y="68" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a5a8a">Records identified from databases</text>
+    <text x="206" y="82" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 4,218)</text>
+    <text x="206" y="94" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">MEDLINE 1,842 / PsycINFO 891 / CENTRAL 624</text>
+    <!-- Other sources -->
+    <rect x="420" y="48" width="300" height="50" fill="#eaf0f7" stroke="#2a5a8a" stroke-width="1.5"/>
+    <text x="570" y="68" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a5a8a">Records from other sources</text>
+    <text x="570" y="82" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 127)</text>
+    <text x="570" y="94" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Reference lists 68 / Trial registries 42 / Experts 17</text>
+    <!-- Database supplement -->
+    <rect x="740" y="48" width="120" height="50" fill="#f5f8fb" stroke="#2a5a8a" stroke-width="1"/>
+    <text x="800" y="64" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Embase 412</text>
+    <text x="800" y="76" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">CINAHL 284</text>
+    <text x="800" y="88" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">SPORTDiscus 165</text>
+    <!-- Arrows merging -->
+    <line x1="206" y1="98" x2="206" y2="118" stroke="#1a2030" stroke-width="1"/>
+    <line x1="570" y1="98" x2="570" y2="118" stroke="#1a2030" stroke-width="1"/>
+    <line x1="206" y1="118" x2="570" y2="118" stroke="#1a2030" stroke-width="1"/>
+    <line x1="388" y1="118" x2="388" y2="128" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,134 383,128 393,128" fill="#1a2030"/>
+    <!-- Duplicates removed -->
+    <rect x="218" y="134" width="340" height="40" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1.5"/>
+    <text x="388" y="152" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#6a4a8a">Records after duplicates removed</text>
+    <text x="388" y="166" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 3,041)</text>
+    <!-- Duplicates excluded -->
+    <line x1="558" y1="154" x2="620" y2="154" stroke="#6a4a8a" stroke-width="1"/>
+    <polygon points="620,154 614,149 614,159" fill="#6a4a8a"/>
+    <rect x="620" y="140" width="160" height="28" fill="#f7f0fa" stroke="#6a4a8a" stroke-width="1"/>
+    <text x="700" y="158" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#6a4a8a">Duplicates removed (n = 1,304)</text>
+    <!-- ===== SCREENING ===== -->
+    <line x1="388" y1="174" x2="388" y2="198" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,204 383,198 393,198" fill="#1a2030"/>
+    <!-- Title/abstract -->
+    <rect x="218" y="204" width="340" height="40" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1.5"/>
+    <text x="388" y="222" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#6a4a8a">Titles and abstracts screened</text>
+    <text x="388" y="236" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 3,041)</text>
+    <!-- Excluded -->
+    <line x1="558" y1="224" x2="620" y2="224" stroke="#6a4a8a" stroke-width="1"/>
+    <polygon points="620,224 614,219 614,229" fill="#6a4a8a"/>
+    <rect x="620" y="198" width="220" height="66" fill="#f7f0fa" stroke="#6a4a8a" stroke-width="1"/>
+    <text x="730" y="214" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#6a4a8a">Records excluded (n = 2,879)</text>
+    <text x="730" y="228" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Not RCT: 1,204</text>
+    <text x="730" y="240" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Wrong population: 892</text>
+    <text x="730" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Wrong intervention/outcome: 783</text>
+    <!-- Arrow down -->
+    <line x1="388" y1="244" x2="388" y2="278" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,284 383,278 393,278" fill="#1a2030"/>
+    <!-- Reports sought -->
+    <rect x="218" y="284" width="340" height="40" fill="#f0eaf7" stroke="#6a4a8a" stroke-width="1.5"/>
+    <text x="388" y="302" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#6a4a8a">Reports sought for retrieval</text>
+    <text x="388" y="316" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 162)</text>
+    <!-- Not retrieved -->
+    <line x1="558" y1="304" x2="620" y2="304" stroke="#6a4a8a" stroke-width="1"/>
+    <polygon points="620,304 614,299 614,309" fill="#6a4a8a"/>
+    <rect x="620" y="290" width="220" height="28" fill="#f7f0fa" stroke="#6a4a8a" stroke-width="1"/>
+    <text x="730" y="308" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#6a4a8a">Reports not retrieved (n = 4)</text>
+    <!-- Arrow down -->
+    <line x1="388" y1="324" x2="388" y2="358" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,364 383,358 393,358" fill="#1a2030"/>
+    <!-- ===== ELIGIBILITY ===== -->
+    <!-- Reports assessed -->
+    <rect x="218" y="364" width="340" height="40" fill="#faf3e6" stroke="#8a6a2a" stroke-width="1.5"/>
+    <text x="388" y="382" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#8a6a2a">Full-text reports assessed for eligibility</text>
+    <text x="388" y="396" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 158)</text>
+    <!-- Excluded with reasons -->
+    <line x1="558" y1="384" x2="620" y2="384" stroke="#8a6a2a" stroke-width="1"/>
+    <polygon points="620,384 614,379 614,389" fill="#8a6a2a"/>
+    <rect x="620" y="348" width="240" height="118" fill="#faf8f0" stroke="#8a6a2a" stroke-width="1"/>
+    <text x="740" y="366" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#8a6a2a">Reports excluded (n = 124)</text>
+    <text x="740" y="382" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Wrong study design (n = 32)</text>
+    <text x="740" y="394" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Wrong population age (n = 28)</text>
+    <text x="740" y="406" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Intervention &lt;4 weeks (n = 18)</text>
+    <text x="740" y="418" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">No validated depression measure (n = 16)</text>
+    <text x="740" y="430" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Insufficient data (n = 14)</text>
+    <text x="740" y="442" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">Confounded design (n = 10)</text>
+    <text x="740" y="454" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#5b6272">&lt;10 per arm (n = 6)</text>
+    <!-- Arrow down to ongoing -->
+    <line x1="388" y1="404" x2="388" y2="438" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,444 383,438 393,438" fill="#1a2030"/>
+    <!-- Ongoing/awaiting classification -->
+    <rect x="218" y="444" width="340" height="56" fill="#faf3e6" stroke="#8a6a2a" stroke-width="1.2"/>
+    <text x="388" y="462" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#8a6a2a">Studies awaiting classification</text>
+    <text x="388" y="476" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Ongoing registered trials (n = 8)</text>
+    <text x="388" y="490" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#5b6272">Conference abstracts pending full publication (n = 3)</text>
+    <!-- Arrow down -->
+    <line x1="388" y1="500" x2="388" y2="528" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,534 383,528 393,528" fill="#1a2030"/>
+    <!-- Eligible studies -->
+    <rect x="218" y="534" width="340" height="40" fill="#faf3e6" stroke="#8a6a2a" stroke-width="1.5"/>
+    <text x="388" y="552" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#8a6a2a">Studies meeting all eligibility criteria</text>
+    <text x="388" y="566" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(n = 34 studies from 37 reports)</text>
+    <!-- Arrow down -->
+    <line x1="388" y1="574" x2="388" y2="608" stroke="#1a2030" stroke-width="1.2"/>
+    <polygon points="388,614 383,608 393,608" fill="#1a2030"/>
+    <!-- ===== INCLUDED ===== -->
+    <!-- Qualitative synthesis -->
+    <rect x="148" y="614" width="240" height="50" fill="#e8f5ee" stroke="#2a6a4a" stroke-width="2"/>
+    <text x="268" y="632" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a6a4a">Included in qualitative synthesis</text>
+    <text x="268" y="648" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(k = 34 studies)</text>
+    <text x="268" y="660" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#5b6272">N = 2,847 participants</text>
+    <!-- Quantitative synthesis -->
+    <rect x="440" y="614" width="240" height="50" fill="#e8f5ee" stroke="#2a6a4a" stroke-width="2"/>
+    <text x="560" y="632" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a6a4a">Included in meta-analysis</text>
+    <text x="560" y="648" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">(k = 31 studies)</text>
+    <text x="560" y="660" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#5b6272">3 excluded: insufficient data</text>
+    <!-- Arrow from qualitative to quantitative -->
+    <line x1="388" y1="639" x2="440" y2="639" stroke="#2a6a4a" stroke-width="1.2"/>
+    <polygon points="440,639 434,634 434,644" fill="#2a6a4a"/>
+    <!-- Bottom note -->
+    <text x="440" y="700" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="9" fill="#5b6272">Flow diagram prepared according to the PRISMA 2020 statement (Page et al., BMJ 2021;372:n71).</text>
+    <text x="440" y="716" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="9" fill="#5b6272">Search conducted 30 September 2025. Last updated 15 January 2026.</text>
+    <!-- PROSPERO -->
+    <text x="440" y="740" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">PROSPERO Registration: CRD42025012847</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 4.</span> Complete PRISMA 2020 flow diagram showing systematic identification (4,345 records from 6 databases and additional sources), deduplication, title/abstract screening, full-text eligibility assessment, and final inclusion of 34 studies (31 in quantitative meta-analysis). Exclusion reasons at the full-text stage are itemized.</div>
+</figure>
+
+## PRISMA 2020 Checklist Compliance
+
+This systematic review adheres to all 27 items of the PRISMA 2020 checklist. Key compliance elements include:
+
+- **Item 1 (Title):** Identifies the report as a systematic review with meta-analysis
+- **Item 2 (Abstract):** Structured abstract with background, objectives, methods, results, and conclusions
+- **Item 6 (Eligibility criteria):** PICO framework with explicit inclusion/exclusion criteria
+- **Item 7 (Information sources):** Six databases plus supplementary sources with dates of coverage
+- **Item 8 (Search strategy):** Full search string with Boolean operators documented
+- **Item 13a (Risk of bias):** Cochrane RoB 2.0 with domain-level judgments
+- **Item 14 (Certainty of evidence):** GRADE framework applied across outcomes
+- **Item 16a (Study selection):** PRISMA flow diagram with counts at each stage
+- **Item 20a (Synthesis methods):** Random-effects meta-analysis with heterogeneity assessment
+- **Item 22 (Publication bias):** Egger's test, funnel plot, and trim-and-fill analysis
+
+The complete PRISMA 2020 checklist with page references is available in the Appendix.

--- a/systematic-review/content/sections/1-search-strategy.md
+++ b/systematic-review/content/sections/1-search-strategy.md
@@ -1,0 +1,122 @@
++++
+title = "1. Search Strategy"
+description = "Databases, search terms, PICO framework, and inclusion/exclusion criteria for systematic identification of eligible studies."
+weight = 1
+template = "post"
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+categories = ["sections"]
+
+[extra]
+section_number = "1"
++++
+
+## Overview
+
+A comprehensive, reproducible search strategy is the foundation of any systematic review. We developed our strategy in consultation with a medical librarian (M.K.) and piloted it iteratively before final execution. The search was registered in PROSPERO (CRD42025012847) prior to data extraction.
+
+## PICO Framework
+
+<div class="pico-box">
+  <p class="pico-label">Population, Intervention, Comparator, Outcome</p>
+  <dl>
+    <dt>Population (P)</dt>
+    <dd>Adolescents aged 12-19 years with elevated depressive symptoms (clinical diagnosis or validated screening instrument score above established cutoff)</dd>
+    <dt>Intervention (I)</dt>
+    <dd>Structured exercise programs of any type (aerobic, resistance, mind-body, combined), delivered for a minimum of 4 weeks with at least 2 sessions per week</dd>
+    <dt>Comparator (C)</dt>
+    <dd>Waitlist control, usual care, attention control, or active comparator (non-exercise activity)</dd>
+    <dt>Outcome (O)</dt>
+    <dd>Change in depressive symptom severity measured by validated instruments (BDI-II, PHQ-A, CDI, CES-D, SMFQ, DASS-21 depression subscale)</dd>
+  </dl>
+</div>
+
+## Databases Searched
+
+We searched six electronic databases from inception to 30 September 2025:
+
+1. **MEDLINE** (via PubMed) -- biomedical literature
+2. **PsycINFO** (via APA PsycNet) -- psychological and behavioral sciences
+3. **Cochrane Central Register of Controlled Trials (CENTRAL)** -- RCTs and quasi-RCTs
+4. **Embase** (via Elsevier) -- biomedical and pharmacological literature
+5. **CINAHL** (via EBSCOhost) -- nursing and allied health
+6. **SPORTDiscus** (via EBSCOhost) -- sport and exercise science
+
+Additionally, we hand-searched reference lists of included studies and relevant systematic reviews, searched ClinicalTrials.gov and WHO ICTRP for ongoing or unpublished trials, and contacted authors of conference abstracts meeting preliminary inclusion criteria.
+
+## Search Terms
+
+The search strategy combined terms across three concept blocks using Boolean operators:
+
+<div class="search-block">
+  <p class="search-block-label">Block 1: Population</p>
+  <p class="search-terms">("adolescen*" OR "teen*" OR "youth" OR "young people" OR "juvenile" OR "minor" OR "high school" OR "secondary school") AND ("age 12-19" OR "pediatric" OR "paediatric")</p>
+</div>
+
+<div class="search-block">
+  <p class="search-block-label">Block 2: Intervention</p>
+  <p class="search-terms">("exercise" OR "physical activity" OR "aerobic" OR "resistance training" OR "strength training" OR "yoga" OR "running" OR "swimming" OR "cycling" OR "walking" OR "sport*" OR "fitness" OR "tai chi" OR "Pilates" OR "dance")</p>
+</div>
+
+<div class="search-block">
+  <p class="search-block-label">Block 3: Outcome</p>
+  <p class="search-terms">("depression" OR "depressive" OR "mood disorder" OR "affective disorder" OR "mental health" OR "psychological wellbeing" OR "BDI" OR "PHQ" OR "CDI" OR "CES-D")</p>
+</div>
+
+The final search string was: **Block 1 AND Block 2 AND Block 3**, filtered to randomized controlled trials where available via database-specific hedges.
+
+## Inclusion Criteria
+
+- **Design:** Randomized controlled trials (individual or cluster randomization)
+- **Participants:** Adolescents aged 12-19 years with elevated depressive symptoms at baseline
+- **Intervention:** Structured exercise program of at least 4 weeks' duration, minimum 2 sessions per week
+- **Outcome:** Pre-post change in depressive symptoms using a validated instrument
+- **Language:** No language restriction (non-English studies translated)
+- **Publication:** Published in peer-reviewed journals or as registered trial reports with sufficient data
+
+## Exclusion Criteria
+
+- Non-randomized designs (cohort, cross-sectional, case-control, pre-post without control)
+- Participants with primary diagnosis other than depression (e.g., anxiety-only, ADHD, eating disorders)
+- Interventions combining exercise with pharmacological changes (confounded designs)
+- Studies with fewer than 10 participants per arm
+- Conference abstracts or dissertations without sufficient outcome data
+- Studies where exercise was incidental to a broader lifestyle intervention and could not be isolated
+
+## Screening Process
+
+Two reviewers (K.A.-M. and S.R.-C.) independently screened titles and abstracts using Rayyan QCRI. Discrepancies were resolved by discussion or, where necessary, by a third reviewer (Y.T.-I.). The same pair independently assessed full texts for eligibility using a pre-piloted form. Inter-rater reliability was assessed using Cohen's kappa.
+
+### Screening Reliability
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 2.</span> Inter-rater reliability for study screening.</caption>
+  <thead>
+    <tr>
+      <th>Stage</th>
+      <th>Agreements</th>
+      <th>Disagreements</th>
+      <th>Cohen's kappa</th>
+      <th>Interpretation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Title/abstract</td>
+      <td class="num">2,924</td>
+      <td class="num">117</td>
+      <td class="num">0.91</td>
+      <td>Almost perfect</td>
+    </tr>
+    <tr>
+      <td>Full-text</td>
+      <td class="num">153</td>
+      <td class="num">9</td>
+      <td class="num">0.88</td>
+      <td>Almost perfect</td>
+    </tr>
+  </tbody>
+</table>
+
+## Data Extraction
+
+Data were extracted independently by two reviewers using a standardized form covering: study characteristics (country, setting, year), participant demographics (age, sex, baseline severity, diagnostic method), intervention details (type, frequency, duration, intensity, supervision), comparator details, outcome measures (instrument, time points, means, standard deviations), and risk-of-bias domains. Where data were reported as medians with interquartile ranges, we estimated means and standard deviations using validated conversion formulae.

--- a/systematic-review/content/sections/2-risk-of-bias.md
+++ b/systematic-review/content/sections/2-risk-of-bias.md
@@ -1,0 +1,230 @@
++++
+title = "2. Risk of Bias"
+description = "Cochrane RoB 2.0 assessment of included studies with traffic-light domain-level visualization."
+weight = 2
+template = "post"
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+categories = ["sections"]
+
+[extra]
+section_number = "2"
++++
+
+## Overview
+
+Risk of bias was assessed using the Cochrane Risk of Bias 2.0 (RoB 2.0) tool for randomized trials. Two reviewers (Y.T.-I. and I.H.) independently evaluated each study across five domains. Disagreements were resolved by consensus with a third reviewer (K.A.-M.). We present domain-level and overall judgments using the standard traffic-light visualization.
+
+## RoB 2.0 Domains
+
+The five domains assessed were:
+
+1. **D1 -- Randomization process:** Adequacy of random sequence generation and allocation concealment
+2. **D2 -- Deviations from intended interventions:** Whether participants, personnel, or analysts deviated from assigned interventions in ways that could affect outcomes
+3. **D3 -- Missing outcome data:** Completeness of outcome data and appropriateness of handling missing values
+4. **D4 -- Measurement of the outcome:** Potential for bias in outcome assessment (blinding of assessors, use of validated instruments)
+5. **D5 -- Selection of reported result:** Risk that results were selected from among multiple measurements, analyses, or subgroups
+
+## Traffic-Light Summary
+
+<figure class="figure figure-wide">
+  <svg viewBox="0 0 780 680" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Risk of bias traffic-light table showing domain-level judgments for 18 representative studies">
+    <rect x="0" y="0" width="780" height="680" fill="#fafaf7"/>
+    <text x="390" y="22" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="12" fill="#1a2030" letter-spacing="0.5">Risk of Bias Summary (RoB 2.0) -- Representative Studies</text>
+    <!-- Column headers -->
+    <text x="200" y="50" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a">Study</text>
+    <text x="350" y="42" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#2a5a8a">D1</text>
+    <text x="350" y="54" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#5b6272">Random.</text>
+    <text x="430" y="42" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#2a5a8a">D2</text>
+    <text x="430" y="54" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#5b6272">Deviat.</text>
+    <text x="510" y="42" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#2a5a8a">D3</text>
+    <text x="510" y="54" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#5b6272">Missing</text>
+    <text x="590" y="42" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#2a5a8a">D4</text>
+    <text x="590" y="54" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#5b6272">Measure</text>
+    <text x="670" y="42" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#2a5a8a">D5</text>
+    <text x="670" y="54" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="7" fill="#5b6272">Report.</text>
+    <text x="740" y="50" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="8" fill="#1a2030">Overall</text>
+    <!-- Header line -->
+    <line x1="30" y1="60" x2="770" y2="60" stroke="#1a2030" stroke-width="1.5"/>
+    <!-- Row helper: y_base = 60 + row*34 -->
+    <!-- Study 1: Andersson 2022 -->
+    <text x="200" y="82" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Andersson et al. 2022</text>
+    <circle cx="350" cy="78" r="10" fill="#2a6a4a"/><text x="350" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="78" r="10" fill="#2a6a4a"/><text x="430" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="78" r="10" fill="#2a6a4a"/><text x="510" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="78" r="10" fill="#c8a020"/><text x="590" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="78" r="10" fill="#2a6a4a"/><text x="670" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="78" r="10" fill="#c8a020"/><text x="740" y="82" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 2: Chen 2021 -->
+    <text x="200" y="116" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Chen et al. 2021</text>
+    <circle cx="350" cy="112" r="10" fill="#2a6a4a"/><text x="350" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="112" r="10" fill="#2a6a4a"/><text x="430" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="112" r="10" fill="#2a6a4a"/><text x="510" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="112" r="10" fill="#2a6a4a"/><text x="590" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="112" r="10" fill="#2a6a4a"/><text x="670" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="112" r="10" fill="#2a6a4a"/><text x="740" y="116" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <!-- Study 3: Da Silva 2023 -->
+    <text x="200" y="150" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Da Silva et al. 2023</text>
+    <circle cx="350" cy="146" r="10" fill="#c8a020"/><text x="350" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="430" cy="146" r="10" fill="#c8a020"/><text x="430" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="146" r="10" fill="#2a6a4a"/><text x="510" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="146" r="10" fill="#c8a020"/><text x="590" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="146" r="10" fill="#2a6a4a"/><text x="670" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="146" r="10" fill="#c8a020"/><text x="740" y="150" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 4: Ekblom 2020 -->
+    <text x="200" y="184" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Ekblom et al. 2020</text>
+    <circle cx="350" cy="180" r="10" fill="#2a6a4a"/><text x="350" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="180" r="10" fill="#2a6a4a"/><text x="430" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="180" r="10" fill="#c8a020"/><text x="510" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="590" cy="180" r="10" fill="#2a6a4a"/><text x="590" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="180" r="10" fill="#2a6a4a"/><text x="670" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="180" r="10" fill="#c8a020"/><text x="740" y="184" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 5: Farahmand 2021 -->
+    <text x="200" y="218" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Farahmand et al. 2021</text>
+    <circle cx="350" cy="214" r="10" fill="#c83030"/><text x="350" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="430" cy="214" r="10" fill="#c8a020"/><text x="430" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="214" r="10" fill="#c83030"/><text x="510" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="590" cy="214" r="10" fill="#c8a020"/><text x="590" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="214" r="10" fill="#2a6a4a"/><text x="670" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="214" r="10" fill="#c83030"/><text x="740" y="218" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <!-- Study 6: Gupta 2023 -->
+    <text x="200" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Gupta et al. 2023</text>
+    <circle cx="350" cy="248" r="10" fill="#2a6a4a"/><text x="350" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="248" r="10" fill="#2a6a4a"/><text x="430" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="248" r="10" fill="#2a6a4a"/><text x="510" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="248" r="10" fill="#2a6a4a"/><text x="590" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="248" r="10" fill="#c8a020"/><text x="670" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="740" cy="248" r="10" fill="#c8a020"/><text x="740" y="252" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 7: Hayashi 2022 -->
+    <text x="200" y="286" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Hayashi et al. 2022</text>
+    <circle cx="350" cy="282" r="10" fill="#2a6a4a"/><text x="350" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="282" r="10" fill="#2a6a4a"/><text x="430" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="282" r="10" fill="#2a6a4a"/><text x="510" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="282" r="10" fill="#c8a020"/><text x="590" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="282" r="10" fill="#2a6a4a"/><text x="670" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="282" r="10" fill="#c8a020"/><text x="740" y="286" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 8: Johansson 2024 -->
+    <text x="200" y="320" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Johansson et al. 2024</text>
+    <circle cx="350" cy="316" r="10" fill="#2a6a4a"/><text x="350" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="316" r="10" fill="#2a6a4a"/><text x="430" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="316" r="10" fill="#2a6a4a"/><text x="510" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="316" r="10" fill="#2a6a4a"/><text x="590" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="316" r="10" fill="#2a6a4a"/><text x="670" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="316" r="10" fill="#2a6a4a"/><text x="740" y="320" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <!-- Study 9: Kim 2021 -->
+    <text x="200" y="354" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Kim et al. 2021</text>
+    <circle cx="350" cy="350" r="10" fill="#c8a020"/><text x="350" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="430" cy="350" r="10" fill="#c8a020"/><text x="430" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="350" r="10" fill="#2a6a4a"/><text x="510" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="350" r="10" fill="#c8a020"/><text x="590" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="350" r="10" fill="#2a6a4a"/><text x="670" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="350" r="10" fill="#c8a020"/><text x="740" y="354" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 10: Larsson 2023 -->
+    <text x="200" y="388" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Larsson et al. 2023</text>
+    <circle cx="350" cy="384" r="10" fill="#2a6a4a"/><text x="350" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="384" r="10" fill="#2a6a4a"/><text x="430" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="384" r="10" fill="#c8a020"/><text x="510" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="590" cy="384" r="10" fill="#2a6a4a"/><text x="590" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="384" r="10" fill="#2a6a4a"/><text x="670" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="384" r="10" fill="#c8a020"/><text x="740" y="388" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 11: Mendez 2022 -->
+    <text x="200" y="422" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Mendez et al. 2022</text>
+    <circle cx="350" cy="418" r="10" fill="#2a6a4a"/><text x="350" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="418" r="10" fill="#c8a020"/><text x="430" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="418" r="10" fill="#2a6a4a"/><text x="510" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="418" r="10" fill="#2a6a4a"/><text x="590" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="418" r="10" fill="#2a6a4a"/><text x="670" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="418" r="10" fill="#c8a020"/><text x="740" y="422" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 12: Nakamura 2024 -->
+    <text x="200" y="456" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Nakamura et al. 2024</text>
+    <circle cx="350" cy="452" r="10" fill="#2a6a4a"/><text x="350" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="452" r="10" fill="#2a6a4a"/><text x="430" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="452" r="10" fill="#2a6a4a"/><text x="510" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="452" r="10" fill="#2a6a4a"/><text x="590" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="452" r="10" fill="#2a6a4a"/><text x="670" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="452" r="10" fill="#2a6a4a"/><text x="740" y="456" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <!-- Study 13: Okonkwo 2022 -->
+    <text x="200" y="490" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Okonkwo et al. 2022</text>
+    <circle cx="350" cy="486" r="10" fill="#2a6a4a"/><text x="350" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="486" r="10" fill="#c8a020"/><text x="430" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="486" r="10" fill="#2a6a4a"/><text x="510" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="486" r="10" fill="#c8a020"/><text x="590" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="486" r="10" fill="#2a6a4a"/><text x="670" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="486" r="10" fill="#c8a020"/><text x="740" y="490" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <!-- Study 14: Park 2023 -->
+    <text x="200" y="524" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Park et al. 2023</text>
+    <circle cx="350" cy="520" r="10" fill="#c83030"/><text x="350" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="430" cy="520" r="10" fill="#c8a020"/><text x="430" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="510" cy="520" r="10" fill="#c83030"/><text x="510" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="590" cy="520" r="10" fill="#c8a020"/><text x="590" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="670" cy="520" r="10" fill="#c8a020"/><text x="670" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="740" cy="520" r="10" fill="#c83030"/><text x="740" y="524" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <!-- Study 15: Ramirez 2024 -->
+    <text x="200" y="558" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Ramirez et al. 2024</text>
+    <circle cx="350" cy="554" r="10" fill="#2a6a4a"/><text x="350" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="430" cy="554" r="10" fill="#2a6a4a"/><text x="430" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="510" cy="554" r="10" fill="#2a6a4a"/><text x="510" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="590" cy="554" r="10" fill="#2a6a4a"/><text x="590" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="670" cy="554" r="10" fill="#2a6a4a"/><text x="670" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="554" r="10" fill="#2a6a4a"/><text x="740" y="558" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <!-- Study 16: Santos 2020 -->
+    <text x="200" y="592" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#1a2030">Santos et al. 2020</text>
+    <circle cx="350" cy="588" r="10" fill="#c8a020"/><text x="350" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="430" cy="588" r="10" fill="#c83030"/><text x="430" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="510" cy="588" r="10" fill="#c8a020"/><text x="510" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">S</text>
+    <circle cx="590" cy="588" r="10" fill="#c83030"/><text x="590" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <circle cx="670" cy="588" r="10" fill="#2a6a4a"/><text x="670" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">L</text>
+    <circle cx="740" cy="588" r="10" fill="#c83030"/><text x="740" y="592" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#fff">H</text>
+    <!-- Bottom line -->
+    <line x1="30" y1="608" x2="770" y2="608" stroke="#1a2030" stroke-width="1"/>
+    <!-- Legend -->
+    <circle cx="200" cy="632" r="8" fill="#2a6a4a"/><text x="212" y="636" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#1a2030">L = Low risk</text>
+    <circle cx="340" cy="632" r="8" fill="#c8a020"/><text x="352" y="636" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#1a2030">S = Some concerns</text>
+    <circle cx="510" cy="632" r="8" fill="#c83030"/><text x="522" y="636" font-family="IBM Plex Sans, sans-serif" font-size="9" fill="#1a2030">H = High risk</text>
+    <text x="390" y="665" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="9" fill="#5b6272">Showing 16 of 34 studies. Full assessment available in Appendix.</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 2.</span> Risk of bias traffic-light summary for representative included studies, assessed using the Cochrane RoB 2.0 tool. Each circle represents the domain-level judgment: green (L) = low risk, yellow (S) = some concerns, red (H) = high risk. The overall judgment follows the most severe domain rating.</div>
+</figure>
+
+## Domain-Level Summary
+
+Across the 34 included studies:
+
+- **D1 (Randomization):** 24 studies (70.6%) were judged low risk, 7 (20.6%) had some concerns, and 3 (8.8%) were high risk. Common issues included inadequate allocation concealment and baseline imbalances.
+- **D2 (Deviations):** 20 studies (58.8%) low risk, 11 (32.4%) some concerns, 3 (8.8%) high risk. The inherent difficulty of blinding exercise interventions meant that most concerns related to awareness of group assignment.
+- **D3 (Missing data):** 22 studies (64.7%) low risk, 9 (26.5%) some concerns, 3 (8.8%) high risk. Attrition rates ranged from 4% to 32%, with a median of 14%.
+- **D4 (Measurement):** 18 studies (52.9%) low risk, 14 (41.2%) some concerns, 2 (5.9%) high risk. Self-report outcome measures in unblinded participants were the primary concern.
+- **D5 (Reporting):** 28 studies (82.4%) low risk, 6 (17.6%) some concerns, 0 (0%) high risk. Pre-registration of protocols was associated with lower risk in this domain.
+
+### Overall Judgments
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 3.</span> Distribution of overall risk-of-bias judgments across 34 included studies.</caption>
+  <thead>
+    <tr>
+      <th>Overall Judgment</th>
+      <th>Count</th>
+      <th>Percentage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="rob-low">Low risk of bias</span></td>
+      <td class="num">12</td>
+      <td class="num">35.3%</td>
+    </tr>
+    <tr>
+      <td><span class="rob-unclear">Some concerns</span></td>
+      <td class="num">18</td>
+      <td class="num">52.9%</td>
+    </tr>
+    <tr>
+      <td><span class="rob-high">High risk of bias</span></td>
+      <td class="num">4</td>
+      <td class="num">11.8%</td>
+    </tr>
+  </tbody>
+</table>
+
+## Sensitivity Analysis
+
+We conducted a sensitivity analysis restricting the meta-analysis to the 12 studies rated as low overall risk of bias. The pooled effect remained significant (SMD = -0.52, 95% CI: -0.70 to -0.34), suggesting that the overall finding is robust to risk-of-bias concerns. Heterogeneity was reduced in this subset (I-squared = 48.2%).

--- a/systematic-review/content/sections/3-meta-analysis.md
+++ b/systematic-review/content/sections/3-meta-analysis.md
@@ -1,0 +1,257 @@
++++
+title = "3. Meta-Analysis"
+description = "Pooled effect sizes, forest plot, heterogeneity assessment, and sensitivity analyses for exercise interventions on adolescent depression."
+weight = 3
+template = "post"
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+categories = ["sections"]
+
+[extra]
+section_number = "3"
++++
+
+## Overview
+
+We conducted random-effects meta-analysis using restricted maximum likelihood (REML) estimation to pool standardized mean differences (SMDs) across studies. The primary outcome was change in depressive symptom severity measured by validated instruments. All analyses were performed in R (version 4.3.2) using the `metafor` package.
+
+## Forest Plot: Overall Effect
+
+<figure class="figure figure-wide">
+  <svg viewBox="0 0 800 620" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Forest plot showing individual study effects and pooled estimate for exercise interventions on adolescent depression">
+    <rect x="0" y="0" width="800" height="620" fill="#fafaf7"/>
+    <text x="400" y="22" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="12" fill="#1a2030" letter-spacing="0.5">Forest Plot: Exercise vs. Control on Depressive Symptoms (SMD)</text>
+    <!-- Column headers -->
+    <text x="140" y="46" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a">Study</text>
+    <text x="310" y="46" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a">N</text>
+    <text x="530" y="46" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a">Effect (SMD, 95% CI)</text>
+    <text x="720" y="46" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="9" fill="#2a5a8a">Weight</text>
+    <line x1="20" y1="52" x2="780" y2="52" stroke="#1a2030" stroke-width="1"/>
+    <!-- Null line at x=530 (SMD=0), scale: 530 + SMD*120 -->
+    <line x1="530" y1="56" x2="530" y2="530" stroke="#1a2030" stroke-width="0.8" stroke-dasharray="4 3"/>
+    <!-- Study rows: y_base = 52 + row*30 -->
+    <!-- Study 1: Andersson 2022 -->
+    <text x="140" y="76" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Andersson 2022</text>
+    <text x="310" y="76" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">86</text>
+    <line x1="458" y1="72" x2="506" y2="72" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="472" y="68" width="8" height="8" fill="#2a5a8a"/>
+    <text x="720" y="76" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">4.2%</text>
+    <!-- Study 2: Chen 2021 -->
+    <text x="140" y="106" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Chen 2021</text>
+    <text x="310" y="106" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">124</text>
+    <line x1="446" y1="102" x2="500" y2="102" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="464" y="97" width="10" height="10" fill="#2a5a8a"/>
+    <text x="720" y="106" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">5.1%</text>
+    <!-- Study 3: Da Silva 2023 -->
+    <text x="140" y="136" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Da Silva 2023</text>
+    <text x="310" y="136" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">62</text>
+    <line x1="476" y1="132" x2="536" y2="132" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="498" y="129" width="7" height="7" fill="#2a5a8a"/>
+    <text x="720" y="136" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">3.0%</text>
+    <!-- Study 4: Ekblom 2020 -->
+    <text x="140" y="166" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Ekblom 2020</text>
+    <text x="310" y="166" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">148</text>
+    <line x1="460" y1="162" x2="502" y2="162" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="474" y="157" width="11" height="11" fill="#2a5a8a"/>
+    <text x="720" y="166" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">5.6%</text>
+    <!-- Study 5: Gupta 2023 -->
+    <text x="140" y="196" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Gupta 2023</text>
+    <text x="310" y="196" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">98</text>
+    <line x1="430" y1="192" x2="490" y2="192" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="452" y="188" width="9" height="9" fill="#2a5a8a"/>
+    <text x="720" y="196" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">4.4%</text>
+    <!-- Study 6: Hayashi 2022 -->
+    <text x="140" y="226" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Hayashi 2022</text>
+    <text x="310" y="226" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">72</text>
+    <line x1="454" y1="222" x2="514" y2="222" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="478" y="219" width="7" height="7" fill="#2a5a8a"/>
+    <text x="720" y="226" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">3.4%</text>
+    <!-- Study 7: Johansson 2024 -->
+    <text x="140" y="256" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Johansson 2024</text>
+    <text x="310" y="256" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">186</text>
+    <line x1="452" y1="252" x2="496" y2="252" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="466" y="246" width="13" height="13" fill="#2a5a8a"/>
+    <text x="720" y="256" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">6.2%</text>
+    <!-- Study 8: Kim 2021 -->
+    <text x="140" y="286" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Kim 2021</text>
+    <text x="310" y="286" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">54</text>
+    <line x1="440" y1="282" x2="530" y2="282" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="478" y="279" width="6" height="6" fill="#2a5a8a"/>
+    <text x="720" y="286" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">2.6%</text>
+    <!-- Study 9: Larsson 2023 -->
+    <text x="140" y="316" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Larsson 2023</text>
+    <text x="310" y="316" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">110</text>
+    <line x1="444" y1="312" x2="498" y2="312" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="462" y="307" width="10" height="10" fill="#2a5a8a"/>
+    <text x="720" y="316" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">4.8%</text>
+    <!-- Study 10: Mendez 2022 -->
+    <text x="140" y="346" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Mendez 2022</text>
+    <text x="310" y="346" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">76</text>
+    <line x1="422" y1="342" x2="494" y2="342" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="450" y="339" width="8" height="8" fill="#2a5a8a"/>
+    <text x="720" y="346" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">3.5%</text>
+    <!-- Study 11: Nakamura 2024 -->
+    <text x="140" y="376" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Nakamura 2024</text>
+    <text x="310" y="376" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">132</text>
+    <line x1="456" y1="372" x2="504" y2="372" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="472" y="367" width="11" height="11" fill="#2a5a8a"/>
+    <text x="720" y="376" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">5.3%</text>
+    <!-- Study 12: Ramirez 2024 -->
+    <text x="140" y="406" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Ramirez 2024</text>
+    <text x="310" y="406" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">164</text>
+    <line x1="442" y1="402" x2="490" y2="402" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="458" y="396" width="12" height="12" fill="#2a5a8a"/>
+    <text x="720" y="406" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">5.8%</text>
+    <!-- Study 13: Santos 2020 -->
+    <text x="140" y="436" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Santos 2020</text>
+    <text x="310" y="436" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">48</text>
+    <line x1="470" y1="432" x2="540" y2="432" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="498" y="429" width="6" height="6" fill="#2a5a8a"/>
+    <text x="720" y="436" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">2.2%</text>
+    <!-- Study 14: Tanaka 2022 -->
+    <text x="140" y="466" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Tanaka 2022</text>
+    <text x="310" y="466" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">92</text>
+    <line x1="440" y1="462" x2="500" y2="462" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="462" y="458" width="9" height="9" fill="#2a5a8a"/>
+    <text x="720" y="466" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">4.2%</text>
+    <!-- Study 15: Weber 2023 -->
+    <text x="140" y="496" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1a2030">Weber 2023</text>
+    <text x="310" y="496" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">82</text>
+    <line x1="436" y1="492" x2="504" y2="492" stroke="#2a5a8a" stroke-width="1.2"/>
+    <rect x="462" y="489" width="8" height="8" fill="#2a5a8a"/>
+    <text x="720" y="496" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">3.8%</text>
+    <!-- Separator before pooled -->
+    <line x1="20" y1="514" x2="780" y2="514" stroke="#1a2030" stroke-width="1.5"/>
+    <!-- Pooled diamond -->
+    <text x="140" y="540" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-weight="700" font-size="10" fill="#2a6a4a">Pooled (k=31)</text>
+    <text x="310" y="540" text-anchor="middle" font-family="JetBrains Mono, monospace" font-weight="700" font-size="9" fill="#2a6a4a">2,847</text>
+    <polygon points="444,536 463,528 482,536 463,544" fill="#2a6a4a" stroke="#2a6a4a" stroke-width="1"/>
+    <text x="720" y="540" text-anchor="middle" font-family="JetBrains Mono, monospace" font-weight="700" font-size="9" fill="#2a6a4a">100%</text>
+    <!-- Scale labels -->
+    <text x="410" y="574" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="8" fill="#5b6272">Favors exercise</text>
+    <text x="640" y="574" text-anchor="middle" font-family="IBM Plex Sans, sans-serif" font-size="8" fill="#5b6272">Favors control</text>
+    <line x1="400" y1="560" x2="660" y2="560" stroke="#1a2030" stroke-width="1"/>
+    <text x="400" y="556" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">-1.0</text>
+    <text x="530" y="556" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">0</text>
+    <text x="660" y="556" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="8" fill="#5b6272">+1.0</text>
+    <!-- Summary stats -->
+    <text x="400" y="600" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="10" fill="#1a2030">SMD = -0.56 (95% CI: -0.72 to -0.40), p &lt; 0.001, I-squared = 68.4%, tau-squared = 0.08</text>
+    <text x="400" y="614" text-anchor="middle" font-family="Crimson Pro, serif" font-style="italic" font-size="9" fill="#5b6272">Showing 15 of 31 studies included in quantitative synthesis. Square size proportional to study weight.</text>
+  </svg>
+  <div class="caption"><span class="fig-num">Figure 3.</span> Forest plot of individual study effects and pooled estimate for the effect of exercise interventions on adolescent depressive symptoms. Squares represent individual study SMDs (size proportional to weight); horizontal lines represent 95% CIs. The diamond represents the pooled random-effects estimate. Negative values indicate a reduction in depressive symptoms favoring the exercise group.</div>
+</figure>
+
+## Heterogeneity Assessment
+
+Substantial heterogeneity was observed across studies (I-squared = 68.4%, tau-squared = 0.08, Cochran's Q = 94.8, df = 30, p < 0.001). The 95% prediction interval ranged from -1.12 to 0.00, indicating that while the average effect favors exercise, individual study settings may yield null effects.
+
+### Sources of Heterogeneity
+
+We explored potential sources of heterogeneity through pre-specified subgroup analyses:
+
+<table class="paper-table">
+  <caption><span class="tab-num">Table 4.</span> Subgroup analyses exploring sources of heterogeneity.</caption>
+  <thead>
+    <tr>
+      <th>Moderator</th>
+      <th>Subgroup</th>
+      <th>k</th>
+      <th>SMD (95% CI)</th>
+      <th>I<sup>2</sup></th>
+      <th>p interaction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3">Exercise type</td>
+      <td>Aerobic</td>
+      <td class="num">22</td>
+      <td class="num">-0.64 (-0.82, -0.46)</td>
+      <td class="num">62.1%</td>
+      <td class="num" rowspan="3">0.08</td>
+    </tr>
+    <tr>
+      <td>Resistance</td>
+      <td class="num">6</td>
+      <td class="num">-0.38 (-0.62, -0.14)</td>
+      <td class="num">44.7%</td>
+    </tr>
+    <tr>
+      <td>Mind-body</td>
+      <td class="num">5</td>
+      <td class="num">-0.51 (-0.78, -0.24)</td>
+      <td class="num">51.2%</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Supervision</td>
+      <td>Supervised</td>
+      <td class="num">24</td>
+      <td class="num">-0.62 (-0.79, -0.45)</td>
+      <td class="num">61.8%</td>
+      <td class="num" rowspan="2">0.12</td>
+    </tr>
+    <tr>
+      <td>Unsupervised</td>
+      <td class="num">7</td>
+      <td class="num">-0.41 (-0.68, -0.14)</td>
+      <td class="num">58.3%</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Duration</td>
+      <td>8+ weeks</td>
+      <td class="num">26</td>
+      <td class="num">-0.61 (-0.78, -0.44)</td>
+      <td class="num">65.2%</td>
+      <td class="num" rowspan="2">0.04</td>
+    </tr>
+    <tr>
+      <td>&lt;8 weeks</td>
+      <td class="num">5</td>
+      <td class="num">-0.32 (-0.58, -0.06)</td>
+      <td class="num">42.1%</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Frequency</td>
+      <td>3+ sessions/week</td>
+      <td class="num">21</td>
+      <td class="num">-0.60 (-0.78, -0.42)</td>
+      <td class="num">66.4%</td>
+      <td class="num" rowspan="2">0.22</td>
+    </tr>
+    <tr>
+      <td>2 sessions/week</td>
+      <td class="num">10</td>
+      <td class="num">-0.48 (-0.72, -0.24)</td>
+      <td class="num">54.8%</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Baseline severity</td>
+      <td>Clinical diagnosis</td>
+      <td class="num">14</td>
+      <td class="num">-0.68 (-0.90, -0.46)</td>
+      <td class="num">58.3%</td>
+      <td class="num" rowspan="2">0.03</td>
+    </tr>
+    <tr>
+      <td>Subclinical symptoms</td>
+      <td class="num">17</td>
+      <td class="num">-0.44 (-0.62, -0.26)</td>
+      <td class="num">62.7%</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="6">k = number of studies. p interaction from meta-regression with moderator as categorical covariate. Only intervention duration and baseline severity reached statistical significance as moderators.</td></tr>
+  </tfoot>
+</table>
+
+## Publication Bias
+
+We assessed publication bias using Egger's regression test and visual inspection of a funnel plot. Egger's test indicated no significant asymmetry (intercept = -0.42, 95% CI: -1.18 to 0.34, p = 0.27). The trim-and-fill method estimated zero missing studies, and the adjusted pooled estimate was unchanged (SMD = -0.56). The fail-safe N was 847, indicating that 847 null studies would be required to reduce the pooled effect to non-significance.
+
+## Meta-Regression
+
+Univariate meta-regression identified two significant predictors of effect size magnitude:
+
+- **Intervention duration** (weeks): beta = -0.014 per week (95% CI: -0.026 to -0.002, p = 0.02), indicating greater effect with longer interventions
+- **Baseline depression severity** (standardized score): beta = -0.18 per SD (95% CI: -0.32 to -0.04, p = 0.01), indicating larger effects in more severely depressed samples
+
+Session frequency, session duration, and participant age were not significant predictors in univariate models (all p > 0.10).

--- a/systematic-review/content/sections/4-grade-evidence.md
+++ b/systematic-review/content/sections/4-grade-evidence.md
@@ -1,0 +1,161 @@
++++
+title = "4. GRADE Evidence"
+description = "Certainty of evidence assessment using the GRADE framework for exercise intervention outcomes."
+weight = 4
+template = "post"
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+categories = ["sections"]
+
+[extra]
+section_number = "4"
++++
+
+## Overview
+
+We assessed the certainty of evidence using the Grading of Recommendations, Assessment, Development, and Evaluations (GRADE) framework. Evidence from randomized controlled trials starts at high certainty and may be downgraded across five domains: risk of bias, inconsistency, indirectness, imprecision, and publication bias.
+
+## GRADE Evidence Profile
+
+<table class="grade-table">
+  <caption><span class="tab-num">Table 5.</span> GRADE evidence profile for the effect of exercise interventions on depressive symptoms in adolescents.</caption>
+  <thead>
+    <tr>
+      <th>Outcome</th>
+      <th>Studies (k)</th>
+      <th>Risk of Bias</th>
+      <th>Inconsistency</th>
+      <th>Indirectness</th>
+      <th>Imprecision</th>
+      <th>Pub. Bias</th>
+      <th>Certainty</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Overall depression symptoms</strong></td>
+      <td class="num">31</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>a</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-moderate">MODERATE</span></td>
+    </tr>
+    <tr>
+      <td>Aerobic exercise subgroup</td>
+      <td class="num">22</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>a</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-moderate">MODERATE</span></td>
+    </tr>
+    <tr>
+      <td>Resistance training subgroup</td>
+      <td class="num">6</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>b</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-low">LOW</span></td>
+    </tr>
+    <tr>
+      <td>Mind-body interventions</td>
+      <td class="num">5</td>
+      <td><span class="grade-cell grade-serious">Serious<sup>c</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>b</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-low">LOW</span></td>
+    </tr>
+    <tr>
+      <td>Supervised programs</td>
+      <td class="num">24</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>a</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-moderate">MODERATE</span></td>
+    </tr>
+    <tr>
+      <td>Unsupervised programs</td>
+      <td class="num">7</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>b</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-low">LOW</span></td>
+    </tr>
+    <tr>
+      <td>Duration 8+ weeks</td>
+      <td class="num">26</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>a</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-moderate">MODERATE</span></td>
+    </tr>
+    <tr>
+      <td>Duration &lt;8 weeks</td>
+      <td class="num">5</td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-not-serious">Not serious</span></td>
+      <td><span class="grade-cell grade-serious">Serious<sup>b</sup></span></td>
+      <td><span class="grade-cell grade-not-serious">Not detected</span></td>
+      <td><span class="grade-certainty grade-low">LOW</span></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="8"><sup>a</sup> Downgraded one level for inconsistency: I-squared > 60%, wide prediction interval. <sup>b</sup> Downgraded one level for imprecision: fewer than 400 participants or wide confidence interval crossing clinically important threshold. <sup>c</sup> Downgraded one level for risk of bias: majority of studies had some concerns or high risk.</td></tr>
+  </tfoot>
+</table>
+
+## Interpretation of Certainty Levels
+
+<div class="grade-legend">
+  <div class="grade-legend-item">
+    <span class="grade-certainty grade-high">HIGH</span>
+    <p>We are very confident that the true effect lies close to the estimate. Further research is very unlikely to change our confidence.</p>
+  </div>
+  <div class="grade-legend-item">
+    <span class="grade-certainty grade-moderate">MODERATE</span>
+    <p>We are moderately confident in the effect estimate. The true effect is likely close to the estimate, but there is a possibility that it is substantially different.</p>
+  </div>
+  <div class="grade-legend-item">
+    <span class="grade-certainty grade-low">LOW</span>
+    <p>Our confidence in the effect estimate is limited. The true effect may be substantially different from the estimate.</p>
+  </div>
+  <div class="grade-legend-item">
+    <span class="grade-certainty grade-very-low">VERY LOW</span>
+    <p>We have very little confidence in the effect estimate. The true effect is likely substantially different from the estimate.</p>
+  </div>
+</div>
+
+## Key GRADE Decisions
+
+### Risk of Bias
+
+We did not downgrade the overall evidence for risk of bias. Although 52.9% of studies had "some concerns" and 11.8% had high risk, the sensitivity analysis restricted to low-risk studies yielded a similar pooled effect (SMD = -0.52 vs. -0.56), indicating that risk-of-bias concerns did not materially alter the estimate.
+
+### Inconsistency
+
+We downgraded one level for inconsistency in analyses where I-squared exceeded 60%. While the prediction interval for the overall analysis included the null (upper bound = 0.00), the direction of the effect was consistent across 29 of 31 studies.
+
+### Indirectness
+
+No downgrade was applied. The included studies directly addressed our PICO question: adolescents with elevated depression, structured exercise programs, and validated depression outcome measures.
+
+### Imprecision
+
+We downgraded one level for subgroup analyses with fewer than 400 total participants or where the confidence interval crossed the clinically important threshold of SMD = -0.20 (minimum clinically important difference).
+
+### Publication Bias
+
+We did not downgrade for publication bias based on non-significant Egger's test, symmetric funnel plot, and large fail-safe N. However, we note that exercise-related trials may be more susceptible to outcome reporting bias (selectively reporting favorable time points or instruments).

--- a/systematic-review/content/sections/5-discussion.md
+++ b/systematic-review/content/sections/5-discussion.md
@@ -1,0 +1,93 @@
++++
+title = "5. Discussion"
+description = "Synthesis of findings, clinical implications, heterogeneity interpretation, comparison with prior reviews, and study limitations."
+weight = 5
+template = "post"
+tags = ["paper", "light", "systematic", "evidence", "methodology"]
+categories = ["sections"]
+
+[extra]
+section_number = "5"
++++
+
+## Summary of Evidence
+
+This systematic review and meta-analysis synthesized evidence from 34 randomized controlled trials encompassing 2,847 adolescents aged 12-19 years. The pooled random-effects analysis demonstrated that structured exercise interventions produce a moderate and statistically significant reduction in depressive symptoms compared with control conditions (SMD = -0.56, 95% CI: -0.72 to -0.40). The overall certainty of evidence was rated as moderate under the GRADE framework, with the primary downgrade attributable to substantial heterogeneity (I-squared = 68.4%).
+
+## Comparison with Prior Reviews
+
+Our findings are broadly consistent with, but more precisely estimated than, previous reviews in this domain:
+
+- **Radovic et al. (2017)** reported an SMD of -0.48 (95% CI: -0.87 to -0.09) based on 11 RCTs, but noted serious imprecision due to the limited evidence base.
+- **Bailey et al. (2018)** found an SMD of -0.61 (95% CI: -0.88 to -0.34) in 18 studies, though their inclusion of quasi-experimental designs may have inflated the estimate.
+- **Recchia et al. (2023)** reported an SMD of -0.53 (95% CI: -0.72 to -0.34) in 21 RCTs, closely aligning with our point estimate.
+
+Our review extends this literature by nearly doubling the available evidence base (34 vs. 18-21 studies in the most recent prior reviews), incorporating 8 studies published in 2023-2025, and providing the first comprehensive GRADE assessment for this specific population-intervention combination.
+
+## Clinical Significance
+
+The pooled SMD of -0.56 corresponds to a moderate effect size and is above the commonly cited minimum clinically important difference threshold of 0.20 for depression scales. To contextualize: this effect is comparable to the standardized effect of group cognitive-behavioral therapy for adolescent depression (SMD approximately -0.47) and somewhat smaller than individual CBT (SMD approximately -0.67), though direct comparisons across reviews should be interpreted cautiously.
+
+### Dose-Response Relationship
+
+Meta-regression identified intervention duration as a significant predictor (beta = -0.014 per week, p = 0.02), suggesting that programs of 8 or more weeks produce meaningfully larger effects than shorter interventions. This is consistent with the neurobiological literature suggesting that exercise-induced increases in brain-derived neurotrophic factor (BDNF) and hippocampal neurogenesis require sustained engagement over multiple weeks.
+
+### Moderation by Baseline Severity
+
+The finding that baseline depression severity predicted larger effect sizes (beta = -0.18 per SD, p = 0.01) has important clinical implications. Adolescents with more severe depressive symptoms may benefit more from exercise interventions, supporting the use of exercise as an adjunctive therapy in clinical populations rather than limiting its recommendation to prevention or mild-symptom contexts.
+
+## Interpretation of Heterogeneity
+
+The substantial heterogeneity (I-squared = 68.4%) warrants careful interpretation. Our pre-specified subgroup analyses identified exercise type, supervision status, duration, and baseline severity as potential sources of variability. However, none of these moderators fully explained the observed heterogeneity, suggesting that unmeasured factors -- including intervention fidelity, cultural context, co-occurring treatments, and outcome measurement variability -- contribute to between-study differences.
+
+The 95% prediction interval (-1.12 to 0.00) indicates that while the average effect is beneficial, a new study conducted in a different setting might observe effects ranging from large benefits to approximately null. This underscores the importance of adapting exercise programs to local contexts rather than assuming uniform benefit.
+
+## Strengths
+
+This review has several methodological strengths:
+
+- **Comprehensive search:** Six databases plus grey literature, hand-searching, and trial registry searches, with no language restrictions
+- **Rigorous screening:** Independent dual screening with high inter-rater reliability (kappa = 0.88-0.91)
+- **Validated assessment tools:** Cochrane RoB 2.0 for risk of bias and GRADE for certainty of evidence
+- **Pre-registration:** Protocol registered in PROSPERO prior to data extraction
+- **Robust sensitivity analyses:** Including leave-one-out analysis, restriction to low-risk studies, trim-and-fill, and meta-regression
+
+## Limitations
+
+Several limitations should be considered when interpreting our findings:
+
+1. **Blinding constraints:** Exercise trials cannot blind participants or intervention providers, which introduces performance bias. The reliance on self-reported outcome measures (used in 28 of 34 studies) compounds this limitation.
+
+2. **Control condition heterogeneity:** Control groups varied from waitlist (no contact) to active attention controls, which likely contributed to between-study variability. Studies using waitlist controls tended to show larger effects.
+
+3. **Short follow-up:** Most studies (26 of 34) assessed outcomes only at the end of the intervention period. Long-term maintenance of antidepressant effects beyond the intervention period remains poorly characterized.
+
+4. **Geographic imbalance:** The majority of included studies were conducted in high-income countries (Europe, East Asia, North America). Evidence from sub-Saharan Africa, South Asia, and Latin America was limited, reducing generalizability.
+
+5. **Outcome measure variability:** Studies used eight different depression instruments, and while we standardized effects using SMD, the conceptual heterogeneity of these measures may contribute to statistical heterogeneity.
+
+6. **Adherence reporting:** Only 18 of 34 studies reported detailed adherence data. The mean adherence rate (where reported) was 78%, but the impact of actual exercise dose (as opposed to prescribed dose) on outcomes could not be systematically assessed.
+
+## Implications for Practice
+
+Based on the available evidence, we offer the following recommendations for clinical practice:
+
+- **Supervised aerobic exercise** programs of at least 8 weeks' duration and 3 sessions per week should be considered as an adjunctive intervention for adolescents with depressive symptoms.
+- Exercise prescriptions should be **individualized** to account for fitness level, preferences, and access to facilities, as adherence is a critical mediator of benefit.
+- **Clinically diagnosed adolescents** may benefit more than those with subclinical symptoms, supporting integration of exercise into multidisciplinary treatment plans.
+- Exercise should be positioned as a **complement to**, not a replacement for, evidence-based psychological and pharmacological treatments for moderate-to-severe depression.
+
+## Implications for Research
+
+Future studies should prioritize:
+
+- **Longer follow-up periods** (6-12 months post-intervention) to assess durability of effects
+- **Objective adherence monitoring** (e.g., accelerometry) alongside self-report
+- **Head-to-head comparisons** between exercise types within the same trial
+- **Representation from low- and middle-income countries**, where the burden of adolescent depression is highest
+- **Mechanistic studies** examining biomarker trajectories (BDNF, cortisol, inflammatory markers) alongside clinical outcomes
+- **Implementation science approaches** to understand how exercise programs can be sustainably integrated into school and clinical settings
+
+## Conclusions
+
+This systematic review and meta-analysis provides moderate-certainty evidence that structured exercise interventions produce clinically meaningful reductions in depressive symptoms among adolescents. The effect is most pronounced for supervised aerobic programs of 8 or more weeks' duration. These findings support the integration of exercise prescriptions into evidence-based care pathways for adolescent depression, while highlighting the need for longer follow-up studies and greater geographic diversity in the evidence base.

--- a/systematic-review/content/sections/_index.md
+++ b/systematic-review/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+This systematic review is organized into five sections following the PRISMA 2020 reporting guidelines. Each section covers a distinct stage of the evidence synthesis process, from systematic search through certainty of evidence assessment and clinical discussion.

--- a/systematic-review/static/css/style.css
+++ b/systematic-review/static/css/style.css
@@ -1,0 +1,870 @@
+/* ============================================================================
+   Systematic Review - Evidence Synthesis Paper
+   Light background, methodical aesthetics. IBM Plex Sans Bold / Source Sans
+   Pro Bold display, STIX Two Text / Crimson Pro body. Accent #2a6a4a,
+   PRISMA blue #2a5a8a, risk-of-bias traffic lights. No gradients, no emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #fafaf7;
+  --paper-2: #f0efe8;
+  --rule: #ccc8ba;
+  --ink: #1a2030;
+  --ink-2: #2a3448;
+  --ink-3: #5b6272;
+  --ink-4: #8a8e9a;
+  --accent: #2a6a4a;
+  --accent-2: #1e5438;
+  --accent-bg: #e8f5ee;
+  --prisma-blue: #2a5a8a;
+  --prisma-blue-bg: #eaf0f7;
+  --prisma-purple: #6a4a8a;
+  --prisma-purple-bg: #f0eaf7;
+  --prisma-amber: #8a6a2a;
+  --prisma-amber-bg: #faf3e6;
+  --rob-low: #2a6a4a;
+  --rob-low-bg: #e8f5ee;
+  --rob-unclear: #c8a020;
+  --rob-unclear-bg: #faf3e6;
+  --rob-high: #c83030;
+  --rob-high-bg: #fce8e8;
+  --grade-high-color: #1a5a3a;
+  --grade-high-bg: #d4edda;
+  --grade-moderate-color: #2a5a8a;
+  --grade-moderate-bg: #d6eaf8;
+  --grade-low-color: #8a6a2a;
+  --grade-low-bg: #faf3e6;
+  --grade-very-low-color: #8a2a2a;
+  --grade-very-low-bg: #fce8e8;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "STIX Two Text", "Crimson Pro", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1.4rem;
+  border-bottom: 2px double var(--rule);
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 64px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.journal-sub {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--ink-3);
+  letter-spacing: 0.1em;
+  margin-top: 0.2em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.site-nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------------- Badge row ---------------- */
+
+.badge-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.8rem;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-width: 1.5px;
+  border-style: solid;
+}
+
+.badge svg { width: 16px; height: 16px; }
+
+.badge-prisma {
+  background: var(--prisma-blue-bg);
+  border-color: var(--prisma-blue);
+  color: var(--prisma-blue);
+}
+
+.badge-grade {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ---------------- Paper article container ---------------- */
+
+.paper-article {
+  padding: 3rem 0 4rem;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.paper-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--prisma-blue);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.paper-authors {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  color: var(--ink-2);
+}
+
+.paper-authors .author-corresponding { font-weight: 600; }
+.paper-authors sup { color: var(--prisma-blue); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-doi {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  letter-spacing: 0.06em;
+  margin-top: 1.2rem;
+}
+
+.paper-doi a { color: var(--prisma-blue); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* ---------------- Abstract box ---------------- */
+
+.abstract-box {
+  background: var(--paper-2);
+  border-left: 3px solid var(--prisma-blue);
+  padding: 1.5rem 1.8rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: var(--prisma-blue);
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.abstract-box p { margin: 0.6rem 0; }
+
+.abstract-box dl {
+  margin: 0.8rem 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+}
+
+.abstract-box dt {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--ink-2);
+  text-transform: uppercase;
+}
+
+.abstract-box dd {
+  margin: 0;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+}
+
+/* ---------------- Section typography ---------------- */
+
+.paper-article h2,
+.paper-content h2 {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 2.4rem 0 0.8rem;
+  padding-top: 0.4rem;
+}
+
+.paper-article h3,
+.paper-content h3 {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--ink);
+  margin: 1.8rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.paper-article h4,
+.paper-content h4 {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-weight: 600;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  margin: 1.4rem 0 0.4rem;
+}
+
+.paper-article p,
+.paper-content p {
+  margin: 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.paper-article a,
+.paper-content a {
+  color: var(--prisma-blue);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.paper-article a:hover,
+.paper-content a:hover { color: var(--accent-2); }
+
+.paper-article ul, .paper-article ol,
+.paper-content ul, .paper-content ol {
+  margin: 1rem 0;
+  padding-left: 1.6rem;
+}
+
+.paper-article li,
+.paper-content li { margin: 0.3rem 0; }
+
+.paper-article code,
+.paper-content code {
+  font-family: "JetBrains Mono", monospace;
+  background: var(--paper-2);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  font-size: 0.88em;
+}
+
+.paper-article strong,
+.paper-content strong { color: var(--ink); font-weight: 700; }
+
+.paper-article em,
+.paper-content em { font-style: italic; }
+
+/* ---------------- Section headers ---------------- */
+
+.paper-section-header {
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  color: var(--prisma-blue);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  color: var(--ink);
+}
+
+.paper-lede {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-3);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+/* ---------------- PICO box ---------------- */
+
+.pico-box {
+  background: var(--prisma-blue-bg);
+  border: 1.5px solid var(--prisma-blue);
+  padding: 1.2rem 1.6rem;
+  margin: 1.5rem 0;
+}
+
+.pico-box .pico-label {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  color: var(--prisma-blue);
+  text-transform: uppercase;
+  margin: 0 0 0.6rem;
+}
+
+.pico-box dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1rem;
+  margin: 0;
+}
+
+.pico-box dt {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+}
+
+.pico-box dd {
+  margin: 0;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+}
+
+/* ---------------- Search blocks ---------------- */
+
+.search-block {
+  background: var(--paper-2);
+  border: 1.5px solid var(--rule);
+  padding: 1rem 1.4rem;
+  margin: 1.2rem 0;
+}
+
+.search-block .search-block-label {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  color: var(--prisma-blue);
+  text-transform: uppercase;
+  margin: 0 0 0.4rem;
+}
+
+.search-block .search-terms {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--ink-2);
+  margin: 0;
+  word-break: break-word;
+}
+
+/* ---------------- Figures ---------------- */
+
+.figure {
+  margin: 2.2rem 0;
+  padding: 1.2rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  break-inside: avoid;
+}
+
+.figure svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 0.8rem;
+}
+
+.figure figcaption,
+.figure .caption {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  line-height: 1.5;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--rule);
+}
+
+.figure .caption .fig-num {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  color: var(--prisma-blue);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.figure-wide {
+  max-width: none;
+}
+
+/* ---------------- Tables ---------------- */
+
+.paper-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.92rem;
+}
+
+.paper-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.paper-table caption .tab-num {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  color: var(--prisma-blue);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.paper-table th,
+.paper-table td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.paper-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.02em;
+}
+
+.paper-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.88rem;
+  text-align: right;
+}
+
+.paper-table tfoot td {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+/* ---------------- Risk of Bias traffic lights ---------------- */
+
+.rob-low {
+  color: var(--rob-low);
+  font-weight: 700;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.88rem;
+}
+
+.rob-unclear {
+  color: var(--rob-unclear);
+  font-weight: 700;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.88rem;
+}
+
+.rob-high {
+  color: var(--rob-high);
+  font-weight: 700;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.88rem;
+}
+
+/* ---------------- GRADE styles ---------------- */
+
+.grade-high {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: var(--grade-high-bg);
+  color: var(--grade-high-color);
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.grade-moderate {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: var(--grade-moderate-bg);
+  color: var(--grade-moderate-color);
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.grade-low {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: var(--grade-low-bg);
+  color: var(--grade-low-color);
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.grade-very-low {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: var(--grade-very-low-bg);
+  color: var(--grade-very-low-color);
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------------- GRADE evidence table ---------------- */
+
+.grade-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.88rem;
+}
+
+.grade-table caption {
+  caption-side: top;
+  text-align: left;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin-bottom: 0.6rem;
+}
+
+.grade-table caption .tab-num {
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  color: var(--prisma-blue);
+  letter-spacing: 0.05em;
+  margin-right: 0.4em;
+}
+
+.grade-table th,
+.grade-table td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.grade-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.grade-table td.num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.84rem;
+  text-align: right;
+}
+
+.grade-table tfoot td {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: var(--ink-3);
+  padding-top: 0.8rem;
+  border-bottom: none;
+}
+
+.grade-cell {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.grade-not-serious { color: var(--accent); }
+.grade-serious { color: var(--rob-unclear); }
+.grade-very-serious { color: var(--rob-high); }
+
+.grade-certainty {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 700;
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* ---------------- GRADE legend ---------------- */
+
+.grade-legend {
+  margin: 2rem 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.grade-legend-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  background: var(--paper-2);
+  border-left: 3px solid var(--rule);
+}
+
+.grade-legend-item .grade-certainty {
+  flex-shrink: 0;
+  min-width: 6rem;
+  text-align: center;
+}
+
+.grade-legend-item p {
+  margin: 0;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  text-align: left;
+}
+
+/* ---------------- Checklist table ---------------- */
+
+.checklist-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.8rem 0;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.88rem;
+}
+
+.checklist-table th,
+.checklist-table td {
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+
+.checklist-table thead th {
+  font-weight: 700;
+  background: var(--paper-2);
+  border-bottom: 2px solid var(--ink);
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+/* ---------------- Section list ---------------- */
+
+.section-list { list-style: decimal; padding-left: 1.6rem; margin: 1.5rem 0; }
+.section-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule);
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+}
+.section-list li a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Buttons ---------------- */
+
+.button-link {
+  display: inline-block;
+  font-family: "IBM Plex Sans", "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--prisma-blue);
+  text-decoration: none;
+  border-bottom: 1px solid var(--prisma-blue);
+  padding-bottom: 0.1rem;
+  letter-spacing: 0.02em;
+}
+
+.button-link:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+.paper-section-footer { margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--rule); }
+
+.error-page { text-align: center; padding: 3rem 0; }
+
+.taxonomy-desc {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  color: var(--ink-3);
+  font-style: italic;
+  margin-bottom: 1.5rem;
+}
+
+/* ---------------- References list ---------------- */
+
+.references-list {
+  list-style: decimal;
+  padding-left: 2rem;
+  margin: 1.5rem 0;
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+}
+
+.references-list li {
+  padding: 0.3rem 0;
+  line-height: 1.5;
+}
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0 3rem;
+  border-top: 2px double var(--rule);
+}
+
+.footer-rule svg { width: 100%; height: 6px; display: block; margin-bottom: 1.2rem; }
+
+.footer-content { max-width: 820px; margin: 0 auto; text-align: center; }
+
+.footer-meta {
+  font-family: "STIX Two Text", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.footer-meta em { font-style: italic; }
+
+.footer-note {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.74rem;
+  color: var(--ink-3);
+  margin: 0.8rem 0 0;
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  body { font-size: 17px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { width: 100%; }
+  .abstract-box dl { grid-template-columns: 1fr; }
+  .abstract-box dt { margin-top: 0.6rem; }
+  .pico-box dl { grid-template-columns: 1fr; }
+  .badge-row { flex-direction: column; }
+  .grade-legend-item { flex-direction: column; gap: 0.4rem; }
+  .grade-table { font-size: 0.78rem; }
+  .grade-table th, .grade-table td { padding: 0.4rem 0.3rem; }
+  .search-block .search-terms { font-size: 0.75rem; }
+  .figure { padding: 0.6rem; }
+  .figure svg { padding: 0.4rem; }
+}
+
+@media (max-width: 480px) {
+  .paper-table, .grade-table, .checklist-table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}

--- a/systematic-review/templates/404.html
+++ b/systematic-review/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article error-page">
+      <h1>404 Not Found</h1>
+      <p>The requested page does not exist. It may have been excluded during screening.</p>
+      <p><a href="{{ base_url }}/" class="button-link">&larr; return to abstract</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/systematic-review/templates/footer.html
+++ b/systematic-review/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#1a2030" stroke-width="1"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2030" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Asante-Mensah K, Ramirez-Cruz S, Tanaka-Ito Y, Holmberg I. Exercise Interventions for Reducing Depression Symptoms in Adolescents: A Systematic Review and Meta-Analysis. <em>J Adolesc Health Psychol.</em> 2026;12(2):84-127. doi:10.41093/jahp.2026.12.02.084</p>
+        <p class="footer-note">ISSN 3024-6189 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/systematic-review/templates/header.html
+++ b/systematic-review/templates/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@500;600;700&family=Source+Sans+Pro:wght@500;600;700&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 64 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Systematic review / evidence synthesis icon -->
+          <rect x="2" y="2" width="60" height="36" fill="none" stroke="#1a2030" stroke-width="1.5"/>
+          <!-- Funnel shape: many studies narrowed to few -->
+          <line x1="8" y1="8" x2="56" y2="8" stroke="#2a5a8a" stroke-width="1.2"/>
+          <line x1="8" y1="12" x2="56" y2="12" stroke="#2a5a8a" stroke-width="0.8"/>
+          <line x1="8" y1="16" x2="56" y2="16" stroke="#2a5a8a" stroke-width="0.8"/>
+          <line x1="14" y1="20" x2="50" y2="20" stroke="#7a5a2a" stroke-width="0.8"/>
+          <line x1="20" y1="24" x2="44" y2="24" stroke="#7a5a2a" stroke-width="0.8"/>
+          <line x1="24" y1="28" x2="40" y2="28" stroke="#2a6a4a" stroke-width="1.2"/>
+          <!-- Diamond for meta-analysis -->
+          <polygon points="32,31 28,34 32,37 36,34" fill="#2a6a4a" stroke="#2a6a4a" stroke-width="0.8"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Adolescent Health Psychology</span>
+          <span class="journal-sub">Vol. 12 &middot; Issue 02 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/prisma/">PRISMA</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/systematic-review/templates/page.html
+++ b/systematic-review/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/systematic-review/templates/post.html
+++ b/systematic-review/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/systematic-review/templates/section.html
+++ b/systematic-review/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/systematic-review/templates/shortcodes/alert.html
+++ b/systematic-review/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/systematic-review/templates/taxonomy.html
+++ b/systematic-review/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">TAXONOMY</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/systematic-review/templates/taxonomy_term.html
+++ b/systematic-review/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">TAXONOMY TERM</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      <p class="taxonomy-desc">Posts tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3647,6 +3647,13 @@
     "glamorous",
     "trendy"
   ],
+  "systematic-review": [
+    "paper",
+    "light",
+    "systematic",
+    "evidence",
+    "methodology"
+  ],
   "tactile-fabric": [
     "light",
     "blog",


### PR DESCRIPTION
## Summary
- Adds evidence synthesis paper with systematic review and meta-analysis of exercise interventions for adolescent depression
- Features inline SVG PRISMA flow diagrams, risk of bias traffic-light grids, forest plots, and GRADE evidence tables
- Uses IBM Plex Sans Bold/Source Sans Pro Bold for methodical display and STIX Two/Crimson Pro for academic body text
- Includes 5 sections: Search Strategy, Risk of Bias, Meta-Analysis, GRADE Evidence, Discussion

## Test plan
- [ ] Verify `hwaro build` completes in `systematic-review/`
- [ ] Verify PRISMA, RoB traffic-light, and forest plot SVGs render correctly
- [ ] Verify tags.json entry is valid JSON and alphabetically sorted
- [ ] Verify no emojis or CSS gradients in any files

Closes #1613