### PR TITLE
feat: add conference-poster example site (closes #1604)

### DIFF
--- a/conference-poster/AGENTS.md
+++ b/conference-poster/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/conference-poster/config.toml
+++ b/conference-poster/config.toml
@@ -1,0 +1,55 @@
+title = "ML Air Quality Prediction: Conference Poster P-247"
+description = "A conference poster presentation on Machine Learning for Real-Time Air Quality Prediction in Urban Environments, featuring model comparison results and sensor network data."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[[taxonomies]]
+name = "authors"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/conference-poster/content/appendix.md
+++ b/conference-poster/content/appendix.md
@@ -1,0 +1,63 @@
++++
+title = "Appendix"
+tags = ["references", "contact", "funding"]
++++
+
+## Contact Information
+
+<div class="contact-block">
+<p><strong>Corresponding Author</strong></p>
+<p>Wei Chen, Ph.D. Candidate</p>
+<p>Department of Environmental Computing</p>
+<p>Metropolitan Institute of Technology</p>
+<p>Email: wei.chen@mit-envcomp.edu</p>
+</div>
+
+### Co-Authors
+
+- **Adaeze Okafor, Ph.D.** -- Center for Urban Atmospheric Research, Metropolitan Institute of Technology
+- **Dimitri Petrov, Ph.D.** -- Department of Computer Science, Greenfield State University
+- **Sakura Nakamura, M.S.** -- Global Climate Analytics Lab, Pacific Environmental Research Institute
+
+## References
+
+1. Chen, W., Okafor, A., Petrov, D., & Nakamura, S. (2025). Deep learning architectures for urban air quality nowcasting: A benchmark study. *Environmental Modelling & Software*, 178, 105892.
+
+2. Zhang, L., & Wang, H. (2024). Transformer-based spatiotemporal models for PM2.5 prediction. *Atmospheric Environment*, 312, 120045.
+
+3. Kumar, R., et al. (2024). Low-cost sensor networks for urban air quality monitoring: Calibration challenges and solutions. *Journal of Environmental Monitoring*, 26(3), 445--462.
+
+4. Li, X., Chen, Y., & Zhou, M. (2023). XGBoost-LSTM hybrid models for multi-step air pollution forecasting. *Science of the Total Environment*, 892, 164523.
+
+5. Rodriguez, M., & Patel, S. (2023). Attention mechanisms in environmental time series prediction: A systematic review. *Environmental Data Science*, 2, e15.
+
+6. World Health Organization. (2021). *WHO global air quality guidelines: Particulate matter (PM2.5 and PM10), ozone, nitrogen dioxide, sulfur dioxide and carbon monoxide*. WHO Press.
+
+7. EPA. (2024). *Air quality sensor performance evaluation protocols*. United States Environmental Protection Agency, Technical Report EPA-600/R-24-012.
+
+8. Vaswani, A., et al. (2017). Attention is all you need. *Advances in Neural Information Processing Systems*, 30, 5998--6008.
+
+## Funding
+
+This research was supported by:
+
+- **National Science Foundation** -- Grant No. NSF-2024-ENV-4821, "Data-Driven Urban Air Quality Prediction Systems"
+- **Environmental Protection Agency** -- STAR Fellowship Program, Award No. FP-2024-0847
+- **Greenfield City Department of Environmental Services** -- Municipal Research Partnership Agreement, Contract No. GC-ENV-2024-031
+- **Metropolitan Institute of Technology** -- Graduate Research Fellowship
+
+## Conference Information
+
+**International Conference on Environmental Data Science 2026 (ICEDS 2026)**
+
+Session: Machine Learning Applications in Environmental Monitoring (Poster Session B)
+
+Poster Number: P-247
+
+Date: April 15, 2026
+
+Venue: Greenfield Convention Center, Greenfield City
+
+## How to Cite This Poster
+
+Chen, W., Okafor, A., Petrov, D., & Nakamura, S. (2026). Machine Learning for Real-Time Air Quality Prediction in Urban Environments. Poster presented at the International Conference on Environmental Data Science 2026, Greenfield City. Poster P-247.

--- a/conference-poster/content/data.md
+++ b/conference-poster/content/data.md
@@ -1,0 +1,59 @@
++++
+title = "Data Specifications"
+tags = ["data", "sensors", "methodology"]
++++
+
+## Sensor Network Specifications
+
+The Greenfield City Air Quality Network (GCAQN) is a purpose-built urban monitoring infrastructure designed for high-density spatiotemporal pollutant measurement.
+
+| Specification | Value |
+|---|---|
+| Total Sensor Nodes | 200 |
+| Coverage Area | 85 km2 |
+| Measurement Interval | 5 minutes |
+| Pollutants Measured | PM2.5, PM10, NO2, O3, CO |
+| Environmental Variables | Temperature, Humidity, Pressure |
+| Deployment Period | January 2024 -- June 2025 |
+| Total Data Points | ~105 million |
+| Uptime (network average) | 97.3% |
+
+## Sensor Hardware
+
+Each node in the GCAQN uses the following sensor modules:
+
+| Component | Model | Range | Accuracy |
+|---|---|---|---|
+| PM Sensor | Plantower PMS7003 | 0--500 ug/m3 | +/- 10 ug/m3 |
+| NO2 Sensor | Alphasense NO2-B43F | 0--200 ppb | +/- 5 ppb |
+| O3 Sensor | Alphasense OX-B431 | 0--500 ppb | +/- 8 ppb |
+| CO Sensor | Alphasense CO-B4 | 0--50 ppm | +/- 0.5 ppm |
+| Temp/Humidity | Sensirion SHT31 | -40 to 125 C | +/- 0.3 C |
+| Pressure | Bosch BMP388 | 300--1100 hPa | +/- 0.5 hPa |
+
+## Supplementary Data Sources
+
+| Source | Provider | Resolution | Coverage |
+|---|---|---|---|
+| Weather Stations | National Weather Service | Hourly | 12 stations |
+| Traffic Density | City Transportation Dept. | 15-minute | 340 detectors |
+| Satellite AOD | NASA MODIS/VIIRS | Daily, 1 km | Metropolitan area |
+| Industrial Emissions | EPA TRI Database | Hourly | 23 facilities |
+| Land Use Classification | USGS NLCD | Static, 30 m | Metropolitan area |
+
+## Data Quality Control
+
+All sensor data underwent a multi-stage quality control pipeline:
+
+1. **Automated range checks** -- Values outside physically plausible ranges were flagged and removed
+2. **Cross-sensor validation** -- Measurements from co-located reference instruments were used to detect sensor drift
+3. **Temporal consistency checks** -- Sudden changes exceeding 3 standard deviations within a 15-minute window were reviewed
+4. **Calibration correction** -- Monthly field calibration against EPA Federal Reference Method instruments was applied retroactively
+
+After quality control, 94.8% of the raw data was retained for model training and evaluation.
+
+## Data Availability
+
+The complete GCAQN dataset, including raw sensor measurements, calibrated values, and supplementary data sources, is available through the Greenfield City Open Data Portal. Processed feature matrices used for model training will be deposited in the Zenodo research data repository following publication of the full paper.
+
+Access requests should be directed to the corresponding author at wei.chen@mit-envcomp.edu.

--- a/conference-poster/content/index.md
+++ b/conference-poster/content/index.md
@@ -1,0 +1,382 @@
++++
+title = "Poster"
+tags = ["paper", "dark", "poster", "conference", "visual"]
++++
+
+<div class="poster-header">
+  <div class="poster-eyebrow">POSTER P-247</div>
+  <h1 class="poster-title">MACHINE LEARNING FOR REAL-TIME AIR QUALITY PREDICTION IN URBAN ENVIRONMENTS</h1>
+  <div class="poster-authors">Wei Chen, Adaeze Okafor, Dimitri Petrov, Sakura Nakamura</div>
+  <div class="poster-institution">Department of Environmental Computing, Metropolitan Institute of Technology</div>
+  <div class="poster-institution">Center for Urban Atmospheric Research, Global Climate Analytics Lab</div>
+  <div class="poster-conference">International Conference on Environmental Data Science 2026</div>
+</div>
+
+<!-- ================================================================== -->
+<!-- PANEL 1: INTRODUCTION (BLUE) -->
+<!-- ================================================================== -->
+
+<div class="poster-panel poster-panel--blue">
+  <div class="poster-panel-header">1. Introduction</div>
+  <div class="poster-panel-body">
+
+<p>Urban air quality monitoring faces critical challenges: sparse sensor coverage, variable pollutant sources, and rapidly changing atmospheric conditions demand prediction systems that can operate in real time. Traditional physics-based dispersion models require extensive computational resources and struggle to incorporate heterogeneous data sources.</p>
+
+<p>Machine learning offers a data-driven alternative capable of integrating meteorological observations, traffic patterns, industrial emissions data, and satellite imagery into unified prediction frameworks. This study compares four ML architectures for real-time PM2.5, NO2, and O3 forecasting across a 200-sensor urban network.</p>
+
+<div class="poster-figure">
+<svg viewBox="0 0 700 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Sensor network diagram showing placement across a city grid">
+  <rect width="700" height="320" fill="#12121e" rx="6"/>
+  <!-- Grid lines -->
+  <line x1="50" y1="40" x2="50" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="130" y1="40" x2="130" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="210" y1="40" x2="210" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="290" y1="40" x2="290" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="370" y1="40" x2="370" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="450" y1="40" x2="450" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="530" y1="40" x2="530" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="610" y1="40" x2="610" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="40" x2="650" y2="40" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="100" x2="650" y2="100" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="160" x2="650" y2="160" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="220" x2="650" y2="220" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="280" x2="650" y2="280" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- Road blocks (darker rectangles) -->
+  <rect x="55" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="135" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="215" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="295" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="375" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="455" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="535" y="45" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="55" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="135" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="215" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="295" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="375" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="455" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="535" y="105" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="55" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="135" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="215" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="295" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="375" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="455" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="535" y="165" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="55" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="135" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="215" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="295" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="375" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="455" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <rect x="535" y="225" width="70" height="50" rx="3" fill="#1a1a28" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- Sensor nodes (circles with glow effect) -->
+  <circle cx="90" cy="70" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="250" cy="70" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="410" cy="70" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="570" cy="70" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="170" cy="130" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="330" cy="130" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="490" cy="130" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="90" cy="190" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="250" cy="190" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="410" cy="190" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="570" cy="190" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="170" cy="250" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="330" cy="250" r="8" fill="#4a90e2" opacity="0.9"/>
+  <circle cx="490" cy="250" r="8" fill="#4a90e2" opacity="0.9"/>
+  <!-- Connection lines between nearby sensors -->
+  <line x1="90" y1="70" x2="170" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="250" y1="70" x2="170" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="250" y1="70" x2="330" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="410" y1="70" x2="330" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="410" y1="70" x2="490" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="570" y1="70" x2="490" y2="130" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="170" y1="130" x2="90" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="170" y1="130" x2="250" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="330" y1="130" x2="250" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="330" y1="130" x2="410" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="490" y1="130" x2="410" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="490" y1="130" x2="570" y2="190" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="90" y1="190" x2="170" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="250" y1="190" x2="170" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="250" y1="190" x2="330" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="410" y1="190" x2="330" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="410" y1="190" x2="490" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <line x1="570" y1="190" x2="490" y2="250" stroke="#4a90e2" stroke-width="2" opacity="0.3"/>
+  <!-- Sensor labels -->
+  <circle cx="90" cy="70" r="4" fill="#f0f0f4"/>
+  <circle cx="250" cy="70" r="4" fill="#f0f0f4"/>
+  <circle cx="410" cy="70" r="4" fill="#f0f0f4"/>
+  <circle cx="570" cy="70" r="4" fill="#f0f0f4"/>
+  <circle cx="170" cy="130" r="4" fill="#f0f0f4"/>
+  <circle cx="330" cy="130" r="4" fill="#f0f0f4"/>
+  <circle cx="490" cy="130" r="4" fill="#f0f0f4"/>
+  <circle cx="90" cy="190" r="4" fill="#f0f0f4"/>
+  <circle cx="250" cy="190" r="4" fill="#f0f0f4"/>
+  <circle cx="410" cy="190" r="4" fill="#f0f0f4"/>
+  <circle cx="570" cy="190" r="4" fill="#f0f0f4"/>
+  <circle cx="170" cy="250" r="4" fill="#f0f0f4"/>
+  <circle cx="330" cy="250" r="4" fill="#f0f0f4"/>
+  <circle cx="490" cy="250" r="4" fill="#f0f0f4"/>
+  <!-- Legend -->
+  <circle cx="630" cy="295" r="6" fill="#4a90e2"/>
+  <text x="642" y="300" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="600">SENSOR</text>
+  <!-- Title -->
+  <text x="350" y="20" fill="#8888a0" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="3">URBAN SENSOR NETWORK -- 200 NODES ACROSS 85 KM2</text>
+</svg>
+<div class="poster-figure-caption">Figure 1. Schematic of the urban sensor network deployment across the metropolitan study area</div>
+</div>
+
+  </div>
+</div>
+
+<!-- ================================================================== -->
+<!-- PANEL 2: METHODS (RED) -->
+<!-- ================================================================== -->
+
+<div class="poster-panel poster-panel--red">
+  <div class="poster-panel-header">2. Methods</div>
+  <div class="poster-panel-body">
+
+<p>Four machine learning architectures were trained and evaluated on 18 months of continuous sensor data (January 2024 -- June 2025). Each model received identical input features: hourly pollutant concentrations, meteorological variables (temperature, humidity, wind speed/direction, pressure), traffic density indices, and satellite-derived AOD measurements.</p>
+
+<div class="poster-figure">
+<svg viewBox="0 0 700 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Diagram of four ML models compared with arrows">
+  <rect width="700" height="220" fill="#12121e" rx="6"/>
+  <!-- Title -->
+  <text x="350" y="28" fill="#8888a0" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="3">MODEL COMPARISON ARCHITECTURE</text>
+  <!-- Input block -->
+  <rect x="20" y="75" width="100" height="70" rx="6" fill="#1a1a28" stroke="#4a90e2" stroke-width="3"/>
+  <text x="70" y="103" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">SENSOR</text>
+  <text x="70" y="121" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">DATA</text>
+  <!-- Arrow from input -->
+  <line x1="120" y1="110" x2="160" y2="60" stroke="#4a90e2" stroke-width="3"/>
+  <line x1="120" y1="110" x2="160" y2="90" stroke="#4a90e2" stroke-width="3"/>
+  <line x1="120" y1="110" x2="160" y2="130" stroke="#4a90e2" stroke-width="3"/>
+  <line x1="120" y1="110" x2="160" y2="165" stroke="#4a90e2" stroke-width="3"/>
+  <!-- Model 1: Random Forest -->
+  <rect x="165" y="40" width="140" height="40" rx="6" fill="#1a1a28" stroke="#e24a4a" stroke-width="3"/>
+  <text x="235" y="65" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">RANDOM FOREST</text>
+  <!-- Model 2: XGBoost -->
+  <rect x="165" y="90" width="140" height="40" rx="6" fill="#1a1a28" stroke="#e24a4a" stroke-width="3"/>
+  <text x="235" y="115" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">XGBOOST</text>
+  <!-- Model 3: LSTM -->
+  <rect x="165" y="140" width="140" height="40" rx="6" fill="#1a1a28" stroke="#e24a4a" stroke-width="3"/>
+  <text x="235" y="165" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">LSTM</text>
+  <!-- Model 4: Transformer -->
+  <rect x="165" y="190" width="140" height="40" rx="6" fill="#1a1a28" stroke="#e24a4a" stroke-width="3"/>
+  <text x="235" y="215" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">TRANSFORMER</text>
+  <!-- Arrows to comparison -->
+  <line x1="305" y1="60" x2="370" y2="110" stroke="#e24a4a" stroke-width="3"/>
+  <line x1="305" y1="110" x2="370" y2="110" stroke="#e24a4a" stroke-width="3"/>
+  <line x1="305" y1="160" x2="370" y2="110" stroke="#e24a4a" stroke-width="3"/>
+  <line x1="305" y1="210" x2="370" y2="140" stroke="#e24a4a" stroke-width="3"/>
+  <!-- Comparison block -->
+  <rect x="370" y="75" width="140" height="70" rx="6" fill="#1a1a28" stroke="#e2c44a" stroke-width="3"/>
+  <text x="440" y="103" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">CROSS-</text>
+  <text x="440" y="121" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">VALIDATION</text>
+  <!-- Arrow to output -->
+  <line x1="510" y1="110" x2="555" y2="110" stroke="#e2c44a" stroke-width="3"/>
+  <!-- Output block -->
+  <rect x="555" y="75" width="125" height="70" rx="6" fill="#1a1a28" stroke="#4ae24a" stroke-width="3"/>
+  <text x="617" y="103" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">PERFORMANCE</text>
+  <text x="617" y="121" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="1">RANKING</text>
+</svg>
+<div class="poster-figure-caption">Figure 2. Model comparison pipeline: four architectures evaluated through 5-fold cross-validation</div>
+</div>
+
+  </div>
+</div>
+
+<!-- ================================================================== -->
+<!-- PANEL 3: RESULTS (GREEN) -->
+<!-- ================================================================== -->
+
+<div class="poster-panel poster-panel--green">
+  <div class="poster-panel-header">3. Results</div>
+  <div class="poster-panel-body">
+
+<div class="metrics-bar">
+  <div class="metric-item">
+    <span class="metric-value metric-value--blue">2.41</span>
+    <span class="metric-label">Best MAE (ug/m3)</span>
+  </div>
+  <div class="metric-item">
+    <span class="metric-value metric-value--green">0.94</span>
+    <span class="metric-label">Best R-Squared</span>
+  </div>
+  <div class="metric-item">
+    <span class="metric-value metric-value--gold">24h</span>
+    <span class="metric-label">Prediction Horizon</span>
+  </div>
+  <div class="metric-item">
+    <span class="metric-value metric-value--red">87%</span>
+    <span class="metric-label">Alert Accuracy</span>
+  </div>
+</div>
+
+<div class="poster-figure">
+<svg viewBox="0 0 700 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar chart comparing four ML models across three metrics">
+  <rect width="700" height="380" fill="#12121e" rx="6"/>
+  <!-- Title -->
+  <text x="350" y="28" fill="#8888a0" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="3">MODEL PERFORMANCE COMPARISON</text>
+  <!-- Y-axis labels -->
+  <text x="40" y="80" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="end">100</text>
+  <text x="40" y="140" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="end">80</text>
+  <text x="40" y="200" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="end">60</text>
+  <text x="40" y="260" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="end">40</text>
+  <text x="40" y="320" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="end">20</text>
+  <!-- Y-axis grid lines -->
+  <line x1="50" y1="76" x2="680" y2="76" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="136" x2="680" y2="136" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="196" x2="680" y2="196" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="256" x2="680" y2="256" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="50" y1="316" x2="680" y2="316" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- Baseline -->
+  <line x1="50" y1="336" x2="680" y2="336" stroke="#585870" stroke-width="2"/>
+  <!-- GROUP 1: Random Forest -->
+  <!-- R2 (scaled: 0.89 -> 89% height) -->
+  <rect x="72" y="106" width="32" height="230" rx="3" fill="#4a90e2"/>
+  <text x="88" y="98" fill="#4a90e2" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">0.89</text>
+  <!-- MAE (scaled: inverted, lower=better, 3.82 -> 62% of max) -->
+  <rect x="108" y="174" width="32" height="162" rx="3" fill="#e24a4a"/>
+  <text x="124" y="166" fill="#e24a4a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">3.82</text>
+  <!-- Accuracy (82%) -->
+  <rect x="144" y="122" width="32" height="214" rx="3" fill="#4ae24a"/>
+  <text x="160" y="114" fill="#4ae24a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">82%</text>
+  <!-- Label -->
+  <text x="120" y="360" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="14" text-anchor="middle" letter-spacing="1">RANDOM FOREST</text>
+  <!-- GROUP 2: XGBoost -->
+  <rect x="222" y="94" width="32" height="242" rx="3" fill="#4a90e2"/>
+  <text x="238" y="86" fill="#4a90e2" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">0.91</text>
+  <rect x="258" y="156" width="32" height="180" rx="3" fill="#e24a4a"/>
+  <text x="274" y="148" fill="#e24a4a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">3.15</text>
+  <rect x="294" y="112" width="32" height="224" rx="3" fill="#4ae24a"/>
+  <text x="310" y="104" fill="#4ae24a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">85%</text>
+  <text x="270" y="360" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="14" text-anchor="middle" letter-spacing="1">XGBOOST</text>
+  <!-- GROUP 3: LSTM -->
+  <rect x="372" y="88" width="32" height="248" rx="3" fill="#4a90e2"/>
+  <text x="388" y="80" fill="#4a90e2" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">0.92</text>
+  <rect x="408" y="144" width="32" height="192" rx="3" fill="#e24a4a"/>
+  <text x="424" y="136" fill="#e24a4a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">2.87</text>
+  <rect x="444" y="108" width="32" height="228" rx="3" fill="#4ae24a"/>
+  <text x="460" y="100" fill="#4ae24a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">86%</text>
+  <text x="420" y="360" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="14" text-anchor="middle" letter-spacing="1">LSTM</text>
+  <!-- GROUP 4: Transformer -->
+  <rect x="522" y="76" width="32" height="260" rx="3" fill="#4a90e2"/>
+  <text x="538" y="68" fill="#4a90e2" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">0.94</text>
+  <rect x="558" y="130" width="32" height="206" rx="3" fill="#e24a4a"/>
+  <text x="574" y="122" fill="#e24a4a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">2.41</text>
+  <rect x="594" y="102" width="32" height="234" rx="3" fill="#4ae24a"/>
+  <text x="610" y="94" fill="#4ae24a" font-family="Inter, sans-serif" font-size="13" font-weight="800" text-anchor="middle">87%</text>
+  <text x="570" y="360" fill="#f0f0f4" font-family="Anton, sans-serif" font-size="14" text-anchor="middle" letter-spacing="1">TRANSFORMER</text>
+  <!-- Legend -->
+  <rect x="80" y="44" width="14" height="14" rx="2" fill="#4a90e2"/>
+  <text x="100" y="55" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="12" font-weight="700">R-SQUARED</text>
+  <rect x="200" y="44" width="14" height="14" rx="2" fill="#e24a4a"/>
+  <text x="220" y="55" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="12" font-weight="700">MAE (INVERTED)</text>
+  <rect x="350" y="44" width="14" height="14" rx="2" fill="#4ae24a"/>
+  <text x="370" y="55" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="12" font-weight="700">ALERT ACCURACY</text>
+</svg>
+<div class="poster-figure-caption">Figure 3. Performance comparison across four ML architectures (higher bars = better performance)</div>
+</div>
+
+  </div>
+</div>
+
+<!-- ================================================================== -->
+<!-- PANEL 4: CONCLUSIONS (GOLD) -->
+<!-- ================================================================== -->
+
+<div class="poster-panel poster-panel--gold">
+  <div class="poster-panel-header">4. Conclusions</div>
+  <div class="poster-panel-body">
+
+<div class="poster-grid">
+<div>
+
+<ul class="takeaway-list">
+<li>The Transformer architecture achieved the best overall performance with an R-squared of 0.94 and MAE of 2.41 ug/m3 for 24-hour PM2.5 forecasts</li>
+<li>All four models significantly outperformed the existing physics-based baseline (R-squared 0.71) currently deployed in the municipal monitoring system</li>
+<li>Real-time inference latency remained below 200ms for all models, confirming feasibility for operational deployment across the full 200-sensor network</li>
+<li>Ensemble approaches combining Transformer and XGBoost predictions showed marginal additional improvement (+0.01 R-squared) at the cost of doubled computational overhead</li>
+</ul>
+
+</div>
+<div>
+
+<div class="qr-block">
+<svg viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="QR code placeholder for supplementary materials">
+  <rect width="180" height="180" fill="#f0f0f4" rx="4"/>
+  <rect x="10" y="10" width="50" height="50" rx="4" fill="#0a0a12"/>
+  <rect x="18" y="18" width="34" height="34" rx="2" fill="#f0f0f4"/>
+  <rect x="24" y="24" width="22" height="22" rx="1" fill="#0a0a12"/>
+  <rect x="120" y="10" width="50" height="50" rx="4" fill="#0a0a12"/>
+  <rect x="128" y="18" width="34" height="34" rx="2" fill="#f0f0f4"/>
+  <rect x="134" y="24" width="22" height="22" rx="1" fill="#0a0a12"/>
+  <rect x="10" y="120" width="50" height="50" rx="4" fill="#0a0a12"/>
+  <rect x="18" y="128" width="34" height="34" rx="2" fill="#f0f0f4"/>
+  <rect x="24" y="134" width="22" height="22" rx="1" fill="#0a0a12"/>
+  <rect x="70" y="10" width="10" height="10" fill="#0a0a12"/>
+  <rect x="90" y="10" width="10" height="10" fill="#0a0a12"/>
+  <rect x="70" y="30" width="10" height="10" fill="#0a0a12"/>
+  <rect x="80" y="40" width="10" height="10" fill="#0a0a12"/>
+  <rect x="100" y="30" width="10" height="10" fill="#0a0a12"/>
+  <rect x="70" y="70" width="10" height="10" fill="#0a0a12"/>
+  <rect x="90" y="70" width="10" height="10" fill="#0a0a12"/>
+  <rect x="110" y="70" width="10" height="10" fill="#0a0a12"/>
+  <rect x="130" y="70" width="10" height="10" fill="#0a0a12"/>
+  <rect x="150" y="70" width="10" height="10" fill="#0a0a12"/>
+  <rect x="70" y="90" width="10" height="10" fill="#0a0a12"/>
+  <rect x="100" y="90" width="10" height="10" fill="#0a0a12"/>
+  <rect x="120" y="90" width="10" height="10" fill="#0a0a12"/>
+  <rect x="150" y="90" width="10" height="10" fill="#0a0a12"/>
+  <rect x="10" y="80" width="10" height="10" fill="#0a0a12"/>
+  <rect x="30" y="80" width="10" height="10" fill="#0a0a12"/>
+  <rect x="10" y="100" width="10" height="10" fill="#0a0a12"/>
+  <rect x="40" y="100" width="10" height="10" fill="#0a0a12"/>
+  <rect x="70" y="110" width="10" height="10" fill="#0a0a12"/>
+  <rect x="90" y="110" width="10" height="10" fill="#0a0a12"/>
+  <rect x="120" y="120" width="10" height="10" fill="#0a0a12"/>
+  <rect x="140" y="120" width="10" height="10" fill="#0a0a12"/>
+  <rect x="160" y="120" width="10" height="10" fill="#0a0a12"/>
+  <rect x="80" y="130" width="10" height="10" fill="#0a0a12"/>
+  <rect x="100" y="140" width="10" height="10" fill="#0a0a12"/>
+  <rect x="120" y="140" width="10" height="10" fill="#0a0a12"/>
+  <rect x="70" y="150" width="10" height="10" fill="#0a0a12"/>
+  <rect x="100" y="160" width="10" height="10" fill="#0a0a12"/>
+  <rect x="130" y="160" width="10" height="10" fill="#0a0a12"/>
+  <rect x="150" y="150" width="10" height="10" fill="#0a0a12"/>
+</svg>
+<div class="qr-label">Scan for Supplementary Materials</div>
+</div>
+
+<div class="contact-block">
+<p><strong>Corresponding Author:</strong> Wei Chen</p>
+<p>wei.chen@mit-envcomp.edu</p>
+<p>Department of Environmental Computing</p>
+<p>Metropolitan Institute of Technology</p>
+</div>
+
+</div>
+</div>
+
+  </div>
+</div>
+
+---
+
+## Poster Sections
+
+Detailed content for each section of this poster is available on the following pages:
+
+- [1. Introduction]({{ base_url }}/sections/1-introduction/) -- Background and objectives
+- [2. Methods]({{ base_url }}/sections/2-methods/) -- Sensor network and model architectures
+- [3. Results]({{ base_url }}/sections/3-results/) -- Detailed performance analysis
+- [4. Conclusions]({{ base_url }}/sections/4-conclusions/) -- Key findings and future work
+
+Additional resources:
+
+- [Data Specifications]({{ base_url }}/data/) -- Sensor network and dataset details
+- [Appendix]({{ base_url }}/appendix/) -- References, contact, and funding

--- a/conference-poster/content/sections/1-introduction.md
+++ b/conference-poster/content/sections/1-introduction.md
@@ -1,0 +1,36 @@
++++
+title = "Introduction"
+weight = 1
+template = "post"
+description = "Background on urban air quality monitoring challenges and the potential of machine learning approaches for real-time pollutant prediction."
+tags = ["introduction", "air-quality", "urban-monitoring"]
+
+[extra]
+section_number = "1"
+panel_color = "blue"
++++
+
+## Background
+
+Urban air pollution remains one of the most pressing public health challenges worldwide. The World Health Organization estimates that ambient air pollution contributes to approximately 4.2 million premature deaths annually, with urban populations bearing a disproportionate burden. Particulate matter (PM2.5), nitrogen dioxide (NO2), and ground-level ozone (O3) are the primary pollutants of concern in metropolitan areas, each presenting distinct temporal and spatial variability patterns.
+
+Traditional air quality monitoring relies on sparse networks of regulatory-grade stations, typically providing measurements at 5 to 15 locations across a metropolitan area. While these stations deliver high-accuracy data, their spatial resolution is insufficient to capture the fine-grained variability driven by traffic corridors, industrial point sources, and localized meteorological conditions.
+
+## Problem Statement
+
+The core challenge addressed by this research is threefold:
+
+1. **Spatial resolution** -- Existing regulatory networks cannot capture street-level variability in pollutant concentrations, leaving significant gaps in exposure assessment for vulnerable populations
+2. **Temporal prediction** -- Physics-based atmospheric dispersion models (e.g., CMAQ, WRF-Chem) require substantial computational resources, limiting their utility for real-time forecasting at the temporal resolution needed for public health advisories
+3. **Data heterogeneity** -- Modern urban monitoring generates data from diverse sources including low-cost sensors, traffic management systems, satellite remote sensing, and weather stations, requiring flexible integration frameworks
+
+## Study Objectives
+
+This poster presents results from a comprehensive evaluation of four machine learning architectures for real-time air quality prediction:
+
+- **Objective 1:** Compare Random Forest, XGBoost, LSTM, and Transformer models on identical training data from a 200-sensor urban network
+- **Objective 2:** Evaluate prediction accuracy across multiple time horizons (1-hour, 6-hour, 12-hour, and 24-hour forecasts) for PM2.5, NO2, and O3
+- **Objective 3:** Assess computational feasibility for operational real-time deployment, including inference latency and resource requirements
+- **Objective 4:** Determine whether ensemble approaches offer meaningful improvements over individual model performance
+
+The study was conducted in the metropolitan region of Greenfield City (population 3.2 million, area 85 square kilometers) using data collected from January 2024 through June 2025.

--- a/conference-poster/content/sections/2-methods.md
+++ b/conference-poster/content/sections/2-methods.md
@@ -1,0 +1,62 @@
++++
+title = "Methods"
+weight = 2
+template = "post"
+description = "Detailed methodology including sensor network design, model architectures, feature engineering, and the training and validation framework."
+tags = ["methods", "machine-learning", "sensor-network"]
+
+[extra]
+section_number = "2"
+panel_color = "red"
++++
+
+## Sensor Network
+
+The Greenfield City Air Quality Network (GCAQN) comprises 200 low-cost sensor nodes deployed across the 85 square kilometer metropolitan area. Each node measures PM2.5, PM10, NO2, O3, CO, temperature, relative humidity, and barometric pressure at 5-minute intervals. Nodes were strategically placed to maximize spatial coverage while ensuring representation of diverse land-use types including residential, commercial, industrial, and transportation corridors.
+
+Data from the sensor network was supplemented with:
+
+- **Meteorological data** from 12 regional weather stations (hourly)
+- **Traffic density indices** from 340 loop detectors operated by the city transportation department (15-minute intervals)
+- **Satellite AOD** measurements from MODIS and VIIRS instruments (daily, 1km resolution)
+- **Industrial emissions** data from 23 permitted facilities (hourly, self-reported)
+
+## Model Architectures
+
+### Random Forest
+
+An ensemble of 500 decision trees with maximum depth of 20, minimum samples per leaf of 5, and maximum features set to the square root of total feature count. Features were computed as rolling statistics (mean, max, min, standard deviation) over 1-hour, 6-hour, and 24-hour windows.
+
+### XGBoost
+
+Gradient-boosted trees with 1000 estimators, maximum depth of 8, learning rate of 0.05, and column subsampling ratio of 0.8. L1 and L2 regularization parameters were tuned via Bayesian optimization. The same rolling-window features were used as for Random Forest.
+
+### LSTM
+
+A two-layer LSTM network with 128 hidden units per layer, followed by a fully connected layer with 64 units. Input sequences of 72 time steps (representing 72 hours of hourly data) were used. Dropout of 0.3 was applied between layers. Training used Adam optimizer with learning rate 0.001 and batch size 256.
+
+### Transformer
+
+A 4-layer Transformer encoder with 8 attention heads and model dimension of 256. Positional encoding was applied to 72-step input sequences. Feed-forward dimension was 512 with GELU activation. Training used AdamW optimizer with cosine learning rate schedule (peak 0.0003, warmup 1000 steps).
+
+## Model Hyperparameters
+
+| Parameter | Random Forest | XGBoost | LSTM | Transformer |
+|---|---|---|---|---|
+| Estimators/Layers | 500 trees | 1000 trees | 2 layers | 4 layers |
+| Depth/Hidden Units | 20 | 8 | 128 | 256 (dim) |
+| Learning Rate | N/A | 0.05 | 0.001 | 0.0003 |
+| Regularization | min_leaf=5 | L1=0.1, L2=0.3 | Dropout 0.3 | Dropout 0.1 |
+| Sequence Length | N/A (windows) | N/A (windows) | 72 steps | 72 steps |
+| Batch Size | N/A | N/A | 256 | 128 |
+| Training Epochs | N/A | Early stop | 100 | 80 |
+
+## Training and Validation
+
+The 18-month dataset (January 2024 -- June 2025) was split as follows:
+
+- **Training set:** January 2024 -- December 2024 (12 months, approximately 1.75 million samples)
+- **Validation set:** January 2025 -- March 2025 (3 months, used for hyperparameter tuning)
+- **Test set:** April 2025 -- June 2025 (3 months, held out for final evaluation)
+
+All models were evaluated using 5-fold temporal cross-validation on the training set, with fold boundaries selected to avoid data leakage from sequential dependencies. Final reported metrics are computed on the held-out test set.

--- a/conference-poster/content/sections/3-results.md
+++ b/conference-poster/content/sections/3-results.md
@@ -1,0 +1,131 @@
++++
+title = "Results"
+weight = 3
+template = "post"
+description = "Detailed performance results including model comparison tables, prediction accuracy across time horizons, and operational feasibility metrics."
+tags = ["results", "performance", "model-comparison"]
+
+[extra]
+section_number = "3"
+panel_color = "green"
++++
+
+## Overall Model Performance
+
+The Transformer architecture achieved the strongest results across all three target pollutants, though the margin over LSTM was relatively narrow. Both deep learning approaches substantially outperformed the tree-based methods for longer prediction horizons.
+
+### PM2.5 Prediction (24-hour forecast)
+
+| Model | MAE (ug/m3) | RMSE (ug/m3) | R-squared | MAPE (%) |
+|---|---|---|---|---|
+| Random Forest | 3.82 | 5.14 | 0.89 | 14.2 |
+| XGBoost | 3.15 | 4.38 | 0.91 | 12.1 |
+| LSTM | 2.87 | 3.92 | 0.92 | 10.8 |
+| **Transformer** | **2.41** | **3.31** | **0.94** | **8.9** |
+| Physics Baseline | 6.73 | 8.91 | 0.71 | 24.6 |
+
+### NO2 Prediction (24-hour forecast)
+
+| Model | MAE (ppb) | RMSE (ppb) | R-squared | MAPE (%) |
+|---|---|---|---|---|
+| Random Forest | 4.21 | 5.67 | 0.86 | 15.8 |
+| XGBoost | 3.54 | 4.89 | 0.89 | 13.4 |
+| LSTM | 3.18 | 4.42 | 0.91 | 11.9 |
+| **Transformer** | **2.73** | **3.78** | **0.93** | **10.1** |
+| Physics Baseline | 7.42 | 9.56 | 0.68 | 27.3 |
+
+### O3 Prediction (24-hour forecast)
+
+| Model | MAE (ppb) | RMSE (ppb) | R-squared | MAPE (%) |
+|---|---|---|---|---|
+| Random Forest | 5.11 | 6.83 | 0.85 | 12.9 |
+| XGBoost | 4.28 | 5.74 | 0.88 | 10.7 |
+| LSTM | 3.94 | 5.21 | 0.90 | 9.8 |
+| **Transformer** | **3.36** | **4.52** | **0.92** | **8.4** |
+| Physics Baseline | 8.15 | 10.42 | 0.66 | 20.8 |
+
+## Performance Across Time Horizons
+
+Model performance degrades with increasing forecast horizon, but the Transformer maintains the smallest degradation rate.
+
+<div class="poster-figure">
+<svg viewBox="0 0 700 340" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing prediction accuracy over 24-hour forecast horizon">
+  <rect width="700" height="340" fill="#12121e" rx="6"/>
+  <text x="350" y="24" fill="#8888a0" font-family="Anton, sans-serif" font-size="13" text-anchor="middle" letter-spacing="3">PM2.5 R-SQUARED BY FORECAST HORIZON</text>
+  <!-- Axes -->
+  <line x1="80" y1="50" x2="80" y2="290" stroke="#585870" stroke-width="2"/>
+  <line x1="80" y1="290" x2="660" y2="290" stroke="#585870" stroke-width="2"/>
+  <!-- Y-axis labels -->
+  <text x="70" y="60" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="700" text-anchor="end">0.98</text>
+  <text x="70" y="120" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="700" text-anchor="end">0.94</text>
+  <text x="70" y="180" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="700" text-anchor="end">0.90</text>
+  <text x="70" y="240" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="700" text-anchor="end">0.86</text>
+  <text x="70" y="290" fill="#8888a0" font-family="Inter, sans-serif" font-size="11" font-weight="700" text-anchor="end">0.82</text>
+  <!-- Y-axis grid lines -->
+  <line x1="80" y1="56" x2="660" y2="56" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="80" y1="116" x2="660" y2="116" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="80" y1="176" x2="660" y2="176" stroke="#2a2a3a" stroke-width="1"/>
+  <line x1="80" y1="236" x2="660" y2="236" stroke="#2a2a3a" stroke-width="1"/>
+  <!-- X-axis labels -->
+  <text x="128" y="310" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="middle">1h</text>
+  <text x="321" y="310" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="middle">6h</text>
+  <text x="514" y="310" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="middle">12h</text>
+  <text x="660" y="310" fill="#8888a0" font-family="Inter, sans-serif" font-size="12" font-weight="700" text-anchor="middle">24h</text>
+  <!-- Transformer line (best) -->
+  <polyline points="128,56 321,86 514,116 660,146" fill="none" stroke="#4a90e2" stroke-width="4"/>
+  <circle cx="128" cy="56" r="6" fill="#4a90e2"/>
+  <circle cx="321" cy="86" r="6" fill="#4a90e2"/>
+  <circle cx="514" cy="116" r="6" fill="#4a90e2"/>
+  <circle cx="660" cy="146" r="6" fill="#4a90e2"/>
+  <!-- LSTM line -->
+  <polyline points="128,68 321,106 514,146 660,176" fill="none" stroke="#4ae24a" stroke-width="4"/>
+  <circle cx="128" cy="68" r="6" fill="#4ae24a"/>
+  <circle cx="321" cy="106" r="6" fill="#4ae24a"/>
+  <circle cx="514" cy="146" r="6" fill="#4ae24a"/>
+  <circle cx="660" cy="176" r="6" fill="#4ae24a"/>
+  <!-- XGBoost line -->
+  <polyline points="128,86 321,136 514,196 660,218" fill="none" stroke="#e2c44a" stroke-width="4"/>
+  <circle cx="128" cy="86" r="6" fill="#e2c44a"/>
+  <circle cx="321" cy="136" r="6" fill="#e2c44a"/>
+  <circle cx="514" cy="196" r="6" fill="#e2c44a"/>
+  <circle cx="660" cy="218" r="6" fill="#e2c44a"/>
+  <!-- Random Forest line -->
+  <polyline points="128,98 321,160 514,226 660,260" fill="none" stroke="#e24a4a" stroke-width="4"/>
+  <circle cx="128" cy="98" r="6" fill="#e24a4a"/>
+  <circle cx="321" cy="160" r="6" fill="#e24a4a"/>
+  <circle cx="514" cy="226" r="6" fill="#e24a4a"/>
+  <circle cx="660" cy="260" r="6" fill="#e24a4a"/>
+  <!-- Legend -->
+  <line x1="120" y1="330" x2="145" y2="330" stroke="#4a90e2" stroke-width="3"/>
+  <text x="150" y="334" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="11" font-weight="700">TRANSFORMER</text>
+  <line x1="260" y1="330" x2="285" y2="330" stroke="#4ae24a" stroke-width="3"/>
+  <text x="290" y="334" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="11" font-weight="700">LSTM</text>
+  <line x1="370" y1="330" x2="395" y2="330" stroke="#e2c44a" stroke-width="3"/>
+  <text x="400" y="334" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="11" font-weight="700">XGBOOST</text>
+  <line x1="500" y1="330" x2="525" y2="330" stroke="#e24a4a" stroke-width="3"/>
+  <text x="530" y="334" fill="#d0d0d8" font-family="Inter, sans-serif" font-size="11" font-weight="700">RANDOM FOREST</text>
+</svg>
+<div class="poster-figure-caption">Figure 4. PM2.5 R-squared degradation across forecast horizons (1h to 24h) for all four models</div>
+</div>
+
+## Air Quality Alert Accuracy
+
+A critical operational metric is the ability to correctly predict exceedance of air quality thresholds. We evaluated each model on its ability to predict PM2.5 exceedances above 35 ug/m3 (the WHO 24-hour guideline) within a 24-hour window.
+
+| Model | Precision | Recall | F1 Score | Alert Accuracy |
+|---|---|---|---|---|
+| Random Forest | 0.79 | 0.84 | 0.81 | 82% |
+| XGBoost | 0.83 | 0.87 | 0.85 | 85% |
+| LSTM | 0.85 | 0.88 | 0.86 | 86% |
+| **Transformer** | **0.87** | **0.89** | **0.88** | **87%** |
+
+## Computational Performance
+
+| Model | Training Time | Inference Latency (per sensor) | GPU Memory |
+|---|---|---|---|
+| Random Forest | 12 min | 0.8 ms | N/A (CPU) |
+| XGBoost | 28 min | 1.2 ms | N/A (CPU) |
+| LSTM | 4.2 hours | 3.4 ms | 2.1 GB |
+| Transformer | 6.8 hours | 5.1 ms | 3.8 GB |
+
+All models achieve sub-200ms total inference time when processing all 200 sensors in parallel, confirming operational feasibility for real-time deployment.

--- a/conference-poster/content/sections/4-conclusions.md
+++ b/conference-poster/content/sections/4-conclusions.md
@@ -1,0 +1,45 @@
++++
+title = "Conclusions"
+weight = 4
+template = "post"
+description = "Key findings, study limitations, future research directions, and acknowledgements for the air quality prediction study."
+tags = ["conclusions", "future-work", "acknowledgements"]
+
+[extra]
+section_number = "4"
+panel_color = "gold"
++++
+
+## Key Findings
+
+This study demonstrates that modern machine learning architectures, particularly Transformer-based models, can deliver accurate and operationally feasible real-time air quality predictions in urban environments. The principal findings are:
+
+1. **Transformer superiority.** The Transformer architecture achieved the best performance across all three pollutants (PM2.5, NO2, O3) and all four forecast horizons (1h, 6h, 12h, 24h), with an R-squared of 0.94 and MAE of 2.41 ug/m3 for 24-hour PM2.5 forecasts.
+
+2. **Substantial improvement over baselines.** All four ML models significantly outperformed the existing physics-based WRF-Chem baseline currently deployed in the Greenfield City municipal monitoring system. The Transformer achieved a 64% reduction in MAE compared to the physics baseline.
+
+3. **Operational feasibility confirmed.** Real-time inference latency remained below 200ms for all models when processing the full 200-sensor network in parallel, confirming that ML-based prediction can be deployed operationally without compromising the timeliness of public health advisories.
+
+4. **Diminishing returns from ensembles.** Ensemble approaches combining Transformer and XGBoost predictions yielded only marginal improvement (+0.01 R-squared) at the cost of doubled computational overhead, suggesting that the standalone Transformer is the most efficient deployment option.
+
+## Limitations
+
+Several limitations should be considered when interpreting these results:
+
+- **Geographic specificity** -- The models were trained and evaluated on data from a single metropolitan area. Transfer learning performance to other cities with different emission profiles, topography, and climate patterns has not been assessed.
+- **Sensor quality** -- Low-cost sensors exhibit higher measurement uncertainty compared to regulatory-grade instruments. While we applied established calibration protocols, residual bias may affect model training.
+- **Temporal coverage** -- The 18-month study period may not fully capture interannual variability in pollution patterns, particularly rare meteorological events (e.g., temperature inversions, wildfire smoke intrusion).
+- **Feature availability** -- Some input features (satellite AOD, industrial emissions) have limited temporal resolution or reporting delays that could constrain real-time operational use.
+
+## Future Work
+
+Ongoing and planned extensions of this research include:
+
+- **Multi-city transfer learning** -- Evaluating pre-trained models on sensor networks in three additional metropolitan areas with fine-tuning on limited local data
+- **Explainability analysis** -- Applying SHAP and attention-weight visualization to understand which input features drive predictions under different atmospheric conditions
+- **Extreme event detection** -- Developing specialized model heads for predicting pollution spikes associated with wildfires, industrial accidents, and severe weather events
+- **Edge deployment** -- Optimizing Transformer inference for deployment on low-power edge computing devices co-located with sensor nodes
+
+## Acknowledgements
+
+This research was supported by the National Science Foundation (Grant No. NSF-2024-ENV-4821), the Environmental Protection Agency STAR Fellowship Program, and the Greenfield City Department of Environmental Services. The authors thank the Metropolitan Institute of Technology High-Performance Computing Center for providing GPU resources, and the Greenfield City Transportation Authority for access to traffic sensor data.

--- a/conference-poster/content/sections/_index.md
+++ b/conference-poster/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Poster Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+All sections of the conference poster on Machine Learning for Real-Time Air Quality Prediction in Urban Environments.

--- a/conference-poster/static/css/style.css
+++ b/conference-poster/static/css/style.css
@@ -1,0 +1,911 @@
+/* ==========================================================================
+   Conference Poster -- Dark Theme with Ultra-Heavy Typography
+   Designed for distance reading at poster sessions
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --bg: #0a0a12;
+  --bg-2: #12121e;
+  --bg-3: #1a1a28;
+  --rule: #2a2a3a;
+  --ink: #f0f0f4;
+  --ink-2: #d0d0d8;
+  --ink-3: #8888a0;
+  --ink-4: #585870;
+  --accent: #4a90e2;
+  --accent-2: #e24a4a;
+  --accent-3: #4ae24a;
+  --accent-4: #e2c44a;
+  --font-display: 'Anton', 'Bebas Neue', 'Impact', sans-serif;
+  --font-body: 'Inter', 'Roboto', 'Helvetica Neue', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  --max-width: 1200px;
+  --poster-gap: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   Reset and Base
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 18px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 1.15rem;
+  line-height: 1.7;
+  margin: 0;
+  padding: 0;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* --------------------------------------------------------------------------
+   Layout
+   -------------------------------------------------------------------------- */
+.site-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.site-main {
+  min-height: calc(100vh - 260px);
+  padding-bottom: 3rem;
+}
+
+/* --------------------------------------------------------------------------
+   Header
+   -------------------------------------------------------------------------- */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 3px solid var(--rule);
+  margin-bottom: 2.5rem;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.site-logo svg {
+  flex-shrink: 0;
+}
+
+.site-logo-text {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.site-logo:hover .site-logo-text {
+  color: var(--accent);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1.75rem;
+}
+
+.site-header nav a {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.site-header nav a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Footer
+   -------------------------------------------------------------------------- */
+.site-footer {
+  margin-top: 4rem;
+  padding: 2rem 0;
+  border-top: 3px solid var(--rule);
+  color: var(--ink-3);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.site-footer p {
+  margin: 0.3rem 0;
+}
+
+.site-footer strong {
+  color: var(--ink-2);
+}
+
+/* --------------------------------------------------------------------------
+   Typography -- Ultra-Heavy for Distance Reading
+   -------------------------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  line-height: 1.15;
+  margin-top: 2em;
+  margin-bottom: 0.6em;
+  color: var(--ink);
+}
+
+h1 {
+  font-size: 3.2rem;
+  letter-spacing: 0.08em;
+  margin-top: 0;
+}
+
+h2 {
+  font-size: 2.4rem;
+  letter-spacing: 0.07em;
+  padding-bottom: 0.4em;
+  border-bottom: 3px solid var(--rule);
+}
+
+h3 {
+  font-size: 1.8rem;
+  color: var(--ink-2);
+}
+
+h4 {
+  font-size: 1.4rem;
+  color: var(--ink-2);
+}
+
+h5 {
+  font-size: 1.2rem;
+  color: var(--ink-3);
+}
+
+h6 {
+  font-size: 1.05rem;
+  color: var(--ink-3);
+}
+
+p {
+  margin: 1.2em 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+strong {
+  font-weight: 800;
+  color: var(--ink);
+}
+
+em {
+  font-style: italic;
+  color: var(--ink-2);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.2s;
+}
+
+a:hover {
+  border-bottom-color: var(--accent);
+}
+
+blockquote {
+  margin: 2rem 0;
+  padding: 1.5rem 2rem;
+  border-left: 6px solid var(--accent);
+  background: var(--bg-2);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink-2);
+}
+
+blockquote p {
+  margin: 0.5em 0;
+}
+
+hr {
+  border: none;
+  border-top: 3px solid var(--rule);
+  margin: 3rem 0;
+}
+
+/* --------------------------------------------------------------------------
+   Lists
+   -------------------------------------------------------------------------- */
+ul, ol {
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+li {
+  margin-bottom: 0.6rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+li::marker {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+/* --------------------------------------------------------------------------
+   Code
+   -------------------------------------------------------------------------- */
+code {
+  background: var(--bg-3);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.95em;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  border: 1px solid var(--rule);
+}
+
+pre {
+  background: var(--bg-2);
+  padding: 1.5rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  border: 2px solid var(--rule);
+  margin: 2rem 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border: none;
+  color: var(--ink-2);
+  font-size: 1rem;
+}
+
+/* --------------------------------------------------------------------------
+   Poster Header -- Title Block
+   -------------------------------------------------------------------------- */
+.poster-header {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: var(--bg-2);
+  border: 3px solid var(--rule);
+  border-radius: 8px;
+  margin-bottom: 3rem;
+}
+
+.poster-eyebrow {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.poster-title {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.1;
+  color: var(--ink);
+  margin: 0.5rem 0 1.5rem;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.poster-authors {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  margin: 1rem 0 0.5rem;
+}
+
+.poster-institution {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink-3);
+  margin: 0.3rem 0;
+}
+
+.poster-conference {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent-4);
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 2px solid var(--rule);
+}
+
+/* --------------------------------------------------------------------------
+   Poster Panel -- Colored Section Blocks
+   -------------------------------------------------------------------------- */
+.poster-panel {
+  background: var(--bg-2);
+  border: 2px solid var(--rule);
+  border-radius: 8px;
+  margin-bottom: 2.5rem;
+  overflow: hidden;
+}
+
+.poster-panel-header {
+  padding: 1rem 2rem;
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--bg);
+  font-weight: 400;
+}
+
+.poster-panel-body {
+  padding: 2rem;
+}
+
+/* Panel color variations */
+.poster-panel--blue {
+  border-top: 8px solid var(--accent);
+}
+
+.poster-panel--blue .poster-panel-header {
+  background: var(--accent);
+}
+
+.poster-panel--red {
+  border-top: 8px solid var(--accent-2);
+}
+
+.poster-panel--red .poster-panel-header {
+  background: var(--accent-2);
+}
+
+.poster-panel--green {
+  border-top: 8px solid var(--accent-3);
+}
+
+.poster-panel--green .poster-panel-header {
+  background: var(--accent-3);
+}
+
+.poster-panel--gold {
+  border-top: 8px solid var(--accent-4);
+}
+
+.poster-panel--gold .poster-panel-header {
+  background: var(--accent-4);
+}
+
+/* --------------------------------------------------------------------------
+   Poster Grid -- Multi-Column Layout
+   -------------------------------------------------------------------------- */
+.poster-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--poster-gap);
+  margin-bottom: 2.5rem;
+}
+
+.poster-grid--three {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.poster-grid--full {
+  grid-template-columns: 1fr;
+}
+
+/* --------------------------------------------------------------------------
+   Metrics Bar -- Big Numbers
+   -------------------------------------------------------------------------- */
+.metrics-bar {
+  display: flex;
+  justify-content: center;
+  gap: 3rem;
+  flex-wrap: wrap;
+  padding: 2rem 0;
+  margin: 2rem 0;
+}
+
+.metric-item {
+  text-align: center;
+  min-width: 160px;
+}
+
+.metric-value {
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  color: var(--ink);
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.metric-value--blue { color: var(--accent); }
+.metric-value--red { color: var(--accent-2); }
+.metric-value--green { color: var(--accent-3); }
+.metric-value--gold { color: var(--accent-4); }
+
+.metric-label {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   SVG Figures
+   -------------------------------------------------------------------------- */
+.poster-figure {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.poster-figure svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.poster-figure-caption {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 2px solid var(--rule);
+}
+
+/* --------------------------------------------------------------------------
+   Tables -- Thick Borders for Visibility
+   -------------------------------------------------------------------------- */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+thead {
+  background: var(--bg-3);
+}
+
+thead th {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+  padding: 1rem 1.25rem;
+  text-align: left;
+  border: 3px solid var(--rule);
+  border-bottom: 4px solid var(--accent);
+}
+
+tbody td {
+  padding: 0.9rem 1.25rem;
+  border: 3px solid var(--rule);
+  color: var(--ink-2);
+}
+
+tbody tr:nth-child(even) {
+  background: var(--bg-2);
+}
+
+tbody tr:hover {
+  background: var(--bg-3);
+}
+
+/* --------------------------------------------------------------------------
+   Paper Article -- Section Pages
+   -------------------------------------------------------------------------- */
+.paper-article {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.paper-section-header {
+  margin-bottom: 2.5rem;
+}
+
+.paper-section-eyebrow {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.paper-section-eyebrow--blue { color: var(--accent); }
+.paper-section-eyebrow--red { color: var(--accent-2); }
+.paper-section-eyebrow--green { color: var(--accent-3); }
+.paper-section-eyebrow--gold { color: var(--accent-4); }
+
+.paper-section-title {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.1;
+  margin: 0.3rem 0 1rem;
+  border-bottom: none;
+}
+
+.paper-lede {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  line-height: 1.6;
+  margin-top: 0;
+}
+
+.paper-content {
+  font-size: 1.15rem;
+  line-height: 1.7;
+}
+
+.paper-content h2 {
+  font-size: 2rem;
+  margin-top: 2.5rem;
+}
+
+.paper-content h3 {
+  font-size: 1.5rem;
+  margin-top: 2rem;
+}
+
+.paper-section-footer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 3px solid var(--rule);
+}
+
+/* --------------------------------------------------------------------------
+   Panel Header Bar for Section Pages
+   -------------------------------------------------------------------------- */
+.panel-bar {
+  height: 8px;
+  border-radius: 4px 4px 0 0;
+  margin-bottom: 2rem;
+}
+
+.panel-bar--blue { background: var(--accent); }
+.panel-bar--red { background: var(--accent-2); }
+.panel-bar--green { background: var(--accent-3); }
+.panel-bar--gold { background: var(--accent-4); }
+
+/* --------------------------------------------------------------------------
+   Button Link
+   -------------------------------------------------------------------------- */
+.button-link {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 0.75rem 1.5rem;
+  border: 2px solid var(--accent);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+}
+
+.button-link:hover {
+  background: var(--accent);
+  color: var(--bg);
+  border-bottom-color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   Section List
+   -------------------------------------------------------------------------- */
+ul.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+}
+
+ul.section-list li {
+  margin-bottom: 0.75rem;
+  padding: 1rem 1.5rem;
+  background: var(--bg-2);
+  border-radius: 6px;
+  border: 2px solid var(--rule);
+  transition: border-color 0.2s;
+}
+
+ul.section-list li:hover {
+  border-color: var(--accent);
+}
+
+ul.section-list li a {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 400;
+}
+
+/* --------------------------------------------------------------------------
+   Taxonomy
+   -------------------------------------------------------------------------- */
+.taxonomy-desc {
+  color: var(--ink-3);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   Pagination
+   -------------------------------------------------------------------------- */
+nav.pagination {
+  margin: 2rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  border: 2px solid var(--rule);
+  color: var(--ink-3);
+  text-decoration: none;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+}
+
+nav.pagination a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  border: 2px solid var(--accent);
+  background: var(--bg-3);
+  color: var(--ink);
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  border: 2px solid var(--rule);
+  color: var(--ink-4);
+  opacity: 0.5;
+}
+
+/* --------------------------------------------------------------------------
+   Key Takeaway List -- Extra Large
+   -------------------------------------------------------------------------- */
+.takeaway-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+}
+
+.takeaway-list li {
+  font-size: 1.3rem;
+  font-weight: 700;
+  padding: 1rem 0;
+  border-bottom: 2px solid var(--rule);
+  color: var(--ink);
+}
+
+.takeaway-list li:last-child {
+  border-bottom: none;
+}
+
+/* --------------------------------------------------------------------------
+   QR Code Placeholder
+   -------------------------------------------------------------------------- */
+.qr-block {
+  display: inline-block;
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.qr-label {
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: 0.75rem;
+}
+
+/* --------------------------------------------------------------------------
+   Contact Block
+   -------------------------------------------------------------------------- */
+.contact-block {
+  background: var(--bg-3);
+  padding: 1.5rem 2rem;
+  border-radius: 6px;
+  border: 2px solid var(--rule);
+  margin: 2rem 0;
+}
+
+.contact-block p {
+  margin: 0.3rem 0;
+}
+
+/* --------------------------------------------------------------------------
+   Alert Shortcode
+   -------------------------------------------------------------------------- */
+.alert {
+  padding: 1.25rem 1.5rem;
+  border: 2px solid var(--rule);
+  border-left: 6px solid var(--accent);
+  background: var(--bg-2);
+  margin: 1.5rem 0;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+.alert strong {
+  color: var(--accent);
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.alert--warning {
+  border-left-color: var(--accent-4);
+}
+
+.alert--warning strong {
+  color: var(--accent-4);
+}
+
+.alert--error {
+  border-left-color: var(--accent-2);
+}
+
+.alert--error strong {
+  color: var(--accent-2);
+}
+
+.alert--success {
+  border-left-color: var(--accent-3);
+}
+
+.alert--success strong {
+  color: var(--accent-3);
+}
+
+/* --------------------------------------------------------------------------
+   404 Page
+   -------------------------------------------------------------------------- */
+.error-404 {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-404 h1 {
+  font-size: 5rem;
+  color: var(--accent-2);
+  margin-bottom: 0.5rem;
+}
+
+.error-404 p {
+  font-size: 1.3rem;
+  color: var(--ink-3);
+}
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 900px) {
+  .poster-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .poster-grid--three {
+    grid-template-columns: 1fr;
+  }
+
+  .poster-title {
+    font-size: 2.2rem;
+  }
+
+  h1 {
+    font-size: 2.4rem;
+  }
+
+  h2 {
+    font-size: 1.8rem;
+  }
+
+  .metric-value {
+    font-size: 2.5rem;
+  }
+
+  .metrics-bar {
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  html {
+    font-size: 16px;
+  }
+
+  .site-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .site-wrapper {
+    padding: 0 1rem;
+  }
+
+  .poster-header {
+    padding: 2rem 1rem;
+  }
+
+  .poster-title {
+    font-size: 1.8rem;
+  }
+
+  .poster-panel-body {
+    padding: 1.25rem;
+  }
+
+  .metrics-bar {
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .paper-section-title {
+    font-size: 2rem;
+  }
+}

--- a/conference-poster/templates/404.html
+++ b/conference-poster/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-404">
+      <h1>404</h1>
+      <p>The page you are looking for does not exist.</p>
+      <p><a href="{{ base_url }}/" class="button-link">Return to Poster</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/conference-poster/templates/footer.html
+++ b/conference-poster/templates/footer.html
@@ -1,0 +1,9 @@
+    <footer class="site-footer">
+      <p><strong>Poster P-247</strong> -- International Conference on Environmental Data Science 2026</p>
+      <p>Please cite as: Chen, W., Okafor, A., Petrov, D., & Nakamura, S. (2026). Machine Learning for Real-Time Air Quality Prediction in Urban Environments. <em>ICEDS 2026 Poster Proceedings</em>, P-247.</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/conference-poster/templates/header.html
+++ b/conference-poster/templates/header.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Bebas+Neue&family=Inter:wght@500;600;700;800&family=Roboto:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">
+        <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="2" y="2" width="36" height="36" rx="4" stroke="#4a90e2" stroke-width="3" fill="none"/>
+          <rect x="8" y="8" width="10" height="10" rx="2" fill="#4a90e2"/>
+          <rect x="22" y="8" width="10" height="10" rx="2" fill="#e24a4a"/>
+          <rect x="8" y="22" width="10" height="10" rx="2" fill="#4ae24a"/>
+          <rect x="22" y="22" width="10" height="10" rx="2" fill="#e2c44a"/>
+        </svg>
+        <span class="site-logo-text">Conference Poster Session</span>
+      </a>
+      <nav>
+        <a href="{{ base_url }}/">Poster</a>
+        <a href="{{ base_url }}/sections/">Sections</a>
+        <a href="{{ base_url }}/data/">Data</a>
+        <a href="{{ base_url }}/appendix/">Contact</a>
+      </nav>
+    </header>

--- a/conference-poster/templates/page.html
+++ b/conference-poster/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/conference-poster/templates/post.html
+++ b/conference-poster/templates/post.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {% if page.extra.panel_color %}
+      <div class="panel-bar panel-bar--{{ page.extra.panel_color }}"></div>
+      {% endif %}
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow paper-section-eyebrow--{{ page.extra.panel_color }}">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; Back to All Sections</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/conference-poster/templates/section.html
+++ b/conference-poster/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/conference-poster/templates/shortcodes/alert.html
+++ b/conference-poster/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert--{{ type }}">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/conference-poster/templates/taxonomy.html
+++ b/conference-poster/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/conference-poster/templates/taxonomy_term.html
+++ b/conference-poster/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -824,6 +824,13 @@
     "elegant",
     "festive"
   ],
+  "conference-poster": [
+    "paper",
+    "dark",
+    "poster",
+    "conference",
+    "visual"
+  ],
   "console": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1604

## Summary
- Add conference-poster dark poster session paper example site
- Features SVG poster section block frames with colored header bars (blue/red/green/gold) and large-format data visualization charts optimized for distance reading
- Typography: Ultra-heavy Anton/Bebas Neue for display readable from 2 meters; clean large Inter Bold/Roboto Medium at poster-scale sizes
- Includes 4 poster sections (Introduction, Methods, Results, Conclusions) plus Data and Appendix pages
- ML air quality prediction topic with sensor network diagrams, model comparison charts, and performance bar charts
- Updates tags.json with paper, dark, poster, conference, visual tags

## Test plan
- [x] hwaro build completes successfully (8 pages generated)
- [x] No CSS gradients used
- [x] All decorative visuals use inline SVG
- [x] No emojis in any files
- [x] tags.json updated with correct entry