### PR TITLE
feat: add arxiv-preprint example site (closes #1612)

### DIFF
--- a/arxiv-preprint/AGENTS.md
+++ b/arxiv-preprint/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/arxiv-preprint/config.toml
+++ b/arxiv-preprint/config.toml
@@ -1,0 +1,193 @@
+# =============================================================================
+# arXiv Preprint - Self-Published Preprint Paper
+# Issue #1612 | Tags: paper, light, preprint, self-published, raw
+# =============================================================================
+
+title = "Sparse Gated Attention for Efficient Long-Context Transformers"
+description = "A self-published preprint presenting Sparse Gated Attention (SGA), a novel attention mechanism for efficient long-context processing in transformers, with version control badges and submission status tracking."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32
+# quality = 20
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+
+# [og.auto_image]
+# enabled = true
+# background = "#ffffff"
+# text_color = "#1a1a1a"
+# accent_color = "#c45a1a"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"
+# output_dir = "og-images"
+# show_title = true
+# style = "default"
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# format = "svg"

--- a/arxiv-preprint/content/appendix.md
+++ b/arxiv-preprint/content/appendix.md
@@ -1,0 +1,127 @@
++++
+title = "Appendix"
+description = "Supplementary materials for Sparse Gated Attention"
+template = "page"
+tags = ["paper", "light", "preprint", "self-published", "raw"]
++++
+
+<div class="appendix-page">
+
+# Appendix
+
+## A. Proof of Sparsity Bound
+
+**Theorem A.1.** *For a gate network with temperature parameter tau > 0 and threshold t = 0.5, the expected fraction of non-zero entries in the gate mask G satisfies:*
+
+E[||G||_0 / n^2] <= sigma((mu_max - t) / tau)
+
+*where mu_max = max_ij mu_ij is the maximum pre-sigmoid logit and sigma is the sigmoid function.*
+
+**Proof sketch.** Each gate entry G_ij = 1[sigma((mu_ij + g) / tau) > t] where g is a standard Gumbel noise sample. The probability that any single entry is active is P(G_ij = 1) = sigma((mu_ij - t) / tau). Summing over all n^2 entries and applying linearity of expectation yields the bound. The tightness of the bound depends on the concentration of the logit distribution around mu_max. In practice, we observe that learned logits are bimodal (strongly positive or strongly negative), making the bound reasonably tight after training convergence. A full proof with finite-sample concentration bounds is available in the extended version.
+
+## B. Gumbel-Sigmoid Convergence
+
+**Proposition B.1.** *The Gumbel-sigmoid estimator with straight-through gradient provides a consistent estimator of the true gradient direction as tau approaches 0, in the sense that:*
+
+lim (tau -> 0) cos(nabla_theta L_STE, nabla_theta L_true) = 1
+
+*where L_STE is the straight-through loss and L_true is the true discrete loss.*
+
+This follows from the standard Gumbel-softmax convergence results (Jang et al., 2017; Maddison et al., 2017) adapted to the binary (sigmoid) case. The key insight is that as tau decreases, the soft samples concentrate on {0, 1} and the bias of the straight-through estimator vanishes.
+
+In our experiments, we use an annealing schedule for tau:
+
+tau(t) = max(tau_min, tau_0 * exp(-r * t))
+
+where tau_0 = 1.0, tau_min = 0.1, r = 0.001, and t is the training step. We find that this schedule provides stable training while achieving near-binary gates by the end of training.
+
+## C. Gate Pattern Visualizations
+
+The learned gate masks reveal interpretable attention patterns across different heads and layers. We categorize the emergent patterns into three types:
+
+### C.1 Local Attention Heads
+
+Approximately 40% of heads in the final model learn near-diagonal gate patterns, effectively implementing local attention windows of varying widths. These heads tend to appear in earlier layers (layers 1-4 of 12) and correlate with syntactic processing -- dependency parsing probes show high accuracy when restricted to these heads.
+
+### C.2 Strided Attention Heads
+
+About 25% of heads develop periodic gate patterns with strides ranging from 4 to 64 tokens. These heads appear predominantly in middle layers (layers 5-8) and seem to serve a "summary" function, aggregating information at regular intervals for downstream processing.
+
+### C.3 Global Bridge Heads
+
+The remaining 35% of heads learn sparse, long-range connections that we term "bridge" patterns. These heads are concentrated in later layers (layers 9-12) and primarily connect:
+
+- Document-level markers (section headings, paragraph boundaries)
+- Coreferent entity mentions across long distances
+- Discourse connectives with their antecedent clauses
+
+The sparsity of bridge heads varies from 5% to 15% density (i.e., 85-95% of attention connections are pruned), yet these heads carry the majority of the long-range information flow as measured by attention rollout analysis.
+
+## D. Hyperparameter Sensitivity
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>Gate Rank</th>
+      <th>Params Overhead</th>
+      <th>LRA Avg (%)</th>
+      <th>Sparsity (%)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>4</td>
+      <td>+0.08%</td>
+      <td>85.9</td>
+      <td>71.2</td>
+    </tr>
+    <tr>
+      <td>8</td>
+      <td>+0.15%</td>
+      <td>86.8</td>
+      <td>65.4</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>16 (default)</strong></td>
+      <td><strong>+0.30%</strong></td>
+      <td><strong>87.2</strong></td>
+      <td><strong>62.0</strong></td>
+    </tr>
+    <tr>
+      <td>32</td>
+      <td>+0.59%</td>
+      <td>87.3</td>
+      <td>60.8</td>
+    </tr>
+    <tr>
+      <td>64</td>
+      <td>+1.18%</td>
+      <td>87.2</td>
+      <td>59.1</td>
+    </tr>
+  </tbody>
+</table>
+
+The gate network rank of 16 provides the best trade-off between expressiveness and parameter overhead. Ranks above 16 provide diminishing returns on LRA accuracy while increasing the parameter count. Ranks below 8 show measurable accuracy degradation, particularly on the Pathfinder task which requires fine-grained spatial reasoning.
+
+## E. Training Details
+
+All models were trained on 8x NVIDIA A100 80GB GPUs using the following configuration:
+
+- **Optimizer:** AdamW (beta_1=0.9, beta_2=0.98, epsilon=1e-8)
+- **Learning rate:** 3e-4 with cosine annealing and 2000-step linear warmup
+- **Weight decay:** 0.01 (applied to all parameters except biases and layer norms)
+- **Batch size:** 256 (effective, using gradient accumulation where needed)
+- **Training steps:** 100,000 for LRA; 200,000 for PG-19
+- **Gate temperature schedule:** tau_0=1.0, tau_min=0.1, exponential decay r=0.001
+- **Gradient clipping:** max norm 1.0
+- **Mixed precision:** BF16 for forward/backward, FP32 for optimizer states
+- **Framework:** JAX/Flax with custom CUDA kernels for sparse attention masking
+
+Training wall-clock time for the base model (125M parameters) on LRA was approximately 4 hours. The PG-19 model (350M parameters) trained for approximately 36 hours.
+
+## F. Broader Impact
+
+Efficient attention mechanisms like SGA can reduce the computational cost of deploying large language models, potentially democratizing access to long-context processing. However, the same efficiency gains could also lower the barrier to generating long-form synthetic text at scale. We encourage responsible deployment and recommend that practitioners consider the downstream applications when integrating SGA into production systems.
+
+</div>

--- a/arxiv-preprint/content/changelog.md
+++ b/arxiv-preprint/content/changelog.md
@@ -1,0 +1,100 @@
++++
+title = "Changelog"
+description = "Version history for arXiv:2604.08123 -- Sparse Gated Attention"
+template = "page"
+tags = ["paper", "light", "preprint", "self-published", "raw"]
++++
+
+<div class="changelog-page">
+
+# Version History
+
+<p class="changelog-intro">This page tracks all revisions submitted to arXiv for paper ID <strong>arXiv:2604.08123</strong>. Each version includes a summary of changes, date of submission, and status.</p>
+
+<div class="changelog-entry">
+
+<div class="changelog-header">
+<svg viewBox="0 0 88 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 3">
+  <rect x="0" y="0" width="24" height="24" rx="4" fill="#1a7a3a"/>
+  <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v3</text>
+  <rect x="28" y="2" width="58" height="20" rx="3" fill="none" stroke="#1a7a3a" stroke-width="1"/>
+  <text x="57" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#1a7a3a">Apr 2026</text>
+</svg>
+<svg viewBox="0 0 120 24" xmlns="http://www.w3.org/2000/svg" class="status-badge" aria-label="Under review">
+  <rect x="0" y="0" width="120" height="24" rx="4" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <circle cx="12" cy="12" r="4" fill="#2a5a8a"/>
+  <text x="22" y="16" font-family="Inter, sans-serif" font-size="9" font-weight="600" fill="#2a5a8a">UNDER REVIEW</text>
+</svg>
+</div>
+
+### Version 3 -- 10 April 2026
+
+**Major changes from v2:**
+
+- Added ablation study on gate network rank (Section 4.3), showing that rank-16 projections suffice for models up to 1.3B parameters
+- Included new results on the SCROLLS benchmark (Table 4), demonstrating SGA's effectiveness on real-world long-document tasks
+- Fixed error in FLOPs computation for the BigBird baseline (Table 1): corrected from 0.45x to 0.48x relative FLOPs
+- Added visualization of learned gate patterns across layers (Appendix C), revealing the emergence of local, strided, and global attention heads
+- Expanded related work section with discussion of Mamba and state-space model alternatives
+- Minor typographic corrections throughout
+
+</div>
+
+<div class="changelog-entry">
+
+<div class="changelog-header">
+<svg viewBox="0 0 92 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 2">
+  <rect x="0" y="0" width="24" height="24" rx="4" fill="#2a5a8a"/>
+  <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v2</text>
+  <rect x="28" y="2" width="62" height="20" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1"/>
+  <text x="59" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#2a5a8a">Mar 2026</text>
+</svg>
+<svg viewBox="0 0 100 24" xmlns="http://www.w3.org/2000/svg" class="status-badge" aria-label="Revised">
+  <rect x="0" y="0" width="100" height="24" rx="4" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <circle cx="12" cy="12" r="4" fill="#2a5a8a"/>
+  <text x="22" y="16" font-family="Inter, sans-serif" font-size="9" font-weight="600" fill="#2a5a8a">REVISED</text>
+</svg>
+</div>
+
+### Version 2 -- 12 March 2026
+
+**Major changes from v1:**
+
+- Replaced the original hard-threshold gating with Gumbel-sigmoid straight-through estimator for improved gradient flow during training
+- Added PG-19 language modeling experiments (Section 4.2), extending evaluation beyond classification to generation
+- Included wall-clock timing benchmarks on A100 GPUs (Table 1, new column)
+- Added comparison with Flash Attention v2, clarifying that SGA is orthogonal to memory-efficient attention implementations
+- Revised Section 3.2 with formal analysis of the expected sparsity ratio as a function of the temperature parameter
+- Added Appendix B with convergence proofs for the Gumbel-sigmoid estimator under the SGA objective
+
+</div>
+
+<div class="changelog-entry">
+
+<div class="changelog-header">
+<svg viewBox="0 0 88 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 1">
+  <rect x="0" y="0" width="24" height="24" rx="4" fill="#c45a1a"/>
+  <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v1</text>
+  <rect x="28" y="2" width="58" height="20" rx="3" fill="none" stroke="#c45a1a" stroke-width="1"/>
+  <text x="57" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#c45a1a">Jan 2026</text>
+</svg>
+<svg viewBox="0 0 110 24" xmlns="http://www.w3.org/2000/svg" class="status-badge" aria-label="Submitted">
+  <rect x="0" y="0" width="110" height="24" rx="4" fill="none" stroke="#c45a1a" stroke-width="1.5"/>
+  <circle cx="12" cy="12" r="4" fill="#c45a1a"/>
+  <text x="22" y="16" font-family="Inter, sans-serif" font-size="9" font-weight="600" fill="#c45a1a">SUBMITTED</text>
+</svg>
+</div>
+
+### Version 1 -- 15 January 2026
+
+**Initial submission.**
+
+- Proposed the Sparse Gated Attention (SGA) mechanism with learned per-head gate masks
+- Evaluated on Long Range Arena (LRA) benchmark across five tasks (ListOps, Text, Retrieval, Image, Pathfinder)
+- Demonstrated 62% FLOPs reduction with improved accuracy over vanilla attention
+- Included preliminary analysis of gate pattern interpretability
+- Used hard-threshold gating (replaced in v2 with Gumbel-sigmoid)
+
+</div>
+
+</div>

--- a/arxiv-preprint/content/index.md
+++ b/arxiv-preprint/content/index.md
@@ -1,0 +1,259 @@
++++
+title = "Sparse Gated Attention: Efficient Long-Context Processing via Learned Gate Masks"
+description = "We propose Sparse Gated Attention (SGA), a novel attention mechanism that learns per-head binary gate masks to dynamically prune uninformative attention connections, achieving sub-quadratic complexity for long-context transformer models."
+template = "page"
+tags = ["paper", "light", "preprint", "self-published", "raw"]
++++
+
+<div class="paper-header">
+
+<p class="paper-eyebrow">PREPRINT</p>
+
+# Sparse Gated Attention: Efficient Long-Context Processing via Learned Gate Masks
+
+<div class="paper-authors">
+  <div class="author">
+    <span class="author-name">Amir Khalili</span>
+    <span class="author-affiliation">ETH Zurich</span>
+  </div>
+  <div class="author">
+    <span class="author-name">Yuna Park</span>
+    <span class="author-affiliation">KAIST</span>
+  </div>
+  <div class="author">
+    <span class="author-name">Stefan Novak</span>
+    <span class="author-affiliation">Charles University, Prague</span>
+  </div>
+  <div class="author">
+    <span class="author-name">Fatima Al-Rashidi</span>
+    <span class="author-affiliation">KAUST</span>
+  </div>
+</div>
+
+<p class="paper-arxiv-id">arXiv:2604.08123v3 [cs.LG] &middot; 15 Jan 2026 (v1), 12 Mar 2026 (v2), 10 Apr 2026 (v3)</p>
+
+<div class="badge-row">
+  <svg viewBox="0 0 88 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 1, January 2026">
+    <rect x="0" y="0" width="24" height="24" rx="4" fill="#c45a1a"/>
+    <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v1</text>
+    <rect x="28" y="2" width="58" height="20" rx="3" fill="none" stroke="#c45a1a" stroke-width="1"/>
+    <text x="57" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#c45a1a">Jan 2026</text>
+  </svg>
+  <svg viewBox="0 0 92 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 2, March 2026">
+    <rect x="0" y="0" width="24" height="24" rx="4" fill="#2a5a8a"/>
+    <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v2</text>
+    <rect x="28" y="2" width="62" height="20" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1"/>
+    <text x="59" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#2a5a8a">Mar 2026</text>
+  </svg>
+  <svg viewBox="0 0 88 24" xmlns="http://www.w3.org/2000/svg" class="version-badge" aria-label="Version 3, April 2026">
+    <rect x="0" y="0" width="24" height="24" rx="4" fill="#1a7a3a"/>
+    <text x="12" y="16" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#ffffff">v3</text>
+    <rect x="28" y="2" width="58" height="20" rx="3" fill="none" stroke="#1a7a3a" stroke-width="1"/>
+    <text x="57" y="15" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#1a7a3a">Apr 2026</text>
+  </svg>
+  <svg viewBox="0 0 120 24" xmlns="http://www.w3.org/2000/svg" class="status-badge" aria-label="Under review">
+    <rect x="0" y="0" width="120" height="24" rx="4" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+    <circle cx="12" cy="12" r="4" fill="#2a5a8a"/>
+    <text x="22" y="16" font-family="Inter, sans-serif" font-size="9" font-weight="600" fill="#2a5a8a">UNDER REVIEW</text>
+  </svg>
+</div>
+
+</div>
+
+<div class="abstract-box">
+
+## Abstract
+
+We propose **Sparse Gated Attention (SGA)**, a novel attention mechanism that learns per-head binary gate masks to dynamically prune uninformative attention connections during inference. Unlike fixed sparse patterns (e.g., local windows, strided access), SGA learns a lightweight gating network that produces differentiable masks over the attention matrix, enabling each head to specialize in attending to contextually relevant positions. The gate network is parameterized as a low-rank projection followed by a straight-through Gumbel-sigmoid estimator, adding fewer than 0.3% additional parameters to a standard transformer. During inference, the learned gates produce hard binary masks, reducing effective attention computation to O(n * k) where k is the average number of retained connections per query.
+
+On the Long Range Arena (LRA) benchmark, SGA achieves **87.2% average accuracy** (vs. 86.1% for vanilla attention) while reducing FLOPs by **62%**. On document-level language modeling (PG-19), SGA matches full-attention perplexity (17.8 vs. 17.6) at sequence lengths of 8192 with **3.1x wall-clock speedup**. We further demonstrate that the learned gate patterns are interpretable, revealing distinct head specializations: some heads attend locally for syntax, while others form long-range "bridge" connections for discourse coherence. Code and pretrained checkpoints are available at `https://github.com/sparse-gated-attention/sga`.
+
+</div>
+
+<div class="key-results">
+
+## Key Results
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>LRA Avg (%)</th>
+      <th>PG-19 PPL</th>
+      <th>FLOPs (rel.)</th>
+      <th>Wall-clock (rel.)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vanilla Transformer</td>
+      <td>86.1</td>
+      <td>17.6</td>
+      <td>1.00x</td>
+      <td>1.00x</td>
+    </tr>
+    <tr>
+      <td>Longformer</td>
+      <td>84.7</td>
+      <td>18.3</td>
+      <td>0.52x</td>
+      <td>0.58x</td>
+    </tr>
+    <tr>
+      <td>BigBird</td>
+      <td>85.3</td>
+      <td>18.1</td>
+      <td>0.48x</td>
+      <td>0.55x</td>
+    </tr>
+    <tr>
+      <td>Linear Attention</td>
+      <td>81.2</td>
+      <td>19.4</td>
+      <td>0.31x</td>
+      <td>0.34x</td>
+    </tr>
+    <tr>
+      <td>Flash Attention v2</td>
+      <td>86.1</td>
+      <td>17.6</td>
+      <td>1.00x</td>
+      <td>0.42x</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>SGA (Ours)</strong></td>
+      <td><strong>87.2</strong></td>
+      <td><strong>17.8</strong></td>
+      <td><strong>0.38x</strong></td>
+      <td><strong>0.32x</strong></td>
+    </tr>
+  </tbody>
+</table>
+
+</div>
+
+<div class="architecture-overview">
+
+## Architecture Overview
+
+<div class="svg-figure">
+<svg viewBox="0 0 700 340" xmlns="http://www.w3.org/2000/svg" class="architecture-diagram" aria-label="Sparse Gated Attention architecture diagram">
+  <!-- Background -->
+  <rect x="0" y="0" width="700" height="340" fill="#fafaf8" rx="4"/>
+
+  <!-- Input -->
+  <rect x="280" y="10" width="140" height="32" rx="3" fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="350" y="31" text-anchor="middle" font-family="Inter, sans-serif" font-size="12" font-weight="600" fill="#333">Input X (n x d)</text>
+
+  <!-- Arrow down -->
+  <line x1="350" y1="42" x2="350" y2="62" stroke="#666" stroke-width="1" marker-end="url(#arrowhead)"/>
+
+  <!-- QKV Projections -->
+  <rect x="120" y="64" width="100" height="28" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="170" y="83" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#2a5a8a">W_Q</text>
+
+  <rect x="300" y="64" width="100" height="28" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="350" y="83" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#2a5a8a">W_K</text>
+
+  <rect x="480" y="64" width="100" height="28" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="530" y="83" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#2a5a8a">W_V</text>
+
+  <!-- Branching arrows from input -->
+  <line x1="350" y1="52" x2="170" y2="64" stroke="#666" stroke-width="1"/>
+  <line x1="350" y1="52" x2="350" y2="64" stroke="#666" stroke-width="1"/>
+  <line x1="350" y1="52" x2="530" y2="64" stroke="#666" stroke-width="1"/>
+
+  <!-- Q, K labels -->
+  <text x="170" y="108" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#666">Q</text>
+  <text x="350" y="108" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#666">K</text>
+  <text x="530" y="108" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#666">V</text>
+
+  <!-- Arrows down from QKV -->
+  <line x1="170" y1="92" x2="170" y2="122" stroke="#666" stroke-width="1"/>
+  <line x1="350" y1="92" x2="350" y2="122" stroke="#666" stroke-width="1"/>
+  <line x1="530" y1="92" x2="530" y2="198" stroke="#666" stroke-width="1"/>
+
+  <!-- Attention score computation -->
+  <rect x="180" y="122" width="250" height="32" rx="3" fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="305" y="143" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#333">A = softmax(QK^T / sqrt(d))</text>
+
+  <!-- Arrows from Q,K into attention -->
+  <line x1="170" y1="112" x2="250" y2="122" stroke="#666" stroke-width="1"/>
+  <line x1="350" y1="112" x2="350" y2="122" stroke="#666" stroke-width="1"/>
+
+  <!-- Gate Network (the novel part) - highlighted -->
+  <rect x="16" y="110" width="130" height="64" rx="4" fill="#fff7f0" stroke="#c45a1a" stroke-width="2"/>
+  <text x="81" y="130" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#c45a1a">Gate Network</text>
+  <text x="81" y="144" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#c45a1a">Low-rank proj.</text>
+  <text x="81" y="158" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#c45a1a">+ Gumbel-sigmoid</text>
+  <text x="81" y="170" text-anchor="middle" font-family="Inter, sans-serif" font-size="8" fill="#999">(+0.3% params)</text>
+
+  <!-- Arrow from Q to Gate -->
+  <line x1="170" y1="108" x2="146" y2="118" stroke="#c45a1a" stroke-width="1.5" stroke-dasharray="4,2"/>
+
+  <!-- Gate mask output -->
+  <rect x="36" y="194" width="90" height="28" rx="3" fill="none" stroke="#c45a1a" stroke-width="1.5"/>
+  <text x="81" y="213" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="600" fill="#c45a1a">G (mask)</text>
+  <line x1="81" y1="174" x2="81" y2="194" stroke="#c45a1a" stroke-width="1.5" marker-end="url(#arrowhead-orange)"/>
+
+  <!-- Hadamard product -->
+  <rect x="180" y="178" width="250" height="32" rx="3" fill="#fff7f0" stroke="#c45a1a" stroke-width="2"/>
+  <text x="305" y="199" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="700" fill="#c45a1a">A_sparse = A * G (element-wise)</text>
+
+  <!-- Arrows into Hadamard -->
+  <line x1="305" y1="154" x2="305" y2="178" stroke="#666" stroke-width="1" marker-end="url(#arrowhead)"/>
+  <line x1="126" y1="208" x2="180" y2="198" stroke="#c45a1a" stroke-width="1.5"/>
+
+  <!-- Output computation -->
+  <rect x="220" y="234" width="220" height="32" rx="3" fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="330" y="255" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#333">Output = A_sparse * V</text>
+
+  <!-- Arrows from sparse attention and V -->
+  <line x1="305" y1="210" x2="305" y2="234" stroke="#666" stroke-width="1" marker-end="url(#arrowhead)"/>
+  <line x1="530" y1="208" x2="440" y2="240" stroke="#666" stroke-width="1"/>
+
+  <!-- Final output -->
+  <rect x="270" y="286" width="120" height="32" rx="3" fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="330" y="307" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#333">Output (n x d)</text>
+  <line x1="330" y1="266" x2="330" y2="286" stroke="#666" stroke-width="1" marker-end="url(#arrowhead)"/>
+
+  <!-- Legend -->
+  <rect x="530" y="250" width="155" height="76" rx="3" fill="#fafaf8" stroke="#ccc" stroke-width="0.75"/>
+  <text x="540" y="266" font-family="Inter, sans-serif" font-size="9" font-weight="600" fill="#333">Legend</text>
+  <line x1="540" y1="280" x2="560" y2="280" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="566" y="284" font-family="Inter, sans-serif" font-size="8" fill="#666">Standard ops</text>
+  <line x1="540" y1="296" x2="560" y2="296" stroke="#c45a1a" stroke-width="2"/>
+  <text x="566" y="300" font-family="Inter, sans-serif" font-size="8" fill="#666">SGA components</text>
+  <line x1="540" y1="312" x2="560" y2="312" stroke="#c45a1a" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <text x="566" y="316" font-family="Inter, sans-serif" font-size="8" fill="#666">Gate input</text>
+
+  <!-- Arrowhead markers -->
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#666" stroke-width="1"/>
+    </marker>
+    <marker id="arrowhead-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#c45a1a" stroke-width="1"/>
+    </marker>
+  </defs>
+</svg>
+<p class="figure-caption">Figure 1. Sparse Gated Attention (SGA) architecture. The gate network (orange) learns per-head binary masks that prune uninformative attention connections, reducing effective computation from O(n^2) to O(n*k).</p>
+</div>
+
+</div>
+
+<div class="paper-structure">
+
+## Structure of the Paper
+
+The remainder of this paper is organized as follows:
+
+- **[Section 1: Introduction](/sections/1-introduction/)** -- Motivation and problem statement for efficient long-context attention.
+- **[Section 2: Related Work](/sections/2-related-work/)** -- Survey of efficient attention mechanisms and sparse transformers.
+- **[Section 3: Method](/sections/3-method/)** -- Detailed description of the Sparse Gated Attention mechanism.
+- **[Section 4: Experiments](/sections/4-experiments/)** -- Evaluation on LRA, PG-19, and ablation studies.
+- **[Section 5: Conclusion](/sections/5-conclusion/)** -- Summary of contributions and future directions.
+- **[Changelog](/changelog/)** -- Version history and revision notes.
+- **[Appendix](/appendix/)** -- Supplementary materials, proofs, and additional experiments.
+
+</div>

--- a/arxiv-preprint/content/sections/1-introduction.md
+++ b/arxiv-preprint/content/sections/1-introduction.md
@@ -1,0 +1,42 @@
++++
+title = "1. Introduction"
+weight = 1
+template = "post"
+description = "Motivation and problem statement for efficient long-context attention in transformer models."
+[extra]
+section_number = "1"
++++
+
+## Motivation
+
+The transformer architecture (Vaswani et al., 2017) has become the dominant paradigm for sequence modeling across natural language processing, computer vision, and scientific computing. However, the standard self-attention mechanism computes pairwise interactions between all positions in the input sequence, resulting in O(n^2) time and memory complexity where n is the sequence length. This quadratic scaling presents a fundamental bottleneck for applications that require processing long contexts -- document summarization, genomic sequence analysis, long-horizon reinforcement learning, and multi-turn dialogue.
+
+Recent years have seen significant progress in reducing the cost of attention. Approaches broadly fall into three categories: (1) fixed sparse patterns that restrict attention to local windows and selected global tokens (Beltagy et al., 2020; Zaheer et al., 2020), (2) low-rank approximations that project keys and values into lower-dimensional spaces (Wang et al., 2020; Katharopoulos et al., 2020), and (3) memory-efficient implementations that reduce the memory footprint without changing the mathematical operation (Dao et al., 2022). Each approach trades off expressiveness for efficiency in different ways.
+
+## Problem Statement
+
+A key limitation of existing sparse attention methods is that their sparsity patterns are **fixed at design time**. Longformer uses a sliding window plus global tokens; BigBird adds random attention on top. These patterns are chosen by the practitioner based on domain intuition and do not adapt to the input or the task. This rigidity means that:
+
+1. **Information loss is uncontrolled.** Some pruned connections may have carried important information for the current input, while retained connections may be uninformative.
+2. **Head specialization is constrained.** All heads within a layer are forced to use the same attention pattern, preventing the model from allocating different heads to local vs. global processing.
+3. **Transfer across tasks is brittle.** A pattern optimized for document classification may be suboptimal for question answering on the same document lengths.
+
+## Our Approach
+
+We propose **Sparse Gated Attention (SGA)**, a mechanism that learns to produce per-head binary gate masks over the attention matrix. The key idea is simple: augment each attention head with a lightweight gate network that takes the query as input and outputs a binary mask indicating which key-value pairs should be attended to. During training, we use a Gumbel-sigmoid relaxation to maintain differentiability. During inference, the gates produce hard binary masks, and only the selected (non-zero) entries of the attention matrix are computed.
+
+SGA is designed to satisfy three desiderata:
+
+1. **Learnable sparsity.** The gate patterns are trained end-to-end with the rest of the model, adapting to the task and data distribution.
+2. **Per-head specialization.** Each attention head has its own gate network, allowing different heads to learn different sparsity patterns (local, global, strided, etc.).
+3. **Minimal overhead.** The gate network uses low-rank parameterization, adding fewer than 0.3% additional parameters to the base model.
+
+## Contributions
+
+The contributions of this paper are as follows:
+
+- We propose SGA, a learned gating mechanism for attention that dynamically prunes connections based on the input context.
+- We provide theoretical analysis showing that the Gumbel-sigmoid estimator converges to the true discrete gradient as the temperature approaches zero (Appendix B).
+- We demonstrate state-of-the-art results on the Long Range Arena benchmark (87.2% average, surpassing both vanilla and existing sparse attention methods) while reducing FLOPs by 62%.
+- We show that SGA matches full-attention perplexity on PG-19 language modeling at 8192 sequence length with 3.1x wall-clock speedup.
+- We analyze the learned gate patterns and show that they are interpretable, with distinct heads specializing in local syntax, periodic summarization, and long-range discourse bridging.

--- a/arxiv-preprint/content/sections/2-related-work.md
+++ b/arxiv-preprint/content/sections/2-related-work.md
@@ -1,0 +1,46 @@
++++
+title = "2. Related Work"
+weight = 2
+template = "post"
+description = "Survey of efficient attention mechanisms, sparse transformers, and learned sparsity in neural networks."
+[extra]
+section_number = "2"
++++
+
+## Efficient Attention Mechanisms
+
+The quest for efficient attention has produced a rich literature. We organize prior work along three axes: fixed sparse patterns, low-rank and kernel approximations, and hardware-aware implementations.
+
+### Fixed Sparse Patterns
+
+**Longformer** (Beltagy et al., 2020) combines sliding-window local attention with task-specific global attention tokens. The local window captures nearby dependencies while global tokens (e.g., the [CLS] token) aggregate information across the full sequence. The attention complexity is O(n * w) where w is the window size, but the fixed pattern cannot adapt to input-dependent long-range dependencies.
+
+**BigBird** (Zaheer et al., 2020) augments local and global attention with random attention edges, providing theoretical guarantees that the resulting graph approximates a universal Turing machine. In practice, the random edges add coverage but are not optimized for the actual information flow in the data.
+
+**Sparse Transformer** (Child et al., 2019) introduced strided attention patterns for autoregressive generation, combining local and strided heads to achieve O(n * sqrt(n)) complexity. The pattern is effective for structured data (images, music) but requires manual selection of stride parameters.
+
+### Low-Rank and Kernel Approximations
+
+**Linear Attention** (Katharopoulos et al., 2020) replaces the softmax kernel with a feature map phi, decomposing attention as phi(Q) * (phi(K)^T * V), achieving O(n * d) complexity. While efficient, the removal of the softmax non-linearity generally degrades performance on tasks requiring sharp attention distributions.
+
+**Performer** (Choromanski et al., 2021) uses random feature maps to approximate the softmax kernel, achieving linear complexity with stronger approximation guarantees. However, the approximation quality degrades for long sequences where the effective rank of the attention matrix is high.
+
+**Linformer** (Wang et al., 2020) projects keys and values to a lower dimension k << n, reducing attention to O(n * k). The projection matrices are fixed per layer, limiting adaptivity to the input.
+
+### Hardware-Aware Implementations
+
+**Flash Attention** (Dao et al., 2022; Dao, 2023) does not change the mathematical operation but reorders the computation to minimize memory reads/writes, achieving significant wall-clock speedups on modern GPUs. Flash Attention is **orthogonal** to SGA: our method reduces the number of operations, while Flash Attention makes each operation faster. In principle, the two can be combined, applying Flash Attention's memory-efficient algorithm to the sparse subsets selected by SGA's gates.
+
+### State-Space Models
+
+**Mamba** (Gu and Dao, 2023) and its predecessors (S4, H3) replace attention entirely with structured state-space layers that process sequences in O(n) time. While effective for language modeling, SSMs struggle on tasks requiring content-based retrieval over long contexts (e.g., the Retrieval task in LRA), where attention-based models retain an advantage. SGA can be seen as a middle ground: it preserves the content-based routing of attention while approaching the efficiency of linear-time models.
+
+## Learned Sparsity in Neural Networks
+
+The idea of learning which computations to skip is not unique to attention. **Mixture of Experts** (Shazeer et al., 2017) routes tokens to a subset of expert networks using a learned gating function. **Conditional computation** (Bengio et al., 2013) frames the problem more generally as learning binary decisions about which modules to execute. **Structured pruning** (Li et al., 2017) learns to remove entire neurons or channels from trained networks.
+
+SGA applies the principle of learned conditional computation specifically to the attention matrix. The gate network can be viewed as a lightweight "router" that decides, for each query, which keys are worth attending to. Unlike MoE routing, which operates at the token-module level, SGA gates operate at the fine-grained token-token level within the attention matrix.
+
+## Differentiable Discrete Optimization
+
+Training binary gates requires propagating gradients through discrete decisions. The **Gumbel-softmax** trick (Jang et al., 2017; Maddison et al., 2017) provides a continuous relaxation of categorical distributions using Gumbel noise and a temperature parameter. The **straight-through estimator** (Bengio et al., 2013) uses the hard discrete sample in the forward pass but passes gradients through the continuous relaxation in the backward pass. SGA combines both techniques in the Gumbel-sigmoid variant (binary case of Gumbel-softmax), which we find provides more stable training than either approach alone.

--- a/arxiv-preprint/content/sections/3-method.md
+++ b/arxiv-preprint/content/sections/3-method.md
@@ -1,0 +1,118 @@
++++
+title = "3. Method"
+weight = 3
+template = "post"
+description = "Detailed description of the Sparse Gated Attention mechanism, gate network architecture, and training procedure."
+[extra]
+section_number = "3"
++++
+
+## Overview
+
+We describe the Sparse Gated Attention (SGA) mechanism in three parts: (1) the gate network architecture that produces binary masks, (2) the integration with standard multi-head attention, and (3) the training procedure using Gumbel-sigmoid relaxation.
+
+## 3.1 Gate Network Architecture
+
+For each attention head h in layer l, we introduce a gate network G_h^l that maps query representations to binary masks. The gate network is parameterized as a low-rank bilinear form:
+
+mu_ij = (q_i^T * W_down) * (k_j^T * W_up)^T / sqrt(r)
+
+where W_down is a d_head x r projection matrix, W_up is a d_head x r projection matrix, r << d_head is the gate rank, and q_i, k_j are the query and key vectors at positions i and j respectively.
+
+The low-rank parameterization is critical for efficiency. With r = 16 (our default) and d_head = 64, the gate network adds only 2 * 64 * 16 = 2,048 parameters per head, or roughly 0.3% overhead for a 12-head, 12-layer transformer.
+
+<div class="svg-figure">
+<svg viewBox="0 0 600 260" xmlns="http://www.w3.org/2000/svg" class="architecture-diagram" aria-label="Gate network detail diagram">
+  <rect x="0" y="0" width="600" height="260" fill="#fafaf8" rx="4"/>
+
+  <!-- Query input -->
+  <rect x="40" y="20" width="100" height="28" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="90" y="39" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#2a5a8a">q_i (d_head)</text>
+
+  <!-- Key input -->
+  <rect x="460" y="20" width="100" height="28" rx="3" fill="none" stroke="#2a5a8a" stroke-width="1.5"/>
+  <text x="510" y="39" text-anchor="middle" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#2a5a8a">k_j (d_head)</text>
+
+  <!-- W_down projection -->
+  <rect x="50" y="72" width="80" height="28" rx="3" fill="#fff7f0" stroke="#c45a1a" stroke-width="1.5"/>
+  <text x="90" y="91" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="600" fill="#c45a1a">W_down</text>
+  <text x="90" y="114" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#999">d_head -> r</text>
+  <line x1="90" y1="48" x2="90" y2="72" stroke="#666" stroke-width="1" marker-end="url(#arr)"/>
+
+  <!-- W_up projection -->
+  <rect x="470" y="72" width="80" height="28" rx="3" fill="#fff7f0" stroke="#c45a1a" stroke-width="1.5"/>
+  <text x="510" y="91" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="600" fill="#c45a1a">W_up</text>
+  <text x="510" y="114" text-anchor="middle" font-family="Inter, sans-serif" font-size="9" fill="#999">d_head -> r</text>
+  <line x1="510" y1="48" x2="510" y2="72" stroke="#666" stroke-width="1" marker-end="url(#arr)"/>
+
+  <!-- Bilinear product -->
+  <rect x="210" y="128" width="180" height="32" rx="3" fill="#fff7f0" stroke="#c45a1a" stroke-width="2"/>
+  <text x="300" y="149" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="700" fill="#c45a1a">mu_ij = q'_i * k'_j^T / sqrt(r)</text>
+  <line x1="90" y1="100" x2="210" y2="138" stroke="#c45a1a" stroke-width="1.5"/>
+  <line x1="510" y1="100" x2="390" y2="138" stroke="#c45a1a" stroke-width="1.5"/>
+
+  <!-- Gumbel noise -->
+  <rect x="50" y="176" width="120" height="28" rx="3" fill="none" stroke="#888" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="110" y="195" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" fill="#888">+ Gumbel noise g</text>
+
+  <!-- Sigmoid -->
+  <rect x="230" y="182" width="140" height="28" rx="3" fill="none" stroke="#c45a1a" stroke-width="1.5"/>
+  <text x="300" y="201" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="600" fill="#c45a1a">sigma((mu + g) / tau)</text>
+  <line x1="300" y1="160" x2="300" y2="182" stroke="#666" stroke-width="1" marker-end="url(#arr)"/>
+  <line x1="170" y1="190" x2="230" y2="196" stroke="#888" stroke-width="1"/>
+
+  <!-- Hard threshold -->
+  <rect x="240" y="228" width="120" height="28" rx="3" fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="300" y="247" text-anchor="middle" font-family="Inter, sans-serif" font-size="10" font-weight="600" fill="#333">G_ij in {0, 1}</text>
+  <line x1="300" y1="210" x2="300" y2="228" stroke="#666" stroke-width="1" marker-end="url(#arr)"/>
+
+  <!-- Training/Inference labels -->
+  <text x="430" y="198" font-family="Inter, sans-serif" font-size="9" fill="#2a5a8a" font-weight="600">Training: soft</text>
+  <text x="430" y="244" font-family="Inter, sans-serif" font-size="9" fill="#333" font-weight="600">Inference: hard</text>
+
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#666" stroke-width="1"/>
+    </marker>
+  </defs>
+</svg>
+<p class="figure-caption">Figure 2. Gate network detail for a single attention head. The low-rank bilinear form computes logits mu_ij, which are passed through a Gumbel-sigmoid with temperature tau to produce differentiable (training) or hard binary (inference) gate masks.</p>
+</div>
+
+## 3.2 Integration with Multi-Head Attention
+
+Standard multi-head attention computes:
+
+head_h = softmax(Q_h * K_h^T / sqrt(d_head)) * V_h
+
+SGA modifies this to:
+
+head_h = [softmax(Q_h * K_h^T / sqrt(d_head)) * G_h] * V_h
+
+where * denotes element-wise multiplication and G_h is the binary gate mask for head h. The masking is applied *after* the softmax, which means that the remaining attention weights are not renormalized. We found empirically that post-softmax masking without renormalization outperforms both pre-softmax masking (replacing pruned logits with -infinity before softmax) and post-softmax masking with renormalization.
+
+The intuition is that post-softmax masking acts as a form of "attention dropout" that the model learns to anticipate during training. The gate network and the attention weights co-adapt: the attention weights learn to concentrate probability on positions that the gate will retain, while the gate learns to retain positions where the attention weights are large.
+
+## 3.3 Training Procedure
+
+During training, we use the Gumbel-sigmoid relaxation with straight-through gradient estimation:
+
+**Forward pass:** G_ij = 1[sigma((mu_ij + g_1 - g_2) / tau) > 0.5] where g_1, g_2 are independent Gumbel(0,1) samples.
+
+**Backward pass:** Gradients are computed as if G_ij = sigma((mu_ij + g_1 - g_2) / tau), i.e., the continuous relaxation is used for gradient computation.
+
+The temperature tau is annealed from 1.0 to 0.1 over the course of training using an exponential schedule. High temperature in the early stages allows exploration of different gate patterns, while low temperature at the end encourages discrete (near-binary) gates.
+
+**Sparsity regularization.** We add a regularization term to the training loss:
+
+L_total = L_task + lambda * (1/n^2) * sum_ij G_ij
+
+where lambda controls the sparsity-accuracy trade-off. In our experiments, lambda = 0.01 provides a good balance. Increasing lambda produces sparser gates at the cost of some accuracy; see the ablation in Appendix D.
+
+## 3.4 Inference Optimization
+
+During inference, the gates produce hard binary masks (tau effectively equals 0). This enables two key optimizations:
+
+1. **Sparse matrix multiplication.** Only the non-zero entries of the masked attention matrix A_sparse = A * G are computed. We implement this as a block-sparse operation using custom CUDA kernels.
+
+2. **Early key-value pruning.** For autoregressive generation, once a key-value pair is gated out by all heads in all subsequent positions, it can be evicted from the KV cache. In practice, this reduces KV cache size by approximately 40% for sequences of length 8192.

--- a/arxiv-preprint/content/sections/4-experiments.md
+++ b/arxiv-preprint/content/sections/4-experiments.md
@@ -1,0 +1,276 @@
++++
+title = "4. Experiments"
+weight = 4
+template = "post"
+description = "Evaluation of Sparse Gated Attention on Long Range Arena, PG-19 language modeling, and SCROLLS benchmarks with ablation studies."
+[extra]
+section_number = "4"
++++
+
+## Experimental Setup
+
+We evaluate SGA on three benchmark suites: the Long Range Arena (LRA) for classification with long sequences, PG-19 for autoregressive language modeling, and SCROLLS for real-world long-document understanding. All models are implemented in JAX/Flax and trained on 8x NVIDIA A100 GPUs. Full training details are provided in Appendix E.
+
+## 4.1 Long Range Arena
+
+The LRA benchmark (Tay et al., 2021) consists of five tasks designed to stress-test long-range dependency modeling: ListOps (mathematical reasoning, length 2048), Text (sentiment classification, length 4096), Retrieval (document similarity, length 4096), Image (sequential CIFAR-10, length 1024), and Pathfinder (spatial reasoning, length 1024).
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>ListOps</th>
+      <th>Text</th>
+      <th>Retrieval</th>
+      <th>Image</th>
+      <th>Pathfinder</th>
+      <th>Avg</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vanilla Transformer</td>
+      <td>37.1</td>
+      <td>65.2</td>
+      <td>79.4</td>
+      <td>42.4</td>
+      <td>71.4</td>
+      <td>59.1</td>
+    </tr>
+    <tr>
+      <td>Longformer</td>
+      <td>35.6</td>
+      <td>62.9</td>
+      <td>78.1</td>
+      <td>41.8</td>
+      <td>69.2</td>
+      <td>57.5</td>
+    </tr>
+    <tr>
+      <td>BigBird</td>
+      <td>36.2</td>
+      <td>64.0</td>
+      <td>79.0</td>
+      <td>42.0</td>
+      <td>70.8</td>
+      <td>58.4</td>
+    </tr>
+    <tr>
+      <td>Linear Attention</td>
+      <td>16.1</td>
+      <td>65.9</td>
+      <td>53.1</td>
+      <td>42.3</td>
+      <td>71.0</td>
+      <td>49.7</td>
+    </tr>
+    <tr>
+      <td>Performer</td>
+      <td>18.0</td>
+      <td>65.4</td>
+      <td>53.8</td>
+      <td>42.8</td>
+      <td>69.5</td>
+      <td>49.9</td>
+    </tr>
+    <tr>
+      <td>FNet</td>
+      <td>35.3</td>
+      <td>65.1</td>
+      <td>59.6</td>
+      <td>38.7</td>
+      <td>67.3</td>
+      <td>53.2</td>
+    </tr>
+    <tr>
+      <td>S4</td>
+      <td>59.6</td>
+      <td>86.1</td>
+      <td>87.1</td>
+      <td>88.6</td>
+      <td>94.2</td>
+      <td>83.1</td>
+    </tr>
+    <tr>
+      <td>Mamba</td>
+      <td>58.8</td>
+      <td>87.3</td>
+      <td>85.6</td>
+      <td>87.9</td>
+      <td>93.8</td>
+      <td>82.7</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>SGA (Ours)</strong></td>
+      <td><strong>60.2</strong></td>
+      <td><strong>88.1</strong></td>
+      <td><strong>88.4</strong></td>
+      <td><strong>89.1</strong></td>
+      <td><strong>95.0</strong></td>
+      <td><strong>84.2</strong></td>
+    </tr>
+  </tbody>
+</table>
+
+SGA achieves the highest average accuracy across all five LRA tasks. The largest gains are on ListOps (+1.4% over S4) and Pathfinder (+0.8% over S4), both of which require precise long-range structural reasoning. On Text and Retrieval, SGA slightly outperforms Mamba and S4, suggesting that content-based attention routing provides value even for tasks where sequential models perform well.
+
+## 4.2 Language Modeling (PG-19)
+
+We evaluate SGA on PG-19, a corpus of full-length Project Gutenberg books, using sequence lengths of 2048, 4096, and 8192 tokens. The model is a 350M parameter transformer with 24 layers and 16 heads.
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>PPL (2048)</th>
+      <th>PPL (4096)</th>
+      <th>PPL (8192)</th>
+      <th>Speedup (8192)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vanilla Transformer</td>
+      <td>18.9</td>
+      <td>17.8</td>
+      <td>17.6</td>
+      <td>1.0x</td>
+    </tr>
+    <tr>
+      <td>Longformer</td>
+      <td>19.5</td>
+      <td>18.6</td>
+      <td>18.3</td>
+      <td>1.7x</td>
+    </tr>
+    <tr>
+      <td>Flash Attention v2</td>
+      <td>18.9</td>
+      <td>17.8</td>
+      <td>17.6</td>
+      <td>2.4x</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>SGA (Ours)</strong></td>
+      <td><strong>19.1</strong></td>
+      <td><strong>17.9</strong></td>
+      <td><strong>17.8</strong></td>
+      <td><strong>3.1x</strong></td>
+    </tr>
+    <tr>
+      <td>SGA + Flash Attn v2</td>
+      <td>19.1</td>
+      <td>17.9</td>
+      <td>17.8</td>
+      <td>3.8x</td>
+    </tr>
+  </tbody>
+</table>
+
+SGA achieves near-parity with vanilla attention in perplexity (17.8 vs. 17.6 at length 8192) while providing a 3.1x wall-clock speedup. The small perplexity gap (0.2 points) is the cost of pruning approximately 62% of attention connections. Notably, SGA composes with Flash Attention v2, yielding a combined 3.8x speedup -- the sparse masks reduce the number of attention entries to compute, and Flash Attention processes those entries with optimal memory access patterns.
+
+## 4.3 Ablation Studies
+
+### Gate Rank
+
+We vary the gate network rank r from 4 to 64 while keeping all other hyperparameters fixed. Results are shown in Appendix D, Table D.1. The rank-16 default provides the best accuracy-efficiency trade-off: increasing rank beyond 16 provides negligible accuracy gains while increasing parameter count and gate computation overhead.
+
+### Sparsity Regularization
+
+The regularization coefficient lambda controls the trade-off between sparsity and accuracy:
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>lambda</th>
+      <th>Sparsity (%)</th>
+      <th>LRA Avg (%)</th>
+      <th>PG-19 PPL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0.0 (no reg.)</td>
+      <td>38.2</td>
+      <td>84.8</td>
+      <td>17.7</td>
+    </tr>
+    <tr>
+      <td>0.005</td>
+      <td>52.1</td>
+      <td>84.4</td>
+      <td>17.7</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>0.01 (default)</strong></td>
+      <td><strong>62.0</strong></td>
+      <td><strong>84.2</strong></td>
+      <td><strong>17.8</strong></td>
+    </tr>
+    <tr>
+      <td>0.05</td>
+      <td>78.4</td>
+      <td>82.1</td>
+      <td>18.4</td>
+    </tr>
+    <tr>
+      <td>0.1</td>
+      <td>88.6</td>
+      <td>78.9</td>
+      <td>19.2</td>
+    </tr>
+  </tbody>
+</table>
+
+Without sparsity regularization (lambda=0), the gates still learn moderate sparsity (38.2%) from the task signal alone, but the resulting masks are less structured and harder to optimize for sparse matrix operations. The default lambda=0.01 achieves 62% sparsity with only a small accuracy reduction. Aggressive regularization (lambda >= 0.05) significantly degrades accuracy, indicating that some attention connections are genuinely important and should not be pruned.
+
+### Post-Softmax vs. Pre-Softmax Masking
+
+We compared three masking strategies on LRA:
+
+- **Pre-softmax:** Replace pruned logits with -infinity before softmax. LRA Avg: 82.8%
+- **Post-softmax (renormalized):** Mask after softmax and renormalize remaining weights to sum to 1. LRA Avg: 83.4%
+- **Post-softmax (no renorm.):** Mask after softmax without renormalization. LRA Avg: **84.2%**
+
+Post-softmax masking without renormalization performs best. The key reason is that renormalization amplifies the remaining attention weights, which can destabilize training when the gate sparsity changes between epochs. Without renormalization, the model learns to place higher raw attention weight on retained connections, achieving a more stable equilibrium between the attention and gate networks.
+
+## 4.4 SCROLLS Benchmark (New in v3)
+
+To evaluate SGA on realistic long-document tasks, we fine-tuned the 350M PG-19 model on four SCROLLS tasks:
+
+<table class="results-table">
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th>QMSum (R-L)</th>
+      <th>QASPER (F1)</th>
+      <th>NarrQA (F1)</th>
+      <th>ContractNLI (EM)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vanilla Transformer</td>
+      <td>19.8</td>
+      <td>31.2</td>
+      <td>24.6</td>
+      <td>78.4</td>
+    </tr>
+    <tr>
+      <td>Longformer</td>
+      <td>18.9</td>
+      <td>29.8</td>
+      <td>23.1</td>
+      <td>76.2</td>
+    </tr>
+    <tr class="highlight-row">
+      <td><strong>SGA (Ours)</strong></td>
+      <td><strong>20.1</strong></td>
+      <td><strong>31.8</strong></td>
+      <td><strong>25.2</strong></td>
+      <td><strong>79.1</strong></td>
+    </tr>
+  </tbody>
+</table>
+
+SGA slightly outperforms vanilla attention on all four SCROLLS tasks while being 2.8x faster at inference. The gains are most pronounced on QASPER and NarrativeQA, both of which require locating specific evidence in long documents -- exactly the scenario where learned attention routing should provide the most benefit.

--- a/arxiv-preprint/content/sections/5-conclusion.md
+++ b/arxiv-preprint/content/sections/5-conclusion.md
@@ -1,0 +1,46 @@
++++
+title = "5. Conclusion"
+weight = 5
+template = "post"
+description = "Summary of contributions, limitations, and future research directions for Sparse Gated Attention."
+[extra]
+section_number = "5"
++++
+
+## Summary
+
+We have presented **Sparse Gated Attention (SGA)**, a mechanism that learns per-head binary gate masks to dynamically prune uninformative attention connections. Unlike fixed sparse patterns, SGA adapts its sparsity structure to the input and task, enabling different heads to specialize in local, strided, or long-range attention patterns. The gate network uses a low-rank bilinear parameterization that adds fewer than 0.3% additional parameters, and the Gumbel-sigmoid straight-through estimator enables end-to-end training through the discrete gating decisions.
+
+Our experiments demonstrate that SGA achieves state-of-the-art results on the Long Range Arena benchmark (84.2% average accuracy) while reducing attention FLOPs by 62%. On PG-19 language modeling, SGA matches vanilla attention perplexity within 0.2 points at sequence length 8192 with a 3.1x wall-clock speedup. On the SCROLLS benchmark, SGA outperforms both vanilla and fixed-sparse attention on real-world long-document understanding tasks.
+
+Analysis of the learned gate patterns reveals interpretable head specializations: local heads for syntax (40%), strided heads for periodic summarization (25%), and sparse global "bridge" heads for discourse-level coherence (35%). This emergent structure provides evidence that the model discovers meaningful attention strategies through the gating mechanism alone, without explicit architectural constraints.
+
+## Limitations
+
+We acknowledge several limitations of the current work:
+
+1. **Scale.** Our largest model is 350M parameters. While the theoretical analysis is scale-independent, we have not yet verified that the observed gate patterns and efficiency gains persist at the 7B+ scale where modern language models operate.
+
+2. **Autoregressive generation.** The current implementation computes gate masks for each new token using the full key cache, adding latency to each generation step. A caching mechanism for gate decisions (analogous to KV caching) could mitigate this.
+
+3. **Training overhead.** While SGA reduces inference cost, training is approximately 15% slower than vanilla attention due to the additional gate network forward and backward passes. The Gumbel noise sampling adds non-trivial overhead on GPU.
+
+4. **Fixed sparsity during inference.** The gate network produces a fixed set of masks for a given input. Dynamic sparsity adaptation during generation (e.g., attending to more positions for difficult tokens) is an interesting direction we have not explored.
+
+## Future Work
+
+Several promising directions emerge from this work:
+
+**Scaling to large models.** Applying SGA to models with 7B-70B parameters would test whether the efficiency gains compound or diminish with scale. The low-rank gate parameterization should scale favorably, as the gate overhead is proportional to model dimension, not sequence length.
+
+**Combining with KV cache compression.** The gate masks naturally identify which key-value pairs are important across multiple positions. This signal could be used to compress the KV cache more aggressively than uniform eviction strategies, potentially enabling even longer context windows.
+
+**Cross-modal applications.** Vision transformers and audio transformers face similar quadratic scaling challenges. The SGA mechanism could be applied to these domains, where the interpretable gate patterns might reveal modality-specific attention strategies (e.g., spatial vs. frequency-domain attention in audio).
+
+**Adaptive computation budgets.** Rather than using a fixed sparsity regularization coefficient, the gate network could be extended to dynamically allocate computation based on input difficulty -- spending more attention on complex passages and less on routine text.
+
+**Hardware co-design.** The block-sparse attention patterns produced by SGA are well-suited to structured sparsity support on modern accelerators (e.g., NVIDIA's sparse tensor cores). Co-designing the gate network to produce hardware-friendly sparsity patterns (e.g., 2:4 structured sparsity) could yield additional speedups.
+
+## Acknowledgments
+
+We thank the anonymous reviewers for their constructive feedback, which significantly improved the paper between v1 and v3. We are grateful to the ETH Zurich HPC team for providing computational resources. AK is supported by a Swiss National Science Foundation grant. YP is supported by a KAIST AI fellowship. FaR is supported by KAUST baseline funding.

--- a/arxiv-preprint/content/sections/_index.md
+++ b/arxiv-preprint/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Full paper sections covering the introduction and motivation for efficient long-context attention, a survey of related work in sparse transformers, the detailed Sparse Gated Attention method, experimental evaluation on LRA and PG-19 benchmarks, and concluding remarks with future directions.

--- a/arxiv-preprint/static/css/style.css
+++ b/arxiv-preprint/static/css/style.css
@@ -1,0 +1,919 @@
+/* ==========================================================================
+   arXiv Preprint - Light LaTeX-like Theme
+   Issue #1612 | Tags: paper, light, preprint, self-published, raw
+   ========================================================================== */
+
+/* --- CSS Variables --- */
+:root {
+  --preprint-orange: #c45a1a;
+  --preprint-orange-light: #fff7f0;
+  --preprint-orange-muted: #e8a06a;
+  --arxiv-blue: #2a5a8a;
+  --arxiv-blue-light: #e8f0f8;
+  --version-green: #1a7a3a;
+  --version-green-light: #e8f5ee;
+  --text-primary: #1a1a1a;
+  --text-secondary: #4a4a4a;
+  --text-muted: #777777;
+  --bg-primary: #ffffff;
+  --bg-paper: #fafaf8;
+  --bg-subtle: #f4f2ee;
+  --border-color: #d4d0c8;
+  --border-light: #e8e4dc;
+  --rule-color: #c8c4bc;
+  --font-display: 'Inter', 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-body: 'STIX Two Text', 'Noto Serif', 'Georgia', 'Times New Roman', serif;
+  --font-mono: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+  --font-heading: 'Inter', 'IBM Plex Sans', sans-serif;
+  --max-width: 740px;
+  --line-height: 1.72;
+}
+
+/* --- Reset & Base --- */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: var(--line-height);
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* --- Preprint Banner --- */
+.preprint-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  background-color: var(--preprint-orange);
+  color: #ffffff;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.preprint-banner .banner-icon {
+  flex-shrink: 0;
+}
+
+/* --- Paper Wrap --- */
+.paper-wrap {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem 2rem;
+}
+
+/* --- Site Header --- */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  border-bottom: 2px solid var(--border-color);
+  margin-bottom: 2.5rem;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.site-logo:hover {
+  text-decoration: none;
+}
+
+.logo-mark {
+  width: 48px;
+  height: 34px;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.logo-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+
+.logo-sub {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.site-nav a {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.site-nav a:hover {
+  color: var(--preprint-orange);
+  border-bottom-color: var(--preprint-orange);
+}
+
+/* --- Main Content --- */
+.site-main {
+  min-height: calc(100vh - 260px);
+}
+
+/* --- Typography --- */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  color: var(--text-primary);
+  margin-top: 2em;
+  margin-bottom: 0.6em;
+  line-height: 1.3;
+  font-weight: 700;
+}
+
+h1 {
+  font-size: 1.65rem;
+  margin-top: 0;
+  line-height: 1.25;
+}
+
+h2 {
+  font-size: 1.25rem;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border-light);
+}
+
+h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+p {
+  margin: 1em 0;
+}
+
+a {
+  color: var(--arxiv-blue);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+strong {
+  font-weight: 700;
+}
+
+em {
+  font-style: italic;
+}
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.75em 1.25em;
+  border-left: 3px solid var(--preprint-orange);
+  background-color: var(--preprint-orange-light);
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+blockquote p:first-child {
+  margin-top: 0;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: 2em 0;
+}
+
+/* --- Code --- */
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background-color: var(--bg-subtle);
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  color: var(--text-primary);
+}
+
+pre {
+  background-color: var(--bg-paper);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  margin: 1.5em 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+/* --- Lists --- */
+ul, ol {
+  padding-left: 1.5em;
+  margin: 1em 0;
+}
+
+li {
+  margin-bottom: 0.35em;
+}
+
+li > ul,
+li > ol {
+  margin-top: 0.35em;
+  margin-bottom: 0;
+}
+
+/* --- Tables --- */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5em 0;
+  font-size: 0.9rem;
+}
+
+th, td {
+  padding: 0.5em 0.75em;
+  text-align: left;
+  border-bottom: 1px solid var(--border-light);
+}
+
+th {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--border-color);
+  background-color: var(--bg-paper);
+}
+
+.results-table {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.results-table th {
+  background-color: var(--bg-subtle);
+}
+
+.results-table td {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.results-table td:first-child {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+}
+
+.results-table .highlight-row {
+  background-color: var(--preprint-orange-light);
+}
+
+.results-table .highlight-row td {
+  border-bottom-color: var(--preprint-orange-muted);
+}
+
+/* --- Paper Header --- */
+.paper-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.paper-eyebrow {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--preprint-orange);
+  background-color: var(--preprint-orange-light);
+  padding: 0.25em 0.75em;
+  border: 1px solid var(--preprint-orange);
+  border-radius: 3px;
+  margin-bottom: 1rem;
+}
+
+.paper-header h1 {
+  font-size: 1.7rem;
+  line-height: 1.3;
+  margin-top: 0.75rem;
+  margin-bottom: 1.25rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* --- Authors --- */
+.paper-authors {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem 2rem;
+  margin: 1.25rem 0;
+}
+
+.author {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.author-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.author-affiliation {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.paper-arxiv-id {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 0.75rem;
+}
+
+/* --- Badge Row --- */
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.version-badge {
+  width: 88px;
+  height: 24px;
+}
+
+.status-badge {
+  width: 120px;
+  height: 24px;
+}
+
+/* --- Abstract Box --- */
+.abstract-box {
+  background-color: var(--bg-paper);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--arxiv-blue);
+  border-radius: 0 4px 4px 0;
+  padding: 1.25rem 1.5rem;
+  margin: 2rem 0;
+}
+
+.abstract-box h2 {
+  font-size: 1.1rem;
+  margin-top: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+  color: var(--arxiv-blue);
+}
+
+.abstract-box p {
+  font-size: 0.92rem;
+  line-height: 1.7;
+  text-align: justify;
+}
+
+/* --- Key Results --- */
+.key-results {
+  margin: 2rem 0;
+}
+
+.key-results h2 {
+  color: var(--preprint-orange);
+  border-bottom-color: var(--preprint-orange-muted);
+}
+
+/* --- SVG Figures --- */
+.svg-figure {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.architecture-diagram {
+  width: 100%;
+  max-width: 700px;
+  height: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.figure-caption {
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-top: 0.75rem;
+  line-height: 1.5;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* --- Architecture Overview --- */
+.architecture-overview {
+  margin: 2rem 0;
+}
+
+.architecture-overview h2 {
+  color: var(--arxiv-blue);
+  border-bottom-color: var(--arxiv-blue);
+}
+
+/* --- Paper Structure --- */
+.paper-structure {
+  margin: 2.5rem 0;
+  padding: 1.25rem 1.5rem;
+  background-color: var(--bg-subtle);
+  border-radius: 4px;
+  border: 1px solid var(--border-light);
+}
+
+.paper-structure h2 {
+  margin-top: 0;
+  font-size: 1rem;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.paper-structure ul {
+  list-style: none;
+  padding: 0;
+}
+
+.paper-structure li {
+  padding: 0.35em 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.paper-structure li:last-child {
+  border-bottom: none;
+}
+
+.paper-structure a {
+  color: var(--arxiv-blue);
+  font-weight: 500;
+}
+
+/* --- Section Article (post.html) --- */
+.paper-article {
+  max-width: 100%;
+}
+
+.paper-section-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.paper-section-eyebrow {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--preprint-orange);
+  margin-bottom: 0.25rem;
+}
+
+.paper-section-title {
+  font-size: 1.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.paper-lede {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.paper-content {
+  margin-bottom: 2rem;
+}
+
+.paper-section-footer {
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.button-link {
+  display: inline-block;
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--arxiv-blue);
+  text-decoration: none;
+  padding: 0.4em 0.75em;
+  border: 1px solid var(--arxiv-blue);
+  border-radius: 3px;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.button-link:hover {
+  background-color: var(--arxiv-blue);
+  color: #ffffff;
+  text-decoration: none;
+}
+
+/* --- Section List (section.html) --- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  background-color: var(--bg-paper);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  border-left: 3px solid var(--arxiv-blue);
+  transition: border-left-color 0.15s;
+}
+
+.section-list li:hover {
+  border-left-color: var(--preprint-orange);
+}
+
+.section-list li a {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.section-list li a:hover {
+  color: var(--preprint-orange);
+  text-decoration: none;
+}
+
+/* --- Changelog --- */
+.changelog-page {
+  margin-bottom: 2rem;
+}
+
+.changelog-intro {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+
+.changelog-entry {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.changelog-entry:last-child {
+  border-bottom: none;
+}
+
+.changelog-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.changelog-entry h3 {
+  margin-top: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.changelog-entry ul {
+  margin: 0.75rem 0;
+}
+
+.changelog-entry li {
+  font-size: 0.92rem;
+  margin-bottom: 0.4em;
+}
+
+/* --- Appendix --- */
+.appendix-page {
+  margin-bottom: 2rem;
+}
+
+.appendix-page h2 {
+  color: var(--preprint-orange);
+  margin-top: 2.5em;
+}
+
+.appendix-page h3 {
+  color: var(--arxiv-blue);
+}
+
+/* --- Taxonomy --- */
+.taxonomy-desc {
+  font-size: 0.92rem;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Error Page --- */
+.error-page {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-page h1 {
+  font-size: 1.5rem;
+  color: var(--text-muted);
+}
+
+.error-page p {
+  color: var(--text-secondary);
+}
+
+/* --- Footer --- */
+.site-footer {
+  margin-top: 3rem;
+  padding-bottom: 1rem;
+}
+
+.footer-rule {
+  margin-bottom: 1rem;
+}
+
+.footer-rule svg {
+  width: 100%;
+  height: 4px;
+  display: block;
+}
+
+.footer-content {
+  text-align: center;
+}
+
+.footer-citation {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin-bottom: 0.5rem;
+}
+
+.footer-id {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin: 0.25rem 0;
+}
+
+.footer-license {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+  margin-top: 0.25rem;
+}
+
+/* --- Pagination --- */
+nav.pagination {
+  margin: 1.5rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: 3px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+}
+
+nav.pagination a:hover {
+  color: var(--arxiv-blue);
+  border-color: var(--arxiv-blue);
+  text-decoration: none;
+}
+
+.pagination-current span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: 3px;
+  border: 1px solid var(--arxiv-blue);
+  background-color: var(--arxiv-blue-light);
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+}
+
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: 3px;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  opacity: 0.5;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+}
+
+/* --- Responsive --- */
+@media (max-width: 700px) {
+  .paper-wrap {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .site-header {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .site-nav {
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .paper-header h1 {
+    font-size: 1.35rem;
+  }
+
+  .paper-authors {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .badge-row {
+    gap: 0.5rem;
+  }
+
+  .abstract-box {
+    padding: 1rem 1.15rem;
+  }
+
+  .results-table {
+    font-size: 0.8rem;
+  }
+
+  .results-table th,
+  .results-table td {
+    padding: 0.35em 0.45em;
+  }
+
+  .architecture-diagram {
+    max-width: 100%;
+  }
+
+  .paper-structure {
+    padding: 1rem 1.15rem;
+  }
+
+  .changelog-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --max-width: 100%;
+  }
+
+  .preprint-banner {
+    font-size: 0.6rem;
+    padding: 0.35rem 0.75rem;
+  }
+
+  .site-nav a {
+    font-size: 0.65rem;
+  }
+
+  .logo-mark {
+    width: 40px;
+    height: 28px;
+  }
+
+  .paper-header h1 {
+    font-size: 1.15rem;
+  }
+
+  table {
+    font-size: 0.8rem;
+  }
+
+  th, td {
+    padding: 0.35em 0.4em;
+  }
+}
+
+/* --- Print Styles --- */
+@media print {
+  .preprint-banner {
+    background-color: #ffffff;
+    color: var(--text-primary);
+    border: 1px solid var(--text-primary);
+  }
+
+  .site-nav,
+  .button-link {
+    display: none;
+  }
+
+  .paper-wrap {
+    max-width: 100%;
+  }
+
+  .site-footer {
+    page-break-before: always;
+  }
+
+  a {
+    color: var(--text-primary);
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: var(--text-muted);
+  }
+
+  .site-nav a[href]::after,
+  .site-logo a[href]::after {
+    content: none;
+  }
+}

--- a/arxiv-preprint/templates/404.html
+++ b/arxiv-preprint/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <h1>404 - Page Not Found</h1>
+      <p>The requested preprint section does not exist or may have been removed in a revision.</p>
+      <p><a href="{{ base_url }}/" class="button-link">Return to Abstract</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/arxiv-preprint/templates/footer.html
+++ b/arxiv-preprint/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 4" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#c45a1a" stroke-width="1" opacity="0.4"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-citation">Khalili A, Park Y, Novak S, Al-Rashidi F. Sparse Gated Attention: Efficient Long-Context Processing via Learned Gate Masks. <em>arXiv preprint</em> arXiv:2604.08123v3. 2026.</p>
+        <p class="footer-id">Preprint ID: arXiv:2604.08123v3 [cs.LG] &middot; Submitted: 15 Jan 2026 &middot; Last revised: 10 Apr 2026</p>
+        <p class="footer-license">CC BY 4.0 &middot; The authors. Self-published preprint &middot; Not peer reviewed &middot; Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/arxiv-preprint/templates/header.html
+++ b/arxiv-preprint/templates/header.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Noto+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=STIX+Two+Text:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="preprint-banner" role="banner" aria-label="Preprint notice">
+    <svg viewBox="0 0 16 16" width="14" height="14" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="banner-icon">
+      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="8" y1="4" x2="8" y2="9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      <circle cx="8" cy="11.5" r="1" fill="currentColor"/>
+    </svg>
+    PREPRINT - NOT PEER REVIEWED
+  </div>
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Paper home">
+        <svg viewBox="0 0 56 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="52" height="36" rx="2" fill="none" stroke="#c45a1a" stroke-width="1.5"/>
+          <rect x="6" y="6" width="44" height="28" rx="1" fill="none" stroke="#2a5a8a" stroke-width="0.75" stroke-dasharray="2,2"/>
+          <text x="28" y="18" text-anchor="middle" font-family="Inter, sans-serif" font-size="7" font-weight="700" fill="#c45a1a">DRAFT</text>
+          <text x="28" y="28" text-anchor="middle" font-family="Inter, sans-serif" font-size="6" font-weight="600" fill="#2a5a8a">v3</text>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-title">arXiv Preprint</span>
+          <span class="logo-sub">arXiv:2604.08123v3 [cs.LG]</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">ABSTRACT</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/changelog/">CHANGELOG</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/arxiv-preprint/templates/page.html
+++ b/arxiv-preprint/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/arxiv-preprint/templates/post.html
+++ b/arxiv-preprint/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/arxiv-preprint/templates/section.html
+++ b/arxiv-preprint/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/arxiv-preprint/templates/shortcodes/alert.html
+++ b/arxiv-preprint/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/arxiv-preprint/templates/taxonomy.html
+++ b/arxiv-preprint/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/arxiv-preprint/templates/taxonomy_term.html
+++ b/arxiv-preprint/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Pages tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -189,6 +189,13 @@
     "saas",
     "minimal"
   ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
+  ],
   "arena": [
     "dark",
     "blog",


### PR DESCRIPTION
## Summary
- Adds self-published preprint paper presenting Sparse Gated Attention for efficient long-context transformers
- Features inline SVG version control badges (v1/v2/v3 with date stamps), submission status indicators, and architecture diagrams
- LaTeX-like light theme with Inter/IBM Plex Sans for display and STIX Two/Noto Serif for body text
- Includes preprint banner, 5 ML paper sections, version changelog, and supplementary appendix

## Test plan
- [ ] Verify `hwaro build` completes in `arxiv-preprint/`
- [ ] Verify version badges and status indicators render as inline SVG
- [ ] Verify tags.json entry is valid JSON and alphabetically sorted
- [ ] Verify no emojis or CSS gradients in any files

Closes #1612