### PR TITLE
feat: add lab-notebook example site (closes #1594)

### DIFF
--- a/lab-notebook/AGENTS.md
+++ b/lab-notebook/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/lab-notebook/config.toml
+++ b/lab-notebook/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Lab Notebook - Laboratory Record Paper
+# Issue #1594 | Tags: paper, light, laboratory, raw, observational
+# =============================================================================
+
+title = "Laboratory Notebook: Electrochemical CO2 Reduction"
+description = "A laboratory record paper documenting experimental observations on copper-tin catalyst performance, featuring grid paper backgrounds, hand-drawn data plots with error bars, and raw data tables."
+base_url = "http://localhost:3000"
+
+sections = ["entries"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/lab-notebook/content/entries/1-electrode-preparation.md
+++ b/lab-notebook/content/entries/1-electrode-preparation.md
@@ -1,0 +1,92 @@
++++
+title = "Electrode Preparation and Characterization"
+description = "Co-electrodeposition of Cu-Sn alloy thin films on glassy carbon substrates. Five compositions prepared and characterized by XRD and SEM."
+weight = 1
+template = "post"
+tags = ["electrode", "preparation", "XRD", "SEM"]
+categories = ["entries"]
+[extra]
+entry_number = "1"
++++
+
+<span class="timestamp">2026-04-07 / 08:30-17:00 JST</span>
+
+## Objective
+
+Prepare Cu-Sn alloy electrodes with five different Cu:Sn molar ratios (pure Cu, 9:1, 7:3, 1:1, 3:7) via co-electrodeposition and characterize morphology and crystal structure.
+
+## Materials
+
+- Glassy carbon discs (5 mm dia., polished to 0.05 um alumina)
+- CuSO4 5H2O (Wako, 99.9%), SnCl2 2H2O (Wako, 99.9%)
+- H2SO4 (conc., for pH adjustment)
+- Deposition bath: variable Cu/Sn ratios at pH 1.8
+
+## Deposition Conditions
+
+| Target Ratio | [Cu2+] (mM) | [Sn2+] (mM) | E_dep (V vs. Ag/AgCl) | Time (s) | Film (nm) |
+|--------------|-------------|-------------|----------------------|----------|-----------|
+| Pure Cu      | 50          | 0           | -0.40                | 300      | 380       |
+| 9:1          | 50          | 8           | -0.45                | 300      | 410       |
+| 7:3          | 50          | 21          | -0.50                | 300      | 420       |
+| 1:1          | 50          | 50          | -0.55                | 300      | 450       |
+| 3:7          | 21          | 50          | -0.60                | 300      | 440       |
+
+## XRD Results
+
+All films show expected alloy phases. Cu5Sn (eta-phase) dominates for Cu:Sn ratios of 7:3 and 1:1. Pure Cu and 9:1 show fcc Cu with minor Sn incorporation. The 3:7 sample shows Cu6Sn5 as the primary phase.
+
+## SEM Observations
+
+<!-- SVG illustrating electrode surface morphology schematic -->
+<figure>
+<svg viewBox="0 0 700 200" xmlns="http://www.w3.org/2000/svg" aria-label="Schematic of electrode surface morphologies" style="width:100%;max-width:700px;display:block;margin:1rem auto;">
+  <defs>
+    <pattern id="g1" width="16" height="16" patternUnits="userSpaceOnUse">
+      <path d="M 16 0 L 0 0 0 16" fill="none" stroke="#d4dde4" stroke-width="0.4"/>
+    </pattern>
+  </defs>
+  <rect x="0" y="0" width="700" height="200" fill="#faf9f4"/>
+  <rect x="0" y="0" width="700" height="200" fill="url(#g1)"/>
+  <!-- Pure Cu: smooth grains -->
+  <text x="70" y="20" text-anchor="middle" font-family="'Caveat',cursive" font-size="11" font-weight="700" fill="#1a1e28">Pure Cu</text>
+  <rect x="20" y="30" width="100" height="100" rx="2" fill="none" stroke="#1a1e28" stroke-width="1"/>
+  <circle cx="50" cy="65" r="14" fill="none" stroke="#2a5faa" stroke-width="0.8"/>
+  <circle cx="78" cy="72" r="12" fill="none" stroke="#2a5faa" stroke-width="0.8"/>
+  <circle cx="62" cy="95" r="15" fill="none" stroke="#2a5faa" stroke-width="0.8"/>
+  <circle cx="92" cy="100" r="10" fill="none" stroke="#2a5faa" stroke-width="0.8"/>
+  <text x="70" y="148" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">smooth, ~1 um grains</text>
+  <!-- 7:3: dendritic -->
+  <text x="210" y="20" text-anchor="middle" font-family="'Caveat',cursive" font-size="11" font-weight="700" fill="#1a1e28">Cu7Sn3</text>
+  <rect x="160" y="30" width="100" height="100" rx="2" fill="none" stroke="#1a1e28" stroke-width="1"/>
+  <path d="M185,100 L190,75 L195,85 L200,55 L205,70 L210,45 L215,65 L220,50 L225,75 L230,60 L235,80" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+  <path d="M175,110 L180,90 L185,95 L190,75 L195,85" fill="none" stroke="#2c5f2d" stroke-width="0.8"/>
+  <path d="M225,105 L230,85 L235,90 L240,70 L245,80" fill="none" stroke="#2c5f2d" stroke-width="0.8"/>
+  <text x="210" y="148" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">dendritic, high SA</text>
+  <!-- 1:1: cauliflower -->
+  <text x="350" y="20" text-anchor="middle" font-family="'Caveat',cursive" font-size="11" font-weight="700" fill="#1a1e28">Cu1Sn1</text>
+  <rect x="300" y="30" width="100" height="100" rx="2" fill="none" stroke="#1a1e28" stroke-width="1"/>
+  <path d="M320,110 Q325,90 330,85 Q335,75 340,80 Q345,70 350,65 Q355,72 360,68 Q365,78 370,82 Q375,92 380,110" fill="none" stroke="#b83220" stroke-width="1"/>
+  <path d="M330,105 Q335,95 340,92 Q345,85 350,88 Q355,82 360,85 Q365,95 370,105" fill="none" stroke="#b83220" stroke-width="0.8"/>
+  <text x="350" y="148" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">cauliflower clusters</text>
+  <!-- 3:7: amorphous-looking -->
+  <text x="490" y="20" text-anchor="middle" font-family="'Caveat',cursive" font-size="11" font-weight="700" fill="#1a1e28">Cu3Sn7</text>
+  <rect x="440" y="30" width="100" height="100" rx="2" fill="none" stroke="#1a1e28" stroke-width="1"/>
+  <path d="M455,100 Q460,92 467,88 Q475,84 480,90 Q485,85 492,82 Q500,86 505,92 Q510,98 520,100" fill="none" stroke="#c07020" stroke-width="0.8"/>
+  <path d="M455,80 Q460,74 467,72 Q475,70 480,74 Q485,70 492,68 Q500,72 505,76 Q510,80 520,82" fill="none" stroke="#c07020" stroke-width="0.8"/>
+  <path d="M455,60 Q465,56 475,58 Q485,55 495,56 Q505,60 515,62" fill="none" stroke="#c07020" stroke-width="0.8"/>
+  <text x="490" y="148" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="#5a6070">layered, compact</text>
+  <!-- Scale bar -->
+  <text x="630" y="20" text-anchor="middle" font-family="'Caveat',cursive" font-size="11" font-weight="700" fill="#1a1e28">Scale</text>
+  <rect x="600" y="30" width="60" height="100" rx="2" fill="none" stroke="#1a1e28" stroke-width="1"/>
+  <line x1="610" y1="90" x2="650" y2="90" stroke="#1a1e28" stroke-width="1.5"/>
+  <line x1="610" y1="86" x2="610" y2="94" stroke="#1a1e28" stroke-width="1"/>
+  <line x1="650" y1="86" x2="650" y2="94" stroke="#1a1e28" stroke-width="1"/>
+  <text x="630" y="84" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">2 um</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.78rem;color:#5a6070;font-family:'IBM Plex Mono',monospace;">Fig. 3. Schematic representation of SEM-observed surface morphologies for different Cu:Sn compositions.</figcaption>
+</figure>
+
+<div class="observation note">
+<strong>Note:</strong> The Cu7Sn3 sample shows the highest surface roughness by the dendritic morphology. This likely contributes to the enhanced catalytic activity observed in later electrolysis experiments. ECSA measurements planned for Entry 2.
+</div>

--- a/lab-notebook/content/entries/2-ecsa-measurement.md
+++ b/lab-notebook/content/entries/2-ecsa-measurement.md
@@ -1,0 +1,40 @@
++++
+title = "Electrochemical Surface Area Measurement"
+description = "Double-layer capacitance method for ECSA determination of all five Cu-Sn electrodes. Cyclic voltammetry in non-faradaic region."
+weight = 2
+template = "post"
+tags = ["ECSA", "capacitance", "cyclic-voltammetry"]
+categories = ["entries"]
+[extra]
+entry_number = "2"
++++
+
+<span class="timestamp">2026-04-08 / 09:00-12:30 JST</span>
+
+## Objective
+
+Determine electrochemical surface area (ECSA) of each Cu-Sn electrode using double-layer capacitance measurements in N2-saturated 0.1 M KHCO3.
+
+## Method
+
+Cyclic voltammetry in the non-faradaic region (0.05--0.15 V vs. RHE) at scan rates 10, 20, 40, 60, 80, 100 mV/s. Slope of (j_a - j_c)/2 vs. scan rate gives C_dl. ECSA = C_dl / C_s, where C_s = 40 uF/cm2 (standard for metallic surfaces).
+
+## Results
+
+| Electrode | C_dl (uF) | ECSA (cm2) | Roughness Factor | Notes |
+|-----------|----------|-----------|-----------------|-------|
+| Pure Cu   | 82       | 2.05      | 1.0x (ref)      | Smooth surface |
+| Cu9Sn1    | 124      | 3.10      | 1.5x            | Slight texturing |
+| Cu7Sn3    | 310      | 7.75      | 3.8x            | Dendritic -- highest |
+| Cu1Sn1    | 198      | 4.95      | 2.4x            | Cauliflower structure |
+| Cu3Sn7    | 145      | 3.63      | 1.8x            | Compact layered |
+
+<div class="observation">
+<strong>Key finding:</strong> Cu7Sn3 has 3.8x the ECSA of pure Cu, consistent with dendritic morphology seen in SEM. However, the FE_CO improvement (71.3% vs. 28.2%) exceeds what ECSA enhancement alone can explain -- electronic effects of Sn alloying must play a role. ECSA-normalized activity to be calculated in Entry 3.
+</div>
+
+## Quality Checks
+
+- All C_dl fits show R2 > 0.998 (good linearity)
+- No redox peaks visible in the CV window (confirmed non-faradaic)
+- Electrode resistance by iR compensation: 12--18 ohm (acceptable)

--- a/lab-notebook/content/entries/3-electrolysis-data.md
+++ b/lab-notebook/content/entries/3-electrolysis-data.md
@@ -1,0 +1,51 @@
++++
+title = "Bulk Electrolysis and Product Analysis"
+description = "Controlled-potential electrolysis at -0.9 V vs. RHE for all compositions. Gas chromatography and HPLC product quantification."
+weight = 3
+template = "post"
+tags = ["electrolysis", "GC", "HPLC", "faradaic-efficiency"]
+categories = ["entries"]
+[extra]
+entry_number = "3"
++++
+
+<span class="timestamp">2026-04-09 / 08:45-18:30 JST</span>
+
+## Objective
+
+Perform controlled-potential electrolysis at -0.9 V vs. RHE on all five electrode compositions. Quantify gaseous products by online GC and liquid products by post-electrolysis HPLC.
+
+## Conditions
+
+- Electrolyte: CO2-saturated 0.1 M KHCO3 (pH 6.8)
+- Applied potential: -0.9 V vs. RHE (iR-corrected)
+- Duration: 60 min per run, 3 replicates per electrode
+- GC sampling: every 15 min (automated injection via 6-port valve)
+- HPLC: post-electrolysis catholyte sample, 20 uL injection
+
+## Complete Product Distribution
+
+| Electrode | FE_CO (%) | FE_HCOO (%) | FE_H2 (%) | FE_CH4 (%) | FE_C2H4 (%) | FE_Tot (%) |
+|-----------|-----------|-------------|-----------|------------|-------------|-----------|
+| Pure Cu   | 28.2+/-4.1 | 8.1+/-1.8  | 58.4+/-3.2 | 3.2+/-0.8 | 1.2+/-0.4  | 99.1      |
+| Cu9Sn1    | 52.1+/-5.3 | 17.8+/-2.6 | 24.6+/-3.8 | 0.4+/-0.2 | 0.0        | 94.9      |
+| Cu7Sn3    | 71.3+/-2.8 | 12.2+/-1.9 | 13.1+/-2.1 | 0.0       | 0.0        | 96.6      |
+| Cu1Sn1    | 58.4+/-6.2 | 21.5+/-3.5 | 16.8+/-2.4 | 0.0       | 0.0        | 96.7      |
+| Cu3Sn7    | 34.1+/-4.8 | 38.2+/-5.1 | 22.4+/-3.0 | 0.0       | 0.0        | 94.7      |
+
+<div class="observation">
+<strong>Observations:</strong> As Sn content increases, hydrocarbon products (CH4, C2H4) are completely suppressed. The Cu7Sn3 composition gives the best CO selectivity while maintaining reasonable current density (-9.4 mA/cm2). Higher Sn content shifts selectivity toward formate production.
+</div>
+
+## ECSA-Normalized Partial Current Densities
+
+When normalized by ECSA (from Entry 2), Cu7Sn3 still shows enhanced CO selectivity beyond the surface area effect:
+
+| Electrode | j_CO / ECSA (mA/cm2_real) | j_HCOO / ECSA (mA/cm2_real) |
+|-----------|--------------------------|----------------------------|
+| Pure Cu   | -1.69                    | -0.49                      |
+| Cu7Sn3    | -0.87                    | -0.15                      |
+
+<div class="observation note">
+<strong>Interpretation:</strong> Intrinsic j_CO per real cm2 is lower for Cu7Sn3 than pure Cu, but intrinsic j_H2 drops by 10x. The Sn alloying effect primarily suppresses HER rather than enhancing CO2RR. This is consistent with weakened H-binding on Sn-modified Cu sites (see Kortlever et al., 2015).
+</div>

--- a/lab-notebook/content/entries/4-anomaly-investigation.md
+++ b/lab-notebook/content/entries/4-anomaly-investigation.md
@@ -1,0 +1,43 @@
++++
+title = "Anomaly Investigation: Current Drop Event"
+description = "Post-mortem analysis of Cu7Sn3 electrode showing sudden deactivation at t=45 min. XPS and SEM investigation of surface restructuring."
+weight = 4
+template = "post"
+tags = ["anomaly", "XPS", "deactivation", "dealloying"]
+categories = ["entries"]
+[extra]
+entry_number = "4"
++++
+
+<span class="timestamp">2026-04-10 / 13:00-17:30 JST</span>
+
+## Background
+
+During Run #3 of Cu7Sn3 at -0.9 V vs. RHE, current density dropped from -9.4 to -3.1 mA/cm2 at t = 45 min. This entry documents the investigation of that anomaly.
+
+## Timeline of Event
+
+| Time (min) | j (mA/cm2) | FE_CO (%) | Observation |
+|-----------|-----------|-----------|-------------|
+| 0         | -9.2      | --        | Normal startup |
+| 15        | -9.4      | 72.1      | Stable |
+| 30        | -9.3      | 70.8      | Stable |
+| 45        | -3.1      | 41.2      | Sudden drop |
+| 60        | -3.0      | 38.6      | No recovery |
+
+## Post-mortem XPS Analysis
+
+- **Before electrolysis:** Cu 2p shows Cu(0)/Cu(I) states; Sn 3d shows Sn(0) with minor Sn(II)
+- **After anomaly:** Sn 3d peak shifts to higher binding energy; Sn(IV) dominant at surface
+- **Depth profile (Ar+ sputtering):** First 5 nm is Sn-oxide-rich; bulk composition unchanged
+
+<div class="observation anomaly">
+<strong>Diagnosis:</strong> Local pH increase at the electrode surface during prolonged electrolysis caused selective oxidation of surface Sn to SnO2. The resulting Sn-oxide layer passivated the electrode. This is consistent with the known instability of Sn in alkaline conditions. The event was triggered by local electrolyte depletion -- convection was inadequate for this run (stirring speed had been accidentally set to 200 rpm instead of 600 rpm).
+</div>
+
+## Corrective Actions
+
+1. Standardize stirring at 600 rpm for all future runs (added to protocol checklist)
+2. Add real-time current monitoring alarm for drops > 30%
+3. Run #3 excluded from mean calculation in Entry 3 data
+4. Additional replicate scheduled for 2026-04-14

--- a/lab-notebook/content/entries/5-stability-test.md
+++ b/lab-notebook/content/entries/5-stability-test.md
@@ -1,0 +1,48 @@
++++
+title = "Long-Term Stability Test"
+description = "Six-hour continuous electrolysis of Cu7Sn3 at -0.9 V vs. RHE with periodic product sampling. Monitoring current retention and selectivity drift."
+weight = 5
+template = "post"
+tags = ["stability", "durability", "time-course", "Cu7Sn3"]
+categories = ["entries"]
+[extra]
+entry_number = "5"
++++
+
+<span class="timestamp">2026-04-12 / 09:30-16:00 JST</span>
+
+## Objective
+
+Assess the long-term stability of the optimized Cu7Sn3 catalyst under continuous CO2 reduction conditions. Target: 6 hours at -0.9 V vs. RHE with product analysis every 30 minutes.
+
+## Conditions
+
+- Electrode: Cu7Sn3 (fresh deposition, same parameters as Entry 1)
+- Potential: -0.9 V vs. RHE (iR-corrected), stirring 600 rpm
+- GC: every 30 min automated sampling
+- HPLC: catholyte sampled at t = 0, 2, 4, 6 h
+
+## Time-Course Data
+
+| t (h) | j (mA/cm2) | FE_CO (%) | FE_HCOO (%) | FE_H2 (%) | Notes |
+|-------|-----------|-----------|-------------|-----------|-------|
+| 0.5   | -9.4      | 72.8      | 11.4        | 12.6      | Stable |
+| 1.0   | -9.3      | 71.5      | 12.0        | 13.2      | Stable |
+| 1.5   | -9.2      | 70.1      | 12.4        | 13.8      | Slight drift |
+| 2.0   | -9.0      | 68.3      | 13.1        | 14.8      | |
+| 2.5   | -8.8      | 66.2      | 13.8        | 15.4      | |
+| 3.0   | -8.5      | 64.8      | 14.2        | 16.1      | |
+| 3.5   | -8.2      | 62.1      | 15.0        | 17.2      | |
+| 4.0   | -7.8      | 59.4      | 15.8        | 18.4      | Electrolyte refreshed |
+| 4.5   | -8.8      | 67.1      | 13.2        | 14.8      | Recovery after refresh |
+| 5.0   | -8.6      | 65.8      | 13.6        | 15.2      | |
+| 5.5   | -8.3      | 63.5      | 14.4        | 16.0      | |
+| 6.0   | -8.0      | 61.2      | 15.1        | 17.0      | End |
+
+<div class="observation">
+<strong>Result:</strong> Current retention after 6 h: 85% of initial value. FE_CO decreases from 72.8% to 61.2% over 6 h (15.9% relative loss). Electrolyte refresh at t = 4 h partially restores both current and selectivity, suggesting that local pH increase and bicarbonate depletion contribute to the gradual decline. Catalyst surface restructuring likely also contributes -- post-test SEM shows some coarsening of dendritic features.
+</div>
+
+<div class="observation note">
+<strong>Next steps:</strong> (1) Test with continuous electrolyte flow cell to eliminate depletion effects. (2) Add iridium oxide counter electrode to minimize Pt contamination risk. (3) Characterize post-test electrode by XRD to check for phase segregation.
+</div>

--- a/lab-notebook/content/entries/_index.md
+++ b/lab-notebook/content/entries/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Notebook Entries"
+sort_by = "weight"
+page_template = "post"
++++
+
+Chronological log of experimental sessions, observations, and data collected during the Cu-Sn electrochemical CO2 reduction study.

--- a/lab-notebook/content/index.md
+++ b/lab-notebook/content/index.md
@@ -1,0 +1,179 @@
++++
+title = "Notebook Cover"
+description = "Laboratory notebook documenting electrochemical CO2 reduction experiments on Cu-Sn bimetallic catalysts, featuring grid paper data plots, raw measurement tables, and observational notes."
+tags = ["paper", "light", "laboratory", "raw", "observational"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Laboratory Notebook &middot; Active &middot; April 2026</p>
+  <h1 class="paper-title">Electrochemical CO2 Reduction on Cu-Sn Bimetallic Catalysts</h1>
+  <p class="paper-subtitle">Investigating faradaic efficiency and product selectivity of electrodeposited Cu-Sn alloy thin films in CO2-saturated 0.1 M KHCO3 at varying potentials and compositions.</p>
+  <div class="paper-meta">
+    <strong>Researcher:</strong> Dr. Yui Hasegawa, Postdoctoral Fellow<br>
+    <strong>Supervisor:</strong> Prof. Ryota Nakamura, Department of Chemistry, University of Tokyo<br>
+    <strong>Project:</strong> JST-CREST Carbon Recycling &middot; <strong>Start Date:</strong> 2026-01-14 &middot; <strong>Notebook:</strong> #ECR-2026-04
+  </div>
+</header>
+
+## Catalyst Composition vs. Faradaic Efficiency
+
+<!-- SVG hand-drawn data plot with axis labels and error bars -->
+<figure>
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" aria-label="Data plot showing faradaic efficiency vs. Cu-Sn composition" style="width:100%;max-width:720px;display:block;margin:1rem auto;">
+  <!-- Grid paper background -->
+  <defs>
+    <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#d4dde4" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect x="0" y="0" width="720" height="380" fill="#faf9f4"/>
+  <rect x="80" y="30" width="600" height="300" fill="url(#grid)"/>
+  <!-- Title (handwritten style) -->
+  <text x="380" y="22" text-anchor="middle" font-family="'Caveat','Architects Daughter',cursive" font-size="15" font-weight="700" fill="#1a1e28">FE for CO production vs. Cu:Sn ratio at -0.9 V vs. RHE</text>
+  <!-- Y axis -->
+  <line x1="80" y1="30" x2="80" y2="330" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="25" y="185" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28" transform="rotate(-90,25,185)">Faradaic Efficiency (%)</text>
+  <!-- Y axis ticks and labels -->
+  <line x1="75" y1="330" x2="80" y2="330" stroke="#1a1e28" stroke-width="1"/><text x="72" y="334" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0</text>
+  <line x1="75" y1="270" x2="80" y2="270" stroke="#1a1e28" stroke-width="1"/><text x="72" y="274" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">20</text>
+  <line x1="75" y1="210" x2="80" y2="210" stroke="#1a1e28" stroke-width="1"/><text x="72" y="214" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">40</text>
+  <line x1="75" y1="150" x2="80" y2="150" stroke="#1a1e28" stroke-width="1"/><text x="72" y="154" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">60</text>
+  <line x1="75" y1="90" x2="80" y2="90" stroke="#1a1e28" stroke-width="1"/><text x="72" y="94" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">80</text>
+  <line x1="75" y1="30" x2="80" y2="30" stroke="#1a1e28" stroke-width="1"/><text x="72" y="34" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">100</text>
+  <!-- X axis -->
+  <line x1="80" y1="330" x2="680" y2="330" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="380" y="368" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28">Cu:Sn Molar Ratio</text>
+  <!-- X axis labels -->
+  <text x="140" y="350" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">Pure Cu</text>
+  <text x="260" y="350" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">9:1</text>
+  <text x="380" y="350" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">7:3</text>
+  <text x="500" y="350" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">1:1</text>
+  <text x="620" y="350" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3:7</text>
+  <!-- CO data points with error bars (circles, hand-drawn connecting line) -->
+  <!-- Pure Cu: FE_CO = 28 +/- 4 -->
+  <line x1="140" y1="234" x2="140" y2="246" stroke="#2a5faa" stroke-width="1.2"/>
+  <line x1="136" y1="234" x2="144" y2="234" stroke="#2a5faa" stroke-width="1"/>
+  <line x1="136" y1="246" x2="144" y2="246" stroke="#2a5faa" stroke-width="1"/>
+  <circle cx="140" cy="240" r="4" fill="#2a5faa"/>
+  <!-- 9:1: FE_CO = 52 +/- 5 -->
+  <line x1="260" y1="168" x2="260" y2="183" stroke="#2a5faa" stroke-width="1.2"/>
+  <line x1="256" y1="168" x2="264" y2="168" stroke="#2a5faa" stroke-width="1"/>
+  <line x1="256" y1="183" x2="264" y2="183" stroke="#2a5faa" stroke-width="1"/>
+  <circle cx="260" cy="174" r="4" fill="#2a5faa"/>
+  <!-- 7:3: FE_CO = 71 +/- 3 -->
+  <line x1="380" y1="114" x2="380" y2="123" stroke="#2a5faa" stroke-width="1.2"/>
+  <line x1="376" y1="114" x2="384" y2="114" stroke="#2a5faa" stroke-width="1"/>
+  <line x1="376" y1="123" x2="384" y2="123" stroke="#2a5faa" stroke-width="1"/>
+  <circle cx="380" cy="117" r="4" fill="#2a5faa"/>
+  <!-- 1:1: FE_CO = 58 +/- 6 -->
+  <line x1="500" y1="144" x2="500" y2="162" stroke="#2a5faa" stroke-width="1.2"/>
+  <line x1="496" y1="144" x2="504" y2="144" stroke="#2a5faa" stroke-width="1"/>
+  <line x1="496" y1="162" x2="504" y2="162" stroke="#2a5faa" stroke-width="1"/>
+  <circle cx="500" cy="156" r="4" fill="#2a5faa"/>
+  <!-- 3:7: FE_CO = 34 +/- 5 -->
+  <line x1="620" y1="219" x2="620" y2="234" stroke="#2a5faa" stroke-width="1.2"/>
+  <line x1="616" y1="219" x2="624" y2="219" stroke="#2a5faa" stroke-width="1"/>
+  <line x1="616" y1="234" x2="624" y2="234" stroke="#2a5faa" stroke-width="1"/>
+  <circle cx="620" cy="228" r="4" fill="#2a5faa"/>
+  <!-- Hand-drawn connecting line for CO -->
+  <path d="M140,240 Q200,200 260,174 Q320,140 380,117 Q440,130 500,156 Q560,190 620,228" fill="none" stroke="#2a5faa" stroke-width="1.5" stroke-dasharray="none"/>
+  <!-- Formate data points (squares, dashed connecting) -->
+  <!-- Pure Cu: FE_HCOO = 8 +/- 2 -->
+  <rect x="137" y="303" width="6" height="6" fill="#b83220"/>
+  <!-- 9:1: FE_HCOO = 18 +/- 3 -->
+  <rect x="257" y="273" width="6" height="6" fill="#b83220"/>
+  <!-- 7:3: FE_HCOO = 12 +/- 2 -->
+  <rect x="377" y="291" width="6" height="6" fill="#b83220"/>
+  <!-- 1:1: FE_HCOO = 22 +/- 4 -->
+  <rect x="497" y="261" width="6" height="6" fill="#b83220"/>
+  <!-- 3:7: FE_HCOO = 38 +/- 5 -->
+  <rect x="617" y="213" width="6" height="6" fill="#b83220"/>
+  <!-- Dashed line for formate -->
+  <path d="M140,306 Q200,290 260,276 Q320,284 380,294 Q440,278 500,264 Q560,238 620,216" fill="none" stroke="#b83220" stroke-width="1.2" stroke-dasharray="6,4"/>
+  <!-- Legend -->
+  <circle cx="500" cy="52" r="4" fill="#2a5faa"/>
+  <text x="510" y="56" font-family="'Caveat','Architects Daughter',cursive" font-size="12" fill="#2a5faa">CO (target product)</text>
+  <rect x="497" y="69" width="6" height="6" fill="#b83220"/>
+  <text x="510" y="76" font-family="'Caveat','Architects Daughter',cursive" font-size="12" fill="#b83220">Formate (side product)</text>
+  <!-- Handwritten annotation -->
+  <text x="400" y="100" font-family="'Caveat','Architects Daughter',cursive" font-size="12" font-weight="700" fill="#2c5f2d">Peak at 7:3!</text>
+  <path d="M395,103 Q390,112 383,117" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+</svg>
+<figcaption style="text-align:center;font-size:0.78rem;color:#5a6070;font-family:'IBM Plex Mono',monospace;">Fig. 1. Faradaic efficiency for CO and formate production on Cu-Sn alloy catalysts at -0.9 V vs. RHE in CO2-saturated 0.1 M KHCO3. Error bars represent 1 std. dev. from n=3 replicates.</figcaption>
+</figure>
+
+## Raw Data Summary
+
+| Cu:Sn Ratio | FE_CO (%) | FE_HCOO (%) | FE_H2 (%) | FE_Total (%) | j_total (mA/cm2) |
+|-------------|-----------|-------------|-----------|--------------|-------------------|
+| Pure Cu     | 28.2      | 8.1         | 58.4      | 94.7         | -12.3             |
+| 9:1         | 52.1      | 17.8        | 24.6      | 94.5         | -10.8             |
+| 7:3         | 71.3      | 12.2        | 13.1      | 96.6         | -9.4              |
+| 1:1         | 58.4      | 21.5        | 16.8      | 96.7         | -8.1              |
+| 3:7         | 34.1      | 38.2        | 22.4      | 94.7         | -7.2              |
+
+## Current Density vs. Applied Potential
+
+<!-- SVG hand-drawn plot: Tafel-like curve -->
+<figure>
+<svg viewBox="0 0 720 340" xmlns="http://www.w3.org/2000/svg" aria-label="Polarization curve for Cu7Sn3 catalyst" style="width:100%;max-width:720px;display:block;margin:1rem auto;">
+  <defs>
+    <pattern id="grid2" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#d4dde4" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect x="0" y="0" width="720" height="340" fill="#faf9f4"/>
+  <rect x="80" y="30" width="580" height="260" fill="url(#grid2)"/>
+  <!-- Title -->
+  <text x="370" y="22" text-anchor="middle" font-family="'Caveat','Architects Daughter',cursive" font-size="15" font-weight="700" fill="#1a1e28">LSV of Cu7Sn3 in CO2-sat. 0.1M KHCO3 (5 mV/s)</text>
+  <!-- Y axis -->
+  <line x1="80" y1="30" x2="80" y2="290" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="22" y="165" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28" transform="rotate(-90,22,165)">j (mA/cm2)</text>
+  <!-- Y ticks -->
+  <text x="72" y="294" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0</text>
+  <text x="72" y="229" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-5</text>
+  <text x="72" y="164" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-10</text>
+  <text x="72" y="99" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-15</text>
+  <text x="72" y="34" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-20</text>
+  <!-- X axis -->
+  <line x1="80" y1="290" x2="660" y2="290" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="370" y="326" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28">E vs. RHE (V)</text>
+  <!-- X ticks -->
+  <text x="80" y="308" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-0.4</text>
+  <text x="225" y="308" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-0.6</text>
+  <text x="370" y="308" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-0.8</text>
+  <text x="515" y="308" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-1.0</text>
+  <text x="660" y="308" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-1.2</text>
+  <!-- CO2-saturated curve (hand-drawn style) -->
+  <path d="M80,288 Q120,287 160,285 Q200,282 225,275 Q260,264 300,248 Q340,225 370,200 Q410,170 450,145 Q490,118 515,98 Q550,75 590,58 Q630,44 660,38" fill="none" stroke="#2a5faa" stroke-width="2"/>
+  <!-- N2-saturated control (dashed) -->
+  <path d="M80,288 Q160,287 225,285 Q300,282 370,276 Q440,268 515,254 Q580,238 660,218" fill="none" stroke="#8a8e98" stroke-width="1.2" stroke-dasharray="6,4"/>
+  <!-- Onset potential marker -->
+  <line x1="160" y1="280" x2="160" y2="40" stroke="#2c5f2d" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="168" y="48" font-family="'Caveat','Architects Daughter',cursive" font-size="11" fill="#2c5f2d">onset ~ -0.5 V</text>
+  <!-- Legend -->
+  <line x1="440" y1="52" x2="470" y2="52" stroke="#2a5faa" stroke-width="2"/>
+  <text x="476" y="56" font-family="'Caveat','Architects Daughter',cursive" font-size="12" fill="#2a5faa">CO2-saturated</text>
+  <line x1="440" y1="70" x2="470" y2="70" stroke="#8a8e98" stroke-width="1.2" stroke-dasharray="6,4"/>
+  <text x="476" y="74" font-family="'Caveat','Architects Daughter',cursive" font-size="12" fill="#8a8e98">N2-saturated (blank)</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.78rem;color:#5a6070;font-family:'IBM Plex Mono',monospace;">Fig. 2. Linear sweep voltammetry of Cu7Sn3 electrode in CO2- and N2-saturated 0.1 M KHCO3. Scan rate 5 mV/s. Onset potential for CO2 reduction observed at approximately -0.5 V vs. RHE.</figcaption>
+</figure>
+
+## Experiment Log
+
+<div class="observation">
+<strong>2026-04-07, 09:15 JST</strong> -- Prepared fresh Cu7Sn3 electrode by co-electrodeposition from CuSO4/SnCl2 bath (50 mM Cu, 21 mM Sn, pH 1.8, -0.5 V vs. Ag/AgCl, 300 s). Film thickness measured by profilometry: 420 +/- 30 nm. XRD confirms Cu5Sn alloy phase with minor Cu peaks.
+</div>
+
+<div class="observation note">
+<strong>2026-04-08, 14:22 JST</strong> -- GC calibration completed. Response factors: CO (1.00), H2 (1.12), CH4 (0.94). HPLC calibration for formate: LOD = 0.05 mM, linear range 0.1-50 mM. All calibration curves R2 > 0.999.
+</div>
+
+<div class="observation anomaly">
+<strong>2026-04-10, 16:48 JST</strong> -- Anomaly: Run #3 of Cu7Sn3 at -0.9 V showed sudden current drop from -9.4 to -3.1 mA/cm2 at t = 45 min. Electrode visually unchanged. Post-mortem XPS shows Sn surface enrichment. Possible dealloying. Excluded from mean calculation -- see Entry 4 for details.
+</div>
+
+<div class="observation">
+<strong>2026-04-12, 10:05 JST</strong> -- Stability test initiated. Cu7Sn3 at -0.9 V vs. RHE, continuous electrolysis. Sampling every 30 min for GC/HPLC. Target: 6 hours. See Entry 5 for time-course data.
+</div>

--- a/lab-notebook/content/protocols.md
+++ b/lab-notebook/content/protocols.md
@@ -1,0 +1,44 @@
++++
+title = "Standard Protocols"
+description = "Standard operating procedures for electrode preparation, electrolysis, and product analysis."
+tags = ["protocol", "SOP", "methods"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Standard Operating Procedures</p>
+  <h1 class="paper-title">Experimental Protocols</h1>
+</header>
+
+## SOP-1: Electrode Preparation by Co-Electrodeposition
+
+1. Polish glassy carbon disc to mirror finish (0.3 um, then 0.05 um alumina)
+2. Sonicate in DI water (5 min), then ethanol (5 min), dry under N2
+3. Prepare deposition bath: CuSO4 + SnCl2 at target ratio, pH 1.8 (H2SO4)
+4. Three-electrode setup: GC working, Pt mesh counter, Ag/AgCl reference
+5. Apply constant potential for 300 s (see Entry 1 for specific potentials per ratio)
+6. Rinse with DI water, dry gently under N2
+7. Characterize by XRD (Bruker D8, Cu K-alpha) and SEM (Hitachi SU8000, 5 kV)
+
+## SOP-2: Controlled-Potential Electrolysis
+
+1. Assemble H-cell with Nafion 117 membrane (pre-treated in 0.5 M H2SO4, 80 C, 1 h)
+2. Fill catholyte: 0.1 M KHCO3 (30 mL), saturate with CO2 for 30 min (pH should reach 6.8)
+3. Fill anolyte: 0.1 M KHCO3 (30 mL), N2 purge
+4. Three-electrode: Cu-Sn working, Pt mesh counter, Ag/AgCl reference
+5. Measure iR drop by EIS at OCP (typically 12--18 ohm)
+6. Apply -0.9 V vs. RHE (iR-corrected) for 60 min
+7. **Stirring: 600 rpm** (see Entry 4 for consequences of insufficient stirring)
+
+## SOP-3: Product Analysis
+
+**Gas-phase (GC):**
+- Instrument: Shimadzu GC-2014, TCD + FID
+- Column: Shincarbon-ST (TCD for H2/CO), HP-PLOT Q (FID for CH4/C2H4)
+- Carrier: Ar (TCD), N2 (FID)
+- Sampling: automated 6-port valve, every 15 min
+
+**Liquid-phase (HPLC):**
+- Instrument: Shimadzu LC-20A, RI detector
+- Column: Aminex HPX-87H (Bio-Rad)
+- Eluent: 5 mM H2SO4, 0.6 mL/min, 60 C
+- Sample: 1 mL catholyte, filtered (0.22 um), 20 uL injection

--- a/lab-notebook/content/summary.md
+++ b/lab-notebook/content/summary.md
@@ -1,0 +1,36 @@
++++
+title = "Interim Summary"
+description = "Summary of key findings from the first two weeks of Cu-Sn CO2 reduction experiments."
+tags = ["summary", "conclusions", "Cu7Sn3"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Interim Summary &middot; Week 2</p>
+  <h1 class="paper-title">Key Findings to Date</h1>
+  <p class="paper-subtitle">Covering experiments from 2026-04-07 through 2026-04-12.</p>
+</header>
+
+## Principal Results
+
+1. **Optimal composition identified:** Cu7Sn3 (7:3 molar ratio) achieves 71.3% faradaic efficiency for CO at -0.9 V vs. RHE -- a 2.5x improvement over pure Cu (28.2%).
+
+2. **HER suppression is the key mechanism:** ECSA-normalized analysis shows that Sn alloying primarily suppresses the hydrogen evolution reaction rather than enhancing CO2 reduction intrinsically. This is consistent with weakened H-adsorption on Cu-Sn surfaces.
+
+3. **Morphological contribution:** Cu7Sn3 deposits form dendritic structures with 3.8x the ECSA of pure Cu, contributing to higher geometric current densities.
+
+4. **Stability concern:** Current and selectivity degrade over 6 h continuous operation (85% current retention, FE_CO drops from 73% to 61%). Electrolyte refreshing partially recovers performance -- local pH increase is a contributing factor.
+
+5. **Operational lesson learned:** Insufficient stirring caused electrode passivation via surface Sn oxidation (Entry 4). Standardized 600 rpm stirring protocol now in place.
+
+## Open Questions
+
+- Does a flow cell configuration resolve the stability issue?
+- What is the Sn surface coverage at the optimal bulk 7:3 ratio? (LEIS or angle-resolved XPS needed)
+- Can the dendritic morphology be decoupled from composition effects by comparing flat Cu7Sn3 prepared by sputtering?
+
+## Upcoming Experiments (Week 3)
+
+- [ ] Flow cell electrolysis with Cu7Sn3 (target: 24 h continuous)
+- [ ] Temperature dependence (15 C, 25 C, 35 C, 45 C) for Arrhenius analysis
+- [ ] In-situ ATR-SEIRAS during CO2 reduction to identify surface intermediates
+- [ ] Sputtered Cu7Sn3 thin film for morphology-decoupled comparison

--- a/lab-notebook/static/css/style.css
+++ b/lab-notebook/static/css/style.css
@@ -1,0 +1,405 @@
+/* ============================================================================
+   Lab Notebook - Laboratory Record Paper
+   Light background with grid paper texture, handwritten-style labels,
+   typewriter mono for data recording.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #faf9f4;
+  --bg-2: #f2f0e8;
+  --bg-3: #e6e3d8;
+  --bg-grid: #d4dde4;
+  --rule: #b8b4a8;
+  --ink: #1a1e28;
+  --ink-2: #2e3240;
+  --ink-3: #5a6070;
+  --ink-4: #8a8e98;
+  --accent: #2c5f2d;
+  --accent-2: #1a4520;
+  --accent-light: #d4e8d4;
+  --data-blue: #2a5faa;
+  --data-red: #b83220;
+  --data-orange: #c07020;
+  --timestamp: #7a6850;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Courier Prime", "IBM Plex Mono", "Courier New", monospace;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 2px solid var(--ink);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 48px; height: 44px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+
+.lab-name {
+  font-family: "Caveat", "Architects Daughter", cursive;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.notebook-ref {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.8rem;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--ink-2);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover { color: var(--accent); }
+
+/* ---------------- Main Content ---------------- */
+
+.site-main {
+  padding: 2rem 0;
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+/* ---------------- Grid paper background for content areas ---------------- */
+
+.grid-paper {
+  background-image:
+    repeating-linear-gradient(0deg, transparent, transparent 23px, var(--bg-grid) 23px, var(--bg-grid) 24px),
+    repeating-linear-gradient(90deg, transparent, transparent 23px, var(--bg-grid) 23px, var(--bg-grid) 24px);
+  background-size: 24px 24px;
+  padding: 1.5rem;
+  border: 1px solid var(--rule);
+  margin: 1.5rem 0;
+}
+
+/* ---------------- Notebook Header ---------------- */
+
+.paper-header {
+  text-align: left;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.8rem;
+  font-weight: 700;
+}
+
+.paper-title {
+  font-family: "Caveat", "Architects Daughter", cursive;
+  font-weight: 700;
+  font-size: 2rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+}
+
+.paper-subtitle {
+  font-family: "Courier Prime", "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.paper-meta {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.7;
+}
+
+.paper-meta strong { color: var(--ink-2); }
+
+/* ---------------- Timestamp stamps ---------------- */
+
+.timestamp {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.72rem;
+  color: var(--timestamp);
+  letter-spacing: 0.06em;
+  border: 1px solid var(--timestamp);
+  padding: 0.15rem 0.5rem;
+  display: inline-block;
+  margin-bottom: 0.6rem;
+}
+
+/* ---------------- Headings ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "Caveat", "Architects Daughter", cursive;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+h1 { font-size: 1.8rem; margin: 2rem 0 0.6rem; }
+h2 { font-size: 1.45rem; margin: 1.8rem 0 0.5rem; }
+h3 { font-size: 1.2rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 1rem; margin: 1.2rem 0 0.4rem; }
+
+/* ---------------- Body Text ---------------- */
+
+p { margin: 0.8em 0; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+blockquote p { margin: 0.4em 0; }
+
+ul, ol { padding-left: 1.5em; }
+li { margin-bottom: 0.3em; }
+
+/* ---------------- Observation blocks ---------------- */
+
+.observation {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  padding: 1rem 1.4rem;
+  margin: 1.2rem 0;
+  font-family: "Courier Prime", "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
+}
+
+.observation.anomaly { border-left-color: var(--data-red); }
+.observation.note { border-left-color: var(--data-blue); }
+.observation.caution { border-left-color: var(--data-orange); }
+
+/* ---------------- Data Tables ---------------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.84rem;
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+}
+
+th, td {
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+th {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 2px solid var(--ink);
+}
+
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------------- Section Header (post.html) ---------------- */
+
+.paper-section-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.4rem;
+  font-weight: 700;
+}
+
+.paper-section-title {
+  font-family: "Caveat", "Architects Daughter", cursive;
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.4rem;
+}
+
+.paper-lede {
+  font-family: "Courier Prime", "IBM Plex Mono", monospace;
+  font-size: 0.85rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.paper-section-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  margin-bottom: 0;
+  padding: 0.7rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+.section-list li a {
+  font-family: "Caveat", "Architects Daughter", cursive;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Code ---------------- */
+
+code {
+  font-family: "IBM Plex Mono", Consolas, monospace;
+  font-size: 0.85em;
+  background: var(--bg-2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: var(--bg-2);
+  padding: 1rem;
+  overflow-x: auto;
+  border: 1px solid var(--bg-3);
+}
+
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy & Pagination ---------------- */
+
+.taxonomy-desc { color: var(--ink-3); font-style: italic; margin-bottom: 1.5rem; }
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; font-size: 0.85rem; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem;
+  padding-bottom: 2rem;
+}
+
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+
+.footer-content { text-align: center; }
+
+.footer-meta {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.75rem;
+  color: var(--ink-3);
+  margin: 0 0 0.3rem;
+}
+
+.footer-note {
+  font-family: "IBM Plex Mono", "Courier Prime", monospace;
+  font-size: 0.68rem;
+  color: var(--ink-4);
+  margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.6rem; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; flex-wrap: wrap; }
+  .grid-paper { padding: 1rem; }
+}

--- a/lab-notebook/templates/404.html
+++ b/lab-notebook/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested notebook entry does not exist.</p>
+      <p><a href="{{ base_url }}/">Return to Notebook Cover</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/lab-notebook/templates/footer.html
+++ b/lab-notebook/templates/footer.html
@@ -1,0 +1,16 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="3" x2="1000" y2="3" stroke="#2c5f2d" stroke-width="0.5" stroke-dasharray="6,4"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Laboratory Notebook #ECR-2026-04 &middot; Electrochemical CO2 Reduction on Cu-Sn Bimetallic Catalysts</p>
+        <p class="footer-note">Maintained by the Nakamura Electrochemistry Group, Department of Chemistry, University of Tokyo. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/lab-notebook/templates/header.html
+++ b/lab-notebook/templates/header.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&family=Architects+Daughter&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Notebook home">
+        <svg viewBox="0 0 48 44" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Notebook with spiral binding -->
+          <rect x="10" y="2" width="34" height="40" rx="2" fill="none" stroke="#2c5f2d" stroke-width="1.5"/>
+          <!-- Spiral rings -->
+          <circle cx="10" cy="8" r="3" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+          <circle cx="10" cy="16" r="3" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+          <circle cx="10" cy="24" r="3" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+          <circle cx="10" cy="32" r="3" fill="none" stroke="#2c5f2d" stroke-width="1"/>
+          <!-- Grid lines on page -->
+          <line x1="16" y1="10" x2="40" y2="10" stroke="#2c5f2d" stroke-width="0.4" opacity="0.3"/>
+          <line x1="16" y1="18" x2="40" y2="18" stroke="#2c5f2d" stroke-width="0.4" opacity="0.3"/>
+          <line x1="16" y1="26" x2="40" y2="26" stroke="#2c5f2d" stroke-width="0.4" opacity="0.3"/>
+          <line x1="16" y1="34" x2="40" y2="34" stroke="#2c5f2d" stroke-width="0.4" opacity="0.3"/>
+          <!-- Pencil mark scribble -->
+          <path d="M18,12 Q24,14 30,11 Q36,16 38,20" fill="none" stroke="#2c5f2d" stroke-width="1" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="lab-name">Electrochemistry Lab -- Prof. R. Nakamura</span>
+          <span class="notebook-ref">Notebook #ECR-2026-04 / Page Series</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">NOTEBOOK</a>
+        <a href="{{ base_url }}/entries/">ENTRIES</a>
+        <a href="{{ base_url }}/protocols/">PROTOCOLS</a>
+        <a href="{{ base_url }}/summary/">SUMMARY</a>
+      </nav>
+    </header>

--- a/lab-notebook/templates/page.html
+++ b/lab-notebook/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/lab-notebook/templates/post.html
+++ b/lab-notebook/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.entry_number %}
+        <p class="paper-section-eyebrow">Entry {{ page.extra.entry_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/entries/" class="button-link">&larr; back to entry index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/lab-notebook/templates/section.html
+++ b/lab-notebook/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">ENTRY INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/lab-notebook/templates/shortcodes/alert.html
+++ b/lab-notebook/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #2c5f2d; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/lab-notebook/templates/taxonomy.html
+++ b/lab-notebook/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/lab-notebook/templates/taxonomy_term.html
+++ b/lab-notebook/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Entries tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4214,5 +4214,12 @@
     "dataset",
     "schema",
     "minimal-text"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
   ]
 }


### PR DESCRIPTION
## Summary
- Add lab-notebook example site: a Laboratory Record Paper documenting electrochemical CO2 reduction experiments on Cu-Sn bimetallic catalysts
- Features SVG grid paper backgrounds, hand-drawn data plots with error bars and axis labels, raw measurement data tables, and observation blocks with timestamps
- Typography uses Caveat Bold / Architects Daughter for handwritten experiment labels and Courier Prime / IBM Plex Mono for typewriter-style data recording
- Includes 5 notebook entries (electrode preparation, ECSA measurement, electrolysis data, anomaly investigation, stability test), protocols page, and interim summary

Closes #1594