### PR TITLE
feat: add citation-graph example site (closes #1593)

### DIFF
--- a/citation-graph/AGENTS.md
+++ b/citation-graph/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/citation-graph/config.toml
+++ b/citation-graph/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Citation Graph - Network Analysis Paper
+# Issue #1593 | Tags: paper, dark, network, citations, visualization
+# =============================================================================
+
+title = "Mapping the Invisible College: Citation Network Topology in Computational Neuroscience"
+description = "A network analysis paper examining citation graph topology, co-citation clusters, and knowledge diffusion pathways across 47,000 publications in computational neuroscience."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/citation-graph/content/appendix.md
+++ b/citation-graph/content/appendix.md
@@ -1,0 +1,54 @@
++++
+title = "Appendix"
+description = "Supplementary tables, sensitivity analyses, and extended cluster statistics."
+tags = ["appendix", "supplementary"]
++++
+
+## A. Full Cluster Statistics
+
+| Cluster | Papers | Edges (internal) | Density | Mean Degree | Max Degree | Diameter |
+|---|---|---|---|---|---|---|
+| A -- Neural Coding | 11,842 | 52,814 | 0.038 | 8.92 | 1,402 | 10 |
+| B -- Connectomics | 9,614 | 37,892 | 0.041 | 7.88 | 1,198 | 9 |
+| C -- Spiking Models | 13,206 | 50,416 | 0.029 | 7.64 | 1,312 | 11 |
+| D -- ML Decoding | 12,556 | 52,082 | 0.033 | 8.30 | 982 | 8 |
+
+## B. Sensitivity to Self-Citation Removal
+
+Removing all self-citations (4.2% of edges) produces minor changes:
+
+| Metric | With Self-Citations | Without |
+|---|---|---|
+| Mean path length | 4.2 | 4.3 |
+| Clustering coefficient | 0.31 | 0.29 |
+| Modularity | 0.42 | 0.43 |
+| Bridge papers identified | 38 | 36 |
+| Top PageRank paper | Unchanged | Unchanged |
+
+The two bridge papers lost after self-citation removal were both single-author works with high self-citation rates (> 25%). All substantive findings are robust to self-citation exclusion.
+
+## C. Alternative Community Detection
+
+We compared Louvain results with two alternative methods:
+
+| Method | Communities | Modularity | NMI with Louvain |
+|---|---|---|---|
+| Louvain | 12 | 0.42 | 1.00 |
+| Leiden | 13 | 0.43 | 0.94 |
+| Infomap | 18 | -- | 0.87 |
+
+The four major clusters are consistently recovered by all three methods (NMI > 0.87). Differences arise primarily in the subdivision of minor satellite communities.
+
+## D. Temporal Robustness
+
+Running community detection on each five-year window independently and computing normalised mutual information (NMI) with the full-period partition:
+
+| Window | NMI with Full Partition |
+|---|---|
+| 2000-2005 | 0.72 |
+| 2006-2010 | 0.81 |
+| 2011-2015 | 0.89 |
+| 2016-2020 | 0.93 |
+| 2021-2025 | 0.91 |
+
+Cluster structure stabilises after 2010 and remains consistent with the full-period partition.

--- a/citation-graph/content/index.md
+++ b/citation-graph/content/index.md
@@ -1,0 +1,267 @@
++++
+title = "Paper Overview"
+description = "Mapping the Invisible College: Citation Network Topology in Computational Neuroscience -- a large-scale bibliometric study of 47,000 publications."
+tags = ["paper", "dark", "network", "citations", "visualization"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Research Article &middot; Open Access</p>
+  <h1 class="paper-title">Mapping the Invisible College: Citation Network Topology in Computational Neuroscience</h1>
+  <p class="paper-authors">
+    Elena Vasquez<sup>1</sup>, Joon-Ho Kim<sup>2</sup>, Chukwuemeka Okonkwo<sup>3</sup>,
+    Margit Lindqvist<sup>4</sup>, Priya Ramaswamy<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Centre for Network Science, Central European University &middot;
+    <sup>2</sup>Department of Brain and Cognitive Sciences, KAIST &middot;
+    <sup>3</sup>African Institute for Mathematical Sciences, Cape Town &middot;
+    <sup>4</sup>Division of Computational Science, KTH Royal Institute of Technology &middot;
+    <sup>5</sup>Centre for Neuroscience, Indian Institute of Science, Bangalore
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.1017/nws.2026.0042</a> &middot; <strong>Data:</strong> <a href="#">Zenodo 10.5281/zenodo.98765432</a> &middot; <strong>Received:</strong> 18 Oct 2025 &middot; <strong>Accepted:</strong> 07 Mar 2026</p>
+</header>
+
+## Abstract
+
+We present a large-scale citation network analysis of 47,218 publications in computational neuroscience spanning 2000--2025. Using bibliographic data from PubMed, Scopus, and Semantic Scholar, we construct a directed citation graph with 312,847 edges and apply community detection, centrality analysis, and temporal decomposition to reveal the disciplinary structure of the field. We identify four dominant co-citation clusters corresponding to (A) neural coding and information theory, (B) connectomics and graph-theoretic brain analysis, (C) spiking network models, and (D) machine-learning-driven neural decoding. The network exhibits small-world topology (mean path length 4.2, clustering coefficient 0.31) and a heavy-tailed degree distribution consistent with preferential attachment. We trace knowledge diffusion pathways between clusters and identify 38 bridge papers that mediate cross-cluster citation flow. Our findings reveal an increasingly interconnected field with growing convergence between biological and artificial neural network communities since 2018.
+
+## Citation Network Overview
+
+<!-- SVG citation network graph with nodes and directional edges -->
+<figure>
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg" aria-label="Citation network graph showing major nodes and directional edges" style="width:100%;max-width:800px;display:block;margin:1rem auto;">
+  <text x="400" y="20" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="11" font-weight="700" fill="#e6edf3" letter-spacing="0.08em">CITATION NETWORK -- TOP 60 NODES BY PAGERANK</text>
+
+  <!-- Background grid -->
+  <line x1="0" y1="480" x2="800" y2="480" stroke="#1e2533" stroke-width="0.5"/>
+  <line x1="0" y1="40" x2="800" y2="40" stroke="#1e2533" stroke-width="0.5"/>
+
+  <!-- Cluster A: Neural Coding (top-left, cyan) -->
+  <circle cx="180" cy="140" r="45" fill="none" stroke="#5ec4e8" stroke-width="0.5" stroke-dasharray="4,4" opacity="0.3"/>
+  <text x="180" y="200" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ec4e8" opacity="0.6">CLUSTER A</text>
+  <!-- Nodes -->
+  <circle cx="160" cy="120" r="12" fill="#0d1117" stroke="#5ec4e8" stroke-width="1.5"/>
+  <text x="160" y="124" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" font-weight="700" fill="#5ec4e8">S01</text>
+  <circle cx="200" cy="110" r="9" fill="#0d1117" stroke="#5ec4e8" stroke-width="1.2"/>
+  <text x="200" y="113" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#5ec4e8">S02</text>
+  <circle cx="175" cy="160" r="8" fill="#0d1117" stroke="#5ec4e8" stroke-width="1"/>
+  <text x="175" y="163" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#5ec4e8">S03</text>
+  <circle cx="145" cy="148" r="7" fill="#0d1117" stroke="#5ec4e8" stroke-width="1"/>
+  <text x="145" y="151" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="5" fill="#5ec4e8">S04</text>
+  <circle cx="210" cy="145" r="6" fill="#0d1117" stroke="#5ec4e8" stroke-width="0.8"/>
+
+  <!-- Cluster B: Connectomics (top-right, orange) -->
+  <circle cx="580" cy="130" r="50" fill="none" stroke="#e8a85e" stroke-width="0.5" stroke-dasharray="4,4" opacity="0.3"/>
+  <text x="580" y="195" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#e8a85e" opacity="0.6">CLUSTER B</text>
+  <circle cx="560" cy="110" r="14" fill="#0d1117" stroke="#e8a85e" stroke-width="1.5"/>
+  <text x="560" y="114" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" font-weight="700" fill="#e8a85e">C01</text>
+  <circle cx="600" cy="125" r="10" fill="#0d1117" stroke="#e8a85e" stroke-width="1.2"/>
+  <text x="600" y="129" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#e8a85e">C02</text>
+  <circle cx="575" cy="155" r="8" fill="#0d1117" stroke="#e8a85e" stroke-width="1"/>
+  <text x="575" y="158" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#e8a85e">C03</text>
+  <circle cx="615" cy="100" r="6" fill="#0d1117" stroke="#e8a85e" stroke-width="0.8"/>
+  <circle cx="545" cy="140" r="6" fill="#0d1117" stroke="#e8a85e" stroke-width="0.8"/>
+
+  <!-- Cluster C: Spiking Networks (bottom-left, purple) -->
+  <circle cx="220" cy="350" r="48" fill="none" stroke="#a85ee8" stroke-width="0.5" stroke-dasharray="4,4" opacity="0.3"/>
+  <text x="220" y="410" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#a85ee8" opacity="0.6">CLUSTER C</text>
+  <circle cx="210" cy="330" r="11" fill="#0d1117" stroke="#a85ee8" stroke-width="1.5"/>
+  <text x="210" y="334" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" font-weight="700" fill="#a85ee8">N01</text>
+  <circle cx="240" cy="355" r="9" fill="#0d1117" stroke="#a85ee8" stroke-width="1.2"/>
+  <text x="240" y="358" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#a85ee8">N02</text>
+  <circle cx="195" cy="370" r="7" fill="#0d1117" stroke="#a85ee8" stroke-width="1"/>
+  <text x="195" y="373" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="5" fill="#a85ee8">N03</text>
+  <circle cx="255" cy="330" r="6" fill="#0d1117" stroke="#a85ee8" stroke-width="0.8"/>
+
+  <!-- Cluster D: ML Decoding (bottom-right, green) -->
+  <circle cx="600" cy="360" r="50" fill="none" stroke="#5ee88a" stroke-width="0.5" stroke-dasharray="4,4" opacity="0.3"/>
+  <text x="600" y="425" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ee88a" opacity="0.6">CLUSTER D</text>
+  <circle cx="590" cy="340" r="13" fill="#0d1117" stroke="#5ee88a" stroke-width="1.5"/>
+  <text x="590" y="344" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" font-weight="700" fill="#5ee88a">M01</text>
+  <circle cx="620" cy="365" r="10" fill="#0d1117" stroke="#5ee88a" stroke-width="1.2"/>
+  <text x="620" y="369" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="6" font-weight="600" fill="#5ee88a">M02</text>
+  <circle cx="575" cy="380" r="7" fill="#0d1117" stroke="#5ee88a" stroke-width="1"/>
+  <text x="575" y="383" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="5" fill="#5ee88a">M03</text>
+  <circle cx="630" cy="340" r="5" fill="#0d1117" stroke="#5ee88a" stroke-width="0.8"/>
+
+  <!-- Directional edges (inter-cluster) with arrowheads -->
+  <defs>
+    <marker id="arrow-cyan" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto">
+      <path d="M0,0 L6,2 L0,4" fill="none" stroke="#5ec4e8" stroke-width="0.8"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto">
+      <path d="M0,0 L6,2 L0,4" fill="none" stroke="#e8a85e" stroke-width="0.8"/>
+    </marker>
+    <marker id="arrow-purple" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto">
+      <path d="M0,0 L6,2 L0,4" fill="none" stroke="#a85ee8" stroke-width="0.8"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto">
+      <path d="M0,0 L6,2 L0,4" fill="none" stroke="#5ee88a" stroke-width="0.8"/>
+    </marker>
+    <marker id="arrow-bridge" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto">
+      <path d="M0,0 L6,2 L0,4" fill="none" stroke="#c9d1d9" stroke-width="0.8"/>
+    </marker>
+  </defs>
+
+  <!-- Intra-cluster edges -->
+  <line x1="170" y1="125" x2="195" y2="113" stroke="#5ec4e8" stroke-width="0.6" opacity="0.4" marker-end="url(#arrow-cyan)"/>
+  <line x1="162" y1="132" x2="170" y2="155" stroke="#5ec4e8" stroke-width="0.6" opacity="0.4"/>
+  <line x1="565" y1="120" x2="595" y2="122" stroke="#e8a85e" stroke-width="0.6" opacity="0.4" marker-end="url(#arrow-orange)"/>
+  <line x1="558" y1="124" x2="572" y2="150" stroke="#e8a85e" stroke-width="0.6" opacity="0.4"/>
+  <line x1="218" y1="335" x2="236" y2="350" stroke="#a85ee8" stroke-width="0.6" opacity="0.4" marker-end="url(#arrow-purple)"/>
+  <line x1="598" y1="350" x2="616" y2="360" stroke="#5ee88a" stroke-width="0.6" opacity="0.4" marker-end="url(#arrow-green)"/>
+
+  <!-- Inter-cluster bridge edges -->
+  <!-- A -> B -->
+  <path d="M212,120 Q400,60 548,112" fill="none" stroke="#c9d1d9" stroke-width="0.8" opacity="0.25" marker-end="url(#arrow-bridge)"/>
+  <!-- A -> C -->
+  <line x1="165" y1="170" x2="205" y2="322" stroke="#c9d1d9" stroke-width="0.8" opacity="0.25" marker-end="url(#arrow-bridge)"/>
+  <!-- B -> D -->
+  <line x1="585" y1="175" x2="592" y2="328" stroke="#c9d1d9" stroke-width="0.8" opacity="0.25" marker-end="url(#arrow-bridge)"/>
+  <!-- C -> D -->
+  <path d="M248,348 Q400,430 578,355" fill="none" stroke="#c9d1d9" stroke-width="0.8" opacity="0.25" marker-end="url(#arrow-bridge)"/>
+  <!-- A -> D (long bridge) -->
+  <path d="M205,155 Q400,280 580,345" fill="none" stroke="#c9d1d9" stroke-width="0.6" opacity="0.15" stroke-dasharray="4,3" marker-end="url(#arrow-bridge)"/>
+  <!-- B -> C (long bridge) -->
+  <path d="M548,148 Q380,260 245,335" fill="none" stroke="#c9d1d9" stroke-width="0.6" opacity="0.15" stroke-dasharray="4,3" marker-end="url(#arrow-bridge)"/>
+
+  <!-- Bridge node in center -->
+  <circle cx="400" cy="240" r="10" fill="#0d1117" stroke="#c9d1d9" stroke-width="1.5"/>
+  <text x="400" y="244" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" font-weight="700" fill="#c9d1d9">BR</text>
+  <text x="400" y="262" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="7" fill="#6e7a8a">Bridge</text>
+  <line x1="180" y1="160" x2="392" y2="235" stroke="#c9d1d9" stroke-width="0.6" opacity="0.2"/>
+  <line x1="560" y1="122" x2="408" y2="235" stroke="#c9d1d9" stroke-width="0.6" opacity="0.2"/>
+  <line x1="220" y1="330" x2="394" y2="248" stroke="#c9d1d9" stroke-width="0.6" opacity="0.2"/>
+  <line x1="590" y1="340" x2="408" y2="248" stroke="#c9d1d9" stroke-width="0.6" opacity="0.2"/>
+
+  <!-- Legend -->
+  <rect x="20" y="440" width="760" height="40" fill="#161b26" rx="3"/>
+  <circle cx="50" cy="460" r="5" fill="none" stroke="#5ec4e8" stroke-width="1.2"/>
+  <text x="62" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ec4e8">Neural Coding</text>
+  <circle cx="180" cy="460" r="5" fill="none" stroke="#e8a85e" stroke-width="1.2"/>
+  <text x="192" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#e8a85e">Connectomics</text>
+  <circle cx="310" cy="460" r="5" fill="none" stroke="#a85ee8" stroke-width="1.2"/>
+  <text x="322" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#a85ee8">Spiking Models</text>
+  <circle cx="445" cy="460" r="5" fill="none" stroke="#5ee88a" stroke-width="1.2"/>
+  <text x="457" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ee88a">ML Decoding</text>
+  <line x1="560" y1="460" x2="580" y2="460" stroke="#c9d1d9" stroke-width="0.8" opacity="0.4" marker-end="url(#arrow-bridge)"/>
+  <text x="588" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#6e7a8a">Citation edge</text>
+  <circle cx="700" cy="460" r="5" fill="none" stroke="#c9d1d9" stroke-width="1.2"/>
+  <text x="712" y="464" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#6e7a8a">Bridge node</text>
+</svg>
+<figcaption>Fig. 1. Citation network of the top 60 papers by PageRank centrality. Node size reflects citation count; colour denotes cluster membership detected via Louvain community detection. Directed edges indicate citation relationships; dashed lines mark cross-cluster bridges.</figcaption>
+</figure>
+
+## Network Summary Statistics
+
+<div class="metric-grid">
+  <div class="metric-card">
+    <span class="metric-value">47,218</span>
+    <span class="metric-label">Publications (nodes)</span>
+  </div>
+  <div class="metric-card">
+    <span class="metric-value">312,847</span>
+    <span class="metric-label">Citations (edges)</span>
+  </div>
+  <div class="metric-card">
+    <span class="metric-value">4.2</span>
+    <span class="metric-label">Mean path length</span>
+  </div>
+  <div class="metric-card">
+    <span class="metric-value">0.31</span>
+    <span class="metric-label">Clustering coefficient</span>
+  </div>
+  <div class="metric-card">
+    <span class="metric-value">4</span>
+    <span class="metric-label">Major clusters</span>
+  </div>
+  <div class="metric-card">
+    <span class="metric-value">38</span>
+    <span class="metric-label">Bridge papers</span>
+  </div>
+</div>
+
+## Co-Citation Cluster Summary
+
+<div class="cluster-legend">
+  <span class="cluster-legend-item"><span class="cluster-dot" style="background:#5ec4e8;"></span> A: Neural Coding &amp; Information Theory (11,842 papers)</span>
+  <span class="cluster-legend-item"><span class="cluster-dot" style="background:#e8a85e;"></span> B: Connectomics &amp; Graph-Theoretic Brain Analysis (9,614 papers)</span>
+  <span class="cluster-legend-item"><span class="cluster-dot" style="background:#a85ee8;"></span> C: Spiking Network Models (13,206 papers)</span>
+  <span class="cluster-legend-item"><span class="cluster-dot" style="background:#5ee88a;"></span> D: ML-Driven Neural Decoding (12,556 papers)</span>
+</div>
+
+| Cluster | Size | Density | Key Journals | Top Author (h-index) |
+|---|---|---|---|---|
+| A -- Neural Coding | 11,842 | 0.038 | *Neural Comput.*, *J. Neurosci.* | Pouget A. (62) |
+| B -- Connectomics | 9,614 | 0.041 | *NeuroImage*, *Brain Struct. Funct.* | Sporns O. (78) |
+| C -- Spiking Models | 13,206 | 0.029 | *PLOS Comput. Biol.*, *Front. Comput. Neurosci.* | Gerstner W. (71) |
+| D -- ML Decoding | 12,556 | 0.033 | *NeurIPS*, *Nature Methods* | Paninski L. (55) |
+
+## Co-Citation Cluster Diagram
+
+<!-- SVG co-citation cluster diagrams for related work visualization -->
+<figure>
+<svg viewBox="0 0 800 380" xmlns="http://www.w3.org/2000/svg" aria-label="Co-citation cluster diagram showing inter-cluster relationships" style="width:100%;max-width:800px;display:block;margin:1rem auto;">
+  <text x="400" y="20" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="11" font-weight="700" fill="#e6edf3" letter-spacing="0.08em">CO-CITATION CLUSTER TOPOLOGY</text>
+
+  <!-- Cluster A: large circle top-left -->
+  <circle cx="200" cy="130" r="70" fill="rgba(94,196,232,0.06)" stroke="#5ec4e8" stroke-width="1"/>
+  <text x="200" y="120" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#5ec4e8">A</text>
+  <text x="200" y="138" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ec4e8" opacity="0.7">Neural Coding</text>
+  <text x="200" y="150" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="8" fill="#6e7a8a">11,842 papers</text>
+
+  <!-- Cluster B: large circle top-right -->
+  <circle cx="580" cy="120" r="65" fill="rgba(232,168,94,0.06)" stroke="#e8a85e" stroke-width="1"/>
+  <text x="580" y="112" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#e8a85e">B</text>
+  <text x="580" y="128" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#e8a85e" opacity="0.7">Connectomics</text>
+  <text x="580" y="140" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="8" fill="#6e7a8a">9,614 papers</text>
+
+  <!-- Cluster C: large circle bottom-left -->
+  <circle cx="220" cy="300" r="60" fill="rgba(168,94,232,0.06)" stroke="#a85ee8" stroke-width="1"/>
+  <text x="220" y="292" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#a85ee8">C</text>
+  <text x="220" y="308" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#a85ee8" opacity="0.7">Spiking Models</text>
+  <text x="220" y="320" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="8" fill="#6e7a8a">13,206 papers</text>
+
+  <!-- Cluster D: large circle bottom-right -->
+  <circle cx="560" cy="290" r="68" fill="rgba(94,232,138,0.06)" stroke="#5ee88a" stroke-width="1"/>
+  <text x="560" y="282" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="12" font-weight="700" fill="#5ee88a">D</text>
+  <text x="560" y="298" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#5ee88a" opacity="0.7">ML Decoding</text>
+  <text x="560" y="310" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="8" fill="#6e7a8a">12,556 papers</text>
+
+  <!-- Inter-cluster coupling edges with weights -->
+  <!-- A-B -->
+  <line x1="268" y1="118" x2="516" y2="112" stroke="#c9d1d9" stroke-width="2.5" opacity="0.3"/>
+  <text x="392" y="108" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.6">0.18</text>
+  <!-- A-C -->
+  <line x1="208" y1="200" x2="216" y2="240" stroke="#c9d1d9" stroke-width="3.5" opacity="0.3"/>
+  <text x="226" y="222" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.6">0.24</text>
+  <!-- A-D -->
+  <line x1="260" y1="165" x2="505" y2="258" stroke="#c9d1d9" stroke-width="1.5" opacity="0.2"/>
+  <text x="380" y="200" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.5">0.09</text>
+  <!-- B-C -->
+  <line x1="530" y1="168" x2="268" y2="268" stroke="#c9d1d9" stroke-width="1" opacity="0.15"/>
+  <text x="400" y="230" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.4">0.05</text>
+  <!-- B-D -->
+  <line x1="572" y1="185" x2="564" y2="222" stroke="#c9d1d9" stroke-width="2" opacity="0.3"/>
+  <text x="582" y="206" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.6">0.14</text>
+  <!-- C-D -->
+  <line x1="278" y1="308" x2="494" y2="296" stroke="#c9d1d9" stroke-width="4" opacity="0.3"/>
+  <text x="386" y="294" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="9" fill="#c9d1d9" opacity="0.6">0.31</text>
+
+  <!-- Label -->
+  <text x="400" y="370" text-anchor="middle" font-family="'IBM Plex Sans',sans-serif" font-size="8" fill="#484f5a">Edge width proportional to bibliographic coupling strength (Jaccard index)</text>
+</svg>
+<figcaption>Fig. 2. Co-citation cluster topology. Circle area is proportional to cluster size. Edge width represents bibliographic coupling strength (Jaccard similarity of reference lists). The strongest coupling (0.31) connects spiking models (C) and ML decoding (D), reflecting growing convergence between biologically inspired and data-driven approaches.</figcaption>
+</figure>
+
+## Degree Distribution
+
+| Metric | Value |
+|---|---|
+| Mean in-degree | 6.63 |
+| Median in-degree | 3 |
+| Max in-degree (most cited) | 1,847 |
+| Power-law exponent (alpha) | 2.74 |
+| KS-test p-value | 0.12 |
+| Small-world sigma | 4.8 |
+| Assortativity (degree) | -0.08 |

--- a/citation-graph/content/methods.md
+++ b/citation-graph/content/methods.md
@@ -1,0 +1,47 @@
++++
+title = "Methods"
+description = "Computational methods, software tools, and reproducibility details for the citation network analysis."
+tags = ["methods", "software", "reproducibility"]
++++
+
+## Software and Tools
+
+All analyses were conducted using the following open-source tools:
+
+| Tool | Version | Purpose |
+|---|---|---|
+| NetworkX | 3.2 | Graph construction, centrality measures |
+| python-louvain | 0.16 | Community detection (Louvain algorithm) |
+| powerlaw | 1.5 | Degree distribution fitting |
+| Semantic Scholar API | v2 | Bibliographic data retrieval |
+| pandas | 2.1 | Data wrangling and deduplication |
+| matplotlib / seaborn | 3.8 / 0.13 | Static visualisations |
+| Gephi | 0.10 | Network layout (ForceAtlas2) |
+
+## Reproducibility
+
+The complete analysis pipeline is available as a Python package at [GitHub](#). The repository includes:
+
+- Raw query logs and API response caches
+- Deduplication scripts with configurable thresholds
+- Jupyter notebooks reproducing all figures and tables
+- Pre-built graph files in GraphML format
+
+## Graph Layout
+
+The network visualisations in this paper use the ForceAtlas2 layout algorithm implemented in Gephi, with the following parameters:
+
+- Scaling: 10.0
+- Gravity: 1.0
+- Edge weight influence: 1.0
+- Prevent overlap: enabled
+- Approximation: Barnes-Hut (theta = 1.2)
+- Iterations: 10,000
+
+Node sizes are proportional to log(in-degree + 1). Node colours reflect Louvain community membership.
+
+## Statistical Tests
+
+- Power-law fitting uses maximum likelihood estimation with the Clauset-Shalizi-Newman method
+- Community detection robustness is assessed via 100 random restarts; we report the partition with the highest modularity
+- Bridge paper significance is tested by bootstrap resampling: we remove each candidate bridge paper 1,000 times and measure the distribution of mean path length changes

--- a/citation-graph/content/sections/1-data-collection.md
+++ b/citation-graph/content/sections/1-data-collection.md
@@ -1,0 +1,46 @@
++++
+title = "1. Data Collection and Corpus Construction"
+description = "Bibliographic data sources, query strategy, and deduplication pipeline for assembling the computational neuroscience corpus."
+weight = 1
+template = "post"
+tags = ["data", "bibliometrics", "corpus"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## Data Sources
+
+We assembled our corpus from three complementary bibliographic databases:
+
+1. **PubMed/MEDLINE** -- queried via the Entrez API for all articles tagged with MeSH terms *Computational Neuroscience*, *Neural Networks (Computer)*, and *Models, Neurological* published between 2000-01-01 and 2025-12-31.
+2. **Scopus** -- queried using the TITLE-ABS-KEY field for the same date range with subject area restricted to Neuroscience and Computer Science.
+3. **Semantic Scholar** -- used the Academic Graph API to retrieve papers in the *Computational Neuroscience* field of study with at least 1 citation.
+
+## Query Strategy
+
+Our Boolean query combined domain-specific terms with methodological descriptors:
+
+```
+("computational neuroscience" OR "neural coding" OR "spiking network"
+ OR "connectomics" OR "brain network" OR "neural decoding")
+AND
+("model" OR "simulation" OR "algorithm" OR "network analysis")
+```
+
+This yielded 82,461 candidate records before deduplication.
+
+## Deduplication Pipeline
+
+We applied a three-stage deduplication procedure:
+
+| Stage | Method | Records Removed |
+|---|---|---|
+| 1. Exact DOI match | DOI string normalisation | 18,204 |
+| 2. Fuzzy title match | Levenshtein distance < 3 | 9,842 |
+| 3. Author-year match | First author surname + year + journal | 7,197 |
+| **Final corpus** | | **47,218** |
+
+## Citation Extraction
+
+For each paper in the final corpus, we extracted all outgoing citations that point to other papers within the corpus (closed-graph constraint). This produced 312,847 directed edges. Self-citations (same first author) account for 4.2% of edges and were retained but flagged for sensitivity analysis.

--- a/citation-graph/content/sections/2-network-construction.md
+++ b/citation-graph/content/sections/2-network-construction.md
@@ -1,0 +1,55 @@
++++
+title = "2. Network Construction and Metrics"
+description = "Graph construction methodology, centrality measures, and global network properties of the citation graph."
+weight = 2
+template = "post"
+tags = ["network", "graph-theory", "centrality"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Graph Representation
+
+The citation network is modelled as a directed graph G = (V, E) where V is the set of 47,218 publications and E is the set of 312,847 citation edges. An edge (u, v) indicates that paper u cites paper v. The graph is stored as a compressed sparse row (CSR) adjacency matrix for efficient traversal.
+
+## Centrality Measures
+
+We computed four centrality measures for each node:
+
+### PageRank
+
+PageRank was computed with a damping factor of 0.85 and convergence tolerance of 1e-8. The top 10 papers by PageRank are dominated by foundational methodological works:
+
+| Rank | Paper | Year | PageRank | In-degree |
+|---|---|---|---|---|
+| 1 | Hodgkin-Huxley revisited (review) | 2006 | 0.00284 | 1,847 |
+| 2 | Small-world brain networks | 2011 | 0.00261 | 1,623 |
+| 3 | Deep learning for neural data | 2019 | 0.00198 | 982 |
+| 4 | Information-theoretic neural code | 2003 | 0.00187 | 1,402 |
+| 5 | Connectome mapping pipeline | 2012 | 0.00175 | 1,198 |
+| 6 | Balanced spiking networks | 2008 | 0.00168 | 1,312 |
+| 7 | Neural population dynamics | 2017 | 0.00154 | 845 |
+| 8 | Graph-theoretic brain analysis | 2010 | 0.00149 | 1,088 |
+| 9 | Bayesian neural decoding | 2014 | 0.00142 | 764 |
+| 10 | Spike sorting benchmark | 2016 | 0.00138 | 691 |
+
+### Betweenness Centrality
+
+Betweenness centrality identifies papers that lie on the shortest paths between many pairs of nodes. High-betweenness papers serve as knowledge bridges between research communities:
+
+- Papers with betweenness > 0.001 constitute only 0.8% of the corpus but carry 34% of all shortest paths
+- The correlation between PageRank and betweenness is moderate (Spearman rho = 0.52), indicating that highly cited papers are not always structurally central
+
+## Global Network Properties
+
+The network exhibits small-world characteristics:
+
+- **Mean path length:** 4.2 (vs. 8.1 for an equivalent random graph)
+- **Clustering coefficient:** 0.31 (vs. 0.007 for random)
+- **Small-world sigma:** 4.8
+- **Network diameter:** 14
+- **Density:** 0.00014
+- **Reciprocity:** 0.12
+
+The heavy-tailed in-degree distribution is well approximated by a power law with exponent alpha = 2.74 (KS-test p = 0.12), consistent with preferential attachment models of citation accumulation.

--- a/citation-graph/content/sections/3-community-detection.md
+++ b/citation-graph/content/sections/3-community-detection.md
@@ -1,0 +1,61 @@
++++
+title = "3. Community Detection and Cluster Analysis"
+description = "Louvain community detection results, cluster characterisation, and inter-cluster coupling analysis."
+weight = 3
+template = "post"
+tags = ["community-detection", "clustering", "louvain"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## Community Detection Method
+
+We applied the Louvain algorithm for modularity optimisation on the undirected projection of the citation graph (treating each directed edge as undirected). The algorithm was run 100 times with different random seeds; we report the partition with the highest modularity score.
+
+## Modularity and Partition Quality
+
+- **Modularity (Q):** 0.42
+- **Number of communities detected:** 12 (4 major, 8 minor)
+- **Coverage of top 4 clusters:** 94.3% of all nodes
+
+The four major clusters account for nearly all papers, with eight smaller satellite communities (containing 5.7% of papers) representing niche subfields such as auditory neuroscience, olfactory coding, and neuromorphic hardware.
+
+## Cluster Characterisation
+
+### Cluster A: Neural Coding and Information Theory
+
+This cluster (11,842 papers, 25.1%) centres on the mathematical formalisation of neural information processing. Core topics include rate coding vs. temporal coding debates, Fisher information in neural populations, and efficient coding hypotheses. The cluster's intellectual core was established by seminal works from the early 2000s on population coding.
+
+**Top journals:** *Neural Computation*, *Journal of Neuroscience*, *PLoS Computational Biology*
+
+### Cluster B: Connectomics and Graph-Theoretic Brain Analysis
+
+The connectomics cluster (9,614 papers, 20.4%) emerged strongly after 2005 with the advent of diffusion tensor imaging (DTI) and resting-state fMRI. Papers in this cluster apply graph-theoretic measures -- degree distribution, modularity, rich-club organisation -- to structural and functional brain networks derived from neuroimaging data.
+
+**Top journals:** *NeuroImage*, *Brain Structure and Function*, *Cerebral Cortex*
+
+### Cluster C: Spiking Network Models
+
+The largest cluster (13,206 papers, 28.0%) encompasses biophysically detailed and simplified spiking neuron models, balanced excitation-inhibition networks, and large-scale cortical simulations. This cluster has deep historical roots in the Hodgkin-Huxley tradition and maintains strong connections to experimental electrophysiology.
+
+**Top journals:** *PLoS Computational Biology*, *Frontiers in Computational Neuroscience*, *Journal of Computational Neuroscience*
+
+### Cluster D: Machine Learning-Driven Neural Decoding
+
+The ML decoding cluster (12,556 papers, 26.6%) is the fastest growing, with 68% of its papers published after 2018. It bridges neuroscience and artificial intelligence, applying deep learning architectures to decode neural population activity, build brain-computer interfaces, and model latent neural dynamics.
+
+**Top journals:** *NeurIPS*, *Nature Methods*, *Nature Neuroscience*, *eLife*
+
+## Inter-Cluster Coupling
+
+Bibliographic coupling strength (Jaccard similarity of reference lists) reveals the following inter-cluster relationships:
+
+| Pair | Coupling | Interpretation |
+|---|---|---|
+| C -- D | 0.31 | Strongest: spiking models increasingly use ML methods |
+| A -- C | 0.24 | Strong: information theory informs spiking model analysis |
+| A -- B | 0.18 | Moderate: network information measures applied to connectomes |
+| B -- D | 0.14 | Moderate: ML applied to neuroimaging data |
+| A -- D | 0.09 | Weak but growing: information-theoretic ML |
+| B -- C | 0.05 | Weakest: different spatial scales (macro vs. micro) |

--- a/citation-graph/content/sections/4-temporal-analysis.md
+++ b/citation-graph/content/sections/4-temporal-analysis.md
@@ -1,0 +1,60 @@
++++
+title = "4. Temporal Evolution of the Network"
+description = "How the citation network has grown and restructured over the 2000-2025 period, including cluster birth, merging, and convergence trends."
+weight = 4
+template = "post"
+tags = ["temporal", "evolution", "growth"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Growth Dynamics
+
+The corpus grew from 487 papers in 2000 to 4,218 papers in 2025, representing a compound annual growth rate (CAGR) of 9.1%. Growth has not been uniform across clusters:
+
+| Period | A (Coding) | B (Connectomics) | C (Spiking) | D (ML Decoding) |
+|---|---|---|---|---|
+| 2000-2005 | 38% | 8% | 42% | 12% |
+| 2006-2010 | 30% | 18% | 35% | 17% |
+| 2011-2015 | 26% | 24% | 28% | 22% |
+| 2016-2020 | 22% | 22% | 24% | 32% |
+| 2021-2025 | 18% | 19% | 20% | 43% |
+
+The ML decoding cluster (D) has grown from 12% of annual output in the early period to 43% in 2021-2025, reflecting the deep learning revolution's impact on neuroscience methodology.
+
+## Convergence Index
+
+We define a convergence index as the fraction of new papers that cite at least two different clusters. This metric has increased steadily:
+
+- **2000-2005:** 8.2% of papers cite multiple clusters
+- **2006-2010:** 14.7%
+- **2011-2015:** 22.3%
+- **2016-2020:** 31.8%
+- **2021-2025:** 41.2%
+
+This trend indicates that computational neuroscience is becoming increasingly integrated, with researchers drawing on multiple methodological traditions rather than working within isolated communities.
+
+## Temporal Snapshots
+
+We constructed five-year temporal snapshots of the citation network and computed modularity for each:
+
+| Period | Nodes | Edges | Modularity (Q) | Clusters | Mean Path |
+|---|---|---|---|---|---|
+| 2000-2005 | 3,842 | 12,104 | 0.58 | 6 | 5.8 |
+| 2006-2010 | 8,216 | 38,492 | 0.52 | 5 | 5.2 |
+| 2011-2015 | 12,408 | 72,618 | 0.48 | 4 | 4.7 |
+| 2016-2020 | 14,892 | 108,204 | 0.44 | 4 | 4.4 |
+| 2021-2025 | 7,860 | 81,429 | 0.38 | 4 | 4.0 |
+
+The declining modularity over time confirms that cluster boundaries are becoming less distinct, consistent with the rising convergence index. The field is evolving from a loosely connected archipelago of specialities into a more cohesive network.
+
+## Key Transition Points
+
+Three periods mark significant structural transitions:
+
+1. **2005-2007:** The connectomics cluster (B) crystallises as DTI-based brain network studies reach critical mass, splitting from a previously undifferentiated neuroimaging community.
+
+2. **2014-2016:** The ML decoding cluster (D) separates from the spiking models cluster (C), driven by the adoption of deep learning methods that diverge from classical biophysical modelling.
+
+3. **2018-2020:** The C-D coupling strength doubles (from 0.15 to 0.31), marking the beginning of convergence between biological and artificial neural network research. This coincides with the emergence of bio-inspired deep learning architectures (spiking neural networks for AI) and ML-based analysis of spiking data.

--- a/citation-graph/content/sections/5-bridge-papers.md
+++ b/citation-graph/content/sections/5-bridge-papers.md
@@ -1,0 +1,65 @@
++++
+title = "5. Bridge Papers and Knowledge Diffusion"
+description = "Identification of bridge papers that mediate cross-cluster citation flow, and analysis of knowledge diffusion pathways."
+weight = 5
+template = "post"
+tags = ["bridge-papers", "diffusion", "interdisciplinary"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## Bridge Paper Identification
+
+We define a bridge paper as a node whose removal would increase the mean shortest path length between any two clusters by more than 5%. Using this criterion on the undirected projection, we identified 38 bridge papers (0.08% of the corpus) that play outsized roles in connecting communities.
+
+## Bridge Paper Characteristics
+
+Bridge papers share several distinguishing features:
+
+| Property | Bridge Papers (n=38) | Corpus Mean |
+|---|---|---|
+| Mean citation count | 842 | 14.2 |
+| Mean betweenness centrality | 0.0024 | 0.00003 |
+| Mean publication year | 2014 | 2016 |
+| Multi-cluster citation fraction | 0.78 | 0.22 |
+| Review paper fraction | 0.42 | 0.08 |
+
+Bridge papers are disproportionately review articles (42% vs. 8% corpus baseline), published slightly earlier than average, and cited across multiple clusters. They serve as entry points for researchers moving between subfields.
+
+## Top 10 Bridge Papers
+
+| Rank | Bridge Clusters | Year | Type | Citations |
+|---|---|---|---|---|
+| 1 | A-B-C-D | 2011 | Review | 1,623 |
+| 2 | A-C-D | 2019 | Methods | 982 |
+| 3 | B-C-D | 2017 | Review | 845 |
+| 4 | A-B-C | 2006 | Theory | 1,402 |
+| 5 | A-B | 2012 | Methods | 1,198 |
+| 6 | C-D | 2018 | Methods | 724 |
+| 7 | A-C | 2008 | Theory | 1,312 |
+| 8 | B-D | 2020 | Methods | 618 |
+| 9 | A-B-D | 2015 | Review | 542 |
+| 10 | C-D | 2021 | Methods | 486 |
+
+The single most central bridge paper (rank 1) is a comprehensive review of computational neuroscience methods that spans all four clusters. It has been cited by 34% of papers published after 2012.
+
+## Knowledge Diffusion Pathways
+
+We traced how methodological innovations propagate across clusters by tracking citation cascades originating from seminal papers in each cluster. Key diffusion pathways include:
+
+### Path 1: Information Theory to Spiking Models (A to C)
+
+Information-theoretic measures (mutual information, transfer entropy) developed in the neural coding community were adopted by spiking network modellers to quantify the information capacity of biophysical circuits. Median diffusion time: 3.2 years.
+
+### Path 2: Connectomics to ML Decoding (B to D)
+
+Graph-theoretic features of brain networks (degree distribution, modularity) are increasingly used as input features for ML-based neural decoders that predict cognitive states from fMRI data. Median diffusion time: 2.8 years.
+
+### Path 3: Spiking Models to ML Decoding (C to D)
+
+This is the strongest and fastest-growing pathway. Spiking neural network architectures developed for biological modelling are being repurposed as energy-efficient AI models, while ML tools (variational autoencoders, recurrent networks) are applied to analyse spiking data. Median diffusion time: 1.9 years.
+
+## Implications
+
+The bridge paper analysis reveals that a small number of synthetic works play a critical role in maintaining the intellectual coherence of computational neuroscience. Without these bridges, the field would fragment into isolated specialities with limited cross-pollination. The accelerating diffusion times suggest that cross-cluster knowledge transfer is becoming more efficient, likely facilitated by interdisciplinary venues such as COSYNE and the growing practice of preprint sharing.

--- a/citation-graph/content/sections/_index.md
+++ b/citation-graph/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The paper is organised into five sections covering data collection, network construction, community detection, temporal analysis, and bridge paper identification.

--- a/citation-graph/static/css/style.css
+++ b/citation-graph/static/css/style.css
@@ -1,0 +1,300 @@
+/* ============================================================================
+   Citation Graph - Network Analysis Paper
+   Dark background, technical sans display, academic serif body.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #0d1117;
+  --bg-2: #161b26;
+  --bg-3: #1e2533;
+  --rule: #2a3040;
+  --ink: #c9d1d9;
+  --ink-2: #a0aab8;
+  --ink-3: #6e7a8a;
+  --ink-4: #484f5a;
+  --accent: #5ec4e8;
+  --accent-2: #3da8cc;
+  --accent-dim: rgba(94,196,232,0.15);
+  --node-primary: #5ec4e8;
+  --node-secondary: #e8a85e;
+  --node-tertiary: #a85ee8;
+  --edge: #3a4a5a;
+  --cluster-a: #5ec4e8;
+  --cluster-b: #e8a85e;
+  --cluster-c: #a85ee8;
+  --cluster-d: #5ee88a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap { max-width: 1000px; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.5rem 0 1.2rem; border-bottom: 1px solid var(--rule);
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.8rem; color: var(--ink); text-decoration: none; }
+.site-logo:hover { color: var(--accent); }
+.logo-mark { width: 48px; height: 48px; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.journal-name { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 700; font-size: 0.95rem; color: var(--ink); letter-spacing: 0.02em; }
+.journal-sub { font-family: "IBM Plex Sans", "Inter", sans-serif; font-weight: 400; font-size: 0.72rem; color: var(--ink-3); letter-spacing: 0.04em; text-transform: uppercase; margin-top: 0.15rem; }
+
+.site-nav { display: flex; gap: 1.6rem; }
+.site-nav a {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em;
+  color: var(--ink-3); text-decoration: none; text-transform: uppercase;
+  padding-bottom: 0.2rem; border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.site-nav a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 2.5rem 0 3rem; }
+
+.paper-article { max-width: 100%; }
+
+.paper-header { margin-bottom: 2.5rem; }
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.75rem; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--accent); margin: 0 0 0.5rem;
+}
+.paper-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 1.8rem; font-weight: 700; line-height: 1.25;
+  color: #e6edf3; margin: 0 0 1rem;
+}
+.paper-authors {
+  font-size: 0.95rem; color: var(--ink-2); margin: 0 0 0.4rem; line-height: 1.5;
+}
+.paper-affiliations {
+  font-size: 0.78rem; color: var(--ink-3); margin: 0 0 0.8rem; line-height: 1.6;
+}
+.paper-doi {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.75rem; color: var(--ink-3); margin: 0;
+}
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* Section header */
+.paper-section-header { margin-bottom: 2rem; }
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.72rem; font-weight: 600; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--accent); margin: 0 0 0.3rem;
+}
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 1.5rem; font-weight: 700; line-height: 1.3;
+  color: #e6edf3; margin: 0 0 0.5rem;
+}
+.paper-lede { font-size: 1rem; color: var(--ink-2); margin: 0; line-height: 1.6; font-style: italic; }
+
+.paper-content { margin-top: 1.5rem; }
+
+/* Section footer */
+.paper-section-footer { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); }
+.button-link {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.82rem; color: var(--accent); text-decoration: none;
+}
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Typography ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  color: #e6edf3; line-height: 1.3;
+}
+h1 { font-size: 1.6rem; margin: 2rem 0 0.8rem; font-weight: 700; }
+h2 { font-size: 1.25rem; margin: 2rem 0 0.6rem; font-weight: 700; }
+h3 { font-size: 1.05rem; margin: 1.5rem 0 0.5rem; font-weight: 600; }
+h4 { font-size: 0.92rem; margin: 1.2rem 0 0.4rem; font-weight: 600; }
+
+p { margin: 0.8rem 0; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+strong { color: #e6edf3; }
+em { font-style: italic; }
+
+sup { font-size: 0.72em; line-height: 0; vertical-align: super; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.2rem 0; padding: 0.6rem 1.2rem;
+  background: var(--bg-2); color: var(--ink-2);
+  font-style: italic;
+}
+
+code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.85em; background: var(--bg-3);
+  padding: 0.15rem 0.4rem; border-radius: 3px;
+  color: var(--accent);
+}
+
+pre {
+  background: var(--bg-2); border: 1px solid var(--rule);
+  padding: 1rem; border-radius: 4px; overflow-x: auto;
+  margin: 1.2rem 0;
+}
+pre code { background: none; padding: 0; color: var(--ink); }
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%; border-collapse: collapse; margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+th {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 600; font-size: 0.78rem; letter-spacing: 0.04em;
+  text-transform: uppercase; text-align: left;
+  padding: 0.6rem 0.8rem; border-bottom: 2px solid var(--rule);
+  color: var(--accent);
+}
+td {
+  padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+tr:hover td { background: var(--bg-2); }
+
+/* ---------------- Figures & SVG ---------------- */
+
+figure {
+  margin: 2rem 0; padding: 0;
+}
+figcaption {
+  text-align: center; font-size: 0.82rem;
+  color: var(--ink-3); font-style: italic;
+  margin-top: 0.8rem;
+}
+
+svg text { -webkit-font-smoothing: antialiased; }
+
+/* Node/edge styling helpers */
+.node-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+}
+.edge-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 400;
+}
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none; padding: 0; margin: 1.5rem 0;
+}
+.section-list li {
+  margin-bottom: 0.5rem; padding: 0.7rem 1rem;
+  background: var(--bg-2); border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+.section-list li a {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 500; color: var(--ink);
+}
+.section-list li a:hover { color: var(--accent); }
+
+/* Taxonomy */
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; }
+
+/* Pagination */
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;
+}
+nav.pagination a {
+  display: inline-block; padding: 0.25rem 0.55rem;
+  border-radius: 4px; border: 1px solid var(--rule);
+  color: var(--ink-3); text-decoration: none;
+  font-family: "IBM Plex Sans", sans-serif; font-size: 0.85rem;
+}
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* Network metric cards */
+.metric-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem; margin: 1.5rem 0;
+}
+.metric-card {
+  background: var(--bg-2); border: 1px solid var(--rule);
+  padding: 1rem 1.2rem; border-radius: 4px;
+}
+.metric-card .metric-value {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 1.6rem; font-weight: 700; color: var(--accent);
+  display: block; margin-bottom: 0.2rem;
+}
+.metric-card .metric-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.75rem; color: var(--ink-3); text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Cluster legend */
+.cluster-legend {
+  display: flex; gap: 1.5rem; flex-wrap: wrap;
+  margin: 1rem 0; padding: 0.8rem 1rem;
+  background: var(--bg-2); border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+.cluster-legend-item {
+  display: flex; align-items: center; gap: 0.4rem;
+  font-family: "IBM Plex Sans", sans-serif; font-size: 0.8rem;
+  color: var(--ink-2);
+}
+.cluster-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  display: inline-block;
+}
+
+/* ---------------- Footer ---------------- */
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0 2rem; }
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+.footer-content { text-align: center; }
+.footer-meta {
+  font-size: 0.78rem; color: var(--ink-3); margin: 0 0 0.3rem; line-height: 1.5;
+}
+.footer-note {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.7rem; color: var(--ink-4); margin: 0; letter-spacing: 0.02em;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1.2rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .site-nav { gap: 1rem; }
+  .paper-title { font-size: 1.35rem; }
+  .metric-grid { grid-template-columns: 1fr 1fr; }
+  table { font-size: 0.82rem; }
+  th, td { padding: 0.4rem 0.5rem; }
+}

--- a/citation-graph/templates/404.html
+++ b/citation-graph/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this paper.</p>
+      <p><a href="{{ base_url }}/">Return to Paper Overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/citation-graph/templates/footer.html
+++ b/citation-graph/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#5ec4e8" stroke-width="0.5" opacity="0.3"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#2a3040" stroke-width="1.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Vasquez E, Kim J, Okonkwo C, et al. Mapping the Invisible College: Citation Network Topology in Computational Neuroscience. <em>Netw. Sci.</em> 2026;14:112-138.</p>
+        <p class="footer-note">ISSN 2050-1242 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/citation-graph/templates/header.html
+++ b/citation-graph/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=STIX+Two+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Citation Graph home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Network graph icon -->
+          <circle cx="24" cy="10" r="4" fill="none" stroke="#5ec4e8" stroke-width="1.5"/>
+          <circle cx="10" cy="30" r="4" fill="none" stroke="#5ec4e8" stroke-width="1.5"/>
+          <circle cx="38" cy="30" r="4" fill="none" stroke="#5ec4e8" stroke-width="1.5"/>
+          <circle cx="24" cy="42" r="3" fill="none" stroke="#5ec4e8" stroke-width="1"/>
+          <line x1="22" y1="14" x2="12" y2="26" stroke="#5ec4e8" stroke-width="1" opacity="0.6"/>
+          <line x1="26" y1="14" x2="36" y2="26" stroke="#5ec4e8" stroke-width="1" opacity="0.6"/>
+          <line x1="14" y1="32" x2="22" y2="40" stroke="#5ec4e8" stroke-width="0.8" opacity="0.4"/>
+          <line x1="34" y1="32" x2="26" y2="40" stroke="#5ec4e8" stroke-width="0.8" opacity="0.4"/>
+          <line x1="14" y1="30" x2="34" y2="30" stroke="#5ec4e8" stroke-width="0.8" opacity="0.3"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Network Science</span>
+          <span class="journal-sub">Research Article &middot; Vol. 14 &middot; Apr 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">PAPER</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/methods/">METHODS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/citation-graph/templates/page.html
+++ b/citation-graph/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/citation-graph/templates/post.html
+++ b/citation-graph/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/citation-graph/templates/section.html
+++ b/citation-graph/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/citation-graph/templates/shortcodes/alert.html
+++ b/citation-graph/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #2a3040; background-color: #161b26; border-left: 5px solid #5ec4e8; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/citation-graph/templates/taxonomy.html
+++ b/citation-graph/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/citation-graph/templates/taxonomy_term.html
+++ b/citation-graph/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -721,6 +721,13 @@
     "docs",
     "cryptography"
   ],
+  "citation-graph": [
+    "paper",
+    "dark",
+    "network",
+    "citations",
+    "visualization"
+  ],
   "clarity-docs": [
     "docs",
     "light",


### PR DESCRIPTION
Closes #1593

## Summary
- Add citation-graph example site: a dark-themed network analysis paper examining citation graph topology in computational neuroscience
- Features inline SVG citation network graphs with nodes and directional edges, co-citation cluster diagrams
- Typography: IBM Plex Sans Bold / Inter Bold for graph node labels, Crimson Pro / STIX Two for body text
- Includes 5 paper sections, methods page, appendix, network metric cards, and cluster legend components
- Tags: paper, dark, network, citations, visualization

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check all SVG diagrams render correctly (citation network, co-citation topology)
- [ ] Verify dark theme styling with no CSS gradients
- [ ] Confirm all navigation links work
- [ ] Check tags.json entry is valid JSON