### PR TITLE
feat: add abstract-noir example site (closes #1592)

### DIFF
--- a/abstract-noir/AGENTS.md
+++ b/abstract-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/abstract-noir/config.toml
+++ b/abstract-noir/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Abstract Noir - Dark Abstract Paper
+# Issue #1592 | Tags: paper, dark, abstract, bold, typography
+# =============================================================================
+
+title = "The Paradox of Deliberate Forgetting: Neural Substrates of Motivated Memory Suppression"
+description = "A dark-themed academic paper emphasising the abstract section with heavy black panel framing, fade/diminish content hierarchy, and bold serif typography."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/abstract-noir/content/appendix.md
+++ b/abstract-noir/content/appendix.md
@@ -1,0 +1,45 @@
++++
+title = "Appendix"
+description = "Supplementary analyses, stimulus lists, and additional statistical details."
+tags = ["appendix", "supplementary"]
++++
+
+## A. Stimulus Norming
+
+All 160 word-image pairs were normed in a separate behavioural study (N = 30, no overlap with fMRI sample). Norming confirmed:
+
+| Property | Neutral (mean) | Negative (mean) | t-test p |
+|---|---|---|---|
+| Valence | 5.1 | 2.3 | < .001 |
+| Arousal | 3.2 | 6.1 | < .001 |
+| Word frequency (log) | 3.4 | 3.3 | .62 |
+| Word length (letters) | 5.8 | 5.9 | .71 |
+| Image complexity | 4.2 | 4.4 | .38 |
+| Semantic relatedness | 6.8 | 6.7 | .54 |
+
+## B. Motion and Exclusion Criteria
+
+Two participants were excluded for excessive head motion (> 2mm translation or > 2 degrees rotation in any run). The remaining 48 participants showed mean framewise displacement of 0.18mm (SD 0.06mm).
+
+## C. Whole-Brain Maps at Reduced Threshold
+
+At a more liberal threshold (p < .001 uncorrected, k > 50), additional clusters emerged in the Forget > Remember contrast:
+
+| Region | Hemisphere | Peak MNI | Cluster Size | Peak t |
+|---|---|---|---|---|
+| Middle frontal gyrus | Left | -38, 42, 24 | 86 | 4.12 |
+| Anterior insula | Right | 34, 22, 4 | 72 | 3.98 |
+| Precuneus | Medial | -2, -68, 42 | 64 | 3.84 |
+| Caudate nucleus | Left | -12, 14, 8 | 58 | 3.72 |
+
+These subthreshold activations are consistent with a broader cognitive control network engaged during memory suppression.
+
+## D. Individual Differences
+
+Forgetting ability (proportion of forget-cued items successfully forgotten) correlated with:
+
+- Working memory capacity (operation span): r = 0.38, p = .008
+- Trait anxiety (STAI): r = -0.42, p = .003
+- Cognitive flexibility (trail-making B-A): r = 0.31, p = .032
+
+Higher working memory capacity and cognitive flexibility predicted better forgetting, while higher trait anxiety predicted poorer forgetting -- consistent with the resource-demanding nature of active suppression.

--- a/abstract-noir/content/index.md
+++ b/abstract-noir/content/index.md
@@ -1,0 +1,110 @@
++++
+title = "Paper Overview"
+description = "The Paradox of Deliberate Forgetting: Neural Substrates of Motivated Memory Suppression -- an fMRI study of directed forgetting with emphasis on abstract framing."
+tags = ["paper", "dark", "abstract", "bold", "typography"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Article &middot; Open Access</p>
+  <h1 class="paper-title">The Paradox of Deliberate Forgetting: Neural Substrates of Motivated Memory Suppression</h1>
+  <p class="paper-authors">
+    Lucienne Moreau<sup>1</sup>, David Ashworth<sup>2</sup>, Nikolai Petrov<sup>3</sup>,
+    Aisha Bello<sup>4</sup>, Tomoko Hayashi<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>Laboratoire de Neurosciences Cognitives, CNRS, Paris &middot;
+    <sup>2</sup>Department of Psychology, University of Edinburgh &middot;
+    <sup>3</sup>Institute for Cognitive Science, HSE University, Moscow &middot;
+    <sup>4</sup>Department of Psychiatry, University of Cape Town &middot;
+    <sup>5</sup>Brain Science Institute, RIKEN, Wako
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.1080/17588928.2026.2048127</a> &middot; <strong>Data:</strong> <a href="#">OpenNeuro ds004892</a> &middot; <strong>Received:</strong> 22 Sep 2025 &middot; <strong>Accepted:</strong> 14 Feb 2026</p>
+</header>
+
+<!-- SVG heavy black panels framing the abstract section -->
+<div class="abstract-panel">
+  <svg viewBox="0 0 700 4" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:4px;display:block;margin-bottom:1.2rem;" aria-hidden="true">
+    <rect x="0" y="0" width="700" height="4" fill="#e8e0d4"/>
+  </svg>
+  <h2 class="abstract-heading">Abstract</h2>
+  <div class="abstract-text">
+    <p>How does the brain deliberately suppress memories it would otherwise retain? This paradox -- the intentional erasure of information by the very system designed to preserve it -- lies at the heart of motivated forgetting. We investigated the neural mechanisms of directed forgetting using event-related fMRI in 48 healthy adults performing a modified item-method directed forgetting paradigm. Participants encoded word-image pairs and received post-stimulus cues to either remember (R) or forget (F) each item.</p>
+    <p>Forget cues elicited robust activation in the right dorsolateral prefrontal cortex (dlPFC), anterior cingulate cortex (ACC), and bilateral hippocampal-prefrontal disconnection patterns. Critically, successful forgetting (items cued to forget that were later not recognised) was associated with increased dlPFC-hippocampal inverse connectivity, suggesting active suppression of memory consolidation rather than passive decay. Emotional items resisted forgetting more strongly than neutral items, with amygdala activation moderating the dlPFC suppression signal.</p>
+    <p>These findings demonstrate that deliberate forgetting is an active, resource-demanding process that operates through top-down prefrontal inhibition of hippocampal memory traces. The failure to suppress emotional memories may explain the persistence of intrusive memories in anxiety and trauma-related disorders, suggesting a mechanism for therapeutic intervention.</p>
+  </div>
+  <div class="abstract-keywords">
+    <strong>Keywords:</strong> directed forgetting, memory suppression, fMRI, prefrontal cortex, hippocampus, emotional memory, cognitive control
+  </div>
+  <svg viewBox="0 0 700 4" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:4px;display:block;margin-top:1.2rem;" aria-hidden="true">
+    <rect x="0" y="0" width="700" height="4" fill="#e8e0d4"/>
+  </svg>
+</div>
+
+<!-- SVG fade/diminish pattern showing content hierarchy below abstract -->
+<figure>
+<svg viewBox="0 0 700 120" xmlns="http://www.w3.org/2000/svg" aria-label="Content hierarchy diminish pattern" style="width:100%;max-width:700px;display:block;margin:2rem auto;" aria-hidden="true">
+  <text x="350" y="15" text-anchor="middle" font-family="'Playfair Display',serif" font-size="9" font-weight="700" fill="#e8e0d4" opacity="0.5" letter-spacing="0.12em">CONTENT HIERARCHY</text>
+  <!-- Full opacity bar: Abstract (above) -->
+  <rect x="50" y="30" width="600" height="10" fill="#e8e0d4" opacity="1"/>
+  <text x="670" y="39" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.8">Abstract</text>
+  <!-- Diminishing bars -->
+  <rect x="50" y="48" width="600" height="8" fill="#e8e0d4" opacity="0.7"/>
+  <text x="670" y="56" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.6">Introduction</text>
+  <rect x="50" y="62" width="600" height="6" fill="#e8e0d4" opacity="0.5"/>
+  <text x="670" y="69" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.4">Methods</text>
+  <rect x="50" y="74" width="600" height="5" fill="#e8e0d4" opacity="0.35"/>
+  <text x="670" y="80" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.3">Results</text>
+  <rect x="50" y="85" width="600" height="4" fill="#e8e0d4" opacity="0.2"/>
+  <text x="670" y="90" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.2">Discussion</text>
+  <rect x="50" y="95" width="600" height="3" fill="#e8e0d4" opacity="0.1"/>
+  <text x="670" y="99" font-family="'Crimson Pro',serif" font-size="8" fill="#e8e0d4" opacity="0.1">References</text>
+</svg>
+</figure>
+
+<div class="content-fade-1">
+
+## Study Design
+
+48 healthy right-handed adults (24 female, age 22-35, mean 27.4) participated after providing written informed consent. All procedures were approved by the CNRS Ethics Committee (Protocol #2025-NC-0194).
+
+### Directed Forgetting Paradigm
+
+Each trial consisted of:
+
+1. **Encoding phase** (3s): Word-image pair presented centrally
+2. **Cue phase** (1.5s): "REMEMBER" or "FORGET" instruction
+3. **Inter-trial interval** (4-8s, jittered)
+
+160 trials total: 80 Remember cues, 80 Forget cues, counterbalanced across emotional valence (40 neutral, 40 negative per cue type).
+
+| Condition | Trials | Recognised | Forgotten | Forgetting Rate |
+|---|---|---|---|---|
+| Remember-Neutral | 40 | 32.4 (81%) | 7.6 (19%) | -- |
+| Remember-Negative | 40 | 34.8 (87%) | 5.2 (13%) | -- |
+| Forget-Neutral | 40 | 14.2 (36%) | 25.8 (64%) | 64% |
+| Forget-Negative | 40 | 22.6 (57%) | 17.4 (43%) | 43% |
+
+</div>
+
+<div class="content-fade-2">
+
+## Key Findings
+
+The primary finding is a double dissociation between remember and forget processes:
+
+- **Remember cues** activated bilateral hippocampus, medial temporal lobe, and ventromedial prefrontal cortex -- the canonical memory encoding network
+- **Forget cues** activated right dlPFC (BA 9/46), ACC (BA 32), and right inferior frontal gyrus -- regions associated with cognitive control and response inhibition
+
+Critically, the forget network showed **inverse functional connectivity** with the hippocampus during successful forgetting trials, measured by psychophysiological interaction (PPI) analysis.
+
+</div>
+
+<div class="content-fade-3">
+
+## Implications
+
+These results support the **active suppression hypothesis** of directed forgetting, in contrast to the **selective rehearsal** account. The involvement of dlPFC and ACC suggests that forgetting requires the same executive control resources used for response inhibition (as in stop-signal tasks), reframing memory suppression as a form of cognitive control.
+
+The emotional moderation effect -- weaker forgetting for negative items, mediated by amygdala activation -- has direct clinical relevance for understanding intrusive memories in PTSD and anxiety disorders.
+
+</div>

--- a/abstract-noir/content/sections/1-introduction.md
+++ b/abstract-noir/content/sections/1-introduction.md
@@ -1,0 +1,32 @@
++++
+title = "1. Introduction"
+description = "The paradox of deliberate forgetting: theoretical background on directed forgetting paradigms and competing accounts of intentional memory suppression."
+weight = 1
+template = "post"
+tags = ["introduction", "directed-forgetting", "theory"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## The Forgetting Paradox
+
+Memory is often framed as a system for preservation: we encode, consolidate, and retrieve information to guide future behaviour. Yet everyday experience and clinical observation reveal that we also need to forget. Outdated phone numbers, superseded passwords, and traumatic experiences all represent information that the cognitive system would benefit from discarding. The ability to deliberately forget is not a failure of memory but a feature of it.
+
+Directed forgetting (DF) paradigms provide the primary experimental tool for studying intentional forgetting. In the **item-method** variant used in this study, participants receive a post-encoding cue on each trial instructing them to either remember or forget the just-presented item. The robust finding is that forget-cued items are later recognised and recalled at lower rates than remember-cued items -- the **directed forgetting effect**.
+
+## Competing Accounts
+
+Two primary theoretical accounts explain the DF effect:
+
+### Selective Rehearsal Hypothesis
+
+According to this account, forget cues simply halt active rehearsal of the item. Forgetting occurs passively because unrehearsed items decay from working memory before consolidation into long-term memory. Under this view, no active suppression mechanism is required.
+
+### Active Suppression Hypothesis
+
+The alternative account proposes that forget cues trigger an active inhibitory process that suppresses the memory trace of the just-encoded item. This view predicts engagement of executive control regions (prefrontal cortex) and active disconnection of encoding circuits (hippocampus) during successful forgetting.
+
+## The Present Study
+
+Distinguishing between these accounts requires neuroimaging evidence. If forgetting is merely passive decay, we would expect *reduced* activation following forget cues (reflecting terminated rehearsal). If forgetting is active suppression, we would expect *increased* activation of control regions and *inverse* connectivity with memory regions. Our event-related fMRI design was specifically powered to detect these connectivity patterns.

--- a/abstract-noir/content/sections/2-methods.md
+++ b/abstract-noir/content/sections/2-methods.md
@@ -1,0 +1,45 @@
++++
+title = "2. Methods"
+description = "Participants, experimental paradigm, fMRI acquisition parameters, and analysis pipeline."
+weight = 2
+template = "post"
+tags = ["methods", "fmri", "paradigm"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Participants
+
+48 healthy right-handed adults (24 female, 24 male; age range 22-35 years, mean 27.4, SD 3.8) were recruited from the CNRS participant pool. Exclusion criteria included neurological or psychiatric history, psychoactive medication use, MRI contraindications, and prior participation in directed forgetting experiments.
+
+## Stimuli
+
+160 word-image pairs were constructed from the International Affective Picture System (IAPS) and a matched word database:
+
+| Category | Count | Valence (mean) | Arousal (mean) |
+|---|---|---|---|
+| Neutral | 80 | 5.1 (SD 0.4) | 3.2 (SD 0.8) |
+| Negative | 80 | 2.3 (SD 0.6) | 6.1 (SD 0.9) |
+
+Words were concrete nouns (4-8 letters, frequency-matched) paired with semantically related images. Assignment of stimuli to Remember/Forget conditions was counterbalanced across participants.
+
+## fMRI Acquisition
+
+Imaging was performed on a Siemens Magnetom Prisma 3T scanner with a 64-channel head coil:
+
+- **Functional:** T2*-weighted EPI, TR = 800ms, TE = 30ms, flip angle = 52, multiband factor = 8, 2mm isotropic voxels, 72 slices, whole-brain coverage
+- **Structural:** T1-weighted MPRAGE, 0.8mm isotropic, TR = 2400ms, TE = 2.2ms, TI = 1000ms
+- **Fieldmap:** Dual-echo gradient echo for B0 distortion correction
+
+## Analysis Pipeline
+
+Preprocessing was performed using fMRIPrep 23.2.0 with default parameters. First-level analysis used SPM12 with the following regressors:
+
+1. Remember-cue onset (parametrically modulated by subsequent memory)
+2. Forget-cue onset (parametrically modulated by subsequent forgetting)
+3. Encoding onset
+4. Motor response
+5. Six motion parameters and their temporal derivatives
+
+Psychophysiological interaction (PPI) analysis used the right dlPFC as seed region (6mm sphere at peak activation) to assess task-dependent connectivity with hippocampus during forget vs. remember trials.

--- a/abstract-noir/content/sections/3-results.md
+++ b/abstract-noir/content/sections/3-results.md
@@ -1,0 +1,51 @@
++++
+title = "3. Results"
+description = "Behavioural directed forgetting effect, whole-brain fMRI contrasts, and psychophysiological interaction analysis."
+weight = 3
+template = "post"
+tags = ["results", "fmri", "connectivity"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## Behavioural Results
+
+The directed forgetting effect was significant for both valence conditions:
+
+| Measure | Remember Items | Forget Items | DF Effect | p |
+|---|---|---|---|---|
+| Recognition (neutral) | 81.0% | 35.5% | 45.5% | < .001 |
+| Recognition (negative) | 87.0% | 56.5% | 30.5% | < .001 |
+| Reaction time (neutral) | 842ms | 1,124ms | 282ms | < .001 |
+| Reaction time (negative) | 798ms | 1,048ms | 250ms | < .001 |
+
+The DF effect was significantly larger for neutral than negative items (interaction: F(1,47) = 18.4, p < .001, partial eta-squared = 0.28), confirming that emotional content resists directed forgetting.
+
+## Whole-Brain Contrasts
+
+### Forget > Remember (cue phase)
+
+The Forget > Remember contrast revealed significant clusters (p < .05, FWE-corrected) in:
+
+| Region | Hemisphere | Peak MNI (x,y,z) | Cluster Size | Peak t |
+|---|---|---|---|---|
+| dlPFC (BA 9/46) | Right | 42, 38, 28 | 428 | 6.82 |
+| ACC (BA 32) | Bilateral | 4, 28, 34 | 312 | 5.94 |
+| Inferior frontal gyrus | Right | 48, 18, 8 | 186 | 5.21 |
+| Supramarginal gyrus | Right | 56, -42, 36 | 142 | 4.88 |
+
+### Remember > Forget (cue phase)
+
+| Region | Hemisphere | Peak MNI (x,y,z) | Cluster Size | Peak t |
+|---|---|---|---|---|
+| Hippocampus | Bilateral | -28, -16, -18 | 384 | 7.14 |
+| Parahippocampal gyrus | Left | -32, -34, -12 | 248 | 6.28 |
+| vmPFC (BA 10/11) | Medial | 2, 48, -8 | 198 | 5.64 |
+| Posterior cingulate | Medial | -4, -52, 28 | 164 | 5.12 |
+
+## PPI Analysis: dlPFC-Hippocampal Connectivity
+
+The critical PPI analysis revealed that right dlPFC showed **negative functional connectivity** with bilateral hippocampus during successful forget trials (beta = -0.34, t(47) = -4.82, p < .001), but **positive connectivity** during successful remember trials (beta = 0.21, t(47) = 3.14, p = .003).
+
+This inverse connectivity pattern was moderated by emotional valence: the negative PPI coupling was weaker for negative items (beta = -0.18, t(47) = -2.64, p = .011) than neutral items (beta = -0.48, t(47) = -5.91, p < .001), suggesting that amygdala engagement partially buffers hippocampal traces from prefrontal suppression.

--- a/abstract-noir/content/sections/4-discussion.md
+++ b/abstract-noir/content/sections/4-discussion.md
@@ -1,0 +1,39 @@
++++
+title = "4. Discussion"
+description = "Interpretation of findings in the context of active suppression vs. selective rehearsal accounts of directed forgetting."
+weight = 4
+template = "post"
+tags = ["discussion", "suppression", "theory"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Evidence for Active Suppression
+
+Our findings provide strong evidence for the active suppression account of directed forgetting. Three converging lines of evidence support this conclusion:
+
+1. **Increased activation, not decreased:** Forget cues elicited greater prefrontal activation than remember cues. If forgetting were simply passive decay from terminated rehearsal, we would expect reduced or equivalent activation.
+
+2. **Inverse connectivity:** The negative PPI coupling between dlPFC and hippocampus during successful forgetting directly demonstrates top-down inhibition of memory consolidation circuits.
+
+3. **Resource dependence:** The reduced forgetting effect for emotional items, mediated by amygdala moderation of the dlPFC-hippocampal pathway, indicates that suppression requires overcoming competing signals -- a hallmark of active, resource-limited processes.
+
+## Comparison with Prior Work
+
+Our results extend previous directed forgetting neuroimaging studies in two important ways. First, the use of sub-second TR (800ms with multiband EPI) allowed us to dissociate cue-phase processing from encoding-phase activity with greater temporal precision than prior block-design studies. Second, our PPI analysis directly tests the connectivity prediction of the active suppression hypothesis, which has been theoretically proposed but rarely empirically demonstrated.
+
+The dlPFC activation peak (MNI 42, 38, 28) closely matches coordinates reported in think/no-think suppression studies, suggesting a shared neural mechanism between reactive suppression (think/no-think) and proactive suppression (directed forgetting).
+
+## The Emotional Memory Paradox
+
+The weaker directed forgetting effect for negative items replicates prior behavioural findings and extends them with a neural mechanism. The amygdala's role in modulating hippocampal-prefrontal connectivity suggests that emotional memories resist forgetting not because they are "stronger" in a generic sense, but because the amygdala actively counteracts prefrontal suppression signals. This creates a tug-of-war between prefrontal control (trying to suppress) and amygdala-mediated consolidation (protecting the trace).
+
+## Limitations
+
+Several limitations should be noted:
+
+- The item-method DF paradigm confounds encoding and suppression to some degree, as forget cues are delivered shortly after encoding
+- Our sample (ages 22-35) limits generalisability to younger and older populations
+- The use of word-image pairs may not generalise to autobiographical or episodic memory suppression
+- PPI analysis captures correlational, not causal, connectivity; future studies using transcranial magnetic stimulation could test the causal role of dlPFC

--- a/abstract-noir/content/sections/5-clinical-implications.md
+++ b/abstract-noir/content/sections/5-clinical-implications.md
@@ -1,0 +1,38 @@
++++
+title = "5. Clinical Implications"
+description = "Translational significance of directed forgetting mechanisms for anxiety, PTSD, and therapeutic interventions."
+weight = 5
+template = "post"
+tags = ["clinical", "ptsd", "intervention"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## From Laboratory to Clinic
+
+The active suppression mechanism we describe has direct relevance for understanding memory disturbances in clinical populations. Intrusive memories -- vivid, unwanted recollections that arise involuntarily -- are a hallmark symptom of post-traumatic stress disorder (PTSD), anxiety disorders, and depression.
+
+Our finding that emotional items resist prefrontal suppression, mediated by amygdala activation, suggests a neural model for intrusive memory persistence: in trauma-exposed individuals, amygdala hyperreactivity may overwhelm the prefrontal control system's capacity to suppress unwanted memory traces.
+
+## Therapeutic Implications
+
+### Pharmacological Approaches
+
+The dlPFC-hippocampal suppression pathway identified in this study represents a potential pharmacological target. Noradrenergic agents (e.g., propranolol) that dampen amygdala reactivity may enhance the efficacy of prefrontal suppression by removing the emotional "shield" protecting traumatic memory traces.
+
+### Cognitive Training
+
+Repeated practice of directed forgetting may strengthen the dlPFC-hippocampal inhibitory pathway, analogous to how motor practice strengthens corticospinal connections. Preliminary evidence from our laboratory suggests that four sessions of DF training improve forgetting rates by 15-20% in healthy adults, with concomitant increases in dlPFC-hippocampal inverse connectivity.
+
+### Neurostimulation
+
+Transcranial direct current stimulation (tDCS) applied to right dlPFC during DF practice enhanced forgetting rates by 12% in a pilot study (n = 16). This suggests that non-invasive brain stimulation could augment cognitive suppression training for clinical populations.
+
+## Future Directions
+
+Three priority areas for future research:
+
+1. Testing directed forgetting mechanisms in clinical populations (PTSD, depression) to determine whether the dlPFC suppression pathway is impaired
+2. Developing and evaluating cognitive training protocols based on repeated DF practice
+3. Combining pharmacological (propranolol) and cognitive (DF training) interventions to test additive or synergistic effects on intrusive memory reduction

--- a/abstract-noir/content/sections/_index.md
+++ b/abstract-noir/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The paper is organised into five sections covering the introduction, methods, results, discussion, and clinical implications.

--- a/abstract-noir/static/css/style.css
+++ b/abstract-noir/static/css/style.css
@@ -1,0 +1,281 @@
+/* ============================================================================
+   Abstract Noir - Dark Abstract Paper
+   Deep black background, heavy serif display, clean academic body.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #080808;
+  --bg-2: #0e0e0e;
+  --bg-3: #1a1a1a;
+  --bg-panel: #050505;
+  --rule: #2a2a2a;
+  --rule-heavy: #e8e0d4;
+  --ink: #b8b0a4;
+  --ink-2: #908880;
+  --ink-3: #605850;
+  --ink-4: #403830;
+  --accent: #e8e0d4;
+  --accent-dim: rgba(232,224,212,0.08);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Lora", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.75;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap { max-width: 860px; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.5rem 0 1.2rem; border-bottom: 3px solid var(--rule-heavy);
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.8rem; color: var(--accent); text-decoration: none; }
+.site-logo:hover { opacity: 0.85; }
+.logo-mark { width: 40px; height: 48px; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.journal-name { font-family: "Playfair Display", "Abril Fatface", serif; font-weight: 900; font-size: 1rem; color: var(--accent); }
+.journal-sub { font-family: "Crimson Pro", "Lora", serif; font-weight: 400; font-size: 0.72rem; color: var(--ink-3); letter-spacing: 0.04em; text-transform: uppercase; margin-top: 0.15rem; }
+
+.site-nav { display: flex; gap: 1.6rem; }
+.site-nav a {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 0.78rem; font-weight: 600; letter-spacing: 0.1em;
+  color: var(--ink-3); text-decoration: none; text-transform: uppercase;
+  padding-bottom: 0.2rem; border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.site-nav a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 2.5rem 0 3rem; }
+
+.paper-article { max-width: 100%; }
+
+/* Paper header - the prominent abstract-focused layout */
+.paper-header { margin-bottom: 2.5rem; }
+.paper-eyebrow {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.75rem; font-weight: 600; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--ink-3); margin: 0 0 1rem;
+}
+.paper-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-size: 2.2rem; font-weight: 900; line-height: 1.15;
+  color: var(--accent); margin: 0 0 1.2rem;
+}
+.paper-authors {
+  font-size: 0.95rem; color: var(--ink-2); margin: 0 0 0.4rem; line-height: 1.5;
+}
+.paper-affiliations {
+  font-size: 0.78rem; color: var(--ink-3); margin: 0 0 0.8rem; line-height: 1.6;
+}
+.paper-doi {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.75rem; color: var(--ink-3); margin: 0;
+}
+.paper-doi a { color: var(--accent); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* THE ABSTRACT: heavy black panel framing */
+.abstract-panel {
+  background: var(--bg-panel);
+  border: 3px solid var(--accent);
+  padding: 2rem 2.5rem;
+  margin: 2rem 0;
+  position: relative;
+}
+.abstract-panel::before {
+  content: "";
+  position: absolute; top: -1px; left: 2rem; right: 2rem;
+  height: 3px; background: var(--accent);
+}
+.abstract-heading {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-size: 1.8rem; font-weight: 900;
+  color: var(--accent); margin: 0 0 1rem;
+  letter-spacing: 0.02em;
+}
+.abstract-text {
+  font-family: "Crimson Pro", "Lora", serif;
+  font-size: 1.05rem; line-height: 1.8;
+  color: var(--ink);
+}
+.abstract-keywords {
+  margin-top: 1.2rem; padding-top: 1rem; border-top: 1px solid var(--rule);
+  font-size: 0.82rem; color: var(--ink-2);
+}
+.abstract-keywords strong { color: var(--accent); }
+
+/* Content hierarchy: fade/diminish pattern below abstract */
+.content-fade-1 { opacity: 0.92; }
+.content-fade-2 { opacity: 0.78; }
+.content-fade-3 { opacity: 0.65; }
+
+/* Diminish SVG patterns */
+.diminish-rule {
+  display: block; width: 100%; margin: 2rem 0;
+}
+
+/* Section header */
+.paper-section-header { margin-bottom: 2rem; }
+.paper-section-eyebrow {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.72rem; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--ink-3); margin: 0 0 0.3rem;
+}
+.paper-section-title {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  font-size: 1.6rem; font-weight: 900; line-height: 1.2;
+  color: var(--accent); margin: 0 0 0.5rem;
+}
+.paper-lede { font-size: 1rem; color: var(--ink-2); margin: 0; line-height: 1.6; font-style: italic; }
+
+.paper-content { margin-top: 1.5rem; }
+
+.paper-section-footer { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); }
+.button-link {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.85rem; color: var(--accent); text-decoration: none;
+}
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Typography ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "Playfair Display", "Abril Fatface", serif;
+  color: var(--accent); line-height: 1.2;
+}
+h1 { font-size: 1.6rem; margin: 2rem 0 0.8rem; font-weight: 900; }
+h2 { font-size: 1.3rem; margin: 2rem 0 0.6rem; font-weight: 700; }
+h3 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; font-weight: 700; }
+h4 { font-size: 0.95rem; margin: 1.2rem 0 0.4rem; font-weight: 700; }
+
+p { margin: 0.8rem 0; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+strong { color: var(--accent); font-weight: 700; }
+em { font-style: italic; }
+
+sup { font-size: 0.72em; line-height: 0; vertical-align: super; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.2rem 0; padding: 0.6rem 1.2rem;
+  background: var(--bg-2); color: var(--ink-2);
+  font-style: italic;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.85em; background: var(--bg-3);
+  padding: 0.15rem 0.4rem; border-radius: 3px;
+  color: var(--accent);
+}
+
+pre {
+  background: var(--bg-2); border: 1px solid var(--rule);
+  padding: 1rem; border-radius: 4px; overflow-x: auto;
+  margin: 1.2rem 0;
+}
+pre code { background: none; padding: 0; color: var(--ink); }
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%; border-collapse: collapse; margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+th {
+  font-family: "Playfair Display", serif;
+  font-weight: 700; font-size: 0.82rem;
+  text-align: left; padding: 0.6rem 0.8rem;
+  border-bottom: 2px solid var(--accent);
+  color: var(--accent);
+}
+td {
+  padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+tr:hover td { background: var(--bg-2); }
+
+/* ---------------- Figures ---------------- */
+
+figure { margin: 2rem 0; padding: 0; }
+figcaption {
+  text-align: center; font-size: 0.82rem;
+  color: var(--ink-3); font-style: italic;
+  margin-top: 0.8rem;
+}
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none; padding: 0; margin: 1.5rem 0;
+}
+.section-list li {
+  margin-bottom: 0.5rem; padding: 0.7rem 1rem;
+  background: var(--bg-2); border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+}
+.section-list li a {
+  font-family: "Playfair Display", serif;
+  font-weight: 700; color: var(--ink);
+}
+.section-list li a:hover { color: var(--accent); }
+
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; }
+
+/* Pagination */
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;
+}
+nav.pagination a {
+  display: inline-block; padding: 0.25rem 0.55rem;
+  border: 1px solid var(--rule);
+  color: var(--ink-3); text-decoration: none;
+  font-family: "Crimson Pro", serif; font-size: 0.85rem;
+}
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0 2rem; }
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 8px; display: block; }
+.footer-content { text-align: center; }
+.footer-meta {
+  font-size: 0.78rem; color: var(--ink-3); margin: 0 0 0.3rem; line-height: 1.5;
+}
+.footer-note {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.7rem; color: var(--ink-4); margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1.2rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .paper-title { font-size: 1.6rem; }
+  .abstract-panel { padding: 1.5rem; }
+  .abstract-heading { font-size: 1.4rem; }
+  table { font-size: 0.82rem; }
+  th, td { padding: 0.4rem 0.5rem; }
+}

--- a/abstract-noir/templates/404.html
+++ b/abstract-noir/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this paper.</p>
+      <p><a href="{{ base_url }}/">Return to Paper Overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/abstract-noir/templates/footer.html
+++ b/abstract-noir/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 8" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <rect x="0" y="0" width="1000" height="3" fill="#e8e0d4"/>
+          <rect x="0" y="5" width="1000" height="1" fill="#e8e0d4" opacity="0.3"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Moreau L, Ashworth D, Petrov N, et al. The Paradox of Deliberate Forgetting: Neural Substrates of Motivated Memory Suppression. <em>Cogn. Neurosci.</em> 2026;31(2):142-168.</p>
+        <p class="footer-note">ISSN 1758-8928 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/abstract-noir/templates/header.html
+++ b/abstract-noir/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Abril+Fatface&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Abstract Noir home">
+        <svg viewBox="0 0 40 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Heavy black panel icon -->
+          <rect x="2" y="2" width="36" height="44" fill="#0a0a0a" stroke="#e8e0d4" stroke-width="1.5"/>
+          <rect x="8" y="10" width="24" height="3" fill="#e8e0d4"/>
+          <rect x="8" y="18" width="24" height="1" fill="#e8e0d4" opacity="0.6"/>
+          <rect x="8" y="22" width="24" height="1" fill="#e8e0d4" opacity="0.4"/>
+          <rect x="8" y="26" width="24" height="1" fill="#e8e0d4" opacity="0.25"/>
+          <rect x="8" y="30" width="24" height="1" fill="#e8e0d4" opacity="0.15"/>
+          <rect x="8" y="34" width="24" height="1" fill="#e8e0d4" opacity="0.08"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Cognitive Neuroscience</span>
+          <span class="journal-sub">Original Article &middot; Vol. 31 &middot; 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">PAPER</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/abstract-noir/templates/page.html
+++ b/abstract-noir/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/abstract-noir/templates/post.html
+++ b/abstract-noir/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/abstract-noir/templates/section.html
+++ b/abstract-noir/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/abstract-noir/templates/shortcodes/alert.html
+++ b/abstract-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #2a2a2a; background-color: #111; border-left: 5px solid #e8e0d4; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/abstract-noir/templates/taxonomy.html
+++ b/abstract-noir/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/abstract-noir/templates/taxonomy_term.html
+++ b/abstract-noir/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -5,6 +5,13 @@
     "deep-sea",
     "immersive"
   ],
+  "abstract-noir": [
+    "paper",
+    "dark",
+    "abstract",
+    "bold",
+    "typography"
+  ],
   "acid-graphics": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1592

## Summary
- Add abstract-noir example site: a dark-themed academic paper emphasising the abstract section with heavy black panel framing
- Features inline SVG heavy black panels framing the abstract, SVG fade/diminish patterns showing content hierarchy
- Typography: Playfair Display Black / Abril Fatface for abstract heading, Crimson Pro / Lora for paper content
- Includes 5 paper sections, appendix, prominent abstract panel with keyword listing
- Tags: paper, dark, abstract, bold, typography

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check abstract panel SVG framing renders correctly
- [ ] Verify diminish/fade pattern SVG displays content hierarchy
- [ ] Confirm dark theme with no CSS gradients
- [ ] Check tags.json entry is valid JSON