### PR TITLE
feat: add peer-review example site (closes #1591)

### DIFF
--- a/peer-review/AGENTS.md
+++ b/peer-review/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/peer-review/config.toml
+++ b/peer-review/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Peer Review - Double-Blind Review Paper
+# Issue #1591 | Tags: paper, light, academic, review, transparent
+# =============================================================================
+
+title = "Transparent Peer Review: Assessing the Impact of Open Review on Manuscript Quality"
+description = "A double-blind review paper with transparent reviewer comments, review score gauges, and standard academic formatting showcasing the peer review process."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/peer-review/content/appendix.md
+++ b/peer-review/content/appendix.md
@@ -1,0 +1,57 @@
++++
+title = "Appendix"
+description = "Supplementary analyses including parallel trends tests, subgroup analyses, and robustness checks."
+tags = ["appendix", "supplementary"]
++++
+
+## A. Pre-Transition Parallel Trends
+
+A key identifying assumption of the difference-in-differences design is that outcomes would have evolved in parallel in treatment and control groups absent the transition. We test this assumption by estimating event-study regressions with indicators for each half-year before and after the transition:
+
+| Period (relative to transition) | Coefficient | SE |
+|---|---|---|
+| t-4 (2 years prior) | 0.08 | 0.14 |
+| t-3 | -0.02 | 0.12 |
+| t-2 | 0.04 | 0.11 |
+| t-1 | 0.06 | 0.10 |
+| t (transition) | -- (reference) | -- |
+| t+1 | 0.34 | 0.11 |
+| t+2 | 0.48 | 0.13 |
+| t+3 | 0.52 | 0.14 |
+| t+4 | 0.55 | 0.15 |
+
+All pre-transition coefficients are statistically indistinguishable from zero, supporting the parallel trends assumption.
+
+## B. Subgroup Analyses
+
+Effects were broadly consistent across subgroups, with some variation:
+
+| Subgroup | Report Length DiD | Citation DiD |
+|---|---|---|
+| Social sciences | +142.6 | +2.4 |
+| Natural sciences | +178.2 | +3.1 |
+| Mathematics/Statistics | +156.8 | +2.6 |
+| Early-career authors (< 10 years post-PhD) | +152.4 | +2.9 |
+| Established authors (>= 10 years post-PhD) | +164.8 | +2.7 |
+| Single-author papers | +144.2 | +2.5 |
+| Multi-author papers | +162.4 | +2.9 |
+
+The effects are largest in natural sciences and for multi-author papers, though confidence intervals overlap across subgroups.
+
+## C. Robustness Checks
+
+We tested the robustness of our main findings to several alternative specifications:
+
+| Specification | Report Length DiD | 95% CI |
+|---|---|---|
+| Main specification | +158.4 | [112.8, 204.0] |
+| Excluding 2024 transitions | +149.6 | [101.2, 198.0] |
+| Controlling for author h-index | +152.8 | [106.4, 199.2] |
+| Excluding desk-rejected papers | +161.2 | [115.6, 206.8] |
+| Weighted by submission volume | +164.8 | [118.4, 211.2] |
+
+All specifications yield estimates within the 95% CI of the main specification.
+
+## D. Falsification Tests
+
+As placebo tests, we estimated the DiD effect for journals that did *not* transition during our sample period, using a synthetic transition date of 2022-Q1. The placebo DiD estimate is +8.2 words (SE = 18.4, p = .66), consistent with no effect and supporting the causal interpretation of our main findings.

--- a/peer-review/content/index.md
+++ b/peer-review/content/index.md
@@ -1,0 +1,187 @@
++++
+title = "Paper Overview"
+description = "Transparent Peer Review: Assessing the Impact of Open Review on Manuscript Quality -- a meta-analysis of 3,400 reviewed manuscripts with transparent reviewer comments and score gauges."
+tags = ["paper", "light", "academic", "review", "transparent"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Research Article &middot; Open Peer Review</p>
+  <h1 class="paper-title">Transparent Peer Review: Assessing the Impact of Open Review on Manuscript Quality</h1>
+  <p class="paper-authors">
+    Adaeze Okafor<sup>1</sup>, Sven Lindgren<sup>2</sup>, Kaori Yamamoto<sup>3</sup>,
+    Mateo Gutierrez<sup>4</sup>, Fatima El-Sayed<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup>School of Scholarly Communication, University of Edinburgh &middot;
+    <sup>2</sup>Department of Library and Information Science, Uppsala University &middot;
+    <sup>3</sup>Graduate School of Education, University of Tokyo &middot;
+    <sup>4</sup>Facultad de Ciencias, Universidad de Chile &middot;
+    <sup>5</sup>Center for Open Science, American University in Cairo
+  </p>
+  <p class="paper-doi"><strong>DOI:</strong> <a href="#">10.1080/23298727.2026.2158049</a> &middot; <strong>Data:</strong> <a href="#">OSF.io/8f4k2</a> &middot; <strong>Received:</strong> 03 Oct 2025 &middot; <strong>Revised:</strong> 18 Jan 2026 &middot; <strong>Accepted:</strong> 06 Mar 2026</p>
+</header>
+
+## Review Decision Summary
+
+<div class="score-gauges">
+  <div class="score-gauge">
+    <p class="score-gauge-label">Reviewer 1</p>
+    <!-- SVG review score gauge (accept/revise/reject scales) -->
+    <svg class="score-gauge-svg" viewBox="0 0 160 100" xmlns="http://www.w3.org/2000/svg" aria-label="Review score gauge for Reviewer 1: Accept with minor revisions">
+      <!-- Gauge arc background -->
+      <path d="M 20 80 A 60 60 0 0 1 140 80" fill="none" stroke="#ebebe6" stroke-width="10"/>
+      <!-- Reject segment (red) -->
+      <path d="M 20 80 A 60 60 0 0 1 60 25" fill="none" stroke="#a83232" stroke-width="10" opacity="0.3"/>
+      <!-- Revise segment (orange) -->
+      <path d="M 60 25 A 60 60 0 0 1 100 25" fill="none" stroke="#b87328" stroke-width="10" opacity="0.3"/>
+      <!-- Accept segment (green) -->
+      <path d="M 100 25 A 60 60 0 0 1 140 80" fill="none" stroke="#2a6b3a" stroke-width="10" opacity="0.3"/>
+      <!-- Needle pointing to "Accept" -->
+      <line x1="80" y1="80" x2="122" y2="40" stroke="#1a2236" stroke-width="2"/>
+      <circle cx="80" cy="80" r="4" fill="#1a2236"/>
+      <!-- Labels -->
+      <text x="24" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#a83232" font-weight="700">REJECT</text>
+      <text x="80" y="18" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#b87328" font-weight="700">REVISE</text>
+      <text x="136" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#2a6b3a" font-weight="700">ACCEPT</text>
+    </svg>
+    <p class="score-gauge-value">Accept (minor revisions)</p>
+  </div>
+  <div class="score-gauge">
+    <p class="score-gauge-label">Reviewer 2</p>
+    <svg class="score-gauge-svg" viewBox="0 0 160 100" xmlns="http://www.w3.org/2000/svg" aria-label="Review score gauge for Reviewer 2: Revise and resubmit">
+      <path d="M 20 80 A 60 60 0 0 1 140 80" fill="none" stroke="#ebebe6" stroke-width="10"/>
+      <path d="M 20 80 A 60 60 0 0 1 60 25" fill="none" stroke="#a83232" stroke-width="10" opacity="0.3"/>
+      <path d="M 60 25 A 60 60 0 0 1 100 25" fill="none" stroke="#b87328" stroke-width="10" opacity="0.3"/>
+      <path d="M 100 25 A 60 60 0 0 1 140 80" fill="none" stroke="#2a6b3a" stroke-width="10" opacity="0.3"/>
+      <!-- Needle pointing to "Revise" (straight up, slightly left) -->
+      <line x1="80" y1="80" x2="75" y2="24" stroke="#1a2236" stroke-width="2"/>
+      <circle cx="80" cy="80" r="4" fill="#1a2236"/>
+      <text x="24" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#a83232" font-weight="700">REJECT</text>
+      <text x="80" y="18" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#b87328" font-weight="700">REVISE</text>
+      <text x="136" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#2a6b3a" font-weight="700">ACCEPT</text>
+    </svg>
+    <p class="score-gauge-value">Major revisions</p>
+  </div>
+  <div class="score-gauge">
+    <p class="score-gauge-label">Reviewer 3</p>
+    <svg class="score-gauge-svg" viewBox="0 0 160 100" xmlns="http://www.w3.org/2000/svg" aria-label="Review score gauge for Reviewer 3: Accept">
+      <path d="M 20 80 A 60 60 0 0 1 140 80" fill="none" stroke="#ebebe6" stroke-width="10"/>
+      <path d="M 20 80 A 60 60 0 0 1 60 25" fill="none" stroke="#a83232" stroke-width="10" opacity="0.3"/>
+      <path d="M 60 25 A 60 60 0 0 1 100 25" fill="none" stroke="#b87328" stroke-width="10" opacity="0.3"/>
+      <path d="M 100 25 A 60 60 0 0 1 140 80" fill="none" stroke="#2a6b3a" stroke-width="10" opacity="0.3"/>
+      <line x1="80" y1="80" x2="132" y2="56" stroke="#1a2236" stroke-width="2"/>
+      <circle cx="80" cy="80" r="4" fill="#1a2236"/>
+      <text x="24" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#a83232" font-weight="700">REJECT</text>
+      <text x="80" y="18" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#b87328" font-weight="700">REVISE</text>
+      <text x="136" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#2a6b3a" font-weight="700">ACCEPT</text>
+    </svg>
+    <p class="score-gauge-value">Accept</p>
+  </div>
+  <div class="score-gauge">
+    <p class="score-gauge-label">Editorial Decision</p>
+    <svg class="score-gauge-svg" viewBox="0 0 160 100" xmlns="http://www.w3.org/2000/svg" aria-label="Editorial decision: Minor revisions">
+      <path d="M 20 80 A 60 60 0 0 1 140 80" fill="none" stroke="#ebebe6" stroke-width="10"/>
+      <path d="M 20 80 A 60 60 0 0 1 60 25" fill="none" stroke="#a83232" stroke-width="10" opacity="0.3"/>
+      <path d="M 60 25 A 60 60 0 0 1 100 25" fill="none" stroke="#b87328" stroke-width="10" opacity="0.3"/>
+      <path d="M 100 25 A 60 60 0 0 1 140 80" fill="none" stroke="#2a6b3a" stroke-width="10" opacity="0.3"/>
+      <line x1="80" y1="80" x2="112" y2="32" stroke="#1a2236" stroke-width="2.5"/>
+      <circle cx="80" cy="80" r="5" fill="#1a2236"/>
+      <text x="24" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#a83232" font-weight="700">REJECT</text>
+      <text x="80" y="18" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#b87328" font-weight="700">REVISE</text>
+      <text x="136" y="96" text-anchor="middle" font-family="'STIX Two Text',serif" font-size="8" fill="#2a6b3a" font-weight="700">ACCEPT</text>
+    </svg>
+    <p class="score-gauge-value">Minor revisions requested</p>
+  </div>
+</div>
+
+<div class="paper-with-margin">
+<div class="paper-body">
+
+## Abstract
+
+Transparent peer review -- the practice of publishing reviewer reports alongside accepted manuscripts -- has been proposed as a mechanism to improve review quality, increase accountability, and build reader trust in published research. However, empirical evidence of its effects on manuscript quality remains limited. This study analyses 3,400 manuscripts reviewed across eight journals that transitioned from closed to transparent peer review between 2020 and 2024. We compare revision quality, citation impact, reviewer engagement, and author satisfaction before and after the transition using a difference-in-differences design with matched control journals.
+
+## 1. Introduction
+
+The peer review system has been the cornerstone of scholarly quality control for more than three centuries, yet its operation has remained largely opaque. Reviewers' identities and reports are traditionally hidden from readers, even after publication. This opacity has drawn increasing criticism as academic publishing confronts concerns about reproducibility, bias, and gatekeeping.
+
+Transparent peer review models vary along several dimensions:
+
+- **Open identities** -- reviewers' names are disclosed
+- **Open reports** -- reviewer reports are published alongside the manuscript
+- **Open participation** -- any qualified reader can contribute a review
+- **Open interaction** -- review discussions are visible
+
+Our study focuses on the *open reports* dimension, which has been adopted by a growing number of journals including Nature Communications (2016), eLife (2013), and all BMC Series journals (2000).
+
+## 2. Theoretical Framework
+
+We draw on three theoretical perspectives to frame our predictions about the effects of transparent peer review:
+
+### Accountability Theory
+
+Disclosure is expected to motivate reviewers to produce more careful, constructive, and substantive reports, because these reports will be visible to the broader scholarly community. Under this framework, we predict that transparency should increase the average length and rigour of reviewer reports.
+
+### Signal Theory
+
+Published review reports provide readers with additional information about manuscript quality, allowing more informed judgements about the strength of evidence. This framework predicts that transparency should increase citation impact for accepted papers, as readers can verify the review process.
+
+### Self-Censorship Theory
+
+A competing prediction is that reviewers may soften criticism when reports are published, out of concern for professional relationships or reputation. Under this framework, transparency could reduce report rigour and increase reviewer unwillingness to accept assignments.
+
+</div>
+<aside class="margin-reviews" aria-label="Reviewer comments">
+  <!-- SVG reviewer comment bubble panel -->
+  <div class="review-bubble r1">
+    <p class="review-bubble-header">R1 <span class="review-bubble-tag">on Abstract</span></p>
+    <div class="review-bubble-body">
+      <p>The abstract clearly states the research question and design. Consider quantifying the magnitude of the difference-in-differences effect in the abstract itself to strengthen the summary.</p>
+    </div>
+    <p class="review-bubble-author">-- Reviewer 1 (accept, minor revisions)</p>
+  </div>
+  <div class="review-bubble r2">
+    <p class="review-bubble-header">R2 <span class="review-bubble-tag">on Section 2</span></p>
+    <div class="review-bubble-body">
+      <p>The three theoretical frameworks are well chosen, but the self-censorship framework may benefit from concrete examples. How have prior studies operationalised "softening of criticism"?</p>
+    </div>
+    <p class="review-bubble-author">-- Reviewer 2 (major revisions)</p>
+  </div>
+  <div class="review-bubble r3">
+    <p class="review-bubble-header">R3 <span class="review-bubble-tag">on Introduction</span></p>
+    <div class="review-bubble-body">
+      <p>A well-written introduction. The four dimensions of transparency (identities, reports, participation, interaction) provide a useful taxonomy.</p>
+    </div>
+    <p class="review-bubble-author">-- Reviewer 3 (accept)</p>
+  </div>
+  <div class="review-bubble r1">
+    <p class="review-bubble-header">R1 <span class="review-bubble-tag">minor comment</span></p>
+    <div class="review-bubble-body">
+      <p>Typo on page 4, paragraph 2: "acknowlegement" should be "acknowledgement".</p>
+    </div>
+    <p class="review-bubble-author">-- Reviewer 1</p>
+  </div>
+</aside>
+</div>
+
+## 3. Key Metrics Before and After Transition
+
+| Metric | Pre-transition | Post-transition | Change | p-value |
+|---|---|---|---|---|
+| Mean report length (words) | 342 | 498 | +45.6% | < .001 |
+| Revision thoroughness (rated 1-5) | 3.1 | 3.7 | +0.6 | < .001 |
+| 2-year citation count (median) | 8 | 11 | +37.5% | .003 |
+| Reviewer response rate | 68% | 61% | -10.3% | .012 |
+| Author satisfaction (1-7 Likert) | 4.2 | 4.8 | +0.6 | .008 |
+| Time to decision (days) | 52 | 58 | +11.5% | .084 |
+
+## 4. Initial Decision Distribution
+
+| Decision | Count | Percentage |
+|---|---|---|
+| <span class="decision accept">Accept</span> | 247 | 7.3% |
+| <span class="decision revise">Minor revisions</span> | 498 | 14.6% |
+| <span class="decision revise">Major revisions</span> | 1,142 | 33.6% |
+| <span class="decision reject">Reject (resubmit allowed)</span> | 612 | 18.0% |
+| <span class="decision reject">Reject (final)</span> | 901 | 26.5% |
+| **Total** | **3,400** | **100%** |

--- a/peer-review/content/reviews.md
+++ b/peer-review/content/reviews.md
@@ -1,0 +1,83 @@
++++
+title = "Review Reports"
+description = "Full transparent reviewer reports and author responses for this manuscript."
+tags = ["reviews", "transparent", "reports"]
++++
+
+## Review Process Timeline
+
+| Stage | Date | Action |
+|---|---|---|
+| Submitted | 2025-10-03 | Manuscript received |
+| Desk review | 2025-10-08 | Sent to peer review |
+| Reviews received | 2025-11-14 | All three reviewer reports returned |
+| Initial decision | 2025-11-21 | <span class="decision revise">Minor revisions requested</span> |
+| Revised submission | 2026-01-18 | Authors submitted revised manuscript and response letter |
+| Final decision | 2026-03-06 | <span class="decision accept">Accept</span> |
+
+## Reviewer 1 Report
+
+**Summary:** This study provides valuable empirical evidence on the effects of transparent peer review using a well-designed difference-in-differences approach. The sample size is large, the analysis is rigorous, and the findings are presented clearly.
+
+**Strengths:**
+
+- Careful matching of treatment and control journals
+- Transparent reporting of coding procedures with inter-rater reliability
+- Thoughtful consideration of competing theoretical predictions
+- Important policy implications grounded in empirical findings
+
+**Suggestions for revision:**
+
+1. The abstract could benefit from quantifying the magnitude of the main DiD effects.
+2. Section 2's theoretical framework discussion would be strengthened by operationalising "softening of criticism" with reference to prior studies.
+3. Consider addressing selection bias more explicitly: journals that chose to transition may differ systematically from those that did not.
+
+**Recommendation:** Accept with minor revisions.
+
+## Reviewer 2 Report
+
+**Summary:** The authors address an important question with a substantial dataset. However, several methodological concerns warrant major revisions.
+
+**Major concerns:**
+
+1. **Selection into transparency:** The eight treatment journals self-selected into the transition. While matched controls help, unobserved confounders (e.g., editorial leadership changes) could drive results.
+2. **Citation impact:** The 2-year window is short; longer-term trends may differ.
+3. **Generalisability:** The treatment journals span diverse disciplines but not clinical medicine or pure humanities. Results may not extend to these fields.
+
+**Minor concerns:**
+
+- The tone assessment Likert scale may conflate politeness with constructiveness
+- Reviewer response rate decline deserves more sustained discussion
+
+**Recommendation:** Major revisions.
+
+## Reviewer 3 Report
+
+**Summary:** A well-executed study on a timely topic. I have only minor suggestions.
+
+**Strengths:**
+
+- Clear writing and logical structure
+- Appropriate statistical methodology
+- Balanced discussion of both benefits and costs of transparency
+
+**Minor suggestions:**
+
+- Consider adding a robustness check excluding journals that transitioned during 2024 (shorter post-period)
+- Figure 2 would benefit from confidence interval bars
+- Typo on page 18: "peer-reivew" should be "peer-review"
+
+**Recommendation:** Accept.
+
+## Author Response (Abridged)
+
+We thank all three reviewers for their thoughtful and constructive comments. We have implemented the following changes in the revised manuscript:
+
+1. **Abstract:** We have added quantitative magnitudes for the main DiD effects (report length: +46%, citations: +38%, satisfaction: +0.63 units).
+2. **Theoretical framework:** Section 2.3 now cites prior operationalisations of reviewer criticism tone (Lee, 2013; Walsh et al., 2000).
+3. **Selection concerns:** We have added a new Appendix C presenting event-study plots to test for pre-transition parallel trends, and a falsification test using non-transitioning journals.
+4. **Timeline robustness:** We have added a robustness check (Appendix D) that excludes 2024 transitions; results are consistent.
+5. **Figure 2:** Now includes 95% confidence interval bars.
+6. **Typographical errors:** All identified typos have been corrected.
+
+We believe the revised manuscript addresses the reviewers' concerns while preserving the core contributions of the original submission.

--- a/peer-review/content/sections/1-methods.md
+++ b/peer-review/content/sections/1-methods.md
@@ -1,0 +1,72 @@
++++
+title = "1. Methods"
+description = "Sample selection, difference-in-differences design, coding procedures for reviewer reports, and matched control journal pairing."
+weight = 1
+template = "post"
+tags = ["methods", "design", "sampling"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## Study Design
+
+We employ a quasi-experimental difference-in-differences (DiD) design to estimate the causal effect of transparent peer review on manuscript quality outcomes. The treatment group comprises eight journals that transitioned from closed to transparent peer review between 2020 and 2024. The control group comprises eight matched journals that maintained closed peer review throughout the study period.
+
+## Treatment Journals
+
+Eight journals transitioned to transparent peer review during our study window:
+
+| Journal | Discipline | Transition Year |
+|---|---|---|
+| *Journal of Quantitative Ecology* | Ecology | 2020 |
+| *Open Sociology Review* | Sociology | 2020 |
+| *Annals of Applied Statistics* | Statistics | 2021 |
+| *Journal of Computational Linguistics* | Linguistics/CS | 2021 |
+| *Cognitive Development Quarterly* | Psychology | 2022 |
+| *European Journal of Political Theory* | Political Science | 2022 |
+| *Integrative Biology Letters* | Biology | 2023 |
+| *Open Mathematics Research* | Mathematics | 2024 |
+
+## Matched Control Journals
+
+Control journals were matched to treatment journals on:
+
+- Discipline and subfield
+- Impact factor (within 20% in year before treatment)
+- Annual submission volume (within 15%)
+- Review model characteristics (double-blind vs. single-blind)
+- Publisher and indexing status
+
+The matching yielded eight treatment-control pairs with mean impact factor difference of 0.08 (SE 0.12) and mean submission volume difference of 7.2% (SE 3.4%).
+
+## Sample
+
+The full analytic sample comprises:
+
+- **Treatment manuscripts:** 1,847 submitted in the 2 years before transition + 1,553 submitted in 2 years after transition
+- **Control manuscripts:** 1,732 submitted in parallel pre-period + 1,496 submitted in parallel post-period
+
+## Coding Procedures
+
+Three independent coders (blind to condition and time period) rated each reviewer report on:
+
+- **Report length:** Word count (automated)
+- **Thoroughness:** 1-5 Likert scale assessing coverage of methods, analysis, and interpretation
+- **Tone:** 1-5 Likert scale (1 = dismissive, 5 = constructive)
+- **Specificity:** Count of specific, actionable suggestions
+
+Inter-rater reliability was high (ICC = 0.86 for thoroughness, 0.79 for tone, 0.91 for specificity).
+
+## Statistical Analysis
+
+The primary DiD model is:
+
+```
+Y_ijt = alpha + beta_1 * Treatment_j + beta_2 * Post_t
+        + beta_3 * (Treatment_j * Post_t) + X_ijt * gamma + e_ijt
+```
+
+where Y_ijt is the outcome for manuscript i in journal j at time t, Treatment_j indicates treatment journals, Post_t indicates post-transition periods, and X_ijt is a vector of manuscript-level controls (length, field, author count, first-author seniority).
+
+Standard errors are clustered at the journal level to account for within-journal correlation.

--- a/peer-review/content/sections/2-results.md
+++ b/peer-review/content/sections/2-results.md
@@ -1,0 +1,56 @@
++++
+title = "2. Results"
+description = "Main difference-in-differences estimates for report quality, citation impact, and review timeline outcomes."
+weight = 2
+template = "post"
+tags = ["results", "did", "citations"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## Report Quality Outcomes
+
+The DiD estimates show statistically significant improvements in reviewer report quality following the transition to transparent peer review:
+
+| Outcome | DiD Estimate | 95% CI | p-value | N |
+|---|---|---|---|---|
+| Report length (words) | +158.4 | [112.8, 204.0] | < .001 | 6,628 |
+| Thoroughness (1-5) | +0.48 | [0.31, 0.65] | < .001 | 6,628 |
+| Specificity (actionable suggestions) | +2.3 | [1.6, 3.0] | < .001 | 6,628 |
+| Tone (1-5, constructive direction) | +0.34 | [0.21, 0.47] | < .001 | 6,628 |
+
+All four quality outcomes improved in the treatment group relative to the control group, contradicting the self-censorship prediction that reviewers would soften criticism when their reports become visible.
+
+## Citation Impact
+
+Manuscripts accepted under transparent review receive more citations than comparable manuscripts accepted under closed review:
+
+| Outcome | DiD Estimate | 95% CI | p-value | N |
+|---|---|---|---|---|
+| 2-year citations | +2.8 | [1.1, 4.5] | .003 | 1,042 (accepted only) |
+| Altmetric score | +18.4 | [9.2, 27.6] | < .001 | 1,042 |
+| Mendeley readership | +14.6 | [8.3, 20.9] | < .001 | 1,042 |
+
+## Review Timeline
+
+Contrary to concerns about transparency delaying review, the increase in time to decision was modest and statistically marginal:
+
+| Outcome | DiD Estimate | 95% CI | p-value | N |
+|---|---|---|---|---|
+| Time to first decision (days) | +6.2 | [-0.8, 13.2] | .084 | 6,628 |
+| Number of review rounds | +0.12 | [-0.04, 0.28] | .142 | 3,400 |
+| Time to final decision (days) | +11.4 | [2.1, 20.7] | .017 | 3,400 |
+
+Time to final decision increased modestly (about 11 days on average), likely reflecting the more thorough review process rather than administrative delays.
+
+## Reviewer Response Rates
+
+A notable negative effect of transparency is a decline in reviewer acceptance rates:
+
+| Outcome | DiD Estimate | 95% CI | p-value |
+|---|---|---|---|
+| Reviewer response rate | -7.2 pp | [-10.8, -3.6] | < .001 |
+| Number of invitations per manuscript | +1.4 | [0.6, 2.2] | .001 |
+
+Editors must invite more potential reviewers to secure the required number of reports under transparent review.

--- a/peer-review/content/sections/3-reviewer-engagement.md
+++ b/peer-review/content/sections/3-reviewer-engagement.md
@@ -1,0 +1,46 @@
++++
+title = "3. Reviewer Engagement Analysis"
+description = "Patterns of reviewer acceptance, decline reasons, and report completion under transparent vs. closed review."
+weight = 3
+template = "post"
+tags = ["reviewers", "engagement", "decline"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## Decline Reasons
+
+Among invited reviewers who declined to review, we surveyed those at treatment journals about their primary reason:
+
+| Reason | Pre-transition | Post-transition | Change |
+|---|---|---|---|
+| Time constraints | 54.2% | 41.8% | -12.4pp |
+| Outside expertise | 21.6% | 19.4% | -2.2pp |
+| Conflict of interest | 8.4% | 7.9% | -0.5pp |
+| Concerns about disclosure | -- | 18.2% | +18.2pp |
+| Other | 15.8% | 12.7% | -3.1pp |
+
+The emergence of a disclosure-related decline reason (absent in the pre-period) accounts for roughly 40% of the overall decline in response rates.
+
+## Characteristics of Declining Reviewers
+
+Reviewers who cited disclosure concerns were disproportionately:
+
+- Early-career researchers (postdocs, assistant professors): OR = 1.84
+- In fields with strong hierarchical norms (clinical medicine, law): OR = 2.12
+- Previously accepting of closed reviews from the same journal: OR = 1.56
+
+Early-career researchers' concerns centered on the potential for reputational damage if they criticised senior scholars' work under their own name.
+
+## Completion Rates
+
+Among reviewers who accepted invitations, completion rates were similar across conditions:
+
+| Metric | Pre-transition | Post-transition |
+|---|---|---|
+| Complete reports submitted | 92.4% | 94.1% |
+| Late submissions (> 14 days past deadline) | 18.2% | 16.4% |
+| Multiple reminder emails required | 31.2% | 28.6% |
+
+Reviewers who commit to reviewing under transparency are slightly *more* likely to complete on time, suggesting self-selection into reliability.

--- a/peer-review/content/sections/4-author-experience.md
+++ b/peer-review/content/sections/4-author-experience.md
@@ -1,0 +1,49 @@
++++
+title = "4. Author Satisfaction and Revision Quality"
+description = "Post-publication author surveys and quality assessment of revised manuscripts before and after the transition to transparent review."
+weight = 4
+template = "post"
+tags = ["authors", "satisfaction", "revisions"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Author Satisfaction Survey
+
+Following the final decision on each manuscript, corresponding authors were invited to complete a 12-item survey on their review experience. Response rate was 56.8% (3,867 responses from 6,806 invitations).
+
+### Composite Satisfaction Score (1-7 Likert)
+
+| Dimension | Pre-transition | Post-transition | DiD | p |
+|---|---|---|---|---|
+| Overall satisfaction | 4.2 | 4.8 | +0.63 | .008 |
+| Perceived fairness | 4.4 | 5.1 | +0.71 | .002 |
+| Usefulness of reports | 4.6 | 5.3 | +0.68 | < .001 |
+| Clarity of decision | 4.8 | 5.2 | +0.38 | .041 |
+| Willingness to re-submit | 4.1 | 4.6 | +0.52 | .018 |
+
+Authors whose manuscripts were accepted report the largest improvements in perceived fairness and usefulness. Authors whose manuscripts were rejected also report modest improvements in perceived fairness, suggesting that transparency benefits authors even when the outcome is negative.
+
+## Revision Quality
+
+For manuscripts receiving a "revise and resubmit" decision, we coded the revised version against reviewer comments to quantify revision thoroughness:
+
+| Measure | Pre-transition | Post-transition | DiD | p |
+|---|---|---|---|---|
+| % of comments addressed | 72.4% | 83.6% | +10.8pp | < .001 |
+| % of comments substantively engaged (not just cosmetic) | 58.1% | 71.8% | +13.2pp | < .001 |
+| Response letter length (words) | 842 | 1,216 | +368 | < .001 |
+| Additional references added | 3.2 | 5.8 | +2.5 | < .001 |
+| New analyses conducted | 1.4 | 2.3 | +0.85 | .004 |
+
+Authors appear to engage more thoroughly with reviewer comments when those comments will be public, possibly anticipating reader scrutiny of their responses.
+
+## Qualitative Themes
+
+Content analysis of open-ended survey responses (N = 1,284) identified four dominant themes in authors' perceptions of transparent review:
+
+1. **Reduced opacity** ("I could see what actually shaped the decision") -- mentioned by 42% of respondents
+2. **Reviewer accountability** ("Comments seemed more carefully considered") -- 38%
+3. **Professional exposure concerns** ("I was nervous my responses would be publicly visible") -- 22%
+4. **Educational value** ("Reading other papers' reviews helps me learn to peer-review") -- 31%

--- a/peer-review/content/sections/5-policy.md
+++ b/peer-review/content/sections/5-policy.md
@@ -1,0 +1,54 @@
++++
+title = "5. Policy Implications"
+description = "Recommendations for journals, publishers, and funders considering transitions to transparent peer review."
+weight = 5
+template = "post"
+tags = ["policy", "recommendations", "publishing"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## Recommendations for Journals
+
+Our findings support the adoption of transparent peer review, but with several policy considerations:
+
+### 1. Preserve Reviewer Anonymity by Default
+
+While publishing reviewer reports improves report quality, our data show that mandating identity disclosure reduces reviewer willingness. We recommend publishing reports with reviewer identity *optional*, allowing reviewers to choose disclosure on a per-report basis. In our sample, 34% of reviewers opted to disclose their identity when given the choice, providing sufficient signalling for those who want accountability while protecting those with concerns.
+
+### 2. Extend Review Timelines Slightly
+
+Editors should allow 1-2 additional weeks per review round to accommodate the more thorough review process that transparency encourages. Authors and editors should be informed of this modest timeline extension upfront.
+
+### 3. Invest in Reviewer Training
+
+Transparency raises the stakes of review quality. Journals should provide structured training materials and templates for new reviewers to help them produce reports that meet the expectations of public scrutiny.
+
+## Recommendations for Funders
+
+Research funders can support the transition to transparent peer review by:
+
+- Requiring publication venues to publish reviewer reports as a condition of funding
+- Providing financial support for the technical infrastructure required (e.g., review report DOIs, Crossref integration)
+- Recognising peer review activity in grant evaluations, giving weight to both the quantity and the (now assessable) quality of reviews
+
+## Recommendations for Early-Career Researchers
+
+Early-career researchers expressed the greatest concern about review disclosure. We recommend:
+
+- Treating peer review as a formal professional activity with measurable outputs
+- Listing high-quality public reviews on CVs alongside publications
+- Seeking mentorship on review practices from senior colleagues during the transition
+
+## Future Research Directions
+
+Several questions remain open:
+
+1. **Long-term citation trajectories:** Our 2-year citation window may underestimate the full impact of transparency. A 10-year follow-up study is warranted.
+2. **Bias and equity:** Does transparency differentially affect reviews of manuscripts from under-represented groups? Preliminary analyses suggest no significant interaction by author gender or geographic region, but statistical power is limited.
+3. **Multi-disciplinary variation:** Our sample covers eight disciplines. Some fields (e.g., clinical medicine) may respond differently to transparency given distinct norms around hierarchical authority.
+
+## Conclusion
+
+The evidence supports transparent peer review as a net improvement over closed review, with larger effects on review quality and citation impact than previously documented. The principal cost -- reduced reviewer response rates -- can be mitigated through policy design that preserves reviewer choice around identity disclosure.

--- a/peer-review/content/sections/_index.md
+++ b/peer-review/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+The paper is organised into five sections covering methods, results, reviewer engagement analysis, author satisfaction, and policy implications.

--- a/peer-review/static/css/style.css
+++ b/peer-review/static/css/style.css
@@ -1,0 +1,338 @@
+/* ============================================================================
+   Peer Review - Double-Blind Review Paper
+   Light background, academic serif throughout, margin review bubbles.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #fdfdfb;
+  --bg-2: #f5f5f1;
+  --bg-3: #ebebe6;
+  --paper: #ffffff;
+  --rule: #d8d4cc;
+  --rule-heavy: #1a2236;
+  --ink: #1a2236;
+  --ink-2: #3a4256;
+  --ink-3: #6a7280;
+  --ink-4: #9aa0ac;
+  --accent: #1a2236;
+  --accept: #2a6b3a;
+  --revise: #b87328;
+  --reject: #a83232;
+  --neutral: #5a6378;
+  --review-bubble: #fefef8;
+  --review-border: #d4cf99;
+  --r1-accent: #2a6b3a;
+  --r2-accent: #b87328;
+  --r3-accent: #5a6378;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "STIX Two Text", "Libertinus Serif", "Noto Serif", "Times New Roman", Times, serif;
+  font-size: 12pt;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap { max-width: 1100px; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.5rem 0 1.2rem; border-bottom: 2px solid var(--rule-heavy);
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.8rem; color: var(--ink); text-decoration: none; }
+.site-logo:hover { color: var(--accept); }
+.logo-mark { width: 44px; height: 48px; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.journal-name { font-family: "STIX Two Text", "Libertinus Serif", serif; font-weight: 700; font-size: 1rem; font-style: italic; color: var(--ink); }
+.journal-sub { font-family: "STIX Two Text", serif; font-weight: 400; font-size: 0.72rem; color: var(--ink-3); letter-spacing: 0.04em; text-transform: uppercase; margin-top: 0.15rem; }
+
+.site-nav { display: flex; gap: 1.6rem; }
+.site-nav a {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.78rem; font-weight: 700; letter-spacing: 0.08em;
+  color: var(--ink-3); text-decoration: none; text-transform: uppercase;
+  padding-bottom: 0.2rem; border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.site-nav a:hover { color: var(--accept); border-bottom-color: var(--accept); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 2.5rem 0 3rem; }
+
+/* Paper layout: two-column with review bubbles in margin */
+.paper-article { max-width: 100%; position: relative; }
+
+.paper-header { margin-bottom: 2.5rem; }
+.paper-eyebrow {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.75rem; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--ink-3); margin: 0 0 0.5rem;
+  font-style: italic;
+}
+.paper-title {
+  font-family: "STIX Two Text", "Libertinus Serif", serif;
+  font-size: 1.9rem; font-weight: 700; line-height: 1.25;
+  color: var(--ink); margin: 0 0 1rem;
+}
+.paper-authors {
+  font-family: "STIX Two Text", serif;
+  font-size: 1rem; color: var(--ink); margin: 0 0 0.4rem; line-height: 1.5;
+  font-style: italic;
+}
+.paper-affiliations {
+  font-size: 0.82rem; color: var(--ink-3); margin: 0 0 0.8rem; line-height: 1.6;
+}
+.paper-doi {
+  font-size: 0.78rem; color: var(--ink-3); margin: 0;
+}
+.paper-doi a { color: var(--accept); text-decoration: none; }
+.paper-doi a:hover { text-decoration: underline; }
+
+/* Margin with review bubbles */
+.paper-with-margin {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 2.5rem;
+  margin: 2rem 0;
+}
+
+.margin-reviews {
+  display: flex; flex-direction: column; gap: 1rem;
+}
+
+/* Review bubble panel */
+.review-bubble {
+  background: var(--review-bubble);
+  border: 1px solid var(--review-border);
+  border-left: 4px solid var(--r1-accent);
+  padding: 0.9rem 1rem;
+  font-size: 0.82rem; line-height: 1.5;
+  position: relative;
+}
+.review-bubble.r2 { border-left-color: var(--r2-accent); }
+.review-bubble.r3 { border-left-color: var(--r3-accent); }
+.review-bubble-header {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700; font-size: 0.78rem;
+  color: var(--r1-accent); margin: 0 0 0.3rem;
+  display: flex; justify-content: space-between; align-items: baseline;
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.review-bubble.r2 .review-bubble-header { color: var(--r2-accent); }
+.review-bubble.r3 .review-bubble-header { color: var(--r3-accent); }
+.review-bubble-tag {
+  font-size: 0.65rem; color: var(--ink-3);
+  font-weight: 400; letter-spacing: 0.04em;
+}
+.review-bubble-body {
+  color: var(--ink-2); margin: 0;
+}
+.review-bubble-body p { margin: 0.4rem 0; }
+.review-bubble-author {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.72rem; color: var(--ink-3); margin-top: 0.5rem;
+  padding-top: 0.5rem; border-top: 1px dashed var(--review-border);
+  font-style: italic;
+}
+
+/* Score gauge panel */
+.score-gauges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+.score-gauge {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 1rem; text-align: center;
+}
+.score-gauge-label {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.78rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--ink-2); margin: 0 0 0.6rem;
+}
+.score-gauge-svg {
+  width: 100%; max-width: 160px; margin: 0 auto;
+  display: block;
+}
+.score-gauge-value {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.85rem; font-weight: 700; color: var(--ink-2);
+  margin-top: 0.4rem;
+}
+
+/* Section header */
+.paper-section-header { margin-bottom: 2rem; }
+.paper-section-eyebrow {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.72rem; font-weight: 700; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--ink-3); margin: 0 0 0.3rem;
+  font-style: italic;
+}
+.paper-section-title {
+  font-family: "STIX Two Text", "Libertinus Serif", serif;
+  font-size: 1.5rem; font-weight: 700; line-height: 1.3;
+  color: var(--ink); margin: 0 0 0.5rem;
+}
+.paper-lede { font-size: 1rem; color: var(--ink-2); margin: 0; line-height: 1.6; font-style: italic; }
+
+.paper-content { margin-top: 1.5rem; }
+
+.paper-section-footer { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); }
+.button-link {
+  font-family: "STIX Two Text", serif;
+  font-size: 0.85rem; color: var(--accept); text-decoration: none;
+}
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Typography ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "STIX Two Text", "Libertinus Serif", serif;
+  color: var(--ink); line-height: 1.3;
+}
+h1 { font-size: 1.4rem; margin: 2rem 0 0.8rem; font-weight: 700; }
+h2 { font-size: 1.2rem; margin: 1.8rem 0 0.6rem; font-weight: 700; }
+h3 { font-size: 1.05rem; margin: 1.5rem 0 0.5rem; font-weight: 700; font-style: italic; }
+h4 { font-size: 0.95rem; margin: 1.2rem 0 0.4rem; font-weight: 700; }
+
+p { margin: 0.8rem 0; text-align: justify; hyphens: auto; }
+
+a { color: var(--accept); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+strong { color: var(--ink); font-weight: 700; }
+em { font-style: italic; }
+
+sup { font-size: 0.72em; line-height: 0; vertical-align: super; }
+
+blockquote {
+  border-left: 3px solid var(--accept);
+  margin: 1.2rem 0; padding: 0.6rem 1.2rem;
+  background: var(--bg-2); color: var(--ink-2);
+  font-style: italic;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.85em; background: var(--bg-3);
+  padding: 0.15rem 0.4rem; border-radius: 3px;
+  color: var(--ink);
+}
+
+pre {
+  background: var(--bg-2); border: 1px solid var(--rule);
+  padding: 1rem; border-radius: 4px; overflow-x: auto;
+  margin: 1.2rem 0;
+}
+pre code { background: none; padding: 0; }
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%; border-collapse: collapse; margin: 1.5rem 0;
+  font-size: 0.92rem;
+}
+th {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700; font-size: 0.85rem;
+  text-align: left; padding: 0.5rem 0.7rem;
+  border-top: 2px solid var(--rule-heavy);
+  border-bottom: 1px solid var(--rule-heavy);
+  color: var(--ink);
+}
+td {
+  padding: 0.4rem 0.7rem; border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+tbody tr:last-child td { border-bottom: 2px solid var(--rule-heavy); }
+tr:hover td { background: var(--bg-2); }
+
+/* Decision tokens */
+.decision {
+  display: inline-block; padding: 0.15rem 0.5rem;
+  font-family: "STIX Two Text", serif;
+  font-size: 0.72rem; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+  border: 1px solid;
+}
+.decision.accept { color: var(--accept); border-color: var(--accept); background: rgba(42,107,58,0.08); }
+.decision.revise { color: var(--revise); border-color: var(--revise); background: rgba(184,115,40,0.08); }
+.decision.reject { color: var(--reject); border-color: var(--reject); background: rgba(168,50,50,0.08); }
+
+/* Figures */
+figure { margin: 2rem 0; padding: 0; }
+figcaption {
+  text-align: center; font-size: 0.85rem;
+  color: var(--ink-3); font-style: italic;
+  margin-top: 0.8rem;
+}
+
+/* Section list */
+.section-list {
+  list-style: none; padding: 0; margin: 1.5rem 0;
+}
+.section-list li {
+  margin-bottom: 0.5rem; padding: 0.7rem 1rem;
+  background: var(--paper); border: 1px solid var(--rule);
+}
+.section-list li a {
+  font-family: "STIX Two Text", serif;
+  font-weight: 700; color: var(--ink);
+}
+.section-list li a:hover { color: var(--accept); }
+
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; }
+
+/* Pagination */
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;
+}
+nav.pagination a {
+  display: inline-block; padding: 0.25rem 0.55rem;
+  border: 1px solid var(--rule);
+  color: var(--ink-3); text-decoration: none;
+  font-family: "STIX Two Text", serif; font-size: 0.85rem;
+}
+nav.pagination a:hover { color: var(--accept); border-color: var(--accept); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer { margin-top: 3rem; padding: 1.5rem 0 2rem; }
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+.footer-content { text-align: center; }
+.footer-meta {
+  font-size: 0.82rem; color: var(--ink-3); margin: 0 0 0.3rem; line-height: 1.5;
+}
+.footer-note {
+  font-size: 0.72rem; color: var(--ink-4); margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 900px) {
+  .paper-with-margin { grid-template-columns: 1fr; gap: 1.5rem; }
+}
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1.2rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .paper-title { font-size: 1.4rem; }
+  table { font-size: 0.85rem; }
+  th, td { padding: 0.4rem 0.5rem; }
+}

--- a/peer-review/templates/404.html
+++ b/peer-review/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested page does not exist in this review.</p>
+      <p><a href="{{ base_url }}/">Return to Paper Overview</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/peer-review/templates/footer.html
+++ b/peer-review/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#1a2236" stroke-width="1.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#1a2236" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Citation: Okafor A, Lindgren S, Yamamoto K, et al. Transparent Peer Review: Assessing the Impact of Open Review on Manuscript Quality. <em>J. Res. Integr.</em> 2026;8(1):34-52.</p>
+        <p class="footer-note">ISSN 2472-1476 &middot; Copyright 2026 The Authors. Open access under CC BY 4.0. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/peer-review/templates/header.html
+++ b/peer-review/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=STIX+Two+Text:ital,wght@0,400;0,700;1,400&family=Libertinus+Serif:ital,wght@0,400;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Peer Review paper home">
+        <svg viewBox="0 0 44 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Review/document icon with checkmark -->
+          <rect x="4" y="2" width="30" height="40" rx="2" fill="none" stroke="#1a2236" stroke-width="1.5"/>
+          <line x1="10" y1="12" x2="28" y2="12" stroke="#1a2236" stroke-width="1" opacity="0.4"/>
+          <line x1="10" y1="18" x2="28" y2="18" stroke="#1a2236" stroke-width="1" opacity="0.4"/>
+          <line x1="10" y1="24" x2="22" y2="24" stroke="#1a2236" stroke-width="1" opacity="0.4"/>
+          <!-- Review bubble -->
+          <rect x="22" y="28" width="18" height="14" rx="3" fill="none" stroke="#2a6b3a" stroke-width="1.2"/>
+          <path d="M26,42 L24,46 L30,42" fill="none" stroke="#2a6b3a" stroke-width="1"/>
+          <line x1="26" y1="33" x2="36" y2="33" stroke="#2a6b3a" stroke-width="0.8" opacity="0.5"/>
+          <line x1="26" y1="37" x2="34" y2="37" stroke="#2a6b3a" stroke-width="0.8" opacity="0.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Research Integrity</span>
+          <span class="journal-sub">Open Peer Review &middot; Vol. 8 &middot; 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">PAPER</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/reviews/">REVIEWS</a>
+        <a href="{{ base_url }}/appendix/">APPENDIX</a>
+      </nav>
+    </header>

--- a/peer-review/templates/page.html
+++ b/peer-review/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/peer-review/templates/post.html
+++ b/peer-review/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/peer-review/templates/section.html
+++ b/peer-review/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/peer-review/templates/shortcodes/alert.html
+++ b/peer-review/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #c8d1e0; background-color: #f5f7fa; border-left: 5px solid #2a6b3a; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/peer-review/templates/taxonomy.html
+++ b/peer-review/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/peer-review/templates/taxonomy_term.html
+++ b/peer-review/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2836,6 +2836,13 @@
     "luxury",
     "soft"
   ],
+  "peer-review": [
+    "paper",
+    "light",
+    "academic",
+    "review",
+    "transparent"
+  ],
   "pendulum": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1591

## Summary
- Add peer-review example site: a light-themed double-blind review paper with transparent reviewer comments
- Features inline SVG reviewer comment bubble panels in the margin, SVG review score gauges (accept/revise/reject scales)
- Typography: STIX Two Text / Libertinus Serif for paper titles, standard academic serif at 12pt for body
- Includes 5 paper sections, full review reports page with reviewer responses, appendix with robustness checks
- Tags: paper, light, academic, review, transparent

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check review score gauge SVGs render with needle pointing correctly
- [ ] Verify margin reviewer comment bubbles display properly
- [ ] Confirm light theme with no CSS gradients
- [ ] Check tags.json entry is valid JSON