### PR TITLE
feat: add retraction-notice example site (closes #1597)

### DIFF
--- a/retraction-notice/AGENTS.md
+++ b/retraction-notice/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/retraction-notice/config.toml
+++ b/retraction-notice/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Retraction Notice - Withdrawn Paper
+# Issue #1597 | Tags: paper, light, retracted, warning, editorial
+# =============================================================================
+
+title = "RETRACTED: A Retraction Notice for Withdrawn Research"
+description = "An editorial retraction notice featuring a large diagonal RETRACTED stamp across all paper content, warning triangle icons in paper headers, and strikethrough academic typography indicating invalidated claims."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/retraction-notice/content/index.md
+++ b/retraction-notice/content/index.md
@@ -1,0 +1,108 @@
++++
+title = "Retraction Notice"
+description = "Editorial retraction of a withdrawn research paper, featuring diagonal RETRACTED stamp overlay, warning triangle icons, and strikethrough typography indicating invalidated claims."
+tags = ["paper", "light", "retracted", "warning", "editorial"]
++++
+
+<div class="retraction-banner">
+  <h2>RETRACTED</h2>
+  <p>This article has been withdrawn from the scientific record</p>
+</div>
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Editorial Retraction Notice &middot; 2026-04-10</p>
+  <h1 class="paper-title">Gut Microbiome Signatures Predict Early-Stage Pancreatic Adenocarcinoma: A Validation Cohort Study</h1>
+  <p class="paper-subtitle">Originally published: <em>Journal of Applied Genomics</em>, Volume 22, Issue 8, August 2024, pp. 1847--1872 &middot; DOI: 10.1234/jag.2024.1872</p>
+  <div class="paper-meta">
+    <strong>Retraction DOI:</strong> 10.1234/jag.2024.1872/retr<br>
+    <strong>Original Authors:</strong> M. Chen, R. Patel, K. Alvarez-Hwang, J. Okonkwo (corresponding)<br>
+    <strong>Retraction Date:</strong> April 10, 2026 &middot;
+    <strong>Decision:</strong> Retracted by Editor-in-Chief<br>
+    <strong>Retraction Category:</strong> Data fabrication &middot; Image manipulation &middot; Unverifiable results
+  </div>
+</header>
+
+## Editor's Statement
+
+<div class="editor-note">
+  <p class="note-label">Editor-in-Chief Statement</p>
+  <p>The Editor-in-Chief of the <em>Journal of Applied Genomics</em>, in consultation with the editorial board and the publisher, is retracting this article. After a 14-month investigation following a reader-submitted concern in February 2025, the Committee on Publication Ethics (COPE) process has concluded that the paper contains unreliable data that cannot support the conclusions drawn.</p>
+  <p>Specifically, the investigation identified: (1) fabricated sequencing counts in three supplementary tables; (2) manipulation of Figure 3 panel B (duplicated band patterns across independent lanes); and (3) an inability to produce the raw data files requested by the investigation committee.</p>
+  <p>The authors were notified on 2025-11-18 and given 120 days to respond. Three of four authors (Chen, Patel, Alvarez-Hwang) agree with the retraction. The corresponding author (Okonkwo) disputes the findings. The Editor-in-Chief's decision stands.</p>
+</div>
+
+## What This Retraction Means
+
+The scientific claims made in the original article are **no longer considered part of the scientific record**. Researchers, clinicians, and reviewers should not cite this work as supporting evidence for any claim. If this work has influenced clinical guidelines or patient care decisions, those decisions should be re-evaluated in light of this retraction.
+
+## Retracted Claims
+
+The following claims from the original paper are retracted:
+
+<div class="retracted-block">
+  <p>A gut microbiome signature comprising 23 bacterial taxa predicts early-stage pancreatic adenocarcinoma with an AUROC of 0.94 (95% CI 0.91--0.97) in a validation cohort of 1,247 individuals from three European medical centers.</p>
+</div>
+
+<div class="retracted-block">
+  <p>The predictive signature remained robust across demographic subgroups, with no significant degradation of AUROC for age strata (< 60 vs. >= 60), sex, or ethnic background. Sensitivity at 90% specificity exceeded 85% in all analyzed subgroups.</p>
+</div>
+
+<div class="retracted-block">
+  <p>Prospective deployment of the test in a primary care setting could increase 5-year pancreatic cancer survival from 12% to an estimated 34% through earlier detection and treatment initiation.</p>
+</div>
+
+## Retraction Timeline
+
+<!-- SVG timeline of retraction process with warning markers -->
+<figure>
+<svg viewBox="0 0 760 220" xmlns="http://www.w3.org/2000/svg" aria-label="Retraction investigation timeline" style="width:100%;max-width:760px;display:block;margin:1rem auto;">
+  <rect x="0" y="0" width="760" height="220" fill="#faf8f5"/>
+  <text x="380" y="20" text-anchor="middle" font-family="'Oswald','Bebas Neue',sans-serif" font-size="12" font-weight="700" fill="#1a1a1a" letter-spacing="0.1em">RETRACTION TIMELINE</text>
+  <!-- Main horizontal axis -->
+  <line x1="60" y1="120" x2="720" y2="120" stroke="#b83220" stroke-width="1.5"/>
+  <!-- Publication -->
+  <circle cx="60" cy="120" r="8" fill="#8a8880" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="60" y="100" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1a1a">2024-08</text>
+  <text x="60" y="146" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="600" fill="#1a1a1a">PUBLISHED</text>
+  <text x="60" y="160" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="9" fill="#6a6a6a" font-style="italic">Vol. 22, Issue 8</text>
+  <!-- Concern raised -->
+  <path d="M195,108 L210,138 L180,138 Z" fill="#fff2e8" stroke="#c07020" stroke-width="1.5"/>
+  <text x="195" y="132" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="700" fill="#c07020">!</text>
+  <text x="195" y="90" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1a1a">2025-02</text>
+  <text x="195" y="168" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="600" fill="#c07020">CONCERN RAISED</text>
+  <text x="195" y="182" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="9" fill="#6a6a6a" font-style="italic">Reader submission</text>
+  <!-- Investigation -->
+  <path d="M330,108 L345,138 L315,138 Z" fill="#fff2e8" stroke="#c07020" stroke-width="1.5"/>
+  <text x="330" y="132" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="700" fill="#c07020">!</text>
+  <text x="330" y="90" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1a1a">2025-04</text>
+  <text x="330" y="168" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="600" fill="#c07020">COPE PROCESS</text>
+  <text x="330" y="182" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="9" fill="#6a6a6a" font-style="italic">Investigation opened</text>
+  <!-- Author notified -->
+  <path d="M465,108 L480,138 L450,138 Z" fill="#fff2e8" stroke="#c07020" stroke-width="1.5"/>
+  <text x="465" y="132" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="700" fill="#c07020">!</text>
+  <text x="465" y="90" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1a1a">2025-11</text>
+  <text x="465" y="168" text-anchor="middle" font-family="'Oswald',sans-serif" font-size="9" font-weight="600" fill="#c07020">AUTHORS NOTIFIED</text>
+  <text x="465" y="182" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="9" fill="#6a6a6a" font-style="italic">120-day response window</text>
+  <!-- Retraction -->
+  <rect x="650" y="108" width="22" height="22" rx="1" fill="#b83220" stroke="#8e2010" stroke-width="2"/>
+  <text x="661" y="124" text-anchor="middle" font-family="'Bebas Neue','Oswald',sans-serif" font-size="11" font-weight="700" fill="#ffffff">X</text>
+  <text x="661" y="90" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" font-weight="700" fill="#b83220">2026-04-10</text>
+  <text x="661" y="158" text-anchor="middle" font-family="'Bebas Neue',sans-serif" font-size="12" font-weight="700" fill="#b83220" letter-spacing="0.1em">RETRACTED</text>
+  <text x="661" y="172" text-anchor="middle" font-family="'Crimson Pro',serif" font-size="9" fill="#6a6a6a" font-style="italic">Editor decision final</text>
+  <!-- Connecting arrows -->
+  <path d="M72,120 L183,120" stroke="#c8b8a0" stroke-width="1" stroke-dasharray="4,3"/>
+  <path d="M207,120 L318,120" stroke="#c8b8a0" stroke-width="1" stroke-dasharray="4,3"/>
+  <path d="M342,120 L453,120" stroke="#c8b8a0" stroke-width="1" stroke-dasharray="4,3"/>
+  <path d="M477,120 L649,120" stroke="#c8b8a0" stroke-width="1" stroke-dasharray="4,3"/>
+</svg>
+<figcaption style="text-align:center;font-size:0.78rem;color:#6a6a6a;font-style:italic;">Fig. 1. Complete timeline from original publication to formal retraction, spanning 20 months.</figcaption>
+</figure>
+
+## Citation Advisory
+
+If you have cited this work in your own research or clinical practice guidelines, please:
+
+1. Replace the citation with alternative, verified sources when possible
+2. Add a footnote indicating that the citation has been retracted
+3. Re-evaluate any conclusions that depended upon the retracted findings
+4. Contact the editorial board (editor@j-applied-genomics.example) for clarification if needed

--- a/retraction-notice/content/original.md
+++ b/retraction-notice/content/original.md
@@ -1,0 +1,44 @@
++++
+title = "Original Article Reference"
+description = "Bibliographic information for the retracted article and how to cite the retraction notice."
+tags = ["original", "citation", "reference"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Original Article Information</p>
+  <h1 class="paper-title">Article Being Retracted</h1>
+</header>
+
+## Original Citation (Now Retracted)
+
+<div class="retracted-block">
+<p>Chen M, Patel R, Alvarez-Hwang K, Okonkwo J. Gut microbiome signatures predict early-stage pancreatic adenocarcinoma: a validation cohort study. <em>Journal of Applied Genomics</em>. 2024 Aug;22(8):1847-1872. doi: 10.1234/jag.2024.1872. [RETRACTED]</p>
+</div>
+
+## Proper Citation Format After Retraction
+
+When referring to this article in subsequent literature, please use one of these formats:
+
+**Vancouver style:**
+> Chen M, Patel R, Alvarez-Hwang K, Okonkwo J. Gut microbiome signatures predict early-stage pancreatic adenocarcinoma: a validation cohort study [RETRACTED]. *J Appl Genomics*. 2024 Aug;22(8):1847-1872. doi: 10.1234/jag.2024.1872. Retraction in: *J Appl Genomics*. 2026 Apr;24(4):R21-R26. doi: 10.1234/jag.2024.1872/retr
+
+**APA style:**
+> Chen, M., Patel, R., Alvarez-Hwang, K., & Okonkwo, J. (2024). Gut microbiome signatures predict early-stage pancreatic adenocarcinoma: A validation cohort study [Retracted]. *Journal of Applied Genomics*, 22(8), 1847--1872. https://doi.org/10.1234/jag.2024.1872 (Retraction published April 2026, *Journal of Applied Genomics*, 24[4], R21--R26, https://doi.org/10.1234/jag.2024.1872/retr)
+
+## Citing the Retraction Notice
+
+If you need to cite this retraction notice specifically:
+
+> Editorial Board, *Journal of Applied Genomics*. Retraction: Gut microbiome signatures predict early-stage pancreatic adenocarcinoma: a validation cohort study. *J Appl Genomics*. 2026 Apr;24(4):R21-R26. doi: 10.1234/jag.2024.1872/retr
+
+## Affected Database Records
+
+This retraction has been communicated to the following databases for record update:
+
+| Database | Status | Identifier |
+|----------|--------|-----------|
+| PubMed / MEDLINE | Retraction notice linked | PMID: 38xxxxxxx |
+| Scopus | Flagged as retracted | EID: 2-s2.0-85xxxxxxxxx |
+| Web of Science | Flagged as retracted | Accession: WOS:000xxxxxxxxxxxx |
+| Retraction Watch Database | Added with full case notes | Watch ID: RW-2026-04-142 |
+| CrossRef | Retraction DOI linked | 10.1234/jag.2024.1872/retr |

--- a/retraction-notice/content/sections/1-data-fabrication.md
+++ b/retraction-notice/content/sections/1-data-fabrication.md
@@ -1,0 +1,43 @@
++++
+title = "Data Fabrication Findings"
+description = "Evidence of fabricated sequencing counts in supplementary tables S3, S7, and S12."
+weight = 1
+template = "post"
+tags = ["fabrication", "data-integrity", "sequencing"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+<div class="editor-note">
+  <p class="note-label">Concern Summary</p>
+  <p>Statistical forensic analysis of supplementary tables S3, S7, and S12 revealed patterns inconsistent with genuine high-throughput sequencing data. Digit-frequency tests (Benford's law), variance-to-mean ratios for Poisson-distributed counts, and terminal-digit preferences all deviate significantly from expected values.</p>
+</div>
+
+## Specific Findings
+
+**Table S3 (Baseline cohort microbiome counts):**
+
+- Terminal digit distribution: excess of 0s and 5s (chi-squared p < 0.0001 vs. uniform)
+- Expected fraction of 0 and 5: 0.20 combined. Observed: 0.47
+- Variance-to-mean ratio: 0.31 (Poisson expectation approximately 1.0, overdispersed negative binomial expectation >> 1.0)
+
+**Table S7 (Validation cohort discovery set):**
+
+- 23 of 247 bacterial taxa showed identical count patterns across 14 independent patient samples (probability < 10^-15 under genuine sampling)
+- Read depth normalizations do not explain the pattern
+
+**Table S12 (Model performance by center):**
+
+- Reported AUROC values across 3 centers (Paris, Milan, Amsterdam) suspiciously identical to 3 decimal places: 0.942, 0.941, 0.943
+- True independent measurements from similar-sized cohorts would be expected to vary by at least 0.02--0.03 due to sampling variability
+
+## Authors' Response
+
+The corresponding author (Okonkwo) provided a 42-page response on 2026-02-15 disputing these findings. The investigation committee, including two external statistical reviewers, found the response did not address the core concerns. The committee voted 7--0 to recommend retraction.
+
+## What Was Invalidated
+
+<div class="retracted-block">
+<p>All AUROC values, sensitivity/specificity estimates, subgroup analyses, and projected clinical impact estimates derived from Tables S3, S7, and S12 are invalidated. Figures 2, 3, 4 and Table 2 of the main text all depend on these data.</p>
+</div>

--- a/retraction-notice/content/sections/2-image-manipulation.md
+++ b/retraction-notice/content/sections/2-image-manipulation.md
@@ -1,0 +1,42 @@
++++
+title = "Image Manipulation in Figure 3"
+description = "Evidence of duplicated band patterns across independent lanes in the qPCR validation gel image (Figure 3, panel B)."
+weight = 2
+template = "post"
+tags = ["image-manipulation", "western-blot", "figure-integrity"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+<div class="editor-note">
+  <p class="note-label">Image Forensic Analysis</p>
+  <p>Independent forensic analysis of Figure 3 panel B (qPCR validation gel) by the journal's image integrity analyst identified clear evidence of digital manipulation, including band duplication, uneven background correction between adjacent lanes, and pixel-level artifacts characteristic of copy-and-paste editing in raster graphics software.</p>
+</div>
+
+## Specific Findings in Figure 3B
+
+The gel image claimed to show qPCR validation of 8 key bacterial taxa across 24 patient samples (6 cases, 6 controls per three replicate runs). Forensic examination revealed:
+
+1. **Band duplication (lanes 4 and 17):** The band at the 180-bp position in lane 4 is pixel-identical to the band in lane 17 (Pearson correlation r = 0.999 for pixel intensities, expected r < 0.85 for independent samples).
+
+2. **Background discontinuities:** Sharp boundary lines visible at 400% zoom indicate image compositing. Background gradient direction changes between adjacent lanes in ways inconsistent with a single gel exposure.
+
+3. **Missing source files:** The authors were unable to produce the raw gel images. The supplementary ZIP file claimed to contain raw TIFFs but contained only the same PNG that appeared in the paper.
+
+## Authors' Response
+
+The corresponding author stated that the original gel images were lost during a laboratory move in 2023. This explanation contradicts the paper's own timeline, which indicates the experiments were performed in 2024.
+
+## What Was Invalidated
+
+<div class="retracted-block">
+<p>Figure 3, Figure S8, and Figure S9 of the original article, along with any claim of independent qPCR validation of the microbiome signature. No validated experimental evidence remains for the signature's predictive performance.</p>
+</div>
+
+## Recommendation for Affected Fields
+
+<div class="editor-note">
+  <p class="note-label">Notice to the Gastrointestinal Oncology Community</p>
+  <p>Clinicians and researchers studying pancreatic cancer microbiome markers should not rely on the retracted Figure 3 qPCR validation. Several subsequent studies (Martinez et al. 2025, Wu et al. 2025) have independently investigated pancreatic cancer microbiome associations with different, non-overlapping taxa sets and should be treated as the current primary evidence base.</p>
+</div>

--- a/retraction-notice/content/sections/3-unverifiable-results.md
+++ b/retraction-notice/content/sections/3-unverifiable-results.md
@@ -1,0 +1,39 @@
++++
+title = "Unverifiable Raw Data"
+description = "Failure of the authors to produce raw sequencing files, sample metadata, and analysis code requested by the investigation committee."
+weight = 3
+template = "post"
+tags = ["reproducibility", "data-sharing", "verification"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+<div class="editor-note">
+  <p class="note-label">Documentation Failure</p>
+  <p>The original article's Data Availability Statement claimed that all raw sequencing data had been deposited in the European Nucleotide Archive (ENA) under accession PRJEB72XXX and that analysis code was available at a public GitHub repository. The investigation confirmed that neither resource contained usable files at the time of the investigation.</p>
+</div>
+
+## Timeline of Data Requests
+
+| Date | Request | Outcome |
+|------|---------|---------|
+| 2025-03-14 | ENA accession PRJEB72XXX (as cited) | Accession does not exist |
+| 2025-04-02 | Raw FASTQ files from corresponding author | No response (30 days) |
+| 2025-05-15 | GitHub repo (as cited) | Repository was deleted 2025-03-20 |
+| 2025-06-10 | Analysis pipeline reconstruction via institutional IT | Institution reports no backup exists |
+| 2025-09-28 | Last-chance request to provide any raw data | 3 Excel files provided, contents inconsistent with supplementary tables |
+
+## Specific Verification Failures
+
+1. **Sequencing reads.** The paper states 127 million paired-end reads were generated across the validation cohort. No FASTQ files, BAM files, or intermediate count tables matching this volume were ever produced.
+
+2. **Sample metadata.** The paper references clinical annotations (tumor staging, treatment history, comorbidities) for 1,247 patients. Consent forms and institutional review board approvals from the three claimed participating hospitals could not be located.
+
+3. **Analysis code.** The data processing pipeline described in the Methods section (DADA2 --> QIIME2 --> custom R scripts) cannot be reproduced without the missing intermediate files. The 3 Excel files provided in September 2025 contain summary statistics only, not the primary data.
+
+## What Was Invalidated
+
+<div class="retracted-block">
+<p>All empirical claims in the original article, including the cohort size, sequencing depth, predictive signature identification, and cross-center validation. Without verifiable primary data, none of the quantitative findings can be independently confirmed.</p>
+</div>

--- a/retraction-notice/content/sections/4-author-dispute.md
+++ b/retraction-notice/content/sections/4-author-dispute.md
@@ -1,0 +1,42 @@
++++
+title = "Author Positions and Dispute"
+description = "Summary of each author's position regarding the retraction and the unresolved dispute with the corresponding author."
+weight = 4
+template = "post"
+tags = ["authorship", "dispute", "cope-process"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## Author-by-Author Positions
+
+<div class="editor-note">
+  <p class="note-label">Position Statements (Received 2026-03-18)</p>
+  <p>Following the investigation committee's determination and the 120-day response period, each of the four authors submitted a written position statement. Three of four agreed to the retraction. One (the corresponding author) disputes the findings.</p>
+</div>
+
+| Author | Position | Reasoning |
+|--------|---------|-----------|
+| Dr. M. Chen (first author) | **Agrees with retraction** | States that analysis work was delegated entirely to the corresponding author and expresses regret at not independently verifying the data. |
+| Dr. R. Patel | **Agrees with retraction** | Was responsible for clinical cohort recruitment only; states that she did not have access to the genomic data during the paper's preparation. |
+| Dr. K. Alvarez-Hwang | **Agrees with retraction** | Contributed to writing only. States that discrepancies identified by the investigation are consistent with concerns she had internally raised before publication that were overruled. |
+| Dr. J. Okonkwo (corresponding author) | **Disputes retraction** | Maintains that all data are genuine, that data loss explains inability to produce raw files, and that the statistical patterns identified by the investigation are coincidental. |
+
+## The Dispute
+
+The corresponding author submitted a 42-page rebuttal to the investigation committee's findings. Key points of disagreement:
+
+1. **Statistical anomalies** -- The author argues that the digit-frequency deviations could reflect specific biological sampling characteristics of the sequencing protocol. The committee's external statistical reviewers (Profs. A. Ioannidis and K. Simonsohn, independent experts) found this argument inconsistent with the protocol described in the paper's methods.
+
+2. **Image manipulation** -- The author states that some image processing was applied to "enhance clarity" and that this was a post-hoc editorial choice, not data manipulation. The committee determined that the specific operations documented (band duplication, background compositing) exceed acceptable editorial modification by the standards adopted by the publisher in 2022.
+
+3. **Missing data** -- The author attributes the missing raw files to a 2023 laboratory move and an overwritten backup server. The committee found this timeline inconsistent with the paper's own 2024 experimental dates and declined to accept the explanation.
+
+## Editorial Decision
+
+Under the COPE retraction guidelines, a retraction can proceed despite author disagreement when the evidence clearly supports it. The Editor-in-Chief's decision was made in consultation with the full editorial board and the publisher's research integrity officer. The decision is final.
+
+## Institutional Response
+
+The home institution of the corresponding author (University of Example, Department of Oncology) was notified on 2025-12-02 and confirmed on 2026-03-31 that an institutional research misconduct inquiry is underway. The outcome of that inquiry is a separate matter from this editorial retraction and will be handled by the institution according to its own policies.

--- a/retraction-notice/content/sections/_index.md
+++ b/retraction-notice/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Investigation Details"
+sort_by = "weight"
+page_template = "post"
++++
+
+Detailed findings from the 14-month investigation that led to the retraction of this article.

--- a/retraction-notice/content/timeline.md
+++ b/retraction-notice/content/timeline.md
@@ -1,0 +1,49 @@
++++
+title = "Complete Investigation Timeline"
+description = "Detailed chronology of all events from original publication through formal retraction."
+tags = ["timeline", "investigation", "cope"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Case Chronology</p>
+  <h1 class="paper-title">Investigation Timeline</h1>
+</header>
+
+<div class="editor-note">
+  <p class="note-label">COPE Process</p>
+  <p>This investigation followed the Committee on Publication Ethics (COPE) Retraction Guidelines (2019). The complete case file is archived with the publisher's research integrity office and can be requested by the institutional authorities of record through formal channels.</p>
+</div>
+
+## Full Chronology
+
+| Date | Event | Action |
+|------|-------|--------|
+| 2024-03-14 | Manuscript submitted | Initial submission to JAG |
+| 2024-05-20 | Peer review completed | 2 of 3 reviewers recommend accept with minor revisions |
+| 2024-07-10 | Revision accepted | Article scheduled for Volume 22, Issue 8 |
+| 2024-08-15 | Article published online | DOI: 10.1234/jag.2024.1872 |
+| 2025-02-06 | Reader concern received | Anonymous reader submits statistical analysis flagging supplementary tables |
+| 2025-02-20 | Editorial review | Concern escalated to Editor-in-Chief |
+| 2025-03-14 | ENA accession check | Cited accession PRJEB72XXX does not exist |
+| 2025-04-02 | COPE process initiated | Formal investigation committee convened |
+| 2025-04-15 | First author contact | Authors asked to provide raw data (30-day window) |
+| 2025-05-15 | Further data requests | GitHub repository found deleted |
+| 2025-06-10 | Institutional contact | Home institution IT asked for server backups |
+| 2025-09-28 | Final data request | Only summary Excel files provided, inconsistent with supp. tables |
+| 2025-10-14 | Statistical forensic analysis | External reviewers confirm Benford's law violations in S3, S7 |
+| 2025-11-05 | Image forensic analysis | Band duplication in Fig. 3B confirmed at 400% pixel resolution |
+| 2025-11-18 | Authors formally notified | 120-day response window under COPE guidelines |
+| 2026-02-15 | Author rebuttal received | 42-page response from corresponding author |
+| 2026-03-10 | Committee review of rebuttal | External reviewers and statistical experts evaluate response |
+| 2026-03-18 | Author position statements | 3 of 4 authors agree with retraction; 1 disputes |
+| 2026-03-31 | Institutional inquiry confirmed | Home institution opens parallel misconduct inquiry |
+| 2026-04-03 | Editorial board vote | 7--0 to proceed with retraction |
+| 2026-04-10 | Retraction published | DOI: 10.1234/jag.2024.1872/retr |
+
+## Key Milestones
+
+- **Duration from concern to retraction:** 14 months and 4 days
+- **Duration from original publication to retraction:** 19 months and 26 days
+- **Number of external reviewers consulted:** 4 (statistical), 2 (image forensics), 2 (clinical relevance)
+- **Number of internal committee members:** 7
+- **Case file total pages:** 387 (including all correspondence, reviewer reports, and forensic analyses)

--- a/retraction-notice/static/css/style.css
+++ b/retraction-notice/static/css/style.css
@@ -1,0 +1,490 @@
+/* ============================================================================
+   Retraction Notice - Withdrawn Paper
+   Light background, heavy display sans for RETRACTED banner, strikethrough
+   academic body text for invalidated claims.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #faf8f5;
+  --bg-2: #f4ede3;
+  --bg-3: #ede2d0;
+  --rule: #c8b8a0;
+  --ink: #1a1a1a;
+  --ink-2: #2e2e2e;
+  --ink-3: #6a6a6a;
+  --ink-4: #9a9a9a;
+  --retracted: #b83220;
+  --retracted-2: #8e2010;
+  --retracted-light: #fff2e8;
+  --warning: #c07020;
+  --note: #8b4513;
+  --strike: #7a6858;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2rem;
+  position: relative;
+}
+
+/* ---------------- Large RETRACTED diagonal stamp ---------------- */
+
+.retracted-stamp {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-20deg);
+  pointer-events: none;
+  z-index: 0;
+  width: 115vw;
+}
+
+.retracted-stamp svg { width: 100%; height: auto; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 3px solid var(--retracted);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  background: var(--bg);
+  position: relative;
+  z-index: 2;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 48px; height: 44px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+
+.journal-name {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.retraction-ref {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.66rem;
+  color: var(--retracted);
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.8rem;
+}
+
+.site-nav a {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--ink-2);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover { color: var(--retracted); }
+
+/* ---------------- Main Content ---------------- */
+
+.site-main {
+  padding: 2rem 0;
+  position: relative;
+  z-index: 1;
+}
+
+.paper-article {
+  max-width: 780px;
+  margin: 0 auto;
+  background: var(--bg);
+  padding: 1.5rem 2rem;
+  border: 1px solid var(--bg-3);
+  position: relative;
+  z-index: 1;
+}
+
+/* ---------------- Retraction Banner ---------------- */
+
+.retraction-banner {
+  background: var(--retracted);
+  color: #ffffff;
+  padding: 1.2rem 1.5rem;
+  margin: 0 -2rem 2rem;
+  border-top: 4px solid var(--retracted-2);
+  border-bottom: 4px solid var(--retracted-2);
+  text-align: center;
+}
+
+.retraction-banner h2 {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-weight: 700;
+  font-size: 2.6rem;
+  letter-spacing: 0.18em;
+  margin: 0 0 0.4rem;
+  color: #ffffff;
+  line-height: 1;
+}
+
+.retraction-banner p {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.88rem;
+  color: #ffffff;
+  margin: 0;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+/* ---------------- Paper Header ---------------- */
+
+.paper-header {
+  text-align: left;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px dashed var(--retracted);
+}
+
+.paper-eyebrow {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--retracted);
+  margin: 0 0 0.8rem;
+  font-weight: 700;
+}
+
+.paper-title {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  font-size: 1.85rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+  letter-spacing: 0.01em;
+  text-decoration: line-through;
+  text-decoration-color: var(--retracted);
+  text-decoration-thickness: 3px;
+}
+
+.paper-subtitle {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.95rem;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+  font-style: italic;
+}
+
+.paper-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.7;
+}
+
+.paper-meta strong { color: var(--ink-2); }
+
+/* ---------------- Retracted content (strikethrough) ---------------- */
+
+.retracted-text {
+  color: var(--strike);
+  text-decoration: line-through;
+  text-decoration-color: var(--retracted);
+  text-decoration-thickness: 1.5px;
+}
+
+.retracted-block {
+  background: var(--bg-2);
+  border: 1px solid var(--bg-3);
+  border-left: 4px solid var(--retracted);
+  padding: 1rem 1.4rem;
+  margin: 1.2rem 0;
+  position: relative;
+  color: var(--strike);
+  text-decoration: line-through;
+  text-decoration-color: var(--retracted);
+  text-decoration-thickness: 1px;
+  text-decoration-style: solid;
+}
+
+.retracted-block::before {
+  content: "RETRACTED";
+  position: absolute;
+  top: -8px;
+  right: 12px;
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  background: var(--retracted);
+  color: #ffffff;
+  padding: 2px 8px;
+  text-decoration: none;
+}
+
+.retracted-block p { color: var(--strike); }
+
+/* ---------------- Editor's Note boxes ---------------- */
+
+.editor-note {
+  background: var(--retracted-light);
+  border: 1px solid var(--warning);
+  border-left: 4px solid var(--warning);
+  padding: 1rem 1.4rem;
+  margin: 1.2rem 0;
+}
+
+.editor-note .note-label {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--warning);
+  margin: 0 0 0.4rem;
+}
+
+.editor-note p { color: var(--ink-2); margin: 0.3em 0; }
+
+/* ---------------- Headings ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+h1 { font-size: 1.6rem; margin: 2rem 0 0.6rem; letter-spacing: 0.02em; }
+h2 { font-size: 1.3rem; margin: 1.8rem 0 0.5rem; letter-spacing: 0.02em; }
+h3 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 0.95rem; margin: 1.2rem 0 0.4rem; }
+
+/* ---------------- Body Text ---------------- */
+
+p { margin: 0.8em 0; }
+
+a { color: var(--retracted); text-decoration: underline; }
+a:hover { color: var(--retracted-2); }
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--note);
+  background: var(--bg-2);
+  color: var(--ink-2);
+  font-style: italic;
+}
+
+ul, ol { padding-left: 1.5em; }
+li { margin-bottom: 0.3em; }
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.88rem;
+}
+
+th, td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+th {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--retracted);
+  border-bottom: 2px solid var(--ink);
+}
+
+/* ---------------- Section Header ---------------- */
+
+.paper-section-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 2px dashed var(--retracted);
+}
+
+.paper-section-eyebrow {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--retracted);
+  margin: 0 0 0.4rem;
+  font-weight: 700;
+}
+
+.paper-section-title {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  font-size: 1.65rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.02em;
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.92rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+  font-style: italic;
+}
+
+.paper-section-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--retracted);
+  text-decoration: none;
+}
+
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  margin-bottom: 0;
+  padding: 0.7rem 0;
+  border-bottom: 1px dashed var(--rule);
+}
+
+.section-list li a {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.section-list li a:hover { color: var(--retracted); }
+
+/* ---------------- Code ---------------- */
+
+code {
+  font-family: "IBM Plex Mono", Consolas, monospace;
+  font-size: 0.85em;
+  background: var(--bg-2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: var(--bg-2);
+  padding: 1rem;
+  overflow-x: auto;
+  border: 1px solid var(--bg-3);
+}
+
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy & Pagination ---------------- */
+
+.taxonomy-desc { color: var(--ink-3); font-style: italic; margin-bottom: 1.5rem; }
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; font-size: 0.85rem; }
+nav.pagination a:hover { color: var(--retracted); border-color: var(--retracted); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem;
+  padding-bottom: 2rem;
+  position: relative;
+  z-index: 2;
+  background: var(--bg);
+}
+
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 8px; display: block; }
+
+.footer-content { text-align: center; }
+
+.footer-meta {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.82rem;
+  color: var(--retracted);
+  font-weight: 700;
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.1em;
+}
+
+.footer-note {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0;
+  font-style: italic;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.5rem; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; flex-wrap: wrap; }
+  .retraction-banner h2 { font-size: 1.8rem; }
+  .paper-article { padding: 1rem 1.2rem; }
+  .retraction-banner { margin: 0 -1.2rem 1.5rem; }
+}

--- a/retraction-notice/templates/404.html
+++ b/retraction-notice/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested retraction page does not exist.</p>
+      <p><a href="{{ base_url }}/">Return to Retraction Notice</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/retraction-notice/templates/footer.html
+++ b/retraction-notice/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 8" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#b83220" stroke-width="1.2"/>
+          <line x1="0" y1="6" x2="1000" y2="6" stroke="#b83220" stroke-width="0.5" stroke-dasharray="4,3"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">THIS ARTICLE HAS BEEN RETRACTED &middot; Retraction published 2026-04-10 &middot; DOI: 10.1234/jag.2024.1872/retr</p>
+        <p class="footer-note">Any use of the original article in derivative work should cite this retraction notice. Editorial Board, Journal of Applied Genomics. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/retraction-notice/templates/header.html
+++ b/retraction-notice/templates/header.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Oswald:wght@400;600;700&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <!-- Large RETRACTED diagonal stamp overlaying all content -->
+    <div class="retracted-stamp" aria-hidden="true">
+      <svg viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+        <!-- Outer stamp border -->
+        <rect x="20" y="30" width="760" height="140" rx="2" fill="none" stroke="#b83220" stroke-width="6" opacity="0.22"/>
+        <rect x="30" y="40" width="740" height="120" rx="2" fill="none" stroke="#b83220" stroke-width="2" opacity="0.22"/>
+        <!-- RETRACTED text -->
+        <text x="400" y="125" text-anchor="middle" font-family="'Bebas Neue','Oswald',sans-serif" font-size="110" font-weight="700" fill="#b83220" opacity="0.22" letter-spacing="0.08em">RETRACTED</text>
+      </svg>
+    </div>
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Retraction home">
+        <!-- SVG warning triangle icon at paper header -->
+        <svg viewBox="0 0 48 44" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Warning triangle -->
+          <path d="M24,4 L44,38 L4,38 Z" fill="#fff2e8" stroke="#b83220" stroke-width="2"/>
+          <!-- Exclamation mark -->
+          <line x1="24" y1="16" x2="24" y2="28" stroke="#b83220" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="24" cy="33" r="1.8" fill="#b83220"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Journal of Applied Genomics &middot; Editorial Board</span>
+          <span class="retraction-ref">Retraction Notice &middot; 2026-04-10 &middot; DOI: 10.1234/jag.2024.1872/retr</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">NOTICE</a>
+        <a href="{{ base_url }}/sections/">DETAILS</a>
+        <a href="{{ base_url }}/original/">ORIGINAL</a>
+        <a href="{{ base_url }}/timeline/">TIMELINE</a>
+      </nav>
+    </header>

--- a/retraction-notice/templates/page.html
+++ b/retraction-notice/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/retraction-notice/templates/post.html
+++ b/retraction-notice/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to details index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/retraction-notice/templates/section.html
+++ b/retraction-notice/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">RETRACTION DETAILS</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/retraction-notice/templates/shortcodes/alert.html
+++ b/retraction-notice/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #fff2e8; border-left: 5px solid #b83220; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/retraction-notice/templates/taxonomy.html
+++ b/retraction-notice/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/retraction-notice/templates/taxonomy_term.html
+++ b/retraction-notice/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4249,5 +4249,12 @@
     "thesis",
     "formal",
     "institutional"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
   ]
 }


### PR DESCRIPTION
## Summary
- Add retraction-notice example site: an editorial retraction notice for a withdrawn research paper on pancreatic cancer microbiome biomarkers
- Features SVG RETRACTED diagonal stamp overlaying entire paper content as a fixed watermark, SVG warning triangle icons at the paper header logo, and a bold retraction banner
- Typography uses Bebas Neue / Oswald Black for the RETRACTED banner and headings, and Crimson Pro with CSS line-through decoration for strikethrough academic body text showing invalidated claims
- Includes 4 investigation detail sections (data fabrication, image manipulation, unverifiable results, author dispute), complete chronological timeline with SVG event markers, original article reference, and editorial statement with COPE process documentation

Closes #1597