### PR TITLE
feat: add center-stage example site (closes #1590)

### DIFF
--- a/center-stage/AGENTS.md
+++ b/center-stage/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/center-stage/config.toml
+++ b/center-stage/config.toml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Center Stage - All Eyes Here
+# Issue #1590 | Tags: event, solo, show, spotlight, centered
+# =============================================================================
+
+title = "Center Stage"
+description = "A solo show event site featuring a single large spotlight hero, solo figure silhouette, and bold theatrical typography centred on the performer."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/center-stage/content/index.md
+++ b/center-stage/content/index.md
@@ -1,0 +1,126 @@
++++
+title = "One Voice, One Night"
+description = "CENTER STAGE -- A solo show with Vera Callahan, one night only at the Orpheum Theatre, Brooklyn."
+tags = ["event", "solo", "show", "spotlight", "centered"]
++++
+
+<section class="spotlight-hero" aria-label="Hero spotlight">
+<!-- SVG single large spotlight circle as the only hero element + solo figure silhouette -->
+<svg class="spotlight-svg" viewBox="0 0 1200 720" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+  <!-- Black stage background -->
+  <rect width="1200" height="720" fill="#050505"/>
+
+  <!-- Floor suggestion -->
+  <rect x="0" y="600" width="1200" height="120" fill="#0a0a0a"/>
+  <line x1="0" y1="600" x2="1200" y2="600" stroke="#1a1a1a" stroke-width="1"/>
+
+  <!-- Spotlight beam from above (traced rays, solid lines, no gradient) -->
+  <!-- Outer spotlight rays -->
+  <polygon points="600,0 480,720 720,720" fill="#f4d35e" opacity="0.03"/>
+  <polygon points="600,0 505,720 695,720" fill="#f4d35e" opacity="0.05"/>
+  <polygon points="600,0 530,720 670,720" fill="#f4d35e" opacity="0.07"/>
+  <polygon points="600,0 555,720 645,720" fill="#f4d35e" opacity="0.1"/>
+
+  <!-- THE single large spotlight circle -->
+  <circle cx="600" cy="440" r="260" fill="#f4d35e" opacity="0.08"/>
+  <circle cx="600" cy="440" r="220" fill="#f4d35e" opacity="0.11"/>
+  <circle cx="600" cy="440" r="180" fill="#f4d35e" opacity="0.15"/>
+  <circle cx="600" cy="440" r="140" fill="#f4d35e" opacity="0.22"/>
+  <circle cx="600" cy="440" r="100" fill="#f4d35e" opacity="0.3"/>
+
+  <!-- Solo figure silhouette standing in the light -->
+  <g transform="translate(600,600)">
+    <!-- Head -->
+    <circle cx="0" cy="-180" r="18" fill="#000000"/>
+    <!-- Shoulders/neck -->
+    <path d="M-6,-162 L-6,-152 L-28,-130 L-30,-95 L-14,-88 L-8,-90 L-6,-60 L6,-60 L8,-90 L14,-88 L30,-95 L28,-130 L6,-152 L6,-162 Z" fill="#000000"/>
+    <!-- Torso -->
+    <path d="M-20,-95 L-22,-40 L-18,0 L-8,0 L-6,-30 L6,-30 L8,0 L18,0 L22,-40 L20,-95 Z" fill="#000000"/>
+    <!-- Legs -->
+    <rect x="-16" y="-5" width="12" height="5" fill="#000000"/>
+    <rect x="4" y="-5" width="12" height="5" fill="#000000"/>
+  </g>
+
+  <!-- Spotlight rim -->
+  <circle cx="600" cy="440" r="260" fill="none" stroke="#f4d35e" stroke-width="0.5" opacity="0.3"/>
+</svg>
+
+<div class="spotlight-content">
+  <p class="performer-eyebrow">One Night Only</p>
+  <h1 class="performer-name">VERA CALLAHAN</h1>
+  <p class="performer-tagline">A Solo Show</p>
+  <p class="performer-date">Saturday, May 16</p>
+  <p class="performer-time">Doors 7:30pm &middot; Show 8:00pm</p>
+  <a href="#tickets" class="cta-button">Reserve a Seat</a>
+</div>
+</section>
+
+<div class="show-info">
+
+## About the Show
+
+For ninety uninterrupted minutes, Vera Callahan holds the stage alone. No band. No scenery. No intermission. Just a voice, a spotlight, and a room full of strangers leaning forward.
+
+"Center Stage" draws from fifteen years of songbook, stripped back to the bone. Songs that filled stadiums. Songs that never left the notebook. Spoken asides that would be cut from any other show. This one runs exactly once.
+
+</div>
+
+<div class="detail-grid">
+  <div class="detail-card">
+    <p class="detail-label">Date</p>
+    <p class="detail-value">MAY 16</p>
+    <p class="detail-sub">Saturday, 2026</p>
+  </div>
+  <div class="detail-card">
+    <p class="detail-label">Venue</p>
+    <p class="detail-value">ORPHEUM</p>
+    <p class="detail-sub">142 Grand Ave, Brooklyn</p>
+  </div>
+  <div class="detail-card">
+    <p class="detail-label">Capacity</p>
+    <p class="detail-value">348</p>
+    <p class="detail-sub">General admission</p>
+  </div>
+  <div class="detail-card">
+    <p class="detail-label">Runtime</p>
+    <p class="detail-value">90 MIN</p>
+    <p class="detail-sub">No intermission</p>
+  </div>
+  <div class="detail-card">
+    <p class="detail-label">Age Rating</p>
+    <p class="detail-value">16+</p>
+    <p class="detail-sub">Some strong language</p>
+  </div>
+  <div class="detail-card">
+    <p class="detail-label">Seat Price</p>
+    <p class="detail-value">$48</p>
+    <p class="detail-sub">Single tier only</p>
+  </div>
+</div>
+
+<div class="show-info">
+
+## Set List (Partial)
+
+> The only set list shared in advance lists the first three songs. The rest are deliberately left blank.
+
+1. Hollow Hours
+2. Before the Letter
+3. A Town We Called Home
+4. ...
+5. ...
+6. ...
+
+## What the Room Hears
+
+"Callahan's solo shows are the closest a performer can come to vanishing and still being heard." -- **The Atlantic**
+
+"Ninety minutes. No escape. You leave knowing you were somewhere." -- **NYT Arts**
+
+"There is no opener. There is no break. There is only the spotlight, and the woman inside it." -- **Pitchfork**
+
+## Access and Accessibility
+
+The Orpheum is step-free from the Grand Avenue entrance. Accessible seating is reserved in rows A-C. Assistive listening devices available at the box office. BSL-interpreted performance available on request -- contact the box office at least two weeks ahead.
+
+</div>

--- a/center-stage/content/performer.md
+++ b/center-stage/content/performer.md
@@ -1,0 +1,40 @@
++++
+title = "The Performer"
+description = "About Vera Callahan -- fifteen years of work, stripped to one voice on one stage."
+tags = ["performer", "bio"]
++++
+
+## VERA CALLAHAN
+
+Vera Callahan has released six studio albums and played every room from Brooklyn basements to arena floors. In 2020, she walked off a tour stage in Chicago, returned her advance, and spent four years writing in a house with no internet.
+
+"Center Stage" is the first show of the next chapter.
+
+## The Work So Far
+
+| Year | Work | Notes |
+|---|---|---|
+| 2011 | *Hollow Hours* (EP) | Self-released debut |
+| 2013 | *Before the Letter* (album) | Pitchfork 8.6 |
+| 2015 | *A Town We Called Home* | Grammy nomination, Best Folk Album |
+| 2017 | *Quiet Country, Loud Year* | UK #3, US #12 |
+| 2019 | *The Long Hall* (live) | Recorded in one take at Red Rocks |
+| 2024 | *Return* (album) | First studio album in 5 years |
+
+## Why Solo
+
+> "I spent a decade pretending a band made the songs bigger. They didn't. They made them louder. That's not the same thing. This show is me finding out what these songs sound like when there's nowhere to hide."
+
+-- Vera Callahan, March 2026
+
+## Contact
+
+Press inquiries: press@centerstage-nyc.example
+
+Tour management: Atlantic Talent Agency, New York
+
+Booking: not booking.
+
+## Rider
+
+No backing musicians. No support act. No recording. One follow-spot. One stool. One microphone on a stand. One glass of water.

--- a/center-stage/content/tickets.md
+++ b/center-stage/content/tickets.md
@@ -1,0 +1,41 @@
++++
+title = "Tickets"
+description = "One show. One night. One price. General admission seating at the Orpheum Theatre, Brooklyn."
+tags = ["tickets", "booking"]
++++
+
+## ONE SHOW. ONE NIGHT. ONE PRICE.
+
+**$48 per seat. 348 seats total. General admission.**
+
+Tickets go on sale Wednesday, April 22 at 10:00am Eastern. No pre-sale. No VIP tier. No promoter holds. No reserved rows except those held for accessibility and press.
+
+## How to Buy
+
+Tickets are sold exclusively through the Orpheum box office:
+
+- **Online:** orpheum-brooklyn.example/tickets
+- **By phone:** (718) 555-0142, Mon-Fri 12:00-6:00pm
+- **In person:** 142 Grand Avenue, Brooklyn, Wed-Sat 2:00-8:00pm
+
+A single purchase is limited to four tickets. Photo ID matching the name on the ticket is required at the door.
+
+## If the Show Sells Out
+
+No second night will be added.
+
+No livestream will be announced.
+
+A recording of the show will not be released.
+
+## Resale Policy
+
+Tickets sold above face value will be voided at the door without refund. If your plans change, resell through the Orpheum's resale portal at face value only.
+
+## Refunds
+
+Refunds available up to 48 hours before the show. After that, no refunds except in case of cancellation by the performer or venue.
+
+## Waiting List
+
+If the show sells out, a waiting list opens for any returned tickets. Add yourself on the purchase page; the system allocates released seats automatically in the order you joined.

--- a/center-stage/content/venue.md
+++ b/center-stage/content/venue.md
@@ -1,0 +1,49 @@
++++
+title = "The Venue"
+description = "The Orpheum Theatre, Brooklyn -- 348 seats, one stage, one light."
+tags = ["venue", "orpheum", "brooklyn"]
++++
+
+## THE ORPHEUM THEATRE
+
+142 Grand Avenue &middot; Brooklyn NY 11217
+
+The Orpheum was built in 1924 as a vaudeville house. It has been a cinema, a church, and -- briefly in 2004 -- a flag warehouse. It reopened as a live venue in 2011 after a restoration that preserved the original plaster, the raked seating, and the 1930s rigging in the flies.
+
+## Getting There
+
+**Subway:** C or G to Clinton-Washington, 3 blocks south.
+**Bus:** B38 stops at Clinton and Grand.
+**Cycling:** Citi Bike station outside the main doors; theatre racks in the lobby.
+**Driving:** Discouraged. Street parking only. Nearest paid garage is six blocks north.
+
+## Inside
+
+The room seats 348 people across three tiers of raked stalls. There is no balcony. The stage is 24 feet wide, 16 feet deep, and 3 feet high. There is one follow-spot rigged dead centre. For this show, nothing else will be used.
+
+## Doors and Timing
+
+- **Doors:** 7:30pm
+- **Show starts:** 8:00pm (hard start, no latecomer admissions)
+- **Show ends:** approximately 9:30pm
+- **No intermission.**
+
+If you arrive after 8:00pm, you will not be seated until the show ends. This is a rule the Orpheum enforces without exception. Please plan accordingly.
+
+## Food and Drink
+
+The lobby bar serves drinks until 7:50pm. Nothing is served during the show. No drinks are permitted in the house. A water station is available near each entrance.
+
+## Photography and Recording
+
+Phones must be in airplane mode from 7:55pm until the show ends. Photography, audio recording, and video recording are prohibited. Approved press photographers will be credentialed at the box office.
+
+## Accessibility
+
+- Step-free entry from Grand Avenue
+- Accessible seating in rows A-C
+- Assistive listening devices at the box office
+- Accessible restrooms on the main and lobby levels
+- Service animals welcome
+
+Contact the box office at least two weeks ahead to request BSL-interpreted performance, large-print programmes, or any other accommodation.

--- a/center-stage/static/css/style.css
+++ b/center-stage/static/css/style.css
@@ -1,0 +1,286 @@
+/* ============================================================================
+   Center Stage - All Eyes Here
+   Black stage background, yellow spotlight, bold theatrical sans.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #050505;
+  --bg-2: #0f0f0f;
+  --bg-3: #1a1a1a;
+  --rule: #2a2a2a;
+  --ink: #ffffff;
+  --ink-2: #cccccc;
+  --ink-3: #888888;
+  --ink-4: #555555;
+  --spot: #f4d35e;
+  --spot-dim: rgba(244,211,94,0.15);
+  --accent: #f4d35e;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-2);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.stage-wrap { max-width: 1200px; margin: 0 auto; padding: 0 2rem; position: relative; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.5rem 0 1.2rem; position: relative; z-index: 10;
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.8rem; color: var(--spot); text-decoration: none; }
+.site-logo:hover { opacity: 0.85; }
+.logo-mark { width: 44px; height: 44px; }
+.logo-text {
+  font-family: "Anton", "Oswald", sans-serif;
+  font-weight: 400; font-size: 1.2rem;
+  color: var(--spot); letter-spacing: 0.08em;
+}
+
+.site-nav { display: flex; gap: 1.8rem; }
+.site-nav a {
+  font-family: "Oswald", "Inter", sans-serif;
+  font-size: 0.82rem; font-weight: 600; letter-spacing: 0.12em;
+  color: var(--ink-3); text-decoration: none; text-transform: uppercase;
+  padding-bottom: 0.3rem; border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.site-nav a:hover { color: var(--spot); border-bottom-color: var(--spot); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 0 0 4rem; position: relative; }
+
+.stage-article { max-width: 100%; }
+
+/* ---------------- HERO: Single large spotlight circle ---------------- */
+
+.spotlight-hero {
+  position: relative;
+  height: 720px;
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+  background: var(--bg);
+  margin: 0 -2rem 4rem;
+}
+
+.spotlight-svg {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  display: block;
+}
+
+.spotlight-content {
+  position: relative; z-index: 2;
+  text-align: center;
+  max-width: 720px;
+  padding: 2rem;
+}
+
+.performer-eyebrow {
+  font-family: "Oswald", sans-serif;
+  font-size: 0.9rem; font-weight: 600; letter-spacing: 0.25em;
+  text-transform: uppercase; color: var(--spot);
+  margin: 0 0 1rem;
+}
+
+.performer-name {
+  font-family: "Anton", "Oswald", sans-serif;
+  font-weight: 400; font-size: 5.5rem; line-height: 0.9;
+  color: var(--ink); margin: 0 0 1rem;
+  letter-spacing: 0.01em;
+}
+
+.performer-tagline {
+  font-family: "Oswald", sans-serif;
+  font-size: 1.2rem; font-weight: 400;
+  color: var(--ink-2); margin: 0 0 2rem;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+
+.performer-date {
+  font-family: "Anton", "Oswald", sans-serif;
+  font-size: 2.4rem; font-weight: 400;
+  color: var(--spot); margin: 1rem 0 0;
+  letter-spacing: 0.04em;
+}
+
+.performer-time {
+  font-family: "Oswald", sans-serif;
+  font-size: 1rem; font-weight: 500;
+  color: var(--ink-3); margin: 0.4rem 0 2rem;
+  letter-spacing: 0.1em;
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 1rem 2.4rem;
+  background: var(--spot); color: var(--bg);
+  font-family: "Anton", "Oswald", sans-serif;
+  font-size: 1.1rem; font-weight: 400; letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 3px solid var(--spot);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.cta-button:hover {
+  background: var(--bg); color: var(--spot);
+}
+
+/* ---------------- Show info sections ---------------- */
+
+.show-info {
+  max-width: 720px; margin: 3rem auto;
+  text-align: center;
+}
+
+.show-info h2 {
+  font-family: "Anton", sans-serif;
+  font-size: 2.2rem; font-weight: 400;
+  color: var(--ink); margin: 2rem 0 1rem;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+
+.show-info p {
+  font-size: 1.05rem; line-height: 1.75;
+  color: var(--ink-2); margin: 1rem 0;
+}
+
+.detail-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem; margin: 2.5rem 0;
+}
+
+.detail-card {
+  background: var(--bg-2); border: 1px solid var(--rule);
+  padding: 1.5rem 1.2rem; text-align: center;
+}
+
+.detail-label {
+  font-family: "Oswald", sans-serif;
+  font-size: 0.72rem; font-weight: 600;
+  color: var(--spot); letter-spacing: 0.15em;
+  text-transform: uppercase; margin: 0 0 0.6rem;
+}
+
+.detail-value {
+  font-family: "Anton", sans-serif;
+  font-size: 1.4rem; font-weight: 400;
+  color: var(--ink); letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.detail-sub {
+  font-family: "Inter", sans-serif;
+  font-size: 0.82rem; color: var(--ink-3);
+  margin: 0.3rem 0 0;
+}
+
+/* ---------------- Typography ---------------- */
+
+h1, h2, h3 {
+  font-family: "Anton", "Oswald", sans-serif;
+  color: var(--ink); line-height: 1.15;
+  font-weight: 400;
+}
+h1 { font-size: 2.4rem; margin: 2rem 0 1rem; text-transform: uppercase; letter-spacing: 0.04em; }
+h2 { font-size: 1.8rem; margin: 1.8rem 0 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+h3 { font-size: 1.3rem; margin: 1.5rem 0 0.6rem; font-family: "Oswald", sans-serif; font-weight: 600; letter-spacing: 0.05em; }
+
+p { margin: 1rem 0; }
+
+a { color: var(--spot); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+strong { color: var(--ink); font-weight: 700; }
+
+/* Tables */
+table {
+  width: 100%; border-collapse: collapse; margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+th {
+  font-family: "Oswald", sans-serif;
+  font-weight: 600; font-size: 0.78rem; letter-spacing: 0.08em;
+  text-transform: uppercase; text-align: left;
+  padding: 0.6rem 0.8rem; border-bottom: 2px solid var(--spot);
+  color: var(--spot);
+}
+td {
+  padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 3px solid var(--spot);
+  margin: 1.5rem 0; padding: 0.6rem 1.2rem;
+  background: var(--bg-2); color: var(--ink-2);
+  font-family: "Oswald", sans-serif;
+  font-style: italic;
+}
+
+/* Section list */
+.section-list {
+  list-style: none; padding: 0; margin: 1.5rem 0;
+}
+.section-list li {
+  margin-bottom: 0.6rem; padding: 0.8rem 1rem;
+  background: var(--bg-2); border: 1px solid var(--rule);
+  border-left: 4px solid var(--spot);
+}
+.section-list li a {
+  font-family: "Oswald", sans-serif;
+  font-weight: 600; color: var(--ink);
+  letter-spacing: 0.04em;
+}
+
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem; padding: 2rem 0;
+  border-top: 1px solid var(--rule);
+  text-align: center;
+}
+.footer-brand {
+  font-family: "Anton", sans-serif;
+  font-size: 0.95rem; letter-spacing: 0.18em;
+  color: var(--spot); margin: 0 0 0.6rem;
+}
+.footer-meta {
+  font-family: "Oswald", sans-serif;
+  font-size: 0.82rem; color: var(--ink-3);
+  letter-spacing: 0.06em; margin: 0 0 0.4rem;
+}
+.footer-copyright {
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem; color: var(--ink-4);
+  margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .stage-wrap { padding: 0 1.2rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .site-nav { gap: 1rem; flex-wrap: wrap; }
+  .spotlight-hero { height: 560px; margin: 0 -1.2rem 2rem; }
+  .performer-name { font-size: 3.2rem; }
+  .performer-date { font-size: 1.6rem; }
+  h1 { font-size: 1.8rem; }
+  h2 { font-size: 1.4rem; }
+}

--- a/center-stage/templates/404.html
+++ b/center-stage/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="stage-article">
+      <h1>404 -- PAGE OFF STAGE</h1>
+      <p>The page you are looking for has left the spotlight.</p>
+      <p><a href="{{ base_url }}/">Return to center stage</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/center-stage/templates/footer.html
+++ b/center-stage/templates/footer.html
@@ -1,0 +1,11 @@
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <p class="footer-brand">CENTER STAGE &middot; SOLO &middot; ONE NIGHT</p>
+        <p class="footer-meta">The Orpheum Theatre &middot; 142 Grand Avenue &middot; Brooklyn NY 11217</p>
+        <p class="footer-copyright">Copyright 2026 Center Stage Productions. All rights reserved.</p>
+      </div>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/center-stage/templates/header.html
+++ b/center-stage/templates/header.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Oswald:wght@400;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="stage-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Center Stage home">
+        <svg viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Single spotlight ring icon -->
+          <circle cx="22" cy="22" r="16" fill="none" stroke="#f4d35e" stroke-width="1.5"/>
+          <circle cx="22" cy="22" r="8" fill="#f4d35e" opacity="0.9"/>
+          <circle cx="22" cy="22" r="4" fill="#0a0a0a"/>
+        </svg>
+        <span class="logo-text">CENTER STAGE</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">SHOW</a>
+        <a href="{{ base_url }}/performer/">PERFORMER</a>
+        <a href="{{ base_url }}/tickets/">TICKETS</a>
+        <a href="{{ base_url }}/venue/">VENUE</a>
+      </nav>
+    </header>

--- a/center-stage/templates/page.html
+++ b/center-stage/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="stage-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/center-stage/templates/section.html
+++ b/center-stage/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="stage-article">
+      <h1>{{ page.title | e }}</h1>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/center-stage/templates/shortcodes/alert.html
+++ b/center-stage/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #2a2a2a; background-color: #0f0f0f; border-left: 5px solid #f4d35e; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/center-stage/templates/taxonomy.html
+++ b/center-stage/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="stage-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/center-stage/templates/taxonomy_term.html
+++ b/center-stage/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="stage-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -624,6 +624,13 @@
     "celestial",
     "trendy"
   ],
+  "center-stage": [
+    "event",
+    "solo",
+    "show",
+    "spotlight",
+    "centered"
+  ],
   "chain-reaction": [
     "event",
     "dark",


### PR DESCRIPTION
Closes #1590

## Summary
- Add center-stage example site: a dark-themed solo show event site with a single large spotlight hero
- Features inline SVG single large spotlight circle as the only hero element with concentric opacity rings
- Features inline SVG solo figure silhouette standing in the light
- Typography: Anton / Oswald (bold theatrical sans) for performer name, Inter for event details
- Includes show landing page, performer bio, tickets page, and venue information
- Tags: event, solo, show, spotlight, centered

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check spotlight circle hero SVG renders with solo figure in center
- [ ] Verify theatrical typography with bold Anton display font
- [ ] Confirm dark theme with no CSS gradients
- [ ] Check tags.json entry is valid JSON