### PR TITLE
feat: add hall-of-voices example site (closes #1589)

### DIFF
--- a/hall-of-voices/AGENTS.md
+++ b/hall-of-voices/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/hall-of-voices/config.toml
+++ b/hall-of-voices/config.toml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Hall of Voices - Resonant Chamber
+# Issue #1589 | Tags: event, poetry, spoken-word, slam, voices
+# =============================================================================
+
+title = "Hall of Voices"
+description = "A spoken-word and poetry slam event site featuring concentric sound wave arcs, open book layout, and expressive display typography for the resonant chamber."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/hall-of-voices/content/index.md
+++ b/hall-of-voices/content/index.md
@@ -1,0 +1,184 @@
++++
+title = "The Night"
+description = "HALL OF VOICES -- A monthly spoken-word and poetry slam in The Long Room, Dublin. First Fridays, always."
+tags = ["event", "poetry", "spoken-word", "slam", "voices"]
++++
+
+<section class="hall-hero" aria-label="Hero with concentric sound waves">
+<!-- SVG concentric sound wave arcs emanating from a center point -->
+<svg class="hero-svg" viewBox="0 0 1200 680" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+  <!-- Paper background -->
+  <rect width="1200" height="680" fill="#f7efde"/>
+
+  <!-- Center point (the mouth, the microphone) -->
+  <circle cx="600" cy="340" r="6" fill="#c9472b"/>
+
+  <!-- Concentric sound wave arcs emanating from the center -->
+  <!-- Inner rings -->
+  <circle cx="600" cy="340" r="28" fill="none" stroke="#c9472b" stroke-width="1.5" opacity="0.85"/>
+  <circle cx="600" cy="340" r="54" fill="none" stroke="#c9472b" stroke-width="1.3" opacity="0.75"/>
+  <circle cx="600" cy="340" r="82" fill="none" stroke="#c9472b" stroke-width="1.2" opacity="0.65"/>
+  <circle cx="600" cy="340" r="112" fill="none" stroke="#c9472b" stroke-width="1.1" opacity="0.55"/>
+  <circle cx="600" cy="340" r="144" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.48"/>
+  <circle cx="600" cy="340" r="178" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.42"/>
+  <circle cx="600" cy="340" r="214" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.36"/>
+  <circle cx="600" cy="340" r="252" fill="none" stroke="#c9472b" stroke-width="0.9" opacity="0.3"/>
+  <circle cx="600" cy="340" r="292" fill="none" stroke="#c9472b" stroke-width="0.9" opacity="0.24"/>
+  <circle cx="600" cy="340" r="334" fill="none" stroke="#c9472b" stroke-width="0.8" opacity="0.18"/>
+  <circle cx="600" cy="340" r="378" fill="none" stroke="#c9472b" stroke-width="0.8" opacity="0.14"/>
+  <circle cx="600" cy="340" r="424" fill="none" stroke="#c9472b" stroke-width="0.7" opacity="0.1"/>
+  <circle cx="600" cy="340" r="472" fill="none" stroke="#c9472b" stroke-width="0.7" opacity="0.08"/>
+  <circle cx="600" cy="340" r="522" fill="none" stroke="#c9472b" stroke-width="0.6" opacity="0.06"/>
+
+  <!-- Subtle interior arc details -->
+  <path d="M 450 340 Q 600 200 750 340" fill="none" stroke="#c9472b" stroke-width="0.5" opacity="0.15"/>
+  <path d="M 400 340 Q 600 150 800 340" fill="none" stroke="#c9472b" stroke-width="0.5" opacity="0.12"/>
+</svg>
+
+<div class="hero-content">
+  <p class="hero-eyebrow">First Fridays &middot; Monthly Residency &middot; Dublin</p>
+  <h1 class="hero-title">Hall of <em>Voices</em></h1>
+  <p class="hero-lede">One room, one microphone, and every voice that walks in.</p>
+  <p class="hero-date">Friday, May 1st</p>
+  <p class="hero-time">DOORS 7:30PM &middot; FIRST READER 8:00PM</p>
+</div>
+</section>
+
+## The Room Tonight
+
+The Long Room holds seventy-two chairs, one microphone, and a tradition that started in a flat above a chemist's in 2018. On the first Friday of every month we open it for three hours. One half is a featured lineup; the other half is open mic. No poems longer than five minutes. No poems shorter than one. No themes, no judges, no slam scoring.
+
+The voices carry. The room is plaster and wood and very old. You will hear what the person behind you is saying before they say it.
+
+## Featured Lineup -- May 1
+
+<div class="lineup-grid">
+  <div class="poet-card">
+    <p class="poet-name">Niamh O Broin</p>
+    <p class="poet-role">Headliner</p>
+    <p class="poet-bio">Irish Times poet of the year 2025. New pamphlet "Low Language" out this spring.</p>
+  </div>
+  <div class="poet-card">
+    <p class="poet-name">Kofi Asamoah</p>
+    <p class="poet-role">Featured</p>
+    <p class="poet-bio">Accra-born, Dublin-based. Founder of the Long Friday Sessions.</p>
+  </div>
+  <div class="poet-card">
+    <p class="poet-name">Irene Vega</p>
+    <p class="poet-role">Featured</p>
+    <p class="poet-bio">Madrid. Bilingual reader. Slam finalist, Berlin 2024.</p>
+  </div>
+  <div class="poet-card">
+    <p class="poet-name">Sean Lacey</p>
+    <p class="poet-role">Host</p>
+    <p class="poet-bio">Co-founded Hall of Voices in 2018. Keeps the mic on time.</p>
+  </div>
+</div>
+
+## From the Book
+
+<!-- SVG open book/pages shape for poetry reading sections -->
+<figure class="book-section">
+<svg class="book-svg" viewBox="0 0 800 320" xmlns="http://www.w3.org/2000/svg" aria-label="Open book frame for poetry reading" aria-hidden="true">
+  <!-- Left page -->
+  <path d="M 30 20 Q 30 10 40 10 L 390 10 L 400 30 L 400 290 L 390 310 L 40 310 Q 30 310 30 300 Z"
+        fill="#faf2e0" stroke="#c9b892" stroke-width="1"/>
+  <!-- Left page lines suggestion -->
+  <line x1="60" y1="50" x2="370" y2="50" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="80" x2="370" y2="80" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="110" x2="350" y2="110" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="140" x2="370" y2="140" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="170" x2="340" y2="170" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="200" x2="370" y2="200" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="230" x2="360" y2="230" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="60" y1="260" x2="340" y2="260" stroke="#e6d8bd" stroke-width="0.5"/>
+
+  <!-- Spine in the middle -->
+  <line x1="400" y1="30" x2="400" y2="290" stroke="#c9b892" stroke-width="1.2"/>
+  <line x1="398" y1="20" x2="398" y2="310" stroke="#c9b892" stroke-width="0.5" opacity="0.5"/>
+  <line x1="402" y1="20" x2="402" y2="310" stroke="#c9b892" stroke-width="0.5" opacity="0.5"/>
+
+  <!-- Right page -->
+  <path d="M 400 30 L 410 10 L 760 10 Q 770 10 770 20 L 770 300 Q 770 310 760 310 L 410 310 L 400 290 Z"
+        fill="#faf2e0" stroke="#c9b892" stroke-width="1"/>
+  <!-- Right page lines -->
+  <line x1="430" y1="50" x2="740" y2="50" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="80" x2="740" y2="80" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="110" x2="720" y2="110" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="140" x2="740" y2="140" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="170" x2="710" y2="170" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="200" x2="740" y2="200" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="230" x2="730" y2="230" stroke="#e6d8bd" stroke-width="0.5"/>
+  <line x1="430" y1="260" x2="710" y2="260" stroke="#e6d8bd" stroke-width="0.5"/>
+
+  <!-- Page corner decorations -->
+  <path d="M 30 20 Q 40 15 50 20" fill="none" stroke="#c9b892" stroke-width="0.5"/>
+  <path d="M 770 20 Q 760 15 750 20" fill="none" stroke="#c9b892" stroke-width="0.5"/>
+</svg>
+</figure>
+
+<div class="open-book">
+<div class="book-page">
+
+### Low Language
+
+<p class="poem-author">Niamh O Broin</p>
+
+<p class="poem-verse">
+We spoke in the old kitchen<br>
+with the door ajar to the yard.<br>
+Nothing we said was important.<br>
+Everything we said was important.<br>
+The cups got cold between us.<br>
+The light went, and no one stood up<br>
+to turn on the lamp, and so<br>
+we sat in what was left of it.
+</p>
+
+</div>
+<div class="book-page">
+
+### After the Long Rain
+
+<p class="poem-author">Kofi Asamoah</p>
+
+<p class="poem-verse">
+The road came back as a road.<br>
+The field came back as a field.<br>
+The child who had been wading<br>
+stood up in shorts that stuck.<br>
+The woman who had been shouting<br>
+lowered her arms. The evening<br>
+kept arriving. The evening<br>
+arrived.
+</p>
+
+</div>
+</div>
+
+<p style="text-align:center;margin:3rem 0;"><a href="#open-mic" class="cta">Sign up for Open Mic</a></p>
+
+## What It Costs
+
+| Ticket | Price | Notes |
+|---|---|---|
+| Standard | EUR 8 | Seat reserved until 7:55pm |
+| Student / Unwaged | EUR 5 | Any ID |
+| Open mic reader | Free | Limited to 12 slots, ballot |
+| Hall pass (12 months) | EUR 60 | Priority entry, guaranteed seat |
+
+## House Rules
+
+1. No poems longer than five minutes. The host will time you.
+2. No recording without the reader's permission. Ask first.
+3. Listen while others read. This is why we come.
+4. Content warnings are welcome; they are not required.
+5. Heckling is for comedy clubs, not for here.
+
+## What Others Have Called It
+
+> "The most honest room in Dublin. Nothing to prove and nowhere to hide."
+> -- Hot Press
+
+> "A small room, a large tradition."
+> -- The Irish Times

--- a/hall-of-voices/content/poets.md
+++ b/hall-of-voices/content/poets.md
@@ -1,0 +1,46 @@
++++
+title = "The Poets"
+description = "Featured readers for the May 1st residency at Hall of Voices, and the full roster for the year ahead."
+tags = ["poets", "lineup"]
++++
+
+## MAY 1 -- FEATURED LINEUP
+
+### Niamh O Broin -- Headliner
+
+Niamh writes in a hybrid of Irish and English, often in the same line. Her 2024 pamphlet *Low Language* won the Strong-Shine Poetry Prize. She lives in Sligo, teaches in Dublin two days a week, and answers email mostly on Thursdays.
+
+> "I write slowly because the sentence is a slow instrument."
+
+### Kofi Asamoah -- Featured
+
+Born in Accra, Kofi moved to Dublin in 2012. He co-founded the Long Friday Sessions in 2016 and has been reading at Hall of Voices since our third month. His work appears in *The Stinging Fly*, *Poetry Ireland Review*, and most recently the anthology *New Irish Writing 2025*.
+
+### Irene Vega -- Featured
+
+Irene is a bilingual Spanish and English reader from Madrid. She was a 2024 slam finalist in Berlin and a 2023 finalist at the Glasgow Poetry Slam. For this show she will read a new sequence about the town of Orihuela where her mother was born.
+
+### Sean Lacey -- Host
+
+Sean co-founded Hall of Voices in 2018 with the intention of holding exactly twelve readings and then stopping. It has now been ninety-four readings. He is unrepentant.
+
+## THE YEAR AHEAD
+
+| Month | Headliner | Notes |
+|---|---|---|
+| May | Niamh O Broin | With Kofi Asamoah, Irene Vega |
+| June | Daragh Byrne | Summer open season |
+| July | -- | No show, venue closure |
+| August | Fatoumata Diallo | Guest from the Dakar circuit |
+| September | Conor MacLean | Return after five years |
+| October | Mei-Lin Chen | Bilingual reading, Mandarin/English |
+| November | Aoife Ni Gabhann | All-Ireland slam champion 2025 |
+| December | Open mic only | Last Friday, no featured slot |
+
+## PAST READERS
+
+Since November 2018 we have hosted 142 featured readers and 612 open-mic readers from seventeen countries. A complete archive is maintained at the Central Library, Ilac Centre. A selected audio archive is available in the lobby on request (one set of headphones; the room does not have the bandwidth for streaming).
+
+## WORK FROM THE HALL
+
+An anthology of work first read at Hall of Voices was published in 2024 by Rough Mirror Press. Copies are available on the merchandise table at the back of the room for EUR 12 (cash preferred; a card reader works when it is working).

--- a/hall-of-voices/content/submit.md
+++ b/hall-of-voices/content/submit.md
@@ -1,0 +1,47 @@
++++
+title = "Open Mic"
+description = "How to read at Hall of Voices -- twelve open mic slots per month, drawn by ballot, no submission fee."
+tags = ["open-mic", "submit"]
++++
+
+## OPEN MIC IS FOR EVERYONE
+
+Twelve slots per month. Five minutes each. Drawn by ballot on the evening. You put your name on a folded card when you arrive, and the host pulls twelve names from a shoebox at 8:50pm.
+
+There is no audition. There is no submission fee. There is no rolling waitlist. If your name is not drawn this month, you may enter next month.
+
+## HOW TO ENTER
+
+1. Arrive by 8:45pm.
+2. At the door, the host offers you a folded card. Write your name on the card.
+3. Fold the card. Drop it in the shoebox at the back of the room.
+4. At 8:50pm, the host pulls twelve names. They are read out in the order pulled.
+5. If your name is called, you have approximately five minutes of warning before you read.
+
+## READING GUIDELINES
+
+- **One poem, or several short ones, within five minutes total.**
+- You may read from a phone, a book, a printed sheet, memory, or a napkin.
+- You may request the lighting be dimmed. You may not request pyrotechnics.
+- Translations are welcome. If you are reading in a language other than English, a printed English version at the merchandise table is appreciated but not required.
+
+## WHAT NOT TO READ
+
+- Prose longer than one paragraph (we have open-mic nights at other venues for that).
+- Song lyrics without permission from the songwriter (this has caught us out).
+- Anything you have not written yourself, unless you credit the author clearly at the start.
+- Anything you do not want to have said out loud. Think about this one.
+
+## ACCESSIBILITY
+
+If you need the mic lowered, the stool moved, or the room darkened, tell the host when you arrive. Hall of Voices has a step-free entrance from the back lane. The stage is one step up; a ramp is available on request.
+
+If you want to sign up in advance because attending the ballot is difficult for you, email us at least a week before the show at: voices@halloffvoices.example. We will reserve you a slot.
+
+## IF YOU NEED A PUSH
+
+Most first-time readers say the five minutes feel like thirty seconds. The room will be on your side. The host will be on your side. The microphone does not bite.
+
+## PRACTICE SESSIONS
+
+If you are working toward a first open mic, we hold an informal practice session on the last Wednesday of each month at 6:30pm in the same room. Smaller group, ten to fifteen people, no ballot, no pressure. Free to attend.

--- a/hall-of-voices/content/venue.md
+++ b/hall-of-voices/content/venue.md
@@ -1,0 +1,63 @@
++++
+title = "The Room"
+description = "The Long Room at 27 Parnell Square -- seventy-two chairs, one mic, plaster walls that were old when this century began."
+tags = ["venue", "long-room"]
++++
+
+## THE LONG ROOM
+
+27 Parnell Square &middot; Dublin D01
+
+The Long Room is on the first floor of the North Parnell Buildings, a Georgian terrace built between 1755 and 1768. The room itself served as a private library, a quaker meeting hall, a bookbinder's workshop, and -- from 1978 to 2015 -- an accountancy office with acoustic tile ceilings.
+
+When we found it in 2018, we pulled down the tiles.
+
+## WHAT YOU WILL SEE
+
+- A plaster ceiling with intact eighteenth-century cornicing
+- A long room, narrower than you expect (14 feet wide, 42 feet long)
+- Seventy-two folding chairs, arranged in rows of six
+- A low platform at the far end, one step up
+- One microphone on a cast-iron stand, pointed at the chair behind it
+- One tall window at the far end, facing south onto Parnell Square
+
+There is no stage lighting. There is no PA beyond the microphone. There is no bar in the room.
+
+## WHAT YOU WILL HEAR
+
+The plaster walls and wooden floor make this room kinder to a speaking voice than any amplifier we could afford. A whisper at the microphone reaches the back row. A stage whisper from the back row reaches the microphone.
+
+This is the room's strongest feature and its occasional weakness. The room does not hide you. The room does not hide anyone.
+
+## GETTING THERE
+
+**Luas:** Red Line to Jervis, 5 minutes walk east.
+**Bus:** Most northbound buses stop within two blocks.
+**DART:** Connolly Station, 10 minutes walk north.
+**Driving:** Avoid. Parking is metered and scarce. Nearest car park is the Ilac Centre.
+
+## DOORS AND TIMING
+
+- **Doors:** 7:30pm
+- **Ballot closes:** 8:45pm (open mic draw at 8:50pm)
+- **First reader:** 8:00pm
+- **Intermission:** 9:00pm, 10 minutes
+- **Last reader:** finishes by 10:30pm
+
+After 9:00pm the street door stays locked. If you need to leave early, tell a volunteer at the back and they will walk you out.
+
+## ACCESSIBILITY
+
+- Step-free entry from the back lane; ring the bell marked "Long Room"
+- Accessible WC on the same floor
+- Portable ramp available for the stage
+- Hearing loop installed, switch T on hearing aids
+
+For BSL-interpreted readings, or any other accommodation, contact us at least two weeks in advance: voices@halloffvoices.example.
+
+## HOUSEKEEPING
+
+- The room is not heated especially well in winter. Bring a jumper.
+- No food in the room. Drinks in closed containers only.
+- Phones on silent. Photography only with the reader's permission.
+- The building is shared with residential flats above; please be quiet on the stairs after 10:30pm.

--- a/hall-of-voices/static/css/style.css
+++ b/hall-of-voices/static/css/style.css
@@ -1,0 +1,349 @@
+/* ============================================================================
+   Hall of Voices - Resonant Chamber
+   Warm paper background, rust accent, expressive display + readable serif.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --paper: #f7efde;
+  --paper-2: #f0e6d0;
+  --paper-3: #e6d8bd;
+  --rule: #c9b892;
+  --ink: #1a1410;
+  --ink-2: #3a2f24;
+  --ink-3: #6a5a48;
+  --ink-4: #968466;
+  --accent: #c9472b;
+  --accent-2: #a33a22;
+  --accent-dim: rgba(201,71,43,0.1);
+  --ink-muted: #7a6a56;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "EB Garamond", "Cormorant Garamond", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+.hall-wrap { max-width: 1100px; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.8rem 0 1.2rem; border-bottom: 1px solid var(--rule);
+  gap: 1.5rem; flex-wrap: wrap;
+}
+
+.site-logo { display: flex; align-items: center; gap: 0.9rem; color: var(--ink); text-decoration: none; }
+.site-logo:hover { color: var(--accent); }
+.logo-mark { width: 48px; height: 48px; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.logo-main {
+  font-family: "Fraunces", "EB Garamond", serif;
+  font-weight: 900; font-size: 1.15rem;
+  font-style: italic;
+  color: var(--ink); letter-spacing: 0.01em;
+}
+.logo-sub {
+  font-family: "EB Garamond", serif;
+  font-weight: 400; font-size: 0.78rem;
+  color: var(--ink-3); margin-top: 0.1rem;
+  font-style: italic;
+}
+
+.site-nav { display: flex; gap: 1.6rem; }
+.site-nav a {
+  font-family: "Fraunces", "EB Garamond", serif;
+  font-size: 0.78rem; font-weight: 600; letter-spacing: 0.1em;
+  color: var(--ink-3); text-decoration: none; text-transform: uppercase;
+  padding-bottom: 0.25rem; border-bottom: 1px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.site-nav a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ---------------- Main & Article ---------------- */
+
+.site-main { padding: 2.5rem 0 3rem; }
+
+.hall-article { max-width: 100%; }
+
+/* ---------------- HERO: Concentric sound wave arcs ---------------- */
+
+.hall-hero {
+  position: relative;
+  padding: 4rem 2rem 5rem;
+  text-align: center;
+  margin: 0 -2rem 3rem;
+}
+
+.hero-svg {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  display: block;
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative; z-index: 2;
+  max-width: 800px; margin: 0 auto;
+}
+
+.hero-eyebrow {
+  font-family: "Fraunces", serif;
+  font-size: 0.85rem; font-weight: 600; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--accent);
+  margin: 0 0 1.4rem;
+  font-style: italic;
+}
+
+.hero-title {
+  font-family: "Fraunces", "EB Garamond", serif;
+  font-weight: 900; font-size: 5rem; line-height: 0.98;
+  font-style: italic;
+  color: var(--ink); margin: 0 0 1.2rem;
+  letter-spacing: -0.015em;
+}
+
+.hero-title em { color: var(--accent); font-style: italic; }
+
+.hero-lede {
+  font-family: "EB Garamond", serif;
+  font-size: 1.25rem; line-height: 1.55;
+  color: var(--ink-2); margin: 0 0 2rem;
+  font-style: italic;
+}
+
+.hero-date {
+  font-family: "Fraunces", serif;
+  font-size: 1.8rem; font-weight: 600;
+  color: var(--ink); margin: 1rem 0 0;
+  font-style: italic;
+}
+
+.hero-time {
+  font-family: "EB Garamond", serif;
+  font-size: 1rem; color: var(--ink-3);
+  letter-spacing: 0.08em;
+}
+
+/* ---------------- Open book / poetry reading section ---------------- */
+
+.book-section {
+  position: relative;
+  padding: 3rem 0;
+  margin: 3rem 0;
+}
+
+.book-svg {
+  width: 100%; max-width: 900px;
+  margin: 0 auto 2rem; display: block;
+}
+
+/* Two-page poetry layout (open book) */
+.open-book {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  max-width: 900px;
+  margin: 2rem auto;
+  position: relative;
+}
+
+.open-book::before {
+  content: "";
+  position: absolute;
+  left: 50%; top: 0; bottom: 0;
+  width: 1px; background: var(--rule);
+  transform: translateX(-0.5px);
+}
+
+.book-page {
+  padding: 0 1rem;
+}
+
+.book-page h3 {
+  font-family: "Fraunces", serif;
+  font-size: 1.3rem; font-weight: 600;
+  font-style: italic;
+  color: var(--accent); margin: 0 0 0.6rem;
+}
+
+.book-page .poem-author {
+  font-family: "EB Garamond", serif;
+  font-size: 0.9rem; color: var(--ink-3);
+  letter-spacing: 0.04em; margin: 0 0 1.2rem;
+  text-transform: uppercase;
+}
+
+.book-page .poem-verse {
+  font-family: "Cormorant Garamond", "EB Garamond", serif;
+  font-size: 1.05rem; line-height: 1.9;
+  color: var(--ink); margin: 0;
+  font-style: italic;
+}
+
+/* Lineup grid */
+.lineup-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  margin: 2.5rem 0;
+}
+
+.poet-card {
+  text-align: center;
+  padding: 1.2rem;
+}
+
+.poet-name {
+  font-family: "Fraunces", serif;
+  font-size: 1.4rem; font-weight: 700;
+  font-style: italic;
+  color: var(--ink); margin: 0 0 0.3rem;
+}
+
+.poet-role {
+  font-family: "EB Garamond", serif;
+  font-size: 0.82rem; color: var(--accent);
+  text-transform: uppercase; letter-spacing: 0.1em;
+  margin: 0 0 0.8rem;
+}
+
+.poet-bio {
+  font-size: 0.95rem; color: var(--ink-2);
+  margin: 0;
+}
+
+/* ---------------- Typography ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "Fraunces", "EB Garamond", serif;
+  color: var(--ink); line-height: 1.25;
+}
+h1 { font-size: 2.3rem; margin: 1.5rem 0 0.8rem; font-weight: 900; font-style: italic; }
+h2 { font-size: 1.7rem; margin: 2rem 0 0.8rem; font-weight: 700; font-style: italic; }
+h3 { font-size: 1.3rem; margin: 1.5rem 0 0.5rem; font-weight: 600; font-style: italic; color: var(--accent); }
+h4 { font-size: 1.05rem; margin: 1.2rem 0 0.4rem; font-weight: 600; }
+
+p { margin: 1rem 0; }
+
+a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+a:hover { border-bottom-color: var(--accent); }
+
+strong { color: var(--ink); font-weight: 600; }
+em { font-style: italic; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.5rem 0; padding: 0.8rem 1.4rem;
+  background: var(--paper-2); color: var(--ink-2);
+  font-family: "Cormorant Garamond", serif;
+  font-style: italic; font-size: 1.15rem;
+  line-height: 1.75;
+}
+
+/* Tables */
+table {
+  width: 100%; border-collapse: collapse; margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+th {
+  font-family: "Fraunces", serif;
+  font-weight: 600; font-size: 0.85rem; font-style: italic;
+  text-align: left;
+  padding: 0.6rem 0.8rem; border-bottom: 2px solid var(--rule);
+  color: var(--accent);
+}
+td {
+  padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--rule);
+  color: var(--ink-2);
+}
+
+/* Section list */
+.section-list {
+  list-style: none; padding: 0; margin: 1.5rem 0;
+}
+.section-list li {
+  margin-bottom: 0.6rem; padding: 0.8rem 1rem;
+  background: var(--paper-2); border: 1px solid var(--rule);
+}
+.section-list li a {
+  font-family: "Fraunces", serif;
+  font-weight: 600; color: var(--ink);
+  font-style: italic;
+  border-bottom: none;
+}
+
+.taxonomy-desc { color: var(--ink-3); margin-bottom: 1.5rem; font-style: italic; }
+
+/* CTA button */
+.cta {
+  display: inline-block;
+  padding: 0.9rem 2.2rem;
+  background: var(--accent); color: var(--paper);
+  font-family: "Fraunces", serif;
+  font-size: 1rem; font-weight: 600; font-style: italic;
+  letter-spacing: 0.06em;
+  border: 2px solid var(--accent);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.cta:hover {
+  background: var(--paper); color: var(--accent);
+  border-bottom-color: transparent;
+}
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem; padding: 2rem 0;
+  text-align: center; position: relative;
+}
+.footer-wave {
+  width: 100%; height: 60px;
+  display: block; margin-bottom: 1.5rem;
+}
+.footer-inner {
+  max-width: 700px; margin: 0 auto;
+}
+.footer-tag {
+  font-family: "Fraunces", serif;
+  font-weight: 600; font-style: italic;
+  font-size: 0.9rem; letter-spacing: 0.14em;
+  color: var(--accent); margin: 0 0 0.6rem;
+}
+.footer-meta {
+  font-family: "EB Garamond", serif;
+  font-size: 0.9rem; color: var(--ink-3);
+  margin: 0 0 0.4rem; font-style: italic;
+}
+.footer-copyright {
+  font-family: "EB Garamond", serif;
+  font-size: 0.8rem; color: var(--ink-4);
+  margin: 0;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 800px) {
+  .open-book { grid-template-columns: 1fr; gap: 1.5rem; }
+  .open-book::before { display: none; }
+}
+
+@media (max-width: 700px) {
+  .hall-wrap { padding: 0 1.2rem; }
+  .site-header { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
+  .site-nav { gap: 1rem; flex-wrap: wrap; }
+  .hall-hero { padding: 2.5rem 1rem 3rem; margin: 0 -1.2rem 2rem; }
+  .hero-title { font-size: 3rem; }
+  .hero-date { font-size: 1.3rem; }
+  h1 { font-size: 1.8rem; }
+  h2 { font-size: 1.4rem; }
+}

--- a/hall-of-voices/templates/404.html
+++ b/hall-of-voices/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="hall-article">
+      <h1>404 -- Silence</h1>
+      <p>Nothing here but the echo. The page has not been written.</p>
+      <p><a href="{{ base_url }}/">Return to the Hall</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/hall-of-voices/templates/footer.html
+++ b/hall-of-voices/templates/footer.html
@@ -1,0 +1,16 @@
+    <footer class="site-footer">
+      <svg class="footer-wave" viewBox="0 0 1000 60" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" aria-hidden="true">
+        <path d="M0,30 Q250,10 500,30 T1000,30" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.6"/>
+        <path d="M0,30 Q250,50 500,30 T1000,30" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.4"/>
+        <path d="M0,30 Q250,20 500,30 T1000,30" fill="none" stroke="#c9472b" stroke-width="0.5" opacity="0.3"/>
+      </svg>
+      <div class="footer-inner">
+        <p class="footer-tag">HALL OF VOICES &middot; MONTHLY RESIDENCY &middot; FIRST FRIDAYS</p>
+        <p class="footer-meta">The Long Room &middot; 27 Parnell Square &middot; Dublin D01</p>
+        <p class="footer-copyright">Copyright 2026 Hall of Voices Collective. All poems remain the property of their authors.</p>
+      </div>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/hall-of-voices/templates/header.html
+++ b/hall-of-voices/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="hall-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Hall of Voices home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Small concentric wave icon -->
+          <circle cx="24" cy="24" r="3" fill="#c9472b"/>
+          <path d="M 14 24 Q 24 14 34 24" fill="none" stroke="#c9472b" stroke-width="1.5"/>
+          <path d="M 14 24 Q 24 34 34 24" fill="none" stroke="#c9472b" stroke-width="1.5"/>
+          <path d="M 9 24 Q 24 9 39 24" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.6"/>
+          <path d="M 9 24 Q 24 39 39 24" fill="none" stroke="#c9472b" stroke-width="1" opacity="0.6"/>
+          <path d="M 4 24 Q 24 4 44 24" fill="none" stroke="#c9472b" stroke-width="0.8" opacity="0.3"/>
+          <path d="M 4 24 Q 24 44 44 24" fill="none" stroke="#c9472b" stroke-width="0.8" opacity="0.3"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Hall of Voices</span>
+          <span class="logo-sub">A Resonant Chamber</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">THE NIGHT</a>
+        <a href="{{ base_url }}/poets/">THE POETS</a>
+        <a href="{{ base_url }}/submit/">OPEN MIC</a>
+        <a href="{{ base_url }}/venue/">THE ROOM</a>
+      </nav>
+    </header>

--- a/hall-of-voices/templates/page.html
+++ b/hall-of-voices/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="hall-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/hall-of-voices/templates/section.html
+++ b/hall-of-voices/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="hall-article">
+      <h1>{{ page.title | e }}</h1>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/hall-of-voices/templates/shortcodes/alert.html
+++ b/hall-of-voices/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #d4c8b0; background-color: #faf2e0; border-left: 5px solid #c9472b; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/hall-of-voices/templates/taxonomy.html
+++ b/hall-of-voices/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="hall-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/hall-of-voices/templates/taxonomy_term.html
+++ b/hall-of-voices/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="hall-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1669,6 +1669,13 @@
     "dark",
     "blog"
   ],
+  "hall-of-voices": [
+    "event",
+    "poetry",
+    "spoken-word",
+    "slam",
+    "voices"
+  ],
   "hammer-drop": [
     "event",
     "light",


### PR DESCRIPTION
Closes #1589

## Summary
- Add hall-of-voices example site: a warm paper-themed poetry and spoken-word event site
- Features inline SVG concentric sound wave arcs emanating from a center point in the hero
- Features inline SVG open book/pages shape for poetry reading sections with two-page layout
- Typography: Fraunces (expressive display font, italic variable) for titles, EB Garamond / Cormorant Garamond for poem listings
- Includes night landing page, featured poets bio, open mic submission guide, and venue details
- Tags: event, poetry, spoken-word, slam, voices

## Test plan
- [ ] Verify `hwaro build` completes without errors
- [ ] Check concentric sound wave arcs SVG renders in hero
- [ ] Verify open book SVG with two-page poem layout displays correctly
- [ ] Confirm warm paper light theme with no CSS gradients
- [ ] Check tags.json entry is valid JSON