### PR TITLE
feat: add meta-analysis example site (closes #1598)

### DIFF
--- a/meta-analysis/AGENTS.md
+++ b/meta-analysis/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/meta-analysis/config.toml
+++ b/meta-analysis/config.toml
@@ -1,0 +1,47 @@
+# =============================================================================
+# Meta-Analysis - Statistical Synthesis Paper
+# Issue #1598 | Tags: paper, light, statistical, synthesis, evidence
+# =============================================================================
+
+title = "Meta-Analysis: Statin Therapy and Cardiovascular Mortality"
+description = "A statistical synthesis paper aggregating evidence from 42 randomized controlled trials on statin therapy, featuring SVG forest plot diagrams with effect sizes and confidence intervals and funnel plot illustrations for publication bias assessment."
+base_url = "http://localhost:3000"
+
+sections = ["sections"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/meta-analysis/content/index.md
+++ b/meta-analysis/content/index.md
@@ -1,0 +1,307 @@
++++
+title = "Summary of Findings"
+description = "Systematic review and meta-analysis of 42 randomized controlled trials on statin therapy for primary and secondary prevention of cardiovascular mortality, featuring forest plot and funnel plot SVG visualizations."
+tags = ["paper", "light", "statistical", "synthesis", "evidence"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Systematic Review &amp; Meta-Analysis &middot; Cochrane Heart Group &middot; 2026</p>
+  <h1 class="paper-title">Statin Therapy for Cardiovascular Mortality: A Systematic Review and Meta-Analysis of 42 Randomized Controlled Trials (1994--2025)</h1>
+  <p class="paper-subtitle">Pooled evidence from 247,891 participants across primary and secondary prevention populations, with subgroup analyses by age, sex, baseline LDL-C, and statin intensity.</p>
+  <p class="paper-authors">
+    <strong>Kwame A. Boateng</strong><sup>1,*</sup>, Siobhan O'Malley<sup>2</sup>, Ravi Subramaniam<sup>3</sup>, Linnea Bergqvist<sup>4</sup>, Tanya N. Grey<sup>5</sup>
+  </p>
+  <p class="paper-affiliations">
+    <sup>1</sup> Cochrane Heart Group, University of Ghana;
+    <sup>2</sup> Trinity College Dublin;
+    <sup>3</sup> All India Institute of Medical Sciences, New Delhi;
+    <sup>4</sup> Karolinska Institutet, Sweden;
+    <sup>5</sup> University of Cape Town, South Africa.
+    <sup>*</sup> Corresponding author.
+  </p>
+  <div class="paper-meta">
+    <strong>PROSPERO:</strong> CRD42024418293 &middot;
+    <strong>Published:</strong> 2026-04-08 &middot;
+    <strong>Funding:</strong> NIHR Cochrane Incentive &middot;
+    <strong>COI:</strong> None declared
+  </div>
+</header>
+
+<div class="key-finding">
+  <p class="finding-label">Key Finding</p>
+  <p>Statin therapy is associated with a statistically significant and clinically meaningful reduction in all-cause cardiovascular mortality across both primary and secondary prevention populations. The pooled risk ratio is <strong>RR 0.79 (95% CI 0.75--0.83)</strong>, representing a 21% relative risk reduction.</p>
+</div>
+
+## Pooled Estimate
+
+<div class="pooled-estimate">
+  <div class="estimate-stat">
+    <span class="estimate-value">0.79</span>
+    <span class="estimate-label">Risk Ratio</span>
+  </div>
+  <div class="estimate-sep"></div>
+  <div class="estimate-stat">
+    <span class="estimate-value">0.75--0.83</span>
+    <span class="estimate-label">95% CI</span>
+  </div>
+  <div class="estimate-sep"></div>
+  <div class="estimate-stat">
+    <span class="estimate-value">42</span>
+    <span class="estimate-label">Trials</span>
+  </div>
+  <div class="estimate-sep"></div>
+  <div class="estimate-stat">
+    <span class="estimate-value">247,891</span>
+    <span class="estimate-label">Participants</span>
+  </div>
+  <div class="estimate-sep"></div>
+  <div class="estimate-stat">
+    <span class="estimate-value">I-sq 32%</span>
+    <span class="estimate-label">Heterogeneity</span>
+  </div>
+</div>
+
+## Forest Plot: Primary Outcome (Cardiovascular Mortality)
+
+<!-- SVG forest plot diagram with effect sizes and confidence intervals -->
+<figure>
+<svg viewBox="0 0 820 460" xmlns="http://www.w3.org/2000/svg" aria-label="Forest plot of 12 representative trials" style="width:100%;max-width:820px;display:block;margin:1rem auto;">
+  <rect x="0" y="0" width="820" height="460" fill="#fafbfc"/>
+  <!-- Title -->
+  <text x="410" y="22" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="13" font-weight="700" fill="#1a1e28">Forest Plot: Cardiovascular Mortality -- Representative Subset</text>
+  <!-- Column headers -->
+  <text x="12" y="50" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.08em">STUDY</text>
+  <text x="180" y="50" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.08em">N</text>
+  <text x="250" y="50" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.08em">EVENTS T/C</text>
+  <text x="560" y="50" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.08em">RR (95% CI)</text>
+  <text x="760" y="50" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.08em">WEIGHT</text>
+  <line x1="10" y1="56" x2="810" y2="56" stroke="#1a1e28" stroke-width="1.5"/>
+  <!-- Null line (RR=1) vertical -->
+  <line x1="560" y1="60" x2="560" y2="390" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Study rows -->
+  <text x="12" y="78" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">4S (Scandinavian 4S)</text>
+  <text x="180" y="78" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">4,444</text>
+  <text x="250" y="78" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">136/189</text>
+  <line x1="470" y1="78" x2="510" y2="78" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="485" y="74" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="78" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.70 (0.58-0.85)</text>
+  <text x="760" y="78" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">4.2%</text>
+
+  <text x="12" y="100" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">WOSCOPS</text>
+  <text x="180" y="100" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">6,595</text>
+  <text x="250" y="100" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">74/135</text>
+  <line x1="485" y1="100" x2="535" y2="100" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="503" y="96" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="100" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.78 (0.65-0.93)</text>
+  <text x="760" y="100" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3.8%</text>
+
+  <text x="12" y="122" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">CARE</text>
+  <text x="180" y="122" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">4,159</text>
+  <text x="250" y="122" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">96/119</text>
+  <line x1="492" y1="122" x2="548" y2="122" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="508" y="118" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="122" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.82 (0.69-0.98)</text>
+  <text x="760" y="122" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3.6%</text>
+
+  <text x="12" y="144" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">LIPID</text>
+  <text x="180" y="144" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">9,014</text>
+  <text x="250" y="144" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">216/284</text>
+  <line x1="478" y1="144" x2="520" y2="144" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="493" y="140" width="12" height="8" fill="#2e4a6b"/>
+  <text x="560" y="144" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.75 (0.65-0.87)</text>
+  <text x="760" y="144" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">5.1%</text>
+
+  <text x="12" y="166" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">HPS (Heart Protection)</text>
+  <text x="180" y="166" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">20,536</text>
+  <text x="250" y="166" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">587/707</text>
+  <line x1="502" y1="166" x2="542" y2="166" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="514" y="161" width="14" height="10" fill="#2e4a6b"/>
+  <text x="560" y="166" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.83 (0.75-0.91)</text>
+  <text x="760" y="166" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">8.3%</text>
+
+  <text x="12" y="188" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">PROSPER</text>
+  <text x="180" y="188" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">5,804</text>
+  <text x="250" y="188" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">217/241</text>
+  <line x1="518" y1="188" x2="573" y2="188" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="537" y="184" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="188" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.90 (0.78-1.04)</text>
+  <text x="760" y="188" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">4.8%</text>
+
+  <text x="12" y="210" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">ASCOT-LLA</text>
+  <text x="180" y="210" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">10,305</text>
+  <text x="250" y="210" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">74/82</text>
+  <line x1="452" y1="210" x2="500" y2="210" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="467" y="206" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="210" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.64 (0.50-0.83)</text>
+  <text x="760" y="210" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3.1%</text>
+
+  <text x="12" y="232" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">TNT</text>
+  <text x="180" y="232" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">10,001</text>
+  <text x="250" y="232" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">149/185</text>
+  <line x1="492" y1="232" x2="538" y2="232" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="508" y="228" width="12" height="8" fill="#2e4a6b"/>
+  <text x="560" y="232" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.81 (0.71-0.93)</text>
+  <text x="760" y="232" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">5.7%</text>
+
+  <text x="12" y="254" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">JUPITER</text>
+  <text x="180" y="254" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">17,802</text>
+  <text x="250" y="254" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">247/247</text>
+  <line x1="489" y1="254" x2="541" y2="254" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="505" y="250" width="12" height="8" fill="#2e4a6b"/>
+  <text x="560" y="254" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.80 (0.67-0.97)</text>
+  <text x="760" y="254" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3.9%</text>
+
+  <text x="12" y="276" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">SHARP</text>
+  <text x="180" y="276" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">9,270</text>
+  <text x="250" y="276" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">230/274</text>
+  <line x1="496" y1="276" x2="547" y2="276" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="514" y="272" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="276" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.84 (0.72-0.99)</text>
+  <text x="760" y="276" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">4.6%</text>
+
+  <text x="12" y="298" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">IMPROVE-IT</text>
+  <text x="180" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">18,144</text>
+  <text x="250" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">537/572</text>
+  <line x1="534" y1="298" x2="576" y2="298" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="548" y="293" width="14" height="10" fill="#2e4a6b"/>
+  <text x="560" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.94 (0.86-1.03)</text>
+  <text x="760" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">7.9%</text>
+
+  <text x="12" y="320" font-family="'Crimson Pro',serif" font-size="10" fill="#1a1e28">STAREE (elderly)</text>
+  <text x="180" y="320" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">9,971</text>
+  <text x="250" y="320" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">178/234</text>
+  <line x1="482" y1="320" x2="528" y2="320" stroke="#2e4a6b" stroke-width="1.2"/>
+  <rect x="498" y="316" width="10" height="8" fill="#2e4a6b"/>
+  <text x="560" y="320" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">0.76 (0.62-0.93)</text>
+  <text x="760" y="320" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">3.4%</text>
+
+  <!-- Summary separator -->
+  <line x1="10" y1="340" x2="810" y2="340" stroke="#1a1e28" stroke-width="1"/>
+  <!-- Summary diamond -->
+  <text x="12" y="365" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="11" font-weight="700" fill="#1a1e28">Pooled (42 trials, random effects)</text>
+  <text x="180" y="365" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28" font-weight="700">247,891</text>
+  <text x="250" y="365" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28" font-weight="700">5,842/7,398</text>
+  <path d="M495,365 L530,358 L565,365 L530,372 Z" fill="#c0392b" stroke="#8e2010" stroke-width="1"/>
+  <text x="560" y="365" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="700" fill="#1a1e28">0.79 (0.75-0.83)</text>
+  <text x="760" y="365" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28" font-weight="700">100%</text>
+
+  <!-- X axis -->
+  <line x1="380" y1="390" x2="720" y2="390" stroke="#1a1e28" stroke-width="1.5"/>
+  <line x1="420" y1="388" x2="420" y2="394" stroke="#1a1e28" stroke-width="1"/>
+  <text x="420" y="406" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.5</text>
+  <line x1="492" y1="388" x2="492" y2="394" stroke="#1a1e28" stroke-width="1"/>
+  <text x="492" y="406" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.7</text>
+  <line x1="560" y1="388" x2="560" y2="394" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="560" y="406" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28" font-weight="700">1.0</text>
+  <line x1="628" y1="388" x2="628" y2="394" stroke="#1a1e28" stroke-width="1"/>
+  <text x="628" y="406" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">1.5</text>
+  <line x1="700" y1="388" x2="700" y2="394" stroke="#1a1e28" stroke-width="1"/>
+  <text x="700" y="406" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">2.0</text>
+  <!-- Axis labels -->
+  <text x="470" y="428" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="600" fill="#1e6e3a">Favors Statin</text>
+  <path d="M520,425 L490,425 M493,422 L490,425 L493,428" fill="none" stroke="#1e6e3a" stroke-width="1"/>
+  <text x="650" y="428" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="600" fill="#b83220">Favors Placebo</text>
+  <path d="M600,425 L630,425 M627,422 L630,425 L627,428" fill="none" stroke="#b83220" stroke-width="1"/>
+  <text x="410" y="448" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">Heterogeneity: I-sq = 32%, tau-sq = 0.012, p = 0.04</text>
+  <text x="680" y="448" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">Overall: Z = 8.47, p &lt; 0.001</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#5a6070;font-style:italic;">Fig. 1. Forest plot for cardiovascular mortality. Twelve representative trials shown; pooled estimate from all 42 trials shown as the red diamond. Squares sized proportional to study weight. Random-effects model (DerSimonian-Laird).</figcaption>
+</figure>
+
+## Funnel Plot: Publication Bias Assessment
+
+<!-- SVG funnel plot for publication bias assessment -->
+<figure>
+<svg viewBox="0 0 720 460" xmlns="http://www.w3.org/2000/svg" aria-label="Funnel plot for publication bias assessment" style="width:100%;max-width:720px;display:block;margin:1rem auto;">
+  <rect x="0" y="0" width="720" height="460" fill="#fafbfc"/>
+  <text x="360" y="22" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="13" font-weight="700" fill="#1a1e28">Funnel Plot: Publication Bias Assessment (42 Trials)</text>
+  <!-- Y axis -->
+  <line x1="100" y1="50" x2="100" y2="380" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="48" y="215" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="11" fill="#1a1e28" transform="rotate(-90,48,215)">Standard Error (log RR)</text>
+  <line x1="95" y1="50" x2="100" y2="50" stroke="#1a1e28" stroke-width="1"/>
+  <text x="90" y="54" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.00</text>
+  <line x1="95" y1="132" x2="100" y2="132" stroke="#1a1e28" stroke-width="1"/>
+  <text x="90" y="136" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.10</text>
+  <line x1="95" y1="215" x2="100" y2="215" stroke="#1a1e28" stroke-width="1"/>
+  <text x="90" y="219" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.20</text>
+  <line x1="95" y1="297" x2="100" y2="297" stroke="#1a1e28" stroke-width="1"/>
+  <text x="90" y="301" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.30</text>
+  <line x1="95" y1="380" x2="100" y2="380" stroke="#1a1e28" stroke-width="1"/>
+  <text x="90" y="384" text-anchor="end" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.40</text>
+  <!-- X axis -->
+  <line x1="100" y1="380" x2="680" y2="380" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="390" y="420" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="11" fill="#1a1e28">log(Risk Ratio)</text>
+  <line x1="170" y1="380" x2="170" y2="385" stroke="#1a1e28" stroke-width="1"/>
+  <text x="170" y="400" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-1.0</text>
+  <line x1="280" y1="380" x2="280" y2="385" stroke="#1a1e28" stroke-width="1"/>
+  <text x="280" y="400" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">-0.5</text>
+  <line x1="390" y1="380" x2="390" y2="385" stroke="#1a1e28" stroke-width="1.5"/>
+  <text x="390" y="400" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28" font-weight="700">0</text>
+  <line x1="500" y1="380" x2="500" y2="385" stroke="#1a1e28" stroke-width="1"/>
+  <text x="500" y="400" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">0.5</text>
+  <line x1="610" y1="380" x2="610" y2="385" stroke="#1a1e28" stroke-width="1"/>
+  <text x="610" y="400" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#5a6070">1.0</text>
+  <!-- Pooled estimate line -->
+  <line x1="337" y1="50" x2="337" y2="380" stroke="#c0392b" stroke-width="1.2" stroke-dasharray="5,3"/>
+  <!-- 95% CI funnel -->
+  <line x1="337" y1="50" x2="180" y2="380" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3" opacity="0.6"/>
+  <line x1="337" y1="50" x2="494" y2="380" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3" opacity="0.6"/>
+  <!-- Inner 99% CI -->
+  <line x1="337" y1="50" x2="210" y2="380" stroke="#2e4a6b" stroke-width="0.6" stroke-dasharray="2,2" opacity="0.4"/>
+  <line x1="337" y1="50" x2="464" y2="380" stroke="#2e4a6b" stroke-width="0.6" stroke-dasharray="2,2" opacity="0.4"/>
+  <!-- Data points: symmetric cluster -->
+  <circle cx="327" cy="70" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="345" cy="78" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="320" cy="90" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="352" cy="95" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="310" cy="110" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="338" cy="115" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="360" cy="125" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="295" cy="140" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="325" cy="148" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="355" cy="155" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="375" cy="165" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="285" cy="180" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="310" cy="195" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="340" cy="200" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="370" cy="205" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="395" cy="215" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="275" cy="225" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="305" cy="235" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="335" cy="240" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="365" cy="250" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="405" cy="255" r="4" fill="#2e4a6b" opacity="0.8"/>
+  <circle cx="250" cy="275" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="290" cy="280" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="330" cy="290" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="375" cy="295" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="420" cy="300" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="230" cy="315" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="275" cy="325" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="320" cy="330" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="360" cy="340" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="400" cy="345" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="210" cy="355" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="260" cy="360" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="310" cy="365" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="360" cy="370" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="410" cy="372" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="445" cy="368" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <circle cx="455" cy="355" r="4" fill="#2e4a6b" opacity="0.75"/>
+  <!-- Legend -->
+  <circle cx="530" cy="70" r="4" fill="#2e4a6b"/>
+  <text x="540" y="74" font-family="'Crimson Pro','STIX Two Text',serif" font-size="10" fill="#1a1e28">Individual trial</text>
+  <line x1="524" y1="88" x2="540" y2="88" stroke="#c0392b" stroke-width="1.2" stroke-dasharray="5,3"/>
+  <text x="545" y="92" font-family="'Crimson Pro','STIX Two Text',serif" font-size="10" fill="#1a1e28">Pooled estimate</text>
+  <line x1="524" y1="104" x2="540" y2="104" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3" opacity="0.6"/>
+  <text x="545" y="108" font-family="'Crimson Pro','STIX Two Text',serif" font-size="10" fill="#1a1e28">95% CI funnel</text>
+  <!-- Egger's test box -->
+  <rect x="520" y="130" width="170" height="80" rx="2" fill="#f0f2f5" stroke="#c8ccd4" stroke-width="1"/>
+  <text x="605" y="148" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.05em">EGGER'S TEST</text>
+  <line x1="535" y1="154" x2="675" y2="154" stroke="#c8ccd4" stroke-width="0.5"/>
+  <text x="532" y="172" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">Intercept: 0.18</text>
+  <text x="532" y="186" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">t(40) = 1.24</text>
+  <text x="532" y="200" font-family="'IBM Plex Mono',monospace" font-size="9" fill="#1a1e28">p = 0.22 (n.s.)</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#5a6070;font-style:italic;">Fig. 2. Funnel plot of all 42 trials. Symmetric distribution around the pooled estimate (red dashed line) and non-significant Egger's test (p = 0.22) suggest no substantial small-study effects or publication bias.</figcaption>
+</figure>

--- a/meta-analysis/content/prisma.md
+++ b/meta-analysis/content/prisma.md
@@ -1,0 +1,91 @@
++++
+title = "PRISMA Flow Diagram"
+description = "Complete PRISMA 2020 flow diagram showing study identification, screening, eligibility, and inclusion."
+tags = ["PRISMA", "flow", "screening"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">PRISMA 2020 Flow Diagram</p>
+  <h1 class="paper-title">Study Selection Process</h1>
+</header>
+
+## Flow of Studies Through the Review
+
+<!-- SVG PRISMA flow diagram -->
+<figure>
+<svg viewBox="0 0 780 640" xmlns="http://www.w3.org/2000/svg" aria-label="PRISMA 2020 flow diagram" style="width:100%;max-width:780px;display:block;margin:1rem auto;">
+  <rect x="0" y="0" width="780" height="640" fill="#fafbfc"/>
+  <!-- Title -->
+  <text x="390" y="22" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="13" font-weight="700" fill="#1a1e28">PRISMA 2020 Flow Diagram</text>
+  <!-- Identification stage (top) -->
+  <text x="130" y="50" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.1em">IDENTIFICATION</text>
+  <line x1="30" y1="55" x2="230" y2="55" stroke="#2e4a6b" stroke-width="0.8"/>
+  <!-- Database boxes -->
+  <rect x="30" y="70" width="230" height="120" rx="2" fill="#f0f2f5" stroke="#2e4a6b" stroke-width="1"/>
+  <text x="145" y="88" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Records from databases</text>
+  <text x="145" y="102" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28">n = 10,440</text>
+  <text x="45" y="122" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">MEDLINE: 3,842</text>
+  <text x="45" y="136" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">Embase: 4,217</text>
+  <text x="45" y="150" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">CENTRAL: 1,195</text>
+  <text x="45" y="164" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">clinicaltrials.gov: 874</text>
+  <text x="45" y="178" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">WHO ICTRP: 312</text>
+  <!-- Arrow down -->
+  <line x1="145" y1="190" x2="145" y2="215" stroke="#2e4a6b" stroke-width="1.2"/>
+  <polygon points="140,210 145,220 150,210" fill="#2e4a6b"/>
+  <!-- Duplicates removed (side arrow) -->
+  <rect x="310" y="100" width="180" height="60" rx="2" fill="#f0f2f5" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="400" y="122" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Duplicates removed</text>
+  <text x="400" y="140" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#b83220">n = 2,194</text>
+  <line x1="260" y1="130" x2="310" y2="130" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="3,2"/>
+  <polygon points="305,126 315,130 305,134" fill="#2e4a6b"/>
+  <!-- Screening stage -->
+  <text x="130" y="240" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.1em">SCREENING</text>
+  <line x1="30" y1="245" x2="230" y2="245" stroke="#2e4a6b" stroke-width="0.8"/>
+  <rect x="30" y="260" width="230" height="55" rx="2" fill="#d4dde8" stroke="#2e4a6b" stroke-width="1"/>
+  <text x="145" y="280" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Records screened</text>
+  <text x="145" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28">n = 8,246</text>
+  <!-- Arrow right to excluded -->
+  <line x1="260" y1="287" x2="310" y2="287" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="3,2"/>
+  <polygon points="305,283 315,287 305,291" fill="#2e4a6b"/>
+  <rect x="310" y="260" width="180" height="55" rx="2" fill="#f0f2f5" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="400" y="280" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Excluded at title/abstract</text>
+  <text x="400" y="298" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#b83220">n = 7,832</text>
+  <!-- Arrow down -->
+  <line x1="145" y1="315" x2="145" y2="340" stroke="#2e4a6b" stroke-width="1.2"/>
+  <polygon points="140,335 145,345 150,335" fill="#2e4a6b"/>
+  <!-- Eligibility stage -->
+  <text x="130" y="365" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.1em">ELIGIBILITY</text>
+  <line x1="30" y1="370" x2="230" y2="370" stroke="#2e4a6b" stroke-width="0.8"/>
+  <rect x="30" y="385" width="230" height="55" rx="2" fill="#d4dde8" stroke="#2e4a6b" stroke-width="1"/>
+  <text x="145" y="405" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Full-text articles assessed</text>
+  <text x="145" y="423" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" fill="#1a1e28">n = 414</text>
+  <!-- Arrow right to excluded -->
+  <line x1="260" y1="412" x2="310" y2="412" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="3,2"/>
+  <polygon points="305,408 315,412 305,416" fill="#2e4a6b"/>
+  <rect x="310" y="360" width="380" height="110" rx="2" fill="#f0f2f5" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="500" y="380" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Excluded at full-text (n = 367)</text>
+  <line x1="330" y1="388" x2="670" y2="388" stroke="#2e4a6b" stroke-width="0.5"/>
+  <text x="325" y="405" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">Duplicate report of same trial: 94</text>
+  <text x="325" y="418" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">Non-randomized design: 78</text>
+  <text x="325" y="431" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">No placebo arm: 76</text>
+  <text x="510" y="405" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">Follow-up &lt; 12 months: 62</text>
+  <text x="510" y="418" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">No mortality data: 41</text>
+  <text x="510" y="431" font-family="'Crimson Pro',serif" font-size="9" fill="#5a6070">Pediatric population: 16</text>
+  <!-- Arrow down -->
+  <line x1="145" y1="440" x2="145" y2="470" stroke="#2e4a6b" stroke-width="1.2"/>
+  <polygon points="140,465 145,475 150,465" fill="#2e4a6b"/>
+  <!-- Included stage -->
+  <text x="130" y="495" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#2e4a6b" letter-spacing="0.1em">INCLUDED</text>
+  <line x1="30" y1="500" x2="230" y2="500" stroke="#2e4a6b" stroke-width="0.8"/>
+  <rect x="30" y="515" width="230" height="55" rx="2" fill="#d4dde8" stroke="#2e4a6b" stroke-width="1.5"/>
+  <text x="145" y="535" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#1a1e28">Studies in review</text>
+  <text x="145" y="553" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="700" fill="#1a1e28">n = 47 articles</text>
+  <!-- Arrow down -->
+  <line x1="145" y1="570" x2="145" y2="590" stroke="#2e4a6b" stroke-width="1.2"/>
+  <polygon points="140,585 145,595 150,585" fill="#2e4a6b"/>
+  <rect x="30" y="595" width="230" height="40" rx="2" fill="#c0392b" stroke="#8e2010" stroke-width="1.5"/>
+  <text x="145" y="613" text-anchor="middle" font-family="'IBM Plex Sans','Inter',sans-serif" font-size="10" font-weight="700" fill="#ffffff">Trials in meta-analysis</text>
+  <text x="145" y="627" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="11" font-weight="700" fill="#ffffff">n = 42</text>
+</svg>
+<figcaption style="text-align:center;font-size:0.82rem;color:#5a6070;font-style:italic;">Fig. 3. PRISMA 2020 flow diagram for the systematic review of statin therapy trials.</figcaption>
+</figure>

--- a/meta-analysis/content/references.md
+++ b/meta-analysis/content/references.md
@@ -1,0 +1,62 @@
++++
+title = "References"
+description = "Bibliography of included trials and methodological references."
+tags = ["references", "bibliography"]
++++
+
+<header class="paper-header">
+  <p class="paper-eyebrow">Bibliography</p>
+  <h1 class="paper-title">References</h1>
+</header>
+
+## Methodological References
+
+1. Page MJ, McKenzie JE, Bossuyt PM, et al. The PRISMA 2020 statement: an updated guideline for reporting systematic reviews. *BMJ*. 2021;372:n71.
+
+2. Higgins JPT, Thomas J, Chandler J, et al., eds. *Cochrane Handbook for Systematic Reviews of Interventions*, version 6.4. Cochrane; 2023.
+
+3. DerSimonian R, Laird N. Meta-analysis in clinical trials. *Control Clin Trials*. 1986;7(3):177-188.
+
+4. Higgins JPT, Thompson SG, Deeks JJ, Altman DG. Measuring inconsistency in meta-analyses. *BMJ*. 2003;327(7414):557-560.
+
+5. Egger M, Davey Smith G, Schneider M, Minder C. Bias in meta-analysis detected by a simple, graphical test. *BMJ*. 1997;315(7109):629-634.
+
+6. Sterne JAC, Savovic J, Page MJ, et al. RoB 2: a revised tool for assessing risk of bias in randomised trials. *BMJ*. 2019;366:l4898.
+
+7. Guyatt GH, Oxman AD, Vist GE, et al. GRADE: an emerging consensus on rating quality of evidence and strength of recommendations. *BMJ*. 2008;336(7650):924-926.
+
+## Selected Included Trials (representative subset)
+
+8. Scandinavian Simvastatin Survival Study Group. Randomised trial of cholesterol lowering in 4444 patients with coronary heart disease: the Scandinavian Simvastatin Survival Study (4S). *Lancet*. 1994;344(8934):1383-1389.
+
+9. Shepherd J, Cobbe SM, Ford I, et al. Prevention of coronary heart disease with pravastatin in men with hypercholesterolemia. West of Scotland Coronary Prevention Study (WOSCOPS). *N Engl J Med*. 1995;333(20):1301-1307.
+
+10. Sacks FM, Pfeffer MA, Moye LA, et al. The effect of pravastatin on coronary events after myocardial infarction in patients with average cholesterol levels. Cholesterol and Recurrent Events Trial (CARE). *N Engl J Med*. 1996;335(14):1001-1009.
+
+11. Long-Term Intervention with Pravastatin in Ischaemic Disease (LIPID) Study Group. Prevention of cardiovascular events and death with pravastatin. *N Engl J Med*. 1998;339(19):1349-1357.
+
+12. Heart Protection Study Collaborative Group. MRC/BHF Heart Protection Study of cholesterol lowering with simvastatin in 20,536 high-risk individuals: a randomised placebo-controlled trial. *Lancet*. 2002;360(9326):7-22.
+
+13. Shepherd J, Blauw GJ, Murphy MB, et al. Pravastatin in elderly individuals at risk of vascular disease (PROSPER). *Lancet*. 2002;360(9346):1623-1630.
+
+14. Sever PS, Dahlof B, Poulter NR, et al. Prevention of coronary and stroke events with atorvastatin (ASCOT-LLA). *Lancet*. 2003;361(9364):1149-1158.
+
+15. LaRosa JC, Grundy SM, Waters DD, et al. Intensive lipid lowering with atorvastatin in patients with stable coronary disease (TNT). *N Engl J Med*. 2005;352(14):1425-1435.
+
+16. Ridker PM, Danielson E, Fonseca FAH, et al. Rosuvastatin to prevent vascular events in men and women with elevated C-reactive protein (JUPITER). *N Engl J Med*. 2008;359(21):2195-2207.
+
+17. Baigent C, Landray MJ, Reith C, et al. The effects of lowering LDL cholesterol with simvastatin plus ezetimibe in patients with chronic kidney disease (SHARP). *Lancet*. 2011;377(9784):2181-2192.
+
+18. Cannon CP, Blazing MA, Giugliano RP, et al. Ezetimibe added to statin therapy after acute coronary syndromes (IMPROVE-IT). *N Engl J Med*. 2015;372(25):2387-2397.
+
+19. STAREE Investigators. Statin therapy for reducing events in the elderly: the STAREE randomized trial. *N Engl J Med*. 2024;391(12):1123-1134.
+
+## Prior Meta-Analyses and Guidelines
+
+20. Cholesterol Treatment Trialists' (CTT) Collaboration. Efficacy and safety of LDL-lowering therapy among men and women. *Lancet*. 2015;385(9976):1397-1405.
+
+21. Mach F, Baigent C, Catapano AL, et al. 2019 ESC/EAS Guidelines for the management of dyslipidaemias. *Eur Heart J*. 2020;41(1):111-188.
+
+22. Grundy SM, Stone NJ, Bailey AL, et al. 2018 AHA/ACC/AACVPR/AAPA/ABC/ACPM/ADA/AGS/APhA/ASPC/NLA/PCNA Guideline on the Management of Blood Cholesterol. *Circulation*. 2019;139(25):e1082-e1143.
+
+*Complete bibliography of all 42 included trials available in Supplementary Table S1.*

--- a/meta-analysis/content/sections/1-methods.md
+++ b/meta-analysis/content/sections/1-methods.md
@@ -1,0 +1,68 @@
++++
+title = "1. Methods"
+description = "Protocol, eligibility criteria, search strategy, data extraction, risk-of-bias assessment, and statistical methods."
+weight = 1
+template = "post"
+tags = ["methods", "protocol", "PRISMA"]
+categories = ["sections"]
+[extra]
+section_number = "1"
++++
+
+## 1.1 Protocol Registration
+
+This systematic review was registered prospectively on PROSPERO (CRD42024418293) on 2024-04-18 and conducted in accordance with the Cochrane Handbook for Systematic Reviews of Interventions (version 6.4). Reporting follows the PRISMA 2020 guidelines.
+
+## 1.2 Eligibility Criteria
+
+**Inclusion criteria:**
+
+- Randomized controlled trials comparing any HMG-CoA reductase inhibitor (statin) against placebo or active comparator
+- Adults aged 18 years or older
+- Minimum follow-up of 12 months
+- Reports cardiovascular mortality as a primary or secondary endpoint
+- Published in a peer-reviewed journal OR registered in a major trial registry with public results
+
+**Exclusion criteria:**
+
+- Non-randomized designs, quasi-experimental studies, or cross-over trials
+- Studies exclusively in pediatric populations
+- Head-to-head statin comparisons without a placebo arm (analyzed separately in sensitivity analyses)
+- Studies with less than 100 participants per arm
+
+## 1.3 Search Strategy
+
+We searched the following databases from inception to 2025-12-31:
+
+- MEDLINE (PubMed): 3,842 records
+- Embase (Elsevier): 4,217 records
+- Cochrane CENTRAL: 1,195 records
+- clinicaltrials.gov: 874 trial registrations
+- WHO ICTRP: 312 trial registrations
+
+Search strings used controlled vocabulary (MeSH terms, Emtree) and free-text keywords. No language restrictions were applied. Reference lists of included studies and prior meta-analyses were manually searched.
+
+## 1.4 Study Selection and Data Extraction
+
+Two reviewers independently screened titles and abstracts against the eligibility criteria, resolving disagreements by consensus with a third reviewer. Full-text review followed the same dual-reviewer process.
+
+Data were extracted using a piloted electronic form capturing:
+
+- Trial characteristics (design, sample size, follow-up, intervention details)
+- Population (age, sex, baseline LDL-C, comorbidities, primary vs. secondary prevention)
+- Outcomes (cardiovascular mortality, all-cause mortality, myocardial infarction, stroke)
+- Risk-of-bias domains (Cochrane RoB 2 tool)
+
+## 1.5 Statistical Analysis
+
+Pooled risk ratios with 95% confidence intervals were calculated using the DerSimonian-Laird random-effects model. Heterogeneity was quantified using the I-squared statistic and tau-squared. Subgroup analyses were planned a priori for:
+
+- Primary vs. secondary prevention
+- Age (< 65 vs. >= 65 years)
+- Sex
+- Baseline LDL-C (< 130 vs. >= 130 mg/dL)
+- Statin intensity (low/moderate vs. high)
+
+Publication bias was assessed visually via funnel plot and statistically via Egger's regression test. Sensitivity analyses excluded high risk-of-bias trials, industry-funded trials (in isolation), and applied trim-and-fill methods.
+
+All analyses were performed in R 4.4.1 using the `metafor` and `meta` packages.

--- a/meta-analysis/content/sections/2-results.md
+++ b/meta-analysis/content/sections/2-results.md
@@ -1,0 +1,83 @@
++++
+title = "2. Results"
+description = "Study selection flow, included trials characteristics, pooled effect estimates, subgroup analyses, and heterogeneity assessment."
+weight = 2
+template = "post"
+tags = ["results", "pooled-estimates", "subgroups"]
+categories = ["sections"]
+[extra]
+section_number = "2"
++++
+
+## 2.1 Study Selection (PRISMA Flow)
+
+Of 10,440 records identified, 42 randomized controlled trials (reported in 47 articles) met inclusion criteria and were included in the quantitative synthesis.
+
+| Stage | Records |
+|-------|---------|
+| Records identified (all sources) | 10,440 |
+| Duplicates removed | -2,194 |
+| Records screened (title/abstract) | 8,246 |
+| Excluded at title/abstract | -7,832 |
+| Full-text articles assessed | 414 |
+| Excluded at full-text (reasons below) | -367 |
+| Studies included in review | 47 |
+| Trials included in meta-analysis | 42 |
+
+Exclusion reasons at full-text: duplicate report of same trial (n = 94), non-randomized design (n = 78), no placebo arm (n = 76), insufficient follow-up (n = 62), no mortality data reported (n = 41), pediatric population (n = 16).
+
+## 2.2 Trial Characteristics
+
+The 42 included trials enrolled a total of 247,891 participants with a median follow-up of 4.3 years (range 1.0--10.4). The trials were conducted in 38 countries across 6 continents, with substantial representation from Europe (43%), North America (28%), and Asia (19%).
+
+| Characteristic | Value |
+|----------------|-------|
+| Total participants | 247,891 |
+| Median age (years) | 62.4 (IQR 55.8--68.2) |
+| Female participants (%) | 31.2 |
+| Primary prevention trials | 15 (36%) |
+| Secondary prevention trials | 22 (52%) |
+| Mixed populations | 5 (12%) |
+| Median follow-up (years) | 4.3 |
+| Median sample size | 4,987 |
+
+## 2.3 Primary Outcome: Cardiovascular Mortality
+
+The pooled risk ratio for cardiovascular mortality was **0.79 (95% CI 0.75--0.83, p < 0.001)**, indicating a 21% relative risk reduction with statin therapy. Heterogeneity was moderate (I-sq = 32%, tau-sq = 0.012, Cochran's Q p = 0.04).
+
+**Absolute effect estimates** (assuming baseline 10-year CV mortality risk of 8%):
+
+- Number needed to treat (NNT) = 59 (95% CI 49--75) to prevent one CV death over 10 years
+- Absolute risk reduction = 1.7% (95% CI 1.3--2.0%)
+
+## 2.4 Subgroup Analyses
+
+| Subgroup | RR (95% CI) | I-sq (%) | p-interaction |
+|----------|-------------|----------|---------------|
+| Primary prevention | 0.81 (0.76--0.87) | 28 | ref. |
+| Secondary prevention | 0.77 (0.72--0.82) | 35 | 0.27 |
+| Age < 65 years | 0.78 (0.73--0.84) | 29 | ref. |
+| Age >= 65 years | 0.82 (0.76--0.89) | 38 | 0.31 |
+| Male | 0.78 (0.73--0.83) | 30 | ref. |
+| Female | 0.82 (0.74--0.91) | 34 | 0.38 |
+| LDL-C < 130 mg/dL | 0.82 (0.76--0.89) | 27 | ref. |
+| LDL-C >= 130 mg/dL | 0.76 (0.71--0.82) | 33 | 0.18 |
+| Low/moderate intensity | 0.82 (0.77--0.88) | 30 | ref. |
+| High intensity | 0.74 (0.68--0.81) | 34 | 0.04 |
+
+The only subgroup with a statistically significant interaction was statin intensity (p = 0.04), with high-intensity regimens producing a larger relative risk reduction. However, this finding was not pre-specified as a confirmatory hypothesis and should be interpreted as hypothesis-generating.
+
+## 2.5 Secondary Outcomes
+
+| Outcome | Pooled RR (95% CI) | Number of trials |
+|---------|-------------------|------------------|
+| All-cause mortality | 0.87 (0.83--0.91) | 42 |
+| Non-fatal myocardial infarction | 0.74 (0.69--0.80) | 38 |
+| Non-fatal stroke | 0.82 (0.76--0.89) | 35 |
+| Revascularization | 0.75 (0.71--0.80) | 31 |
+
+## 2.6 Heterogeneity and Publication Bias
+
+Heterogeneity was moderate (I-sq = 32%) and largely explained by baseline risk profiles of the included populations rather than trial-level methodological differences.
+
+Funnel plot inspection showed approximate symmetry around the pooled estimate. Egger's test for small-study effects was not statistically significant (intercept 0.18, t(40) = 1.24, p = 0.22). Trim-and-fill sensitivity analysis imputed 2 hypothetically missing studies on the null side, with adjusted pooled RR = 0.80 (95% CI 0.76--0.84), essentially unchanged from the primary analysis.

--- a/meta-analysis/content/sections/3-heterogeneity.md
+++ b/meta-analysis/content/sections/3-heterogeneity.md
@@ -1,0 +1,58 @@
++++
+title = "3. Heterogeneity Investigation"
+description = "Sources of between-trial heterogeneity, meta-regression analyses, and subgroup interaction tests."
+weight = 3
+template = "post"
+tags = ["heterogeneity", "meta-regression", "I-squared"]
+categories = ["sections"]
+[extra]
+section_number = "3"
++++
+
+## 3.1 Heterogeneity Quantification
+
+The primary analysis showed moderate heterogeneity (I-sq = 32%, 95% CI 8--51%). Visual inspection of the forest plot suggested that most of this heterogeneity came from a small number of trials with unusually large or small effect sizes, rather than from systematic differences across the main body of evidence.
+
+## 3.2 Meta-Regression
+
+We performed meta-regression to identify trial-level characteristics associated with differences in effect size:
+
+| Covariate | Beta (log RR) | 95% CI | p-value |
+|-----------|---------------|--------|---------|
+| Baseline CV mortality (%) | -0.012 | (-0.023 to -0.001) | 0.032 |
+| Mean age (years) | +0.004 | (-0.001 to +0.009) | 0.18 |
+| Proportion female (%) | +0.002 | (-0.003 to +0.007) | 0.44 |
+| Mean baseline LDL-C (mg/dL) | -0.003 | (-0.006 to +0.000) | 0.07 |
+| Publication year | +0.001 | (-0.004 to +0.006) | 0.72 |
+| Industry funding (binary) | +0.018 | (-0.025 to +0.061) | 0.41 |
+| High-intensity statin (binary) | -0.089 | (-0.172 to -0.006) | 0.036 |
+
+**Interpretations:**
+
+- Trials enrolling higher-risk populations (higher baseline CV mortality) showed slightly larger relative risk reductions -- consistent with absolute benefit scaling with baseline risk.
+- High-intensity statin regimens achieved modestly larger effect sizes, consistent with the subgroup analysis in Section 2.4.
+- Industry funding was not associated with effect size, counter to the hypothesis of publication or outcome reporting bias favoring industry-funded trials.
+
+## 3.3 Influence Analysis
+
+Leave-one-out sensitivity analysis recomputed the pooled estimate 42 times, each time excluding one trial. The pooled RR ranged from 0.78 to 0.80 across these iterations, indicating that no single trial drove the overall finding. The most influential trial (HPS) had the highest weight (8.3%) but excluding it changed the pooled estimate from RR 0.79 to RR 0.78.
+
+## 3.4 Prediction Interval
+
+While the confidence interval for the pooled estimate (0.75--0.83) reflects uncertainty in the average true effect, the **95% prediction interval** is more relevant for clinical application, reflecting the plausible range of true effects in a new trial similar to those included:
+
+**95% Prediction Interval: RR 0.63 to 0.99**
+
+This suggests that in a typical new trial, the true effect is likely to fall between a 37% relative risk reduction and essentially no effect. Most plausible effects are favorable, but the upper bound approaches null, particularly for populations at low baseline risk.
+
+## 3.5 Certainty of Evidence (GRADE)
+
+The overall certainty of evidence for the primary outcome (cardiovascular mortality) is rated **HIGH** using the GRADE framework:
+
+- Risk of bias: not downgraded (most trials at low risk of bias)
+- Inconsistency: not downgraded (I-sq = 32%, most effects favor treatment)
+- Indirectness: not downgraded (PICO well-matched)
+- Imprecision: not downgraded (narrow CI, effect estimate clinically meaningful)
+- Publication bias: not downgraded (symmetric funnel, non-significant Egger's test)
+
+No factors supported upgrading certainty (not applicable for randomized evidence with adequate design).

--- a/meta-analysis/content/sections/4-limitations.md
+++ b/meta-analysis/content/sections/4-limitations.md
@@ -1,0 +1,46 @@
++++
+title = "4. Discussion and Limitations"
+description = "Interpretation of results, comparison with prior meta-analyses, strengths and limitations of this review."
+weight = 4
+template = "post"
+tags = ["discussion", "limitations", "interpretation"]
+categories = ["sections"]
+[extra]
+section_number = "4"
++++
+
+## 4.1 Principal Findings
+
+This systematic review and meta-analysis of 42 randomized controlled trials involving 247,891 participants confirms that statin therapy produces a clinically meaningful and statistically significant reduction in cardiovascular mortality (pooled RR 0.79, 95% CI 0.75--0.83). The magnitude of this effect (21% relative risk reduction) is consistent across sex, age, and baseline LDL-C subgroups, with modest evidence that high-intensity statin regimens produce somewhat larger effects than low/moderate intensity regimens.
+
+## 4.2 Comparison with Prior Evidence
+
+Our findings align with the previously published Cholesterol Treatment Trialists' (CTT) individual participant data meta-analysis, which reported a per-mmol/L LDL-C reduction RR of 0.78 (95% CI 0.76--0.81) for major vascular events. Our current review updates the evidence base with 8 trials published since the last CTT update (2019), including the STAREE trial in community-dwelling elderly (published 2024) and 3 trials conducted primarily in low- and middle-income countries.
+
+## 4.3 Strengths
+
+- **Comprehensive search:** Our search covered 5 databases and trial registries with no language restrictions, identifying a larger pool of evidence than prior reviews.
+- **Rigorous methodology:** All stages of screening, extraction, and risk-of-bias assessment were performed in duplicate with disagreement resolved by consensus.
+- **Prospective registration:** Protocol was registered on PROSPERO before data extraction began.
+- **Diverse populations:** Inclusion of trials from 38 countries provides broader generalizability than prior reviews dominated by trials in European and North American populations.
+- **Advanced statistical methods:** Use of prediction intervals, meta-regression, and GRADE assessment provides a nuanced picture beyond simple pooled estimates.
+
+## 4.4 Limitations
+
+Several important limitations merit consideration:
+
+1. **Aggregate-level data.** We used summary-level data extracted from published reports rather than individual patient data. This limits our ability to investigate subgroup effects with the precision of IPD meta-analysis.
+
+2. **Residual heterogeneity.** Although heterogeneity was moderate and largely explained by baseline risk, some unexplained between-trial variation remains. Our prediction interval spans from RR 0.63 to 0.99, indicating that in some settings the true effect may be small.
+
+3. **Outcome definitions.** Cardiovascular mortality was defined heterogeneously across trials (some included sudden cardiac death, others restricted to MI and stroke-related deaths). We used the primary trial-level adjudicated CV mortality definition without attempting to harmonize across trials.
+
+4. **Adverse events not synthesized.** This review focused on efficacy. A comprehensive risk-benefit evaluation requires pooled analysis of adverse events (muscle symptoms, new-onset diabetes, hepatic enzyme elevations), which is conducted in a companion review (CRD42024418304).
+
+5. **Generalizability to very elderly.** Although the STAREE trial addressed the 70+ population specifically, only 3 of 42 trials enrolled primarily those aged 75 or older. Evidence for this age group remains less robust than for the 50--70 age range.
+
+## 4.5 Implications
+
+**For practice:** The evidence supports statin therapy as a first-line intervention for reduction of cardiovascular mortality in adults meeting established risk thresholds. Benefits are consistent across demographic subgroups, with slightly larger effects for high-intensity regimens.
+
+**For research:** Priority areas for future RCTs include: (a) statins in primary prevention for populations aged 75+, (b) head-to-head comparisons of statin with newer lipid-lowering agents (PCSK9 inhibitors, bempedoic acid) in settings with limited access to those agents, and (c) implementation trials evaluating real-world adherence and effectiveness in diverse healthcare systems.

--- a/meta-analysis/content/sections/5-conclusions.md
+++ b/meta-analysis/content/sections/5-conclusions.md
@@ -1,0 +1,32 @@
++++
+title = "5. Conclusions"
+description = "Summary conclusions, evidence certainty, and implications for clinical guidelines."
+weight = 5
+template = "post"
+tags = ["conclusions", "GRADE", "guidelines"]
+categories = ["sections"]
+[extra]
+section_number = "5"
++++
+
+## Conclusions
+
+Among adults at elevated cardiovascular risk, statin therapy reduces cardiovascular mortality by approximately 21% (pooled RR 0.79, 95% CI 0.75--0.83) compared with placebo or no treatment. This effect is consistent across primary and secondary prevention populations and across demographic subgroups defined by age, sex, and baseline LDL-C. The evidence base (42 randomized controlled trials, 247,891 participants) is extensive, methodologically rigorous, and free of detectable publication bias.
+
+The certainty of evidence is HIGH (GRADE framework). There is no remaining equipoise regarding whether statin therapy reduces cardiovascular mortality; questions for future research concern optimization (dose intensity, combination with other agents), precision (identification of non-responders), and implementation (adherence, access in low-resource settings).
+
+## Summary of Key Numerical Findings
+
+| Outcome | Pooled Estimate | Certainty |
+|---------|-----------------|-----------|
+| Cardiovascular mortality | RR 0.79 (0.75--0.83) | HIGH |
+| All-cause mortality | RR 0.87 (0.83--0.91) | HIGH |
+| Non-fatal MI | RR 0.74 (0.69--0.80) | HIGH |
+| Non-fatal stroke | RR 0.82 (0.76--0.89) | HIGH |
+| Revascularization | RR 0.75 (0.71--0.80) | HIGH |
+| NNT (10-year CV mortality) | 59 (49--75) | HIGH |
+| 95% Prediction Interval (CV mortality) | 0.63--0.99 | -- |
+
+## Implications for Guidelines
+
+The 2023 ESC, 2023 ACC/AHA, and 2024 NICE guidelines for lipid management are consistent with the evidence synthesized in this review. Our findings support continued adherence to current guideline recommendations for statin therapy in primary and secondary prevention. No modifications to existing guidelines are indicated by this updated synthesis; the main contribution is quantitative refinement of effect estimates and extension of the evidence base to newer populations (elderly, low- and middle-income countries).

--- a/meta-analysis/content/sections/_index.md
+++ b/meta-analysis/content/sections/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Full Report Sections"
+sort_by = "weight"
+page_template = "post"
++++
+
+Complete methodology, results, and sensitivity analyses for the statin meta-analysis.

--- a/meta-analysis/static/css/style.css
+++ b/meta-analysis/static/css/style.css
@@ -1,0 +1,457 @@
+/* ============================================================================
+   Meta-Analysis - Statistical Synthesis Paper
+   Light background. Clean sans for figures. Compact serif for text.
+   No gradients. No emojis.
+   ============================================================================ */
+
+:root {
+  --bg: #fafbfc;
+  --bg-2: #f0f2f5;
+  --bg-3: #e4e8ed;
+  --rule: #c8ccd4;
+  --ink: #1a1e28;
+  --ink-2: #2e3240;
+  --ink-3: #5a6070;
+  --ink-4: #8a8e98;
+  --accent: #2e4a6b;
+  --accent-2: #1a324b;
+  --accent-light: #d4dde8;
+  --diamond: #c0392b;
+  --favor-tx: #1e6e3a;
+  --favor-ctl: #b83220;
+  --null: #5a6070;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Crimson Pro", "STIX Two Text", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.paper-wrap {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------------- Header ---------------- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1.2rem;
+  border-bottom: 2px solid var(--accent);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.logo-mark { width: 52px; height: 40px; }
+
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+
+.journal-name {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}
+
+.review-ref {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.8rem;
+}
+
+.site-nav a {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--ink-2);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover { color: var(--accent); }
+
+/* ---------------- Main Content ---------------- */
+
+.site-main {
+  padding: 2rem 0;
+}
+
+.paper-article {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+/* ---------------- Paper Header ---------------- */
+
+.paper-header {
+  text-align: left;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.8rem;
+  font-weight: 700;
+}
+
+.paper-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.85rem;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+  letter-spacing: -0.005em;
+}
+
+.paper-subtitle {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.98rem;
+  color: var(--ink-3);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+  font-style: italic;
+}
+
+.paper-authors {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.95rem;
+  color: var(--ink-2);
+  margin: 0 0 0.4rem;
+  line-height: 1.5;
+}
+
+.paper-authors sup { color: var(--accent); font-size: 0.7em; }
+
+.paper-affiliations {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-style: italic;
+  font-size: 0.84rem;
+  color: var(--ink-3);
+  margin: 0.2rem 0 0;
+}
+
+.paper-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
+  color: var(--ink-3);
+  margin: 1rem 0 0;
+  line-height: 1.7;
+}
+
+.paper-meta strong { color: var(--ink-2); }
+
+/* ---------------- Key Finding Box (statistical) ---------------- */
+
+.key-finding {
+  background: var(--bg-2);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--accent);
+  padding: 1.2rem 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.key-finding .finding-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.5rem;
+}
+
+.key-finding p:last-child { margin-bottom: 0; }
+
+/* ---------------- Pooled estimate callout ---------------- */
+
+.pooled-estimate {
+  background: var(--bg-2);
+  border: 2px solid var(--accent);
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pooled-estimate .estimate-stat { text-align: center; }
+
+.pooled-estimate .estimate-value {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--accent);
+  display: block;
+  line-height: 1.1;
+}
+
+.pooled-estimate .estimate-label {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.2rem;
+}
+
+.pooled-estimate .estimate-sep {
+  width: 1px;
+  height: 2rem;
+  background: var(--rule);
+}
+
+/* ---------------- Headings ---------------- */
+
+h1, h2, h3, h4 {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--ink);
+}
+
+h1 { font-size: 1.6rem; margin: 2rem 0 0.6rem; }
+h2 { font-size: 1.3rem; margin: 1.8rem 0 0.5rem; }
+h3 { font-size: 1.08rem; margin: 1.5rem 0 0.5rem; }
+h4 { font-size: 0.95rem; margin: 1.2rem 0 0.4rem; font-style: italic; }
+
+/* ---------------- Body Text ---------------- */
+
+p { margin: 0.8em 0; }
+
+a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+a:hover { border-bottom-color: var(--accent); }
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--accent);
+  background: var(--bg-2);
+  color: var(--ink-2);
+}
+
+ul, ol { padding-left: 1.5em; }
+li { margin-bottom: 0.3em; }
+
+/* ---------------- Tables ---------------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.86rem;
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+}
+
+th, td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+th {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 2px solid var(--ink);
+}
+
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+}
+
+/* Table for forest plot summary */
+.summary-row td {
+  font-weight: 700;
+  border-top: 2px solid var(--ink);
+  border-bottom: none;
+  background: var(--bg-2);
+}
+
+/* ---------------- Section Header ---------------- */
+
+.paper-section-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.paper-section-eyebrow {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.4rem;
+  font-weight: 700;
+}
+
+.paper-section-title {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 1.25;
+  color: var(--ink);
+  margin: 0 0 0.4rem;
+}
+
+.paper-lede {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.92rem;
+  color: var(--ink-3);
+  margin: 0;
+  line-height: 1.6;
+  font-style: italic;
+}
+
+.paper-section-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.button-link {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.button-link:hover { text-decoration: underline; }
+
+/* ---------------- Section List ---------------- */
+
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.section-list li {
+  margin-bottom: 0;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--bg-3);
+}
+
+.section-list li a {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.section-list li a:hover { color: var(--accent); }
+
+/* ---------------- Code ---------------- */
+
+code {
+  font-family: "IBM Plex Mono", Consolas, monospace;
+  font-size: 0.85em;
+  background: var(--bg-2);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: var(--bg-2);
+  padding: 1rem;
+  overflow-x: auto;
+  border: 1px solid var(--bg-3);
+}
+
+pre code { background: none; padding: 0; }
+
+/* ---------------- Taxonomy & Pagination ---------------- */
+
+.taxonomy-desc { color: var(--ink-3); font-style: italic; margin-bottom: 1.5rem; }
+
+nav.pagination { margin: 1.5rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border: 1px solid var(--rule); color: var(--ink-3); text-decoration: none; font-size: 0.85rem; }
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------------- Footer ---------------- */
+
+.site-footer {
+  margin-top: 3rem;
+  padding-bottom: 2rem;
+}
+
+.footer-rule { margin-bottom: 1rem; }
+.footer-rule svg { width: 100%; height: 6px; display: block; }
+
+.footer-content { text-align: center; }
+
+.footer-meta {
+  font-family: "IBM Plex Sans", "Inter", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  margin: 0 0 0.3rem;
+  font-weight: 600;
+}
+
+.footer-note {
+  font-family: "Crimson Pro", "STIX Two Text", serif;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  margin: 0;
+  font-style: italic;
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 700px) {
+  .paper-wrap { padding: 0 1rem; }
+  .paper-title { font-size: 1.5rem; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; flex-wrap: wrap; }
+  .pooled-estimate { flex-direction: column; gap: 0.8rem; }
+  .pooled-estimate .estimate-sep { width: 3rem; height: 1px; }
+}

--- a/meta-analysis/templates/404.html
+++ b/meta-analysis/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>404 -- Page Not Found</h1>
+      <p>The requested section does not exist in this meta-analysis.</p>
+      <p><a href="{{ base_url }}/">Return to Summary</a></p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meta-analysis/templates/footer.html
+++ b/meta-analysis/templates/footer.html
@@ -1,0 +1,17 @@
+    <footer class="site-footer">
+      <div class="footer-rule" aria-hidden="true">
+        <svg viewBox="0 0 1000 6" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1000" y2="2" stroke="#2e4a6b" stroke-width="0.5"/>
+          <line x1="0" y1="5" x2="1000" y2="5" stroke="#2e4a6b" stroke-width="1.2"/>
+        </svg>
+      </div>
+      <div class="footer-content">
+        <p class="footer-meta">Cochrane Systematic Review &amp; Meta-Analysis &middot; Registration: CRD42024418293 &middot; PROSPERO</p>
+        <p class="footer-note">Funded by the NIHR Cochrane Incentive Award Scheme. No conflicts of interest declared. Typeset with Hwaro.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/meta-analysis/templates/header.html
+++ b/meta-analysis/templates/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=STIX+Two+Text:ital,wght@0,400;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="paper-wrap">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Meta-analysis home">
+        <svg viewBox="0 0 52 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Forest plot style logo -->
+          <line x1="26" y1="4" x2="26" y2="36" stroke="#2e4a6b" stroke-width="1" stroke-dasharray="2,2"/>
+          <!-- Study rows with squares and confidence intervals -->
+          <line x1="8" y1="10" x2="38" y2="10" stroke="#2e4a6b" stroke-width="0.8"/>
+          <rect x="22" y="7" width="6" height="6" fill="#2e4a6b"/>
+          <line x1="12" y1="18" x2="34" y2="18" stroke="#2e4a6b" stroke-width="0.8"/>
+          <rect x="16" y="15" width="6" height="6" fill="#2e4a6b"/>
+          <line x1="6" y1="26" x2="42" y2="26" stroke="#2e4a6b" stroke-width="0.8"/>
+          <rect x="20" y="23" width="6" height="6" fill="#2e4a6b"/>
+          <!-- Diamond (summary) -->
+          <path d="M14,34 L26,31 L38,34 L26,37 Z" fill="#c0392b"/>
+        </svg>
+        <span class="logo-text">
+          <span class="journal-name">Cochrane Review &middot; Statistical Synthesis</span>
+          <span class="review-ref">Systematic Review &amp; Meta-Analysis &middot; 2026</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">SUMMARY</a>
+        <a href="{{ base_url }}/sections/">SECTIONS</a>
+        <a href="{{ base_url }}/prisma/">PRISMA</a>
+        <a href="{{ base_url }}/references/">REFERENCES</a>
+      </nav>
+    </header>

--- a/meta-analysis/templates/page.html
+++ b/meta-analysis/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meta-analysis/templates/post.html
+++ b/meta-analysis/templates/post.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        {% if page.extra.section_number %}
+        <p class="paper-section-eyebrow">Section {{ page.extra.section_number }}</p>
+        {% endif %}
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="paper-lede">{{ page.description | e }}</p>
+        {% endif %}
+      </header>
+      <div class="paper-content">
+        {{ content }}
+      </div>
+      <footer class="paper-section-footer">
+        <a href="{{ base_url }}/sections/" class="button-link">&larr; back to section index</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meta-analysis/templates/section.html
+++ b/meta-analysis/templates/section.html
@@ -1,0 +1,15 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <header class="paper-section-header">
+        <p class="paper-section-eyebrow">SECTION INDEX</p>
+        <h1 class="paper-section-title">{{ page.title | e }}</h1>
+      </header>
+      {{ content }}
+      <ul class="section-list">
+        {{ section.list }}
+      </ul>
+      {{ pagination }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meta-analysis/templates/shortcodes/alert.html
+++ b/meta-analysis/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f4f6fa; border-left: 5px solid #2e4a6b; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/meta-analysis/templates/taxonomy.html
+++ b/meta-analysis/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/meta-analysis/templates/taxonomy_term.html
+++ b/meta-analysis/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="paper-article">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with this term:</p>
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4277,5 +4277,12 @@
     "retracted",
     "warning",
     "editorial"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
   ]
 }


### PR DESCRIPTION
## Summary
- Add meta-analysis example site: a Statistical Synthesis Paper aggregating 42 randomized controlled trials on statin therapy and cardiovascular mortality (247,891 participants)
- Features a detailed SVG forest plot diagram with individual effect sizes, confidence intervals, study weights, and a pooled summary diamond; SVG funnel plot with 95% CI funnel lines and Egger's test results box; SVG PRISMA 2020 flow diagram
- Typography uses IBM Plex Sans / Inter Bold for figure titles, column headers, and display text; Crimson Pro / STIX Two Text for minimal serif body text between figures; IBM Plex Mono for numerical data
- Includes 5 full report sections (methods, results, heterogeneity, limitations, conclusions), PRISMA flow page, references, and subgroup analysis tables

Closes #1598