### PR TITLE
feat: add hardcore-pit example site (closes #1586)

### DIFF
--- a/hardcore-pit/AGENTS.md
+++ b/hardcore-pit/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/hardcore-pit/config.toml
+++ b/hardcore-pit/config.toml
@@ -1,0 +1,90 @@
+# =============================================================================
+# Hardcore Pit - Controlled Chaos
+# Issue #1586 | Tags: event, punk, hardcore, show, chaotic
+# Site name variant of mosh-pit; existing mosh-pit/ was built from issue #1642.
+# =============================================================================
+
+title = "BASEMENT MATINEE - HARDCORE PIT FEST"
+description = "Sunday basement matinee. Six bands. Paint splatter flyers. Permanent marker setlists. Safety pins and combat boots encouraged."
+base_url = "http://localhost:3000"
+
+sections = ["bands"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "DIY show info. No AI training. Pay the bands."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/hardcore-pit/content/bands/_index.md
+++ b/hardcore-pit/content/bands/_index.md
@@ -1,0 +1,7 @@
++++
+title = "All Bands"
+description = "Six bands on the bill. Zines for each."
+template = "section"
++++
+
+Every band's zine, one slot at a time. Click a card for the full write-up.

--- a/hardcore-pit/content/bands/burn-pile.md
+++ b/hardcore-pit/content/bands/burn-pile.md
@@ -1,0 +1,31 @@
++++
+title = "Burn Pile"
+description = "Philly via Dayton. Four records deep. Polite wall of death."
+template = "post"
+
+[extra]
+slot = "02"
+origin = "PHILLY / DAYTON"
+formed = "OCT 2019"
+set_time = "14:00 - 14:30"
++++
+
+## The Zine
+
+Four-piece with a long van and a longer memory. Seven years, four records, never a lineup change. Their last LP, *Coal Dog Promise*, was pressed in a farm-building in Erie, Pennsylvania.
+
+## Gear Notes
+
+- Brings their own kick pedal and snare.
+- Will use the house bass cab; prefers front-loaded 15.
+- Set list is taped to the monitor wedge.
+
+## Merch
+
+- *Coal Dog Promise* LP, 18 USD, black or marbled ochre.
+- Previous four records in a mixed stack, 8 USD each.
+- Patches sewn in the van on the drive in, 3 USD.
+
+## Request
+
+The wall of death at the end of the third-to-last song is run by Dwight. He will wait, he will count, he will keep it clean. Please follow his hand signal.

--- a/hardcore-pit/content/bands/down-the-drain.md
+++ b/hardcore-pit/content/bands/down-the-drain.md
@@ -1,0 +1,31 @@
++++
+title = "Down the Drain"
+description = "Cleveland all-womxn four-piece. Third time at this basement. New LP August."
+template = "post"
+
+[extra]
+slot = "05"
+origin = "CLEVELAND"
+formed = "MAR 2018"
+set_time = "16:40 - 17:20"
++++
+
+## The Zine
+
+Four-piece, three records and two splits since 2018, each one a noisy step louder than the last. *Dropwise*, the August LP, was tracked live in a basement that is not this basement but rhymes with it.
+
+## Gear Notes
+
+- Two guitar rigs, one vocal mic.
+- Second guitarist swaps to baritone for the last two songs.
+- House bass amp is fine; house kick pedal is not.
+
+## Merch
+
+- *Dropwise* preorder, 20 USD, new t-shirt color for every 50 sold.
+- Back catalog in the suitcase, 8 - 15 USD.
+- No credit cards, no Venmo, no PayPal - cash or local check only.
+
+## Ask
+
+Please pit in front, not to the sides. Their bassist is on the left and her cab is on the right; a clear center gives her the patch cable length she needs.

--- a/hardcore-pit/content/bands/even-hands.md
+++ b/hardcore-pit/content/bands/even-hands.md
@@ -1,0 +1,31 @@
++++
+title = "Even Hands"
+description = "Four song split with Burn Pile last spring. Dina's band."
+template = "post"
+
+[extra]
+slot = "03"
+origin = "LOCAL"
+formed = "JAN 2024"
+set_time = "14:45 - 15:20"
++++
+
+## The Zine
+
+Dina's band (yes, the Dina who co-books this basement). Five tracks on their side of a split cassette with Burn Pile. Four-piece, two guitars, one tuned to standard, one tuned three full steps below.
+
+## Gear Notes
+
+- Two combos; stage-right amp is on top of the stage-left amp.
+- Singer uses an SM7B; treat it gently.
+- No click track, no metronome, no setlist - they play off a sign language cue.
+
+## Merch
+
+- Split cassette with Burn Pile, 6 USD.
+- Four-song 7-inch flexi, 4 USD.
+- Pins at the door, price whatever you think is fair.
+
+## Ask
+
+Dina has asked for the front of the room to be clear for the two minute intro. Please give them the space. It's a quiet intro and it matters.

--- a/hardcore-pit/content/bands/gravel-harvest.md
+++ b/hardcore-pit/content/bands/gravel-harvest.md
@@ -1,0 +1,31 @@
++++
+title = "Gravel Harvest"
+description = "Chicago via Gary. Saxophone over d-beat. Thirty minutes flat."
+template = "post"
+
+[extra]
+slot = "04"
+origin = "CHICAGO / GARY"
+formed = "JUN 2022"
+set_time = "15:45 - 16:20"
++++
+
+## The Zine
+
+Five-piece: guitar, bass, drums, tenor sax, and a vocalist who reads their lyrics off index cards. Their record *Interstate Loss* is a thirty-eight minute straight d-beat with a sax line that comes in over the bridge of every track.
+
+## Gear Notes
+
+- Sax plugged through a Boss RE-20 into a bass amp.
+- Drummer brings sticks and floor tom; uses house kick and snare.
+- The thirty minute set is one continuous track; do not expect breaks.
+
+## Merch
+
+- *Interstate Loss* LP, 15 USD, clear vinyl with a gravel-texture insert.
+- Lyric zine with the vocalist's index cards reproduced, 5 USD.
+- No shirts, no patches, no bootleg stencils.
+
+## Stay for the Closer
+
+The last five minutes of the set is the entire reason they drive here. Please don't leave early to beat the load-out line.

--- a/hardcore-pit/content/bands/last-open-window.md
+++ b/hardcore-pit/content/bands/last-open-window.md
@@ -1,0 +1,31 @@
++++
+title = "Last Open Window"
+description = "Richmond powerviolence reunion set. Drove twelve hours. Load out starts the second the last note ends."
+template = "post"
+
+[extra]
+slot = "06"
+origin = "RICHMOND"
+formed = "2011 - REUNION 2026"
+set_time = "17:40 - 18:30"
++++
+
+## The Zine
+
+Reunion set for a band that broke up in 2016 and has reformed exactly once, for exactly this weekend, because their old drummer is back in town after a decade. Forty minutes, maybe a little longer if the energy stays.
+
+## Gear Notes
+
+- Brings everything but the PA.
+- Singer prefers the vocal mic taped to a pipe, not a stand.
+- Drummer plays seated on a milk crate; don't offer a throne.
+
+## Merch
+
+- Reunion short-run 12-inch, 22 USD, edition of 300, no repress.
+- Old records in a box; ask at the suitcase for what's left.
+- Long sleeve with the 2014 European tour backprint, 25 USD.
+
+## Hard Stop
+
+The band has asked for a one minute ovation then a one minute load-out. They are back in the van at 19:00. That's the whole reason we can book them at all.

--- a/hardcore-pit/content/bands/rib-cage-column.md
+++ b/hardcore-pit/content/bands/rib-cage-column.md
@@ -1,0 +1,30 @@
++++
+title = "Rib Cage Column"
+description = "Local three-piece. First show. Eight songs. Thirty minutes flat."
+template = "post"
+
+[extra]
+slot = "01"
+origin = "IRON ST NEIGHBORHOOD"
+formed = "FEB 2026"
+set_time = "13:15 - 13:45"
++++
+
+## The Zine
+
+Three kids from the block who practiced six Sunday afternoons before they booked themselves on this show. Guitar through a Peavey, bass through a combo amp that buzzes on an open A, and a drum kit short one cymbal stand.
+
+## Gear Notes
+
+- Guitar tunes to drop D, one string hand-tightened between every song.
+- Drum kit is shared with Even Hands; no adjustments after soundcheck.
+- Vocal is a single SM58 on a borrowed stand; spit at your own risk.
+
+## Merch
+
+- Xeroxed demo CD-R, 3 USD or a trade.
+- Hand-silk-screened shirt, 12 USD, 3 of each size.
+
+## If You Like Them
+
+Tell them so. It's their first show. Give them the corner and they'll give you the rest of the afternoon.

--- a/hardcore-pit/content/doors.md
+++ b/hardcore-pit/content/doors.md
@@ -1,0 +1,97 @@
++++
+title = "Doors & Donations"
+description = "Door hours, sliding scale, and how the money gets counted."
+template = "page"
+tags = ["event", "punk", "doors", "donations"]
++++
+
+<section class="pit-hero">
+<p class="hero-stamp">XXX DOOR OPENS 12:45 XXX</p>
+<h1 class="hero-title"><span class="word word-1">DOORS</span><br><span class="word word-2">&amp;</span> <span class="word word-3">BUCKETS</span></h1>
+<p class="hero-sub">Flat hall at 413 Iron Street. Basement level. Buzzer 4-C. Doors open at 12:45. First band at 13:15. We don't sell tickets in advance and we don't have a will-call list.</p>
+</section>
+
+<section class="setlist-wrap">
+<h2>Door Sliding Scale</h2>
+<div class="setlist-row">
+  <div class="setlist-slot">$3</div>
+  <div class="setlist-name">Low-Income / Student / Unemployed</div>
+  <div class="setlist-time">NO QUESTIONS</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">$7</div>
+  <div class="setlist-name">Suggested Donation</div>
+  <div class="setlist-time">PAYS THE BANDS</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">$15</div>
+  <div class="setlist-name">Pay-It-Forward</div>
+  <div class="setlist-time">COVERS ONE AT THE LOW END</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">$0</div>
+  <div class="setlist-name">Broke</div>
+  <div class="setlist-time">NO ONE TURNED AWAY FOR LACK OF FUNDS</div>
+</div>
+</section>
+
+<section class="pit-safety">
+<h2>Where the Money Goes</h2>
+<div class="safety-grid">
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>60% - Bands</strong>
+    <p>Split evenly six ways. Touring bands get a floor at the bookers' apartments if asked in advance.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>25% - Rent</strong>
+    <p>Flat hall rent on the basement is 400 USD a month. We pay half from shows, half from our pockets.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>10% - Gear</strong>
+    <p>PA repair. Replacement mics. A new fuse every other show. Earplugs at the door.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>5% - Solidarity</strong>
+    <p>Split each season between a local bail fund and a free-store collective two blocks up.</p>
+  </div>
+</div>
+
+</div>
+</section>
+
+<div class="mono-rule">X - COUNTED ON A BEDSHEET ON THE FLOOR AFTER LOAD-OUT - RECEIPTS POSTED ON THE WALL THURSDAY - X</div>

--- a/hardcore-pit/content/index.md
+++ b/hardcore-pit/content/index.md
@@ -1,0 +1,235 @@
++++
+title = "Hardcore Pit Fest - Basement Matinee"
+description = "Six bands, one basement, Sunday afternoon. Paint splatter flyer, safety pin iconography, and controlled chaos in every corner of the room."
+template = "page"
+tags = ["event", "punk", "hardcore", "show", "chaotic"]
++++
+
+<section class="pit-hero">
+<p class="hero-stamp">XXX SUNDAY MATINEE - 413 IRON STREET BASEMENT XXX</p>
+
+<h1 class="hero-title"><span class="word word-1">HARDCORE</span><br><span class="word word-2">PIT</span> <span class="word word-3">FEST</span></h1>
+
+<p class="hero-sub">Six bands, one basement, a donation bucket, and exactly one bathroom. Doors 13:00. Hard stop 19:00. Pay the bands. Watch the corners. Pick up anyone who falls.</p>
+
+<p class="hero-date">SUN 05 / JUL / 2026</p>
+</section>
+
+<div class="mono-rule">X - NO DRUGS - NO CROWD KILLING - NO BOOTLEG MERCH - ACCOUNTABILITY OVER HIERARCHY - X</div>
+
+<section class="band-row">
+<h2>This Sunday</h2>
+<div class="band-cards">
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">01</p>
+<h3>RIB CAGE COLUMN</h3>
+<p class="set-time">13:15 - 13:45</p>
+<p>Local three-piece, first show. Eight songs. Please show up early; a half-empty room on band one sets the tone for the day.</p>
+<a href="/bands/rib-cage-column/">READ ZINE</a>
+</article>
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">02</p>
+<h3>BURN PILE</h3>
+<p class="set-time">14:00 - 14:30</p>
+<p>Philly via Dayton. Four records deep. Brings their own kick pedal. Will end with the wall of death but it will be polite.</p>
+<a href="/bands/burn-pile/">READ ZINE</a>
+</article>
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">03</p>
+<h3>EVEN HANDS</h3>
+<p class="set-time">14:45 - 15:20</p>
+<p>Four song split with Burn Pile last spring. Bassist is Dina who co-books this space. Please tip.</p>
+<a href="/bands/even-hands/">READ ZINE</a>
+</article>
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">04</p>
+<h3>GRAVEL HARVEST</h3>
+<p class="set-time">15:45 - 16:20</p>
+<p>Chicago via Gary. Saxophone over d-beat. Thirty minutes flat. Stay for the closer - it's the point.</p>
+<a href="/bands/gravel-harvest/">READ ZINE</a>
+</article>
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">05</p>
+<h3>DOWN THE DRAIN</h3>
+<p class="set-time">16:40 - 17:20</p>
+<p>Cleveland all-womxn four-piece. Third time at this basement. New LP due in August. Merch in a suitcase, no credit cards.</p>
+<a href="/bands/down-the-drain/">READ ZINE</a>
+</article>
+
+<article class="band-card">
+<svg class="pin-top" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  <circle cx="10" cy="14" r="2" fill="#E63946"/>
+  <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+</svg>
+<p class="slot-num">06</p>
+<h3>LAST OPEN WINDOW</h3>
+<p class="set-time">17:40 - 18:30</p>
+<p>Richmond powerviolence, reunion set. 40 minutes because they hauled twelve hours. Load-out starts the second the last note ends.</p>
+<a href="/bands/last-open-window/">READ ZINE</a>
+</article>
+
+</div>
+</section>
+
+<section class="pit-safety">
+<h2>Pit Safety Log</h2>
+<div class="safety-grid">
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>Catch the Fallen</strong>
+    <p>If someone goes down, form a ring, pick them up. Don't keep windmilling around them.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>No Windmills Near the Wall</strong>
+    <p>There are pipes. There are amps. Keep arm arcs in the center third of the room.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>Exit Stays Clear</strong>
+    <p>Don't pile gear on the stair. If you're not moving, back up against the north wall.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>Accountability Over Fists</strong>
+    <p>We've got a door person and two floor watches. Harassment = out. No exceptions.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>Water Station</strong>
+    <p>Back left corner, near the first aid kit. Take a cup, fill it, pass it back if you grab two.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>Hard 19:00 Cutoff</strong>
+    <p>We share the block. The building next door closes at 8. Quiet load-out helps us keep booking here.</p>
+  </div>
+</div>
+
+</div>
+</section>
+
+<section class="setlist-wrap">
+<h2>Full Running Order</h2>
+<div class="setlist-row">
+  <div class="setlist-slot">01</div>
+  <div class="setlist-name">Rib Cage Column</div>
+  <div class="setlist-time">13:15 - 13:45</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">02</div>
+  <div class="setlist-name">Burn Pile</div>
+  <div class="setlist-time">14:00 - 14:30</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">03</div>
+  <div class="setlist-name">Even Hands</div>
+  <div class="setlist-time">14:45 - 15:20</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">04</div>
+  <div class="setlist-name">Gravel Harvest</div>
+  <div class="setlist-time">15:45 - 16:20</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">05</div>
+  <div class="setlist-name">Down the Drain</div>
+  <div class="setlist-time">16:40 - 17:20</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">06</div>
+  <div class="setlist-name">Last Open Window</div>
+  <div class="setlist-time">17:40 - 18:30</div>
+</div>
+<div class="setlist-row">
+  <div class="setlist-slot">X</div>
+  <div class="setlist-name">Load-out / Clean / Out by 19:00</div>
+  <div class="setlist-time">18:30 - 19:00</div>
+</div>
+</section>
+
+<div class="mono-rule">X - 7 USD SUGGESTED - NO ONE TURNED AWAY - EVERY DOLLAR TO THE BANDS AND THE LANDLORD - X</div>

--- a/hardcore-pit/content/rules.md
+++ b/hardcore-pit/content/rules.md
@@ -1,0 +1,122 @@
++++
+title = "Pit Rules & Accountability"
+description = "How this basement runs, how we handle conflict, and what we ask of everyone in the room."
+template = "page"
+tags = ["event", "punk", "rules", "hardcore"]
++++
+
+<section class="pit-hero">
+<p class="hero-stamp">XXX THIS IS HOW WE KEEP BOOKING SHOWS XXX</p>
+<h1 class="hero-title"><span class="word word-1">PIT</span> <span class="word word-2">RULES</span></h1>
+<p class="hero-sub">Not handed down from anyone. Written by the bookers, the floor watch, and the people who've been in the room for seven years. Open to your input at the door after.</p>
+</section>
+
+<div class="mono-rule">X - PLAY LOUD - LEAVE CLEAN - LOOK OUT FOR EACH OTHER - X</div>
+
+<section class="band-row">
+<h2>House Rules</h2>
+<div class="band-cards">
+
+<article class="band-card">
+<p class="slot-num">01</p>
+<h3>No Crowd Killers</h3>
+<p class="set-time">FLOOR WATCH WILL POINT YOU TO THE DOOR</p>
+<p>Swinging to hit people isn't pitting. We'll tap you on the shoulder once. After that you leave, show's over for you.</p>
+</article>
+
+<article class="band-card">
+<p class="slot-num">02</p>
+<h3>Harassment = Out</h3>
+<p class="set-time">NON-NEGOTIABLE - AT THE DOOR, IN THE PIT, OUT FRONT</p>
+<p>If it happens, tell any of us at the merch table. We'll handle it. You won't be asked to repeat yourself.</p>
+</article>
+
+<article class="band-card">
+<p class="slot-num">03</p>
+<h3>No Bootleg Merch</h3>
+<p class="set-time">IF IT'S NOT IN THE SUITCASE, DON'T SELL IT</p>
+<p>Bands are here to be paid. Don't sell copies outside. Don't hawk trades in the bathroom.</p>
+</article>
+
+<article class="band-card">
+<p class="slot-num">04</p>
+<h3>Pick Up the Fallen</h3>
+<p class="set-time">FORM THE RING</p>
+<p>If someone goes down, stop pitting for three seconds and form a ring until they stand up. Then keep going.</p>
+</article>
+
+<article class="band-card">
+<p class="slot-num">05</p>
+<h3>Exit Stays Clear</h3>
+<p class="set-time">STAIRS UP AND BACK DOOR BOTH</p>
+<p>Do not set down gear, jackets, or drinks on the stair. Fire marshal won't come; we will.</p>
+</article>
+
+<article class="band-card">
+<p class="slot-num">06</p>
+<h3>Hard 19:00 Cutoff</h3>
+<p class="set-time">QUIET LOAD OUT OR THIS SPACE IS OVER</p>
+<p>The building next door wakes up at 4 AM. We keep booking here only if we keep the promise: cutoff at 19:00, van loaded by 19:30, block quiet after.</p>
+</article>
+
+</div>
+</section>
+
+<section class="pit-safety">
+<h2>Accountability Process</h2>
+<div class="safety-grid">
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>01 - Tell Us</strong>
+    <p>Any floor watch (red armband) or either booker. No intake form, no waiver, no paperwork.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>02 - We Act</strong>
+    <p>Someone talks to the person you name. Outcome is usually out for the day. Sometimes out for the year.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>03 - Follow Up</strong>
+    <p>We'll check in, by the method you ask for, the following week. If you want nothing, we respect nothing.</p>
+  </div>
+</div>
+
+<div class="safety-cell">
+  <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="14" r="6" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+    <circle cx="10" cy="14" r="2" fill="#E63946"/>
+    <path d="M 16 14 L 40 38 L 44 34 L 20 10" fill="none" stroke="#0a0a0a" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M 40 38 Q 48 44 42 46 Q 34 44 34 38" fill="none" stroke="#0a0a0a" stroke-width="2.5"/>
+  </svg>
+  <div>
+    <strong>04 - No Cops</strong>
+    <p>We don't call them unless a life is on the line. If you need other support we will help find it.</p>
+  </div>
+</div>
+
+</div>
+</section>

--- a/hardcore-pit/static/css/style.css
+++ b/hardcore-pit/static/css/style.css
@@ -1,0 +1,631 @@
+/* =============================================================================
+   Hardcore Pit - Controlled Chaos
+   Black / white / red. Flat colors only. No gradients. Alternate rotations.
+   ============================================================================= */
+
+:root {
+  --ink: #0a0a0a;
+  --paper: #f3efe6;
+  --paper-stock: #ece6d6;
+  --red: #E63946;
+  --red-deep: #B0172A;
+  --rule: #1a1a1a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: 'Rubik Mono One', 'Helvetica Neue', sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* Torn banner -------------------------------------------------------------- */
+.pit-banner {
+  background: var(--ink);
+  color: var(--paper);
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.12em;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  text-transform: uppercase;
+  border-bottom: 4px solid var(--red);
+}
+.banner-x {
+  color: var(--red);
+  font-family: 'Permanent Marker', cursive;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+.banner-shout { font-weight: bold; letter-spacing: 0.22em; }
+.banner-mono { color: #c4bfa8; letter-spacing: 0.14em; }
+
+/* Layout ------------------------------------------------------------------- */
+.pit-wrap {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 32px 60px;
+}
+.bg-splat {
+  position: absolute;
+  width: 420px;
+  height: 420px;
+  pointer-events: none;
+  z-index: 0;
+}
+.bg-splat-1 { top: 200px; left: -80px; }
+.bg-splat-2 { top: 720px; right: -80px; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 26px 0;
+  border-bottom: 4px solid var(--ink);
+  position: relative;
+  z-index: 1;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.site-logo {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  text-decoration: none;
+  color: var(--ink);
+  transform: rotate(-2deg);
+}
+.logo-pin { width: 54px; height: 54px; flex-shrink: 0; }
+.logo-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 32px;
+  line-height: 0.9;
+  color: var(--ink);
+  display: block;
+  letter-spacing: 0.02em;
+}
+.logo-sub {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 13px;
+  display: block;
+  margin-top: 6px;
+  letter-spacing: 0.14em;
+  color: var(--red);
+  text-transform: uppercase;
+}
+
+.site-nav { display: flex; gap: 20px; flex-wrap: wrap; }
+.site-nav a {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 15px;
+  color: var(--ink);
+  background: var(--paper-stock);
+  padding: 8px 14px;
+  border: 2px solid var(--ink);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.site-nav a:nth-child(2n) { transform: rotate(-2deg); }
+.site-nav a:nth-child(2n+1) { transform: rotate(2deg); }
+.site-nav a:hover { background: var(--ink); color: var(--paper); }
+
+.site-main { position: relative; z-index: 1; padding-top: 40px; }
+
+/* Hero --------------------------------------------------------------------- */
+.pit-hero {
+  padding: 48px 20px 64px;
+  text-align: center;
+  position: relative;
+  border: 6px solid var(--ink);
+  background: var(--paper);
+  margin-bottom: 56px;
+}
+.pit-hero::before {
+  content: '';
+  position: absolute;
+  top: -12px;
+  left: -12px;
+  right: -12px;
+  bottom: -12px;
+  border: 2px solid var(--red);
+  pointer-events: none;
+  transform: rotate(-0.5deg);
+}
+.hero-stamp {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.24em;
+  color: var(--red);
+  margin: 0 0 20px;
+  text-transform: uppercase;
+}
+.hero-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 180px;
+  line-height: 0.88;
+  margin: 0;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+}
+.hero-title .word {
+  display: inline-block;
+}
+.hero-title .word-1 { transform: rotate(-3deg); color: var(--ink); }
+.hero-title .word-2 { transform: rotate(2deg); color: var(--red); }
+.hero-title .word-3 { transform: rotate(-1deg); color: var(--ink); }
+
+.hero-sub {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 18px;
+  margin: 24px auto 0;
+  max-width: 720px;
+  color: var(--ink);
+  letter-spacing: 0.08em;
+  line-height: 1.5;
+}
+
+.hero-date {
+  display: inline-block;
+  font-family: 'Permanent Marker', cursive;
+  font-size: 46px;
+  color: var(--red);
+  background: var(--ink);
+  padding: 8px 22px;
+  margin-top: 28px;
+  transform: rotate(-2deg);
+  letter-spacing: 0.04em;
+}
+
+/* Band row ----------------------------------------------------------------- */
+.band-row { margin: 56px 0; }
+.band-row h2 {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 64px;
+  color: var(--ink);
+  margin: 0 0 28px;
+  transform: rotate(-2deg);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.band-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 22px;
+}
+.band-card {
+  position: relative;
+  padding: 22px 22px 24px;
+  background: var(--paper-stock);
+  border: 3px solid var(--ink);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.band-card:nth-child(odd) { transform: rotate(-1.5deg); }
+.band-card:nth-child(even) { transform: rotate(1.5deg); }
+.band-card::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 20px;
+  right: 20px;
+  height: 12px;
+  border-top: 3px dashed var(--ink);
+}
+.band-card::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 20px;
+  right: 20px;
+  height: 12px;
+  border-bottom: 3px dashed var(--ink);
+}
+.band-card .pin-top {
+  position: absolute;
+  top: -10px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+}
+.band-card h3 {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 24px;
+  color: var(--ink);
+  margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.1;
+}
+.band-card .slot-num {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 44px;
+  color: var(--red);
+  line-height: 1;
+  margin: 0;
+}
+.band-card .set-time {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.14em;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.band-card p {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  margin: 0;
+  line-height: 1.5;
+}
+.band-card a {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 13px;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 6px 12px;
+  text-decoration: none;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  align-self: flex-start;
+}
+.band-card a:hover { background: var(--red); }
+
+/* Pit Map (safety pin illustrations) --------------------------------------- */
+.pit-safety {
+  margin: 56px 0;
+  padding: 32px;
+  border: 4px dashed var(--ink);
+  background: var(--paper-stock);
+}
+.pit-safety h2 {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 56px;
+  margin: 0 0 24px;
+  transform: rotate(-1deg);
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.safety-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.safety-cell {
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  padding: 18px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+.safety-cell svg { width: 48px; height: 48px; flex-shrink: 0; }
+.safety-cell strong {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 16px;
+  color: var(--red);
+  display: block;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.safety-cell p {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  margin: 8px 0 0;
+  letter-spacing: 0.04em;
+}
+
+/* Setlist rows ------------------------------------------------------------- */
+.setlist-wrap {
+  margin: 56px 0;
+  padding: 32px;
+  border: 4px solid var(--ink);
+  background: var(--paper-stock);
+}
+.setlist-wrap h2 {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 56px;
+  color: var(--red);
+  margin: 0 0 20px;
+  transform: rotate(1deg);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.setlist-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 140px;
+  gap: 16px;
+  padding: 12px 0;
+  border-top: 2px solid var(--ink);
+  align-items: center;
+  font-family: 'Cutive Mono', monospace;
+  font-size: 15px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.setlist-row:last-child { border-bottom: 2px solid var(--ink); }
+.setlist-row:nth-child(odd) { transform: rotate(-0.8deg); }
+.setlist-row:nth-child(even) { transform: rotate(0.6deg); }
+.setlist-slot {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 28px;
+  color: var(--red);
+}
+.setlist-name {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 20px;
+  color: var(--ink);
+  letter-spacing: 0.06em;
+}
+.setlist-time {
+  text-align: right;
+  color: var(--ink);
+  font-weight: bold;
+}
+
+/* Splatter hero variant ---------------------------------------------------- */
+.mono-rule {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  color: var(--ink);
+  letter-spacing: 0.16em;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  padding: 14px 0;
+  margin: 40px 0;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+/* Section listing --------------------------------------------------------- */
+.section-head { margin: 40px 0 28px; text-align: center; }
+.section-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 120px;
+  color: var(--ink);
+  transform: rotate(-2deg);
+  margin: 0;
+  line-height: 0.9;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+.section-content p {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 16px;
+  text-align: center;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.band-list {
+  list-style: none;
+  padding: 0;
+  margin: 32px 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+.band-list li {
+  border: 3px solid var(--ink);
+  background: var(--paper-stock);
+  padding: 16px 18px;
+}
+.band-list li:nth-child(odd) { transform: rotate(-1deg); }
+.band-list li:nth-child(even) { transform: rotate(1deg); }
+.band-list li a {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 20px;
+  color: var(--ink);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.band-list li a:hover { color: var(--red); }
+
+/* Band detail article ----------------------------------------------------- */
+.band-article {
+  padding: 24px 0 48px;
+  max-width: 820px;
+  margin: 0 auto;
+}
+.band-article-head {
+  border: 4px solid var(--ink);
+  padding: 28px 32px;
+  background: var(--paper-stock);
+  margin-bottom: 28px;
+  transform: rotate(-0.8deg);
+}
+.band-slot {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.22em;
+  color: var(--red);
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+.band-article-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 84px;
+  color: var(--ink);
+  margin: 0 0 14px;
+  line-height: 0.95;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+.band-article-lede {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 20px;
+  color: var(--red);
+  margin: 0 0 20px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.band-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin: 0;
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.band-meta dt { color: var(--red); display: inline; font-weight: bold; }
+.band-meta dd { display: inline; margin: 0 0 0 6px; }
+.band-meta > div { display: inline-block; }
+
+.band-content h2 {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 24px;
+  color: var(--ink);
+  margin: 28px 0 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-left: 6px solid var(--red);
+  padding-left: 14px;
+}
+.band-content h3 {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 18px;
+  color: var(--red);
+  margin: 22px 0 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.band-content p {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  line-height: 1.6;
+}
+.band-content ul { padding-left: 22px; font-family: 'Cutive Mono', monospace; }
+.band-content ul li { margin: 6px 0; font-size: 16px; }
+.band-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  font-family: 'Cutive Mono', monospace;
+  font-size: 14px;
+}
+.band-content table th,
+.band-content table td {
+  border: 2px solid var(--ink);
+  padding: 8px 10px;
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.band-content table th {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.band-article-foot { margin-top: 36px; text-align: center; }
+.pin-link {
+  font-family: 'Rubik Mono One', sans-serif;
+  font-size: 14px;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 10px 16px;
+  text-decoration: none;
+  letter-spacing: 0.1em;
+  display: inline-block;
+  border: 2px solid var(--ink);
+  text-transform: uppercase;
+}
+.pin-link:hover { background: var(--red); }
+
+/* Error -------------------------------------------------------------------- */
+.error-page { padding: 72px 0; text-align: center; }
+.error-marker {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 24px;
+  letter-spacing: 0.3em;
+  color: var(--red);
+  margin-bottom: 14px;
+}
+.error-page h1 {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 72px;
+  transform: rotate(-1deg);
+  margin: 0 0 20px;
+  text-transform: uppercase;
+}
+
+.taxonomy-desc {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 15px;
+  letter-spacing: 0.12em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+/* Footer ------------------------------------------------------------------- */
+.site-footer {
+  margin-top: 60px;
+  padding-top: 28px;
+  border-top: 4px solid var(--ink);
+  position: relative;
+  z-index: 1;
+}
+.footer-scrawl svg { width: 100%; height: 10px; display: block; margin-bottom: 24px; }
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 24px;
+  margin-bottom: 24px;
+}
+.footer-label {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 22px;
+  color: var(--red);
+  margin: 0 0 8px;
+  letter-spacing: 0.02em;
+}
+.footer-mono {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 13px;
+  color: var(--ink);
+  letter-spacing: 0.1em;
+  margin: 2px 0;
+  text-transform: uppercase;
+}
+.footer-tag {
+  font-family: 'Cutive Mono', monospace;
+  font-size: 13px;
+  text-align: center;
+  letter-spacing: 0.14em;
+  color: var(--ink);
+  border-top: 2px solid var(--ink);
+  padding-top: 14px;
+  margin: 12px 0 0;
+  text-transform: uppercase;
+}
+
+/* Responsive -------------------------------------------------------------- */
+@media (max-width: 960px) {
+  .hero-title { font-size: 110px; }
+  .section-title { font-size: 80px; }
+  .band-article-title { font-size: 56px; }
+  .setlist-row { grid-template-columns: 60px 1fr 100px; }
+}
+@media (max-width: 600px) {
+  .pit-wrap { padding: 0 18px 40px; }
+  .hero-title { font-size: 72px; }
+  .pit-banner { font-size: 12px; padding: 8px 14px; }
+  .site-header { flex-direction: column; align-items: flex-start; }
+}

--- a/hardcore-pit/templates/404.html
+++ b/hardcore-pit/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="error-page">
+      <p class="error-marker">XXX WRONG EXIT XXX</p>
+      <h1>404 - NO SET AT THIS VENUE</h1>
+      <p>The flyer you followed was a misprint. Go back to the room with the PA.</p>
+      <p><a href="{{ base_url }}/" class="pin-link">&larr; BACK TO THE FLYER</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/hardcore-pit/templates/footer.html
+++ b/hardcore-pit/templates/footer.html
@@ -1,0 +1,39 @@
+    <footer class="site-footer">
+      <div class="footer-scrawl">
+        <svg viewBox="0 0 1000 10" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M 0 5 Q 50 0 100 5 T 200 5 T 300 5 T 400 5 T 500 5 T 600 5 T 700 5 T 800 5 T 900 5 T 1000 5" fill="none" stroke="#E63946" stroke-width="3"/>
+        </svg>
+      </div>
+      <div class="footer-grid">
+        <div class="footer-col">
+          <p class="footer-label">VENUE</p>
+          <p class="footer-mono">413 IRON ST</p>
+          <p class="footer-mono">BSMT - BACK ALLEY</p>
+          <p class="footer-mono">BUZZER 4-C</p>
+        </div>
+        <div class="footer-col">
+          <p class="footer-label">BOOKERS</p>
+          <p class="footer-mono">BOBBY 555-0142</p>
+          <p class="footer-mono">DINA 555-0188</p>
+          <p class="footer-mono">NO VOICEMAIL</p>
+        </div>
+        <div class="footer-col">
+          <p class="footer-label">DONATIONS</p>
+          <p class="footer-mono">7 USD SUGGESTED</p>
+          <p class="footer-mono">NO ONE TURNED AWAY</p>
+          <p class="footer-mono">PAY THE BANDS</p>
+        </div>
+        <div class="footer-col">
+          <p class="footer-label">FIRST AID</p>
+          <p class="footer-mono">MERCH TABLE LEFT</p>
+          <p class="footer-mono">WATER STATION BACK</p>
+          <p class="footer-mono">EXIT IS ALWAYS CLEAR</p>
+        </div>
+      </div>
+      <p class="footer-tag">HARDCORE PIT - MADE BY HAND AND PLAYED LOUD - TYPESET WITH HWARO - NO RE-USE WITHOUT ASKING</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/hardcore-pit/templates/header.html
+++ b/hardcore-pit/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Rubik+Mono+One&family=Cutive+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="pit-banner" role="banner">
+    <span class="banner-x">X</span>
+    <span class="banner-shout">ALL AGES - NO CROWD KILLERS - NO BOOTLEG MERCH</span>
+    <span class="banner-x">X</span>
+    <span class="banner-mono">DOORS 13:00 - LAST BAND 18:30 - HARD STOP 19:00</span>
+  </div>
+  <div class="pit-wrap">
+    <svg class="bg-splat bg-splat-1" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M 120 40 C 140 20 180 30 190 60 C 230 50 260 80 250 110 C 280 120 300 160 280 200 C 310 220 310 270 270 280 C 280 320 240 350 210 330 C 190 370 130 360 120 320 C 70 340 30 300 50 260 C 20 240 30 190 70 180 C 40 150 60 100 100 100 C 90 70 100 50 120 40 Z" fill="#E63946" opacity="0.12"/>
+    </svg>
+    <svg class="bg-splat bg-splat-2" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M 200 60 C 240 40 290 80 280 120 C 320 140 330 190 300 220 C 330 260 290 310 250 300 C 240 350 180 360 160 320 C 120 340 80 300 100 260 C 60 240 70 180 110 170 C 90 130 130 90 170 100 C 170 70 180 60 200 60 Z" fill="#0a0a0a" opacity="0.1"/>
+    </svg>
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Hardcore Pit home">
+        <svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg" class="logo-pin" aria-hidden="true">
+          <circle cx="20" cy="20" r="8" fill="none" stroke="#0a0a0a" stroke-width="3"/>
+          <circle cx="20" cy="20" r="3" fill="#E63946"/>
+          <path d="M 28 20 L 56 48 L 62 42 L 34 14" fill="none" stroke="#0a0a0a" stroke-width="3" stroke-linecap="round"/>
+          <path d="M 56 48 Q 68 56 58 64 Q 46 66 44 58" fill="none" stroke="#0a0a0a" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="58" cy="62" r="2" fill="#E63946"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-title">HARDCORE<br>PIT</span>
+          <span class="logo-sub">BASEMENT MATINEE - SUNDAY</span>
+        </span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">FLYER</a>
+        <a href="{{ base_url }}/bands/">BANDS</a>
+        <a href="{{ base_url }}/rules/">PIT RULES</a>
+        <a href="{{ base_url }}/doors/">DOORS</a>
+      </nav>
+    </header>

--- a/hardcore-pit/templates/page.html
+++ b/hardcore-pit/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/hardcore-pit/templates/post.html
+++ b/hardcore-pit/templates/post.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="band-article">
+      <header class="band-article-head">
+        {% if page.extra.slot %}
+        <p class="band-slot">SLOT {{ page.extra.slot }}</p>
+        {% endif %}
+        <h1 class="band-article-title">{{ page.title | e }}</h1>
+        {% if page.description %}
+        <p class="band-article-lede">{{ page.description | e }}</p>
+        {% endif %}
+        {% if page.extra.origin %}
+        <dl class="band-meta">
+          <dt>ORIGIN</dt><dd>{{ page.extra.origin }}</dd>
+          <dt>FORMED</dt><dd>{{ page.extra.formed }}</dd>
+          <dt>SET TIME</dt><dd>{{ page.extra.set_time }}</dd>
+        </dl>
+        {% endif %}
+      </header>
+      <div class="band-content">
+        {{ content }}
+      </div>
+      <footer class="band-article-foot">
+        <a href="{{ base_url }}/bands/" class="pin-link">&larr; BACK TO BAND LIST</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/hardcore-pit/templates/section.html
+++ b/hardcore-pit/templates/section.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <header class="section-head">
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </header>
+    <div class="section-content">
+      {{ content }}
+    </div>
+    <ul class="band-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/hardcore-pit/templates/shortcodes/alert.html
+++ b/hardcore-pit/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/hardcore-pit/templates/taxonomy.html
+++ b/hardcore-pit/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/hardcore-pit/templates/taxonomy_term.html
+++ b/hardcore-pit/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1698,6 +1698,13 @@
     "blog",
     "aviation"
   ],
+  "hardcore-pit": [
+    "event",
+    "punk",
+    "hardcore",
+    "show",
+    "chaotic"
+  ],
   "haute-couture": [
     "elegant",
     "fashion",


### PR DESCRIPTION
Closes #1586

Site name is `hardcore-pit` because `mosh-pit/` already exists (added from issue #1642 in PR #1738). Design follows issue #1586's distinct 'Controlled Chaos' brief.