### PR TITLE
Add gossamer example site

### DIFF
--- a/gossamer/AGENTS.md
+++ b/gossamer/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/gossamer/config.toml
+++ b/gossamer/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Gossamer"
+description = "Welcome to my personal blog powered by Hwaro."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/gossamer/content/about.md
+++ b/gossamer/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About"
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/gossamer/content/archives.md
+++ b/gossamer/content/archives.md
@@ -1,0 +1,5 @@
++++
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/gossamer/content/index.md
+++ b/gossamer/content/index.md
@@ -1,0 +1,15 @@
++++
+title = "Gossamer"
+description = "A delicate and elegant blog theme for Hwaro"
++++
+
+Welcome to Gossamer. This is a refined, typography-focused theme designed to present your content with clarity and grace. It uses a minimalist layout, allowing the words and ideas to take center stage.
+
+## Features
+
+- **Elegant Typography**: Utilizing Inter and Playfair Display for a classic yet modern feel.
+- **Clean Layout**: A distraction-free reading experience.
+- **Responsive**: Beautifully scales from mobile to desktop.
+- **Hwaro Powered**: Lightning fast static site generation.
+
+Feel free to explore the [posts](/posts/) or learn more [about](/about/) this theme.

--- a/gossamer/content/posts/_index.md
+++ b/gossamer/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/gossamer/content/posts/the-art-of-minimalism.md
+++ b/gossamer/content/posts/the-art-of-minimalism.md
@@ -1,0 +1,18 @@
++++
+title = "The Art of Minimalism in Web Design"
+date = "2024-04-15"
+tags = ["design", "minimalism"]
+categories = ["thoughts"]
+authors = ["designer"]
+description = "Exploring the delicate balance of removing the unnecessary to elevate the essential."
++++
+
+Minimalism isn't about having less just for the sake of it. It's about removing distractions so that the core message can shine through clearly. In web design, this translates to focusing heavily on typography, whitespace, and a restricted color palette.
+
+> "Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away." — Antoine de Saint-Exupéry
+
+When designing Gossamer, the goal was to create an environment that feels light and breathable. The interplay between the sans-serif *Inter* for functional text and the elegant serif *Playfair Display* for headings creates a rhythm that guides the reader's eye naturally down the page.
+
+### Embracing Whitespace
+
+Whitespace (or negative space) is the active ingredient in minimal design. It groups related elements together and separates distinct concepts. It gives the content room to breathe. Don't be afraid of empty screen real estate.

--- a/gossamer/static/css/style.css
+++ b/gossamer/static/css/style.css
@@ -1,0 +1,148 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #1a1a1a;
+  --accent-color: #2c3e50;
+  --secondary-bg: #f8f9fa;
+  --border-color: #eaeaea;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --font-serif: 'Playfair Display', Georgia, serif;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-sans);
+  color: var(--text-color);
+  background-color: var(--bg-color);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.site-header {
+  padding: 2rem 5%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.site-title a {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-color);
+  text-decoration: none;
+  letter-spacing: -0.5px;
+}
+
+.site-nav ul {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+}
+
+.site-nav a {
+  color: var(--text-color);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.site-nav a:hover {
+  color: var(--accent-color);
+}
+
+main {
+  max-width: 800px;
+  margin: 4rem auto;
+  padding: 0 1.5rem;
+}
+
+.page-title {
+  font-family: var(--font-serif);
+  font-size: 3rem;
+  margin-bottom: 2rem;
+  color: var(--text-color);
+  line-height: 1.2;
+}
+
+.post-meta {
+  color: #666;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.content {
+  font-size: 1.1rem;
+}
+
+.content p {
+  margin-bottom: 1.5rem;
+}
+
+.content h2, .content h3 {
+  font-family: var(--font-serif);
+  margin: 2rem 0 1rem;
+  color: var(--accent-color);
+}
+
+.post-list {
+  list-style: none;
+}
+
+.post-item {
+  margin-bottom: 3rem;
+  padding-bottom: 3rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.post-item-title {
+  font-family: var(--font-serif);
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-item-title a {
+  color: var(--text-color);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.post-item-title a:hover {
+  color: var(--accent-color);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  color: #666;
+  border-top: 1px solid var(--border-color);
+  margin-top: 4rem;
+  font-size: 0.9rem;
+}
+
+/* Elegant touches */
+::selection {
+  background: rgba(44, 62, 80, 0.1);
+}
+
+.content a {
+  color: var(--accent-color);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.content blockquote {
+  border-left: 3px solid var(--accent-color);
+  padding-left: 1.5rem;
+  margin: 2rem 0;
+  font-style: italic;
+  color: #555;
+}

--- a/gossamer/static/js/search.js
+++ b/gossamer/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/gossamer/templates/404.html
+++ b/gossamer/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+
+<div style="text-align: center; margin: 6rem 0;">
+  <h1 class="page-title" style="font-size: 5rem; margin-bottom: 1rem;">404</h1>
+  <p style="font-size: 1.2rem; color: #666; margin-bottom: 2rem;">The page you are looking for does not exist.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; padding: 0.8rem 2rem; background: var(--accent-color); color: white; text-decoration: none; border-radius: 4px;">Return Home</a>
+</div>
+
+{% include "footer.html" %}

--- a/gossamer/templates/footer.html
+++ b/gossamer/templates/footer.html
@@ -1,0 +1,8 @@
+  </main>
+  <footer class="site-footer">
+    <p>&copy; {{ site.title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+  </footer>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/gossamer/templates/header.html
+++ b/gossamer/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page and page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{% if page %}{{ page.section }}{% endif %}">
+  <header class="site-header">
+    <div class="site-title">
+      <a href="{{ base_url }}/">{{ site.title }}</a>
+    </div>
+    <nav class="site-nav">
+      <ul>
+        <li><a href="{{ base_url }}/">Home</a></li>
+        <li><a href="{{ base_url }}/posts/">Posts</a></li>
+        <li><a href="{{ base_url }}/about/">About</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>

--- a/gossamer/templates/page.html
+++ b/gossamer/templates/page.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<article class="page">
+  <h1 class="page-title">{{ page.title }}</h1>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/gossamer/templates/post.html
+++ b/gossamer/templates/post.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+
+<article class="post">
+  <h1 class="page-title">{{ page.title }}</h1>
+
+  <div class="post-meta">
+    {% if page.date %}
+      <time datetime="{{ page.date }}">{{ page.date }}</time>
+    {% endif %}
+    {% if page.authors %}
+      <span>by {{ page.authors | join(", ") }}</span>
+    {% endif %}
+  </div>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.tags %}
+  <div class="post-tags" style="margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+    <strong>Tags:</strong>
+    {% for tag in page.tags %}
+      <a href="{{ base_url }}/tags/{{ tag }}/" style="margin-right: 0.5rem;">#{{ tag }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/gossamer/templates/section.html
+++ b/gossamer/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+
+<div class="section-header">
+  <h1 class="page-title">{{ section.title }}</h1>
+  {% if section.description %}
+    <p class="section-description" style="color: #666; font-size: 1.1rem; margin-bottom: 3rem;">{{ section.description }}</p>
+  {% endif %}
+</div>
+
+{% if section.content %}
+<div class="content" style="margin-bottom: 3rem;">
+  {{ section.content | safe }}
+</div>
+{% endif %}
+
+<div class="post-list">
+  {{ section.list | safe }}
+</div>
+
+{{ pagination | safe }}
+
+{% include "footer.html" %}

--- a/gossamer/templates/shortcodes/alert.html
+++ b/gossamer/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/gossamer/templates/taxonomy.html
+++ b/gossamer/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+
+<div class="taxonomy-header">
+  <h1 class="page-title">{{ taxonomy_name | capitalize }}</h1>
+</div>
+
+<ul class="taxonomy-list" style="list-style: none; display: flex; flex-wrap: wrap; gap: 1rem;">
+  {% for term in taxonomy_terms %}
+    <li>
+      <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term }}/" style="display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--border-color); border-radius: 4px; text-decoration: none; color: var(--text-color); transition: all 0.2s;">
+        {{ term }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/gossamer/templates/taxonomy_term.html
+++ b/gossamer/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+
+<div class="taxonomy-term-header">
+  <h1 class="page-title">{{ taxonomy_name | capitalize }}: {{ taxonomy_term }}</h1>
+</div>
+
+<div class="post-list">
+  {{ content | safe }}
+</div>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,16 +1,16 @@
 {
-  "abyss": [
-    "dark",
-    "blog",
-    "deep-sea",
-    "immersive"
-  ],
   "abstract-noir": [
     "paper",
     "dark",
     "abstract",
     "bold",
     "typography"
+  ],
+  "abyss": [
+    "dark",
+    "blog",
+    "deep-sea",
+    "immersive"
   ],
   "acid-graphics": [
     "dark",
@@ -196,13 +196,6 @@
     "saas",
     "minimal"
   ],
-  "arxiv-preprint": [
-    "paper",
-    "light",
-    "preprint",
-    "self-published",
-    "raw"
-  ],
   "arena": [
     "dark",
     "blog",
@@ -218,6 +211,13 @@
     "portfolio",
     "art-nouveau",
     "botanical"
+  ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
   ],
   "ascii": [
     "dark",
@@ -305,18 +305,18 @@
     "elegant",
     "batik"
   ],
+  "bauhaus": [
+    "light",
+    "portfolio",
+    "design",
+    "geometric"
+  ],
   "bayesian-prior": [
     "paper",
     "dark",
     "bayesian",
     "probabilistic",
     "visualization"
-  ],
-  "bauhaus": [
-    "light",
-    "portfolio",
-    "design",
-    "geometric"
   ],
   "bazaar": [
     "light",
@@ -436,18 +436,18 @@
     "botanical",
     "vintage"
   ],
+  "boutique": [
+    "light",
+    "store",
+    "fashion",
+    "elegant"
+  ],
   "box-office": [
     "event",
     "tickets",
     "sales",
     "urgency",
     "countdown"
-  ],
-  "boutique": [
-    "light",
-    "store",
-    "fashion",
-    "elegant"
   ],
   "bramble": [
     "light",
@@ -598,6 +598,13 @@
     "waterfall",
     "scroll-driven"
   ],
+  "case-report": [
+    "paper",
+    "light",
+    "clinical",
+    "case-study",
+    "medical"
+  ],
   "cassette": [
     "dark",
     "blog",
@@ -674,6 +681,13 @@
     "dark",
     "docs",
     "changelog"
+  ],
+  "chase-frame": [
+    "book",
+    "dark",
+    "letterpress",
+    "mechanical",
+    "craft"
   ],
   "chiaroscuro": [
     "dark",
@@ -815,19 +829,19 @@
     "blog",
     "medieval"
   ],
-  "cold-case": [
-    "paper",
-    "dark",
-    "forensic",
-    "investigation",
-    "reopened"
-  ],
   "cohort-study": [
     "paper",
     "light",
     "cohort",
     "survival",
     "epidemiological"
+  ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
   ],
   "colosseum": [
     "light",
@@ -861,17 +875,17 @@
     "docs",
     "data-pipeline"
   ],
-  "confetti": [
-    "celebration",
-    "elegant",
-    "festive"
-  ],
   "conference-poster": [
     "paper",
     "dark",
     "poster",
     "conference",
     "visual"
+  ],
+  "confetti": [
+    "celebration",
+    "elegant",
+    "festive"
   ],
   "console": [
     "dark",
@@ -1042,6 +1056,13 @@
     "dark",
     "landing",
     "dashboard"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
   ],
   "deconstructed": [
     "light",
@@ -1260,6 +1281,13 @@
     "repeat",
     "popular",
     "demanded"
+  ],
+  "encore-night": [
+    "event",
+    "concert",
+    "farewell",
+    "encore",
+    "emotional"
   ],
   "enigma": [
     "dark",
@@ -1617,6 +1645,11 @@
     "judgment",
     "dramatic"
   ],
+  "gossamer": [
+    "blog",
+    "minimal",
+    "elegant"
+  ],
   "gothic": [
     "dark",
     "blog",
@@ -1633,6 +1666,20 @@
     "blog",
     "street-art",
     "urban"
+  ],
+  "grand-finale": [
+    "event",
+    "festival",
+    "finale",
+    "closing",
+    "spectacular"
+  ],
+  "grant-proposal": [
+    "paper",
+    "light",
+    "proposal",
+    "funding",
+    "persuasive"
   ],
   "graphite-docs": [
     "docs",
@@ -1724,18 +1771,18 @@
     "fashion",
     "magazine"
   ],
-  "hearth": [
-    "light",
-    "blog",
-    "traditional",
-    "elegant"
-  ],
   "headliner-bold": [
     "event",
     "festival",
     "lineup",
     "headliner",
     "hierarchy"
+  ],
+  "hearth": [
+    "light",
+    "blog",
+    "traditional",
+    "elegant"
   ],
   "heavy-curtain": [
     "event",
@@ -1908,6 +1955,13 @@
     "iridescent",
     "oil"
   ],
+  "iron-stage": [
+    "event",
+    "festival",
+    "metal",
+    "industrial",
+    "heavy"
+  ],
   "ironclad": [
     "dark",
     "landing",
@@ -2007,6 +2061,13 @@
     "light",
     "blog",
     "science"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
   ],
   "labyrinth": [
     "dark",
@@ -2362,6 +2423,13 @@
     "dashboard",
     "time-based",
     "auto-theme"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
   ],
   "meteor": [
     "dark",
@@ -2761,6 +2829,13 @@
     "blog",
     "glamorous"
   ],
+  "opening-act": [
+    "event",
+    "opening",
+    "season",
+    "premiere",
+    "fresh"
+  ],
   "opening-night": [
     "event",
     "dark",
@@ -3095,6 +3170,13 @@
     "blog",
     "rural"
   ],
+  "preprint-rush": [
+    "paper",
+    "light",
+    "preprint",
+    "urgent",
+    "draft"
+  ],
   "pressure-cooker": [
     "event",
     "dark",
@@ -3135,6 +3217,13 @@
     "light",
     "saas"
   ],
+  "proof-sheet": [
+    "book",
+    "light",
+    "proof",
+    "unfinished",
+    "editorial"
+  ],
   "protocol": [
     "dark",
     "docs",
@@ -3153,6 +3242,13 @@
     "elegant",
     "glamorous"
   ],
+  "pulp-fiction": [
+    "book",
+    "dark",
+    "pulp",
+    "lurid",
+    "cheap"
+  ],
   "pulsar": [
     "dark",
     "blog",
@@ -3168,6 +3264,13 @@
     "showcase",
     "metallic",
     "luxury"
+  ],
+  "pyrotechnic": [
+    "event",
+    "show",
+    "pyrotechnics",
+    "fireworks",
+    "explosive"
   ],
   "qualitative-study": [
     "paper",
@@ -3293,9 +3396,23 @@
     "repousse",
     "metalwork"
   ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
+  ],
   "resume": [
     "light",
     "resume"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
   ],
   "retro-radar": [
     "dark",
@@ -3365,6 +3482,13 @@
     "assembly",
     "formal",
     "attendance"
+  ],
+  "roll-scroll": [
+    "book",
+    "light",
+    "scroll",
+    "continuous",
+    "ancient"
   ],
   "rooftop": [
     "dark",
@@ -3927,6 +4051,13 @@
     "blog",
     "academic"
   ],
+  "thesis-defense": [
+    "paper",
+    "dark",
+    "thesis",
+    "formal",
+    "institutional"
+  ],
   "thunderdome": [
     "event",
     "dark",
@@ -4099,6 +4230,13 @@
     "dark",
     "landing",
     "luxury"
+  ],
+  "velvet-rope": [
+    "event",
+    "gala",
+    "exclusive",
+    "luxury",
+    "velvet"
   ],
   "venetian": [
     "light",
@@ -4291,138 +4429,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "grant-proposal": [
-    "paper",
-    "light",
-    "proposal",
-    "funding",
-    "persuasive"
-  ],
-  "reproducibility": [
-    "paper",
-    "light",
-    "replication",
-    "comparison",
-    "verdict"
-  ],
-  "case-report": [
-    "paper",
-    "light",
-    "clinical",
-    "case-study",
-    "medical"
-  ],
-  "data-paper": [
-    "paper",
-    "light",
-    "dataset",
-    "schema",
-    "minimal-text"
-  ],
-  "lab-notebook": [
-    "paper",
-    "light",
-    "laboratory",
-    "raw",
-    "observational"
-  ],
-  "preprint-rush": [
-    "paper",
-    "light",
-    "preprint",
-    "urgent",
-    "draft"
-  ],
-  "thesis-defense": [
-    "paper",
-    "dark",
-    "thesis",
-    "formal",
-    "institutional"
-  ],
-  "retraction-notice": [
-    "paper",
-    "light",
-    "retracted",
-    "warning",
-    "editorial"
-  ],
-  "meta-analysis": [
-    "paper",
-    "light",
-    "statistical",
-    "synthesis",
-    "evidence"
-  ],
-  "opening-act": [
-    "event",
-    "opening",
-    "season",
-    "premiere",
-    "fresh"
-  ],
-  "grand-finale": [
-    "event",
-    "festival",
-    "finale",
-    "closing",
-    "spectacular"
-  ],
-  "pyrotechnic": [
-    "event",
-    "show",
-    "pyrotechnics",
-    "fireworks",
-    "explosive"
-  ],
-  "iron-stage": [
-    "event",
-    "festival",
-    "metal",
-    "industrial",
-    "heavy"
-  ],
-  "velvet-rope": [
-    "event",
-    "gala",
-    "exclusive",
-    "luxury",
-    "velvet"
-  ],
-  "roll-scroll": [
-    "book",
-    "light",
-    "scroll",
-    "continuous",
-    "ancient"
-  ],
-  "encore-night": [
-    "event",
-    "concert",
-    "farewell",
-    "encore",
-    "emotional"
-  ],
-  "proof-sheet": [
-    "book",
-    "light",
-    "proof",
-    "unfinished",
-    "editorial"
-  ],
-  "pulp-fiction": [
-    "book",
-    "dark",
-    "pulp",
-    "lurid",
-    "cheap"
-  ],
-  "chase-frame": [
-    "book",
-    "dark",
-    "letterpress",
-    "mechanical",
-    "craft"
   ]
 }


### PR DESCRIPTION
Adds a new `gossamer` Hwaro example site.
- Initialized with `hwaro init gossamer --scaffold blog`
- Elegant, minimal design focused on typography (Inter and Playfair Display)
- Relative path configuration (`base_url = "/"`)
- Includes a sample post and cleaned up default content
- Added to `tags.json` with tags: "blog", "minimal", "elegant"

---
*PR created automatically by Jules for task [16541420222172041364](https://jules.google.com/task/16541420222172041364) started by @chei-l*