### PR TITLE
feat: add codex-rotundus example site (closes #1568)

### DIFF
--- a/codex-rotundus/AGENTS.md
+++ b/codex-rotundus/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/codex-rotundus/config.toml
+++ b/codex-rotundus/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Codex Rotundus - Circular Book Publication
+# Issue #1568 | Tags: book, dark, circular, unusual, experimental
+# =============================================================================
+
+title = "Codex Rotundus"
+description = "A dark circular book publication inspired by the 15th-century Codex Rotundus: round page frames, radial section dividers emanating from the binding, curved-path display type following the page contour, and center-justified prose radiating from the spine."
+base_url = "http://localhost:3000"
+
+sections = ["folios"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/codex-rotundus/content/colophon.md
+++ b/codex-rotundus/content/colophon.md
@@ -1,0 +1,24 @@
++++
+title = "Colophon"
+description = "Typography, sources, and a note on building this site."
++++
+
+<span class="folio-number">Finis</span>
+
+# Colophon
+
+<p class="lede">A note on type, materials, and method.</p>
+
+<p class="rubric">De typis</p>
+
+The display face on every folio is **Cinzel**, a roman capital based on inscriptional letterforms. It is set along curved SVG paths that trace the contour of each disc, following the method used by the original scribes when they laid out their rim rubrics with a compass.
+
+The body face is **Cormorant Garamond**, a broad-spectrum old-style that reads well at small sizes and holds its shape inside the tight central column of a round page. The rubricated words and drop capitals are set in **UnifrakturCook**, a textura blackletter, at a slightly larger size than the body.
+
+<p class="rubric">De instrumentis</p>
+
+Every decorative element on this site is inline SVG. The circular page frames, the radial dividers, the rim rubrics, the central binding marker: all are drawn as vector geometry, not as images. There are no gradients. The palette is three colors: vellum-black for the page, aged gold for the rule work, iron-gall for the body ink.
+
+<p class="rubric">De libro originali</p>
+
+The Codex Rotundus itself rests in the treasury of Hildesheim Cathedral in Lower Saxony, Germany, catalogued as Hs. 728. It is displayed open to folio 21 verso. This site does not reproduce its contents. It only borrows its shape.

--- a/codex-rotundus/content/folios/1-on-the-binding.md
+++ b/codex-rotundus/content/folios/1-on-the-binding.md
@@ -1,0 +1,21 @@
++++
+title = "On the Binding"
+description = "Folio II - on the central stitched arc that holds the round book together."
+tags = ["binding", "craft"]
++++
+
+<span class="folio-number">Folio II</span>
+
+# On the Binding
+
+<p class="lede">The binding of a round book is not a spine. It is a chord.</p>
+
+<span class="drop-cap">A</span>
+
+conventional codex folds paper in half and sews along the fold. The fold is a straight line, the sewing station is a row of holes along it, and the whole structure opens like a hinge. A round book cannot fold along a straight line without crushing the disc into a half-moon. So the makers of the Codex Rotundus stitched only a short arc along the left edge of each disc, never at the center.
+
+<p class="rubric">Stitch as chord</p>
+
+That stitched arc behaves like a chord of the circle. It is shorter than a diameter but long enough to restrain the pages. The pages hinge open along the chord and swing outward. The thickness of the binding is absorbed into the disc itself, which is slightly thicker on the stitched side than on the outer rim. The book sits naturally in its wooden drum case with the stitched edge downward.
+
+The binding is therefore not an axis but an off-center line. Every page rotates around it. The geometric center of the disc is empty. On this site the central circle represents that emptiness: the binding is implied but not drawn.

--- a/codex-rotundus/content/folios/2-radial-reading.md
+++ b/codex-rotundus/content/folios/2-radial-reading.md
@@ -1,0 +1,25 @@
++++
+title = "Radial Reading"
+description = "Folio III - on how center-justified prose radiates from a central binding."
+tags = ["typography", "reading"]
++++
+
+<span class="folio-number">Folio III</span>
+
+# Radial Reading
+
+<p class="lede">The line of type is still straight. The page is not.</p>
+
+<span class="drop-cap">C</span>
+
+enter-justified prose is usually reserved for titles, inscriptions, and verse. When it is used for body text it tires the eye because every line begins and ends in a different column, forcing the reader to hunt for the start of each new line. On a round page this objection is neutralized. The reader is already scanning radially, from the binding at the center toward the rim.
+
+<p class="rubric">De lectione radiali</p>
+
+Paragraphs here sit in a tight central column, narrow enough to be read at a single focal distance. The column is as wide as the radius of the inscribed square within the disc. Anything wider spills into the curvature; anything narrower wastes the page. The result is readable but strange: the lines are straight, and yet the hand of the reader, turning the disc, traces a circle.
+
+<blockquote>
+A straight column of type set inside a round page. The tension between the two is the whole of the design.
+</blockquote>
+
+This folio demonstrates the column geometry. It is the base pattern for every other folio in this codex.

--- a/codex-rotundus/content/folios/3-rim-rubrics.md
+++ b/codex-rotundus/content/folios/3-rim-rubrics.md
@@ -1,0 +1,21 @@
++++
+title = "Rim Rubrics"
+description = "Folio IV - curved type following the contour of the disc."
+tags = ["typography", "scribes"]
++++
+
+<span class="folio-number">Folio IV</span>
+
+# Rim Rubrics
+
+<p class="lede">Type that curves along the edge of the disc is not ornament. It is the column rule.</p>
+
+<span class="drop-cap">O</span>
+
+n the rim of every folio, running along the inside of the outer border, a scribe of the Rotundus wrote the chapter rubric in red ink. The rubric followed the circumference of the page, so the letters tilted according to their position on the rim. Near the top, they stood upright; at the sides, they leaned inward; at the bottom, they read upside down if you tried to read them with the book stationary.
+
+<p class="rubric">De rubricis in margine</p>
+
+The rubric was therefore a reading instrument. To read it, you rotated the disc. By the time you had completed the rubric, you had rotated the book exactly once, and your attention had swept over every marginal note along the way. The rubric was the table of contents, the bookmark, and the ritual of turning the page all at once.
+
+On this folio the rim text is set with SVG `textPath`, which is the modern equivalent of the scribe's compass-and-quill method. The curved type traces the same arc a scribe would have used. No static image. Just type following a mathematical curve.

--- a/codex-rotundus/content/folios/4-radial-dividers.md
+++ b/codex-rotundus/content/folios/4-radial-dividers.md
@@ -1,0 +1,37 @@
++++
+title = "Radial Dividers"
+description = "Folio V - on section rules that emanate from the central binding."
+tags = ["typography", "structure"]
++++
+
+<span class="folio-number">Folio V</span>
+
+# Radial Dividers
+
+<p class="lede">A section break in a round book is a spoke.</p>
+
+<span class="drop-cap">I</span>
+
+n a rectangular codex a section break is a horizontal rule set across the column width. It works because the column has two parallel sides to anchor to. In a round codex the column has no parallel sides. A horizontal rule placed in a disc would have to choose where to stop at each end, and every choice is arbitrary.
+
+<p class="rubric">De lineis radialibus</p>
+
+The scribes of the Rotundus solved this by replacing horizontal rules with radial spokes. A section break was drawn as a short line segment running outward from the central binding toward the rim, passing between one block of text and the next. The line was always aligned with the radius. The eye, already swinging around the binding, registered the spoke as a pause in the rotation.
+
+<svg viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg" class="radial-wheel" aria-hidden="true">
+  <circle cx="150" cy="150" r="140" fill="none" stroke="#b08d3a" stroke-width="1"/>
+  <circle cx="150" cy="150" r="110" fill="none" stroke="#b08d3a" stroke-width="0.4" stroke-dasharray="2 4"/>
+  <circle cx="150" cy="150" r="8" fill="#b08d3a"/>
+  <g stroke="#b08d3a" stroke-width="1" fill="none" stroke-linecap="round">
+    <line x1="150" y1="30"  x2="150" y2="60"/>
+    <line x1="270" y1="150" x2="240" y2="150"/>
+    <line x1="150" y1="270" x2="150" y2="240"/>
+    <line x1="30"  y1="150" x2="60"  y2="150"/>
+    <line x1="235" y1="65"  x2="214" y2="86"/>
+    <line x1="235" y1="235" x2="214" y2="214"/>
+    <line x1="65"  y1="235" x2="86"  y2="214"/>
+    <line x1="65"  y1="65"  x2="86"  y2="86"/>
+  </g>
+</svg>
+
+Eight spokes make eight sections. That is the canonical rotation for a prayer book: one section for each of the canonical hours of the day.

--- a/codex-rotundus/content/folios/5-why-round.md
+++ b/codex-rotundus/content/folios/5-why-round.md
@@ -1,0 +1,25 @@
++++
+title = "Why Round"
+description = "Folio VI - on the purpose of making a book that cannot lie flat."
+tags = ["craft", "reading"]
++++
+
+<span class="folio-number">Folio VI</span>
+
+# Why Round
+
+<p class="lede">The round book was never a joke. It was a devotion.</p>
+
+<span class="drop-cap">T</span>
+
+he Codex Rotundus was a prayer book for a single canon at Hildesheim Cathedral. It was carried in a leather pouch on the belt, and the round shape was an exact match for that pouch: a small drum that could be drawn out with one hand during the long hours between services. It was a pocket book before the pocket was square.
+
+<p class="rubric">De usu cotidiano</p>
+
+A round book is also a kind of clock. The eight canonical hours could be marked on the rim like the hours on a sundial, and the canon could turn to the correct page by rotating the disc to the correct hour. The prayer book and the day were geometrically aligned.
+
+<blockquote>
+A round book is not an experiment with the codex. It is an acceptance of the codex as an object bound in time.
+</blockquote>
+
+There is no modern reason to read a round book. There was never a modern reason. The Codex Rotundus is a medieval object made for a medieval purpose. This site repeats it because repeating things is how we keep learning to read.

--- a/codex-rotundus/content/folios/_index.md
+++ b/codex-rotundus/content/folios/_index.md
@@ -1,0 +1,14 @@
++++
+title = "The Folios"
+description = "Index of folios bound in the Codex Rotundus."
++++
+
+<span class="folio-number">Index</span>
+
+# The Folios
+
+<p class="lede">Five round folios, bound at the center, read outward.</p>
+
+Each folio is a single complete page of the codex, drawn as a disc. The binding runs through the geometric center of every one. Text radiates from that center toward the rim. The rim itself carries the folio rubric in curved type, following the edge of the disc as the scribe's hand would have traced it.
+
+Turn to any folio below.

--- a/codex-rotundus/content/history.md
+++ b/codex-rotundus/content/history.md
@@ -1,0 +1,20 @@
++++
+title = "History"
+description = "A brief account of the original Codex Rotundus at Hildesheim."
++++
+
+<span class="folio-number">Apparatus</span>
+
+# History
+
+<p class="lede">The Codex Rotundus was made in Bruges around 1480 for a canon named Peter of Hildesheim.</p>
+
+<span class="drop-cap">T</span>
+
+he original is a Book of Hours - the standard lay prayer book of the late medieval period, containing the little office of the Virgin, the seven penitential psalms, the office of the dead, and various suffrages. What distinguishes it from every other Book of Hours of the era is its shape. It is a codex cut into discs, bound along a short arc, and stored in a cylindrical case of tooled leather.
+
+<p class="rubric">Provenance</p>
+
+It is written in a single scribal hand on vellum cut into circular leaves of about nine centimeters in diameter. The text block is a tight central column with rubrics and capitals in red and blue. Thirty-two pages survive. Fifteen full-page miniatures depict scenes from the life of Christ. Six of those miniatures are circular compositions that fill the disc to the rim.
+
+The book was acquired by Hildesheim Cathedral in the early sixteenth century and has remained there since, displayed in the treasury in its original drum case. It is one of only two known surviving circular medieval codices in Europe.

--- a/codex-rotundus/content/index.md
+++ b/codex-rotundus/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "Folio I"
+description = "First folio of the Codex Rotundus - a round book read outward from the binding."
++++
+
+<span class="folio-number">Folio I &middot; Rotunda</span>
+
+# Round Book
+
+<p class="lede">A codex is a stack of folded sheets. A rotunda is a circle. Bind the one inside the other and reading becomes a kind of rotation.</p>
+
+<span class="drop-cap">I</span>
+
+n the cathedral library at Hildesheim, bound in a wooden box shaped like a small drum, rests the Codex Rotundus: a Book of Hours cut into perfect discs. Its makers sewed the pages along a short stitched arc on the left edge so the disc could hinge open. Each leaf is read not by turning a corner but by rotating the whole body of the book.
+
+This site is a tribute to that object. Every page is a round folio. The binding sits at the center; the text radiates outward. The page numbers, chapter rubrics, and marginal glosses all curve along the rim, as they do in the original codex. The reader is not asked to read in straight lines.
+
+<p class="rubric">De forma libri</p>
+
+Nothing here is decorative in the modern sense. The circle is the page. The radial line is the column rule. The central ring is the binding. The gold arcs are the chapter labels, set the way a scribe would have set them if the tool had been a compass instead of a ruler.
+
+<span class="folio-number">Turn to any folio</span>
+
+- [The Folios](/folios/)
+- [History](/history/)
+- [Colophon](/colophon/)

--- a/codex-rotundus/static/css/style.css
+++ b/codex-rotundus/static/css/style.css
@@ -1,0 +1,348 @@
+/* =============================================================================
+   Codex Rotundus - Circular Book Publication
+   Issue #1568 | dark, circular, experimental
+   Palette: deep vellum-black, aged gold, iron-gall ink
+   No gradients. SVG decorations only.
+   ============================================================================= */
+
+:root {
+  --ink: #e7ddc5;
+  --ink-soft: #c7b992;
+  --ink-dim: #8a7a55;
+  --gold: #b08d3a;
+  --gold-deep: #8a6a24;
+  --rubric: #8a2a1c;
+  --bg: #1b1510;
+  --bg-panel: #231b13;
+  --border: #3a2c1d;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Cormorant Garamond", "EB Garamond", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  text-align: center;
+  min-height: 100vh;
+  padding: 0 0 3rem;
+}
+
+.codex-frame {
+  padding: 1.5rem 2rem 0;
+}
+
+.codex-masthead {
+  display: block;
+  width: 100%;
+  max-width: 1100px;
+  height: 120px;
+  margin: 0 auto;
+}
+.codex-masthead-bottom { height: 90px; }
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  max-width: 880px;
+  margin: 0.5rem auto 0;
+  padding: 0.75rem 2rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--ink);
+  text-decoration: none;
+  font-family: "Cinzel", serif;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+}
+.logo-mark { width: 40px; height: 40px; display: block; }
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-family: "Cinzel", serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--gold); border-bottom-color: var(--gold); }
+
+/* --- Round folio --------------------------------------------------------- */
+.site-main {
+  padding: 2rem 1rem;
+}
+
+.round-folio {
+  position: relative;
+  width: min(800px, 96vw);
+  aspect-ratio: 1 / 1;
+  margin: 2rem auto 3rem;
+  background-color: var(--bg-panel);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    0 10px 40px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+
+.folio-ornament {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.folio-body {
+  position: absolute;
+  top: 16%;
+  left: 16%;
+  right: 16%;
+  bottom: 16%;
+  z-index: 3;
+  overflow: auto;
+  padding: 2.5rem 1rem 3rem;
+  text-align: center;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gold-deep) transparent;
+}
+.folio-body::-webkit-scrollbar { width: 6px; }
+.folio-body::-webkit-scrollbar-thumb { background: var(--gold-deep); border-radius: 3px; }
+
+/* Typography within the round folio */
+.folio-body h1,
+.folio-body h2,
+.folio-body h3 {
+  font-family: "Cinzel", serif;
+  color: var(--gold);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin: 1.4em 0 0.4em;
+  text-align: center;
+}
+.folio-body h1 { font-size: 1.6rem; letter-spacing: 0.22em; margin-top: 0; }
+.folio-body h2 { font-size: 1.15rem; }
+.folio-body h3 { font-size: 1rem; color: var(--ink-soft); }
+
+.folio-body h1::after,
+.folio-body h2::after {
+  content: "";
+  display: block;
+  width: 40px;
+  height: 1px;
+  margin: 0.5em auto 0;
+  background-color: var(--gold-deep);
+}
+
+.folio-body p {
+  max-width: 34ch;
+  margin: 0.9em auto;
+  text-align: center;
+  color: var(--ink);
+  font-size: 1.02rem;
+  line-height: 1.8;
+}
+.folio-body p + p { text-indent: 0; }
+
+.folio-body .lede {
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.1rem;
+  max-width: 30ch;
+}
+
+.folio-body .rubric {
+  color: var(--rubric);
+  font-family: "UnifrakturCook", "Cinzel", serif;
+  font-size: 1.1em;
+  font-weight: 700;
+}
+
+.folio-body .drop-cap {
+  float: none;
+  display: block;
+  font-family: "UnifrakturCook", serif;
+  color: var(--rubric);
+  font-size: 3.4rem;
+  line-height: 1;
+  margin: 0 auto 0.4em;
+  font-weight: 700;
+}
+
+.folio-body blockquote {
+  font-style: italic;
+  color: var(--ink-soft);
+  border: none;
+  margin: 1.5em auto;
+  padding: 0 1rem;
+  max-width: 28ch;
+  position: relative;
+}
+.folio-body blockquote::before,
+.folio-body blockquote::after {
+  content: "";
+  display: block;
+  width: 24px;
+  height: 1px;
+  margin: 0.6em auto;
+  background-color: var(--gold-deep);
+}
+
+.folio-body a {
+  color: var(--gold);
+  text-decoration: none;
+  border-bottom: 1px solid var(--gold-deep);
+}
+.folio-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+.folio-body ul, .folio-body ol {
+  list-style: none;
+  padding: 0;
+  margin: 1em auto;
+  max-width: 32ch;
+  text-align: center;
+}
+.folio-body ul li,
+.folio-body ol li {
+  padding: 0.35em 0;
+  border-bottom: 1px dotted var(--border);
+}
+.folio-body ul li:last-child,
+.folio-body ol li:last-child { border-bottom: none; }
+
+/* Section list (list of folios) */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem auto 0;
+  max-width: 34ch;
+}
+.section-list li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border);
+  font-family: "Cinzel", serif;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+.section-list li a {
+  color: var(--ink);
+  text-decoration: none;
+  border: none;
+}
+.section-list li a:hover { color: var(--gold); }
+
+/* Radial folio heading decoration */
+.folio-number {
+  display: block;
+  font-family: "Cinzel", serif;
+  color: var(--gold);
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  margin-bottom: 0.5em;
+  text-transform: uppercase;
+}
+
+/* --- Radial content wheel ------------------------------------------------ */
+.radial-wheel {
+  display: block;
+  width: 80%;
+  max-width: 420px;
+  margin: 1.5em auto;
+}
+
+/* --- Pagination / taxonomy ----------------------------------------------- */
+.taxonomy-desc {
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  margin: 0 auto 1em;
+}
+
+nav.pagination { margin-top: 1.5rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.7em;
+  border: 1px solid var(--border);
+  font-family: "Cinzel", serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+nav.pagination a:hover { color: var(--gold); border-color: var(--gold); }
+.pagination-current span { color: var(--gold); border-color: var(--gold); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1100px;
+  margin: 2rem auto 0;
+  padding: 0 2rem 1rem;
+  text-align: center;
+}
+.footer-line {
+  font-family: "Cinzel", serif;
+  color: var(--ink-soft);
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  margin: 0.2em 0;
+}
+.footer-line-small { color: var(--ink-dim); font-size: 0.7rem; font-style: italic; letter-spacing: 0.15em; text-transform: none; font-family: "Cormorant Garamond", serif; }
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 700px) {
+  body { font-size: 15px; }
+  .codex-masthead { height: 80px; }
+  .codex-masthead-bottom { height: 60px; }
+  .site-header {
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem 1rem;
+  }
+  .site-nav { justify-content: center; }
+  .round-folio { width: 96vw; }
+  .folio-body {
+    top: 14%; left: 12%; right: 12%; bottom: 14%;
+    padding: 1.2rem 0.2rem 1.5rem;
+  }
+  .folio-body h1 { font-size: 1.15rem; letter-spacing: 0.18em; }
+  .folio-body h2 { font-size: 0.95rem; }
+  .folio-body p { font-size: 0.92rem; max-width: 28ch; }
+  .folio-body .drop-cap { font-size: 2.4rem; }
+}

--- a/codex-rotundus/templates/404.html
+++ b/codex-rotundus/templates/404.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="round-folio">
+      <svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" class="folio-ornament" aria-hidden="true">
+        <circle cx="400" cy="400" r="380" fill="none" stroke="#8a2a1c" stroke-width="1"/>
+        <circle cx="400" cy="400" r="360" fill="none" stroke="#8a2a1c" stroke-width="0.5"/>
+        <circle cx="400" cy="400" r="10" fill="#8a2a1c"/>
+      </svg>
+      <div class="folio-body">
+        <h1>Folio Lost</h1>
+        <p>This folio has fallen from the binding. The page you seek no longer rests within this codex.</p>
+        <p><a href="{{ base_url }}/">Return to the first folio</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/codex-rotundus/templates/footer.html
+++ b/codex-rotundus/templates/footer.html
@@ -1,0 +1,20 @@
+  <footer class="site-footer">
+    <svg viewBox="0 0 1200 140" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" class="codex-masthead codex-masthead-bottom" aria-hidden="true">
+      <defs>
+        <path id="mast-arc-bottom" d="M 100,10 A 500,500 0 0 0 1100,10" fill="none"/>
+      </defs>
+      <g fill="#b08d3a">
+        <circle cx="600" cy="10" r="3"/>
+        <circle cx="460" cy="16" r="2"/>
+        <circle cx="740" cy="16" r="2"/>
+      </g>
+      <text font-family="Cinzel, serif" font-size="12" font-weight="500" letter-spacing="6" fill="#8a6a24">
+        <textPath href="#mast-arc-bottom" startOffset="50%" text-anchor="middle">FINIS  &#183;  COLOPHON  &#183;  MMXXVI</textPath>
+      </text>
+    </svg>
+    <p class="footer-line">Codex Rotundus &middot; a round-folio reader</p>
+    <p class="footer-line footer-line-small">Bound at the center. Read outward.</p>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/codex-rotundus/templates/header.html
+++ b/codex-rotundus/templates/header.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400&family=UnifrakturCook:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="codex-frame" aria-hidden="true">
+    <svg viewBox="0 0 1200 140" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" class="codex-masthead">
+      <defs>
+        <path id="mast-arc-top" d="M 100,130 A 500,500 0 0 1 1100,130" fill="none"/>
+      </defs>
+      <g fill="#b08d3a">
+        <circle cx="600" cy="130" r="3"/>
+        <circle cx="460" cy="124" r="2"/>
+        <circle cx="740" cy="124" r="2"/>
+        <circle cx="320" cy="112" r="1.5"/>
+        <circle cx="880" cy="112" r="1.5"/>
+      </g>
+      <text font-family="Cinzel, serif" font-size="18" font-weight="700" letter-spacing="8" fill="#b08d3a">
+        <textPath href="#mast-arc-top" startOffset="50%" text-anchor="middle">CODEX  ROTUNDUS  &#183;  CIRCULAR  FOLIO</textPath>
+      </text>
+    </svg>
+  </div>
+  <header class="site-header">
+    <a href="{{ base_url }}/" class="site-logo" aria-label="Codex Rotundus home">
+      <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+        <circle cx="24" cy="24" r="22" fill="none" stroke="#b08d3a" stroke-width="1"/>
+        <circle cx="24" cy="24" r="17" fill="none" stroke="#b08d3a" stroke-width="0.75"/>
+        <line x1="24" y1="2" x2="24" y2="46" stroke="#b08d3a" stroke-width="0.6"/>
+        <line x1="2" y1="24" x2="46" y2="24" stroke="#b08d3a" stroke-width="0.6"/>
+        <line x1="8.6" y1="8.6" x2="39.4" y2="39.4" stroke="#b08d3a" stroke-width="0.4"/>
+        <line x1="39.4" y1="8.6" x2="8.6" y2="39.4" stroke="#b08d3a" stroke-width="0.4"/>
+        <circle cx="24" cy="24" r="4" fill="#b08d3a"/>
+      </svg>
+      <span class="logo-text">Codex Rotundus</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="{{ base_url }}/">Folio I</a>
+      <a href="{{ base_url }}/folios/">Folios</a>
+      <a href="{{ base_url }}/history/">History</a>
+      <a href="{{ base_url }}/colophon/">Colophon</a>
+    </nav>
+  </header>

--- a/codex-rotundus/templates/page.html
+++ b/codex-rotundus/templates/page.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="round-folio">
+      <svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" class="folio-ornament" aria-hidden="true">
+        <defs>
+          <path id="page-arc-top-{{ page.slug }}" d="M 400,80 m -300,0 a 300,300 0 0 1 600,0" fill="none"/>
+          <path id="page-arc-bottom-{{ page.slug }}" d="M 400,720 m -300,0 a 300,300 0 0 0 600,0" fill="none"/>
+        </defs>
+        <circle cx="400" cy="400" r="380" fill="none" stroke="#b08d3a" stroke-width="1"/>
+        <circle cx="400" cy="400" r="360" fill="none" stroke="#b08d3a" stroke-width="0.5"/>
+        <circle cx="400" cy="400" r="330" fill="none" stroke="#8a6a24" stroke-width="0.4" stroke-dasharray="2 4"/>
+        <circle cx="400" cy="400" r="10" fill="#b08d3a"/>
+        <circle cx="400" cy="400" r="4" fill="#1b1510"/>
+        <g stroke="#b08d3a" stroke-width="0.5" fill="none">
+          <line x1="400" y1="40" x2="400" y2="100"/>
+          <line x1="400" y1="700" x2="400" y2="760"/>
+          <line x1="40" y1="400" x2="100" y2="400"/>
+          <line x1="700" y1="400" x2="760" y2="400"/>
+        </g>
+        <text font-family="Cinzel, serif" font-size="14" font-weight="700" letter-spacing="6" fill="#b08d3a">
+          <textPath href="#page-arc-top-{{ page.slug }}" startOffset="50%" text-anchor="middle">{{ page.title | upper | e }}</textPath>
+        </text>
+        <text font-family="Cinzel, serif" font-size="10" letter-spacing="4" fill="#8a6a24">
+          <textPath href="#page-arc-bottom-{{ page.slug }}" startOffset="50%" text-anchor="middle">&#10049;  FOLIO  &#10049;  ROTUNDA  &#10049;</textPath>
+        </text>
+      </svg>
+      <div class="folio-body">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/codex-rotundus/templates/section.html
+++ b/codex-rotundus/templates/section.html
@@ -1,0 +1,40 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="round-folio">
+      <svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" class="folio-ornament" aria-hidden="true">
+        <defs>
+          <path id="sec-arc-top-{{ page.slug }}" d="M 400,80 m -300,0 a 300,300 0 0 1 600,0" fill="none"/>
+          <path id="sec-arc-bottom-{{ page.slug }}" d="M 400,720 m -300,0 a 300,300 0 0 0 600,0" fill="none"/>
+        </defs>
+        <circle cx="400" cy="400" r="380" fill="none" stroke="#b08d3a" stroke-width="1"/>
+        <circle cx="400" cy="400" r="360" fill="none" stroke="#b08d3a" stroke-width="0.5"/>
+        <circle cx="400" cy="400" r="330" fill="none" stroke="#8a6a24" stroke-width="0.4" stroke-dasharray="2 4"/>
+        <g stroke="#b08d3a" stroke-width="0.5" fill="none">
+          <line x1="400" y1="40" x2="400" y2="100"/>
+          <line x1="400" y1="700" x2="400" y2="760"/>
+          <line x1="40" y1="400" x2="100" y2="400"/>
+          <line x1="700" y1="400" x2="760" y2="400"/>
+          <line x1="115" y1="115" x2="165" y2="165"/>
+          <line x1="685" y1="115" x2="635" y2="165"/>
+          <line x1="115" y1="685" x2="165" y2="635"/>
+          <line x1="685" y1="685" x2="635" y2="635"/>
+        </g>
+        <circle cx="400" cy="400" r="10" fill="#b08d3a"/>
+        <circle cx="400" cy="400" r="4" fill="#1b1510"/>
+        <text font-family="Cinzel, serif" font-size="14" font-weight="700" letter-spacing="6" fill="#b08d3a">
+          <textPath href="#sec-arc-top-{{ page.slug }}" startOffset="50%" text-anchor="middle">{{ page.title | upper | e }}</textPath>
+        </text>
+        <text font-family="Cinzel, serif" font-size="10" letter-spacing="4" fill="#8a6a24">
+          <textPath href="#sec-arc-bottom-{{ page.slug }}" startOffset="50%" text-anchor="middle">&#10049;  INDEX  &#10049;  OF  &#10049;  FOLIOS  &#10049;</textPath>
+        </text>
+      </svg>
+      <div class="folio-body">
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/codex-rotundus/templates/shortcodes/alert.html
+++ b/codex-rotundus/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/codex-rotundus/templates/taxonomy.html
+++ b/codex-rotundus/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="round-folio">
+      <svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" class="folio-ornament" aria-hidden="true">
+        <defs>
+          <path id="tax-arc-top-{{ page.slug }}" d="M 400,80 m -300,0 a 300,300 0 0 1 600,0" fill="none"/>
+        </defs>
+        <circle cx="400" cy="400" r="380" fill="none" stroke="#b08d3a" stroke-width="1"/>
+        <circle cx="400" cy="400" r="360" fill="none" stroke="#b08d3a" stroke-width="0.5"/>
+        <circle cx="400" cy="400" r="10" fill="#b08d3a"/>
+        <circle cx="400" cy="400" r="4" fill="#1b1510"/>
+        <text font-family="Cinzel, serif" font-size="14" font-weight="700" letter-spacing="6" fill="#b08d3a">
+          <textPath href="#tax-arc-top-{{ page.slug }}" startOffset="50%" text-anchor="middle">TAXONOMY  OF  THE  ROUND  CODEX</textPath>
+        </text>
+      </svg>
+      <div class="folio-body">
+        <p class="taxonomy-desc">Terms radiating from the binding:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/codex-rotundus/templates/taxonomy_term.html
+++ b/codex-rotundus/templates/taxonomy_term.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="round-folio">
+      <svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg" class="folio-ornament" aria-hidden="true">
+        <defs>
+          <path id="taxterm-arc-{{ page.slug }}" d="M 400,80 m -300,0 a 300,300 0 0 1 600,0" fill="none"/>
+        </defs>
+        <circle cx="400" cy="400" r="380" fill="none" stroke="#b08d3a" stroke-width="1"/>
+        <circle cx="400" cy="400" r="360" fill="none" stroke="#b08d3a" stroke-width="0.5"/>
+        <circle cx="400" cy="400" r="10" fill="#b08d3a"/>
+        <circle cx="400" cy="400" r="4" fill="#1b1510"/>
+        <text font-family="Cinzel, serif" font-size="14" font-weight="700" letter-spacing="6" fill="#b08d3a">
+          <textPath href="#taxterm-arc-{{ page.slug }}" startOffset="50%" text-anchor="middle">FOLIOS  BOUND  UNDER  {{ page.title | upper | e }}</textPath>
+        </text>
+      </svg>
+      <div class="folio-body">
+        <p class="taxonomy-desc">Folios gathered under this term:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -829,6 +829,13 @@
     "blog",
     "medieval"
   ],
+  "codex-rotundus": [
+    "book",
+    "dark",
+    "circular",
+    "unusual",
+    "experimental"
+  ],
   "cohort-study": [
     "paper",
     "light",


### PR DESCRIPTION
## Summary
- Dark circular book publication inspired by the 15th-century Codex Rotundus (Hildesheim Cathedral, Hs. 728)
- Every page is a round folio: inline SVG circular frames at codex-rotundus proportions, SVG radial spokes as section dividers, and curved-path rim rubrics set with SVG textPath following the disc contour
- Cinzel display (curved along SVG paths), Cormorant Garamond body (center-justified radiating from the binding), UnifrakturCook for rubrics and drop capitals
- Tags: book, dark, circular, unusual, experimental

## Test plan
- [ ] Run `hwaro build` inside `codex-rotundus/` and confirm no template warnings
- [ ] Check that the circular folio frames render cleanly in a browser
- [ ] Verify rim rubric text follows the arc on the top and bottom of each disc
- [ ] Confirm the body column stays readable at mobile widths
- [ ] Check `tags.json` entry is valid JSON