### PR TITLE
feat: add misprint example site (closes #1567)

### DIFF
--- a/misprint/AGENTS.md
+++ b/misprint/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/misprint/config.toml
+++ b/misprint/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Misprint - Error Celebration Publication
+# Issue #1567 | Tags: book, dark, error, accidental, artistic
+# =============================================================================
+
+title = "Misprint"
+description = "A dark publication that collects the accidents of letterpress printing - ink smears, roller marks, double impressions, wrong-font substitutions. The errors are the subject. Inline SVG patterns re-create ink failures without compromising legibility."
+base_url = "http://localhost:3000"
+
+sections = ["specimens"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/misprint/content/glossary.md
+++ b/misprint/content/glossary.md
@@ -1,0 +1,46 @@
++++
+title = "Glossary"
+description = "A short glossary of the language of printing failure."
++++
+
+<p class="eyebrow">Glossary &middot; Apparatus</p>
+
+# The <em>Language</em> of Failure
+
+<p class="lede">A short glossary of the printing terms for errors, accidents, and the apparatus of the spoilage pile. Set in Special Elite, the typewriter face of the press-room inspector.</p>
+
+<div class="colophon-box">
+<strong>Pi</strong> / <strong>Pie</strong> &mdash; type spilled from a chase, usually because the chase was dropped. Also the noun for the resulting pile of mixed sorts. <em>Pieing the type</em> is the act of causing the spill.
+</div>
+
+<div class="colophon-box">
+<strong>Spoil</strong> / <strong>Waste</strong> &mdash; any sheet that came off the press with a defect that prevents it from being sold. The pressman's bucket. The ratio of waste to good sheets is called the <em>spoilage rate</em>.
+</div>
+
+<div class="colophon-box">
+<strong>Kiss impression</strong> &mdash; the lightest possible contact between platen and form: the type just touches the paper. A doubled kiss impression may look like a single impression at slightly higher ink weight.
+</div>
+
+<div class="colophon-box">
+<strong>Slur</strong> &mdash; a smear produced when the paper shifts during the impression. The image is still readable but the edges of every letter are blurred in a single direction.
+</div>
+
+<div class="colophon-box">
+<strong>Wrong-font</strong> &mdash; abbreviated <strong>wf</strong> in proofreading. A letter set in the wrong typeface, size, or weight. Often caused by a stray sort misfiled in the wrong case compartment.
+</div>
+
+<div class="colophon-box">
+<strong>Fat-face</strong> &mdash; the heavy display faces of the nineteenth century. When over-inked, a fat-face letter fills in its counters faster than any other style, producing the solid black rectangles we call <em>blots</em>.
+</div>
+
+<div class="colophon-box">
+<strong>Over-inking</strong> &mdash; too much ink deposited on the form by the composition rollers. The cause of filled counters, smeared serifs, and in extreme cases sheets where the ink has seeped through to the verso.
+</div>
+
+<div class="colophon-box">
+<strong>Ghost</strong> &mdash; the faint second image of a letter in a double impression. Sometimes there is a third ghost from a third unsuccessful strike. A triple ghost is rare and is the holy grail of this journal.
+</div>
+
+<div class="colophon-box">
+<strong>Roller mark</strong> &mdash; a visible band of ink deposited in a single pass of the composition roller, usually curved because the roller bounced on an uneven form. The mark records the full path of the roller as a permanent line on the paper.
+</div>

--- a/misprint/content/index.md
+++ b/misprint/content/index.md
@@ -1,0 +1,30 @@
++++
+title = "Press Room"
+description = "A publication devoted to the accidents of the letterpress - smears, doubles, wrong-font substitutions."
++++
+
+<p class="eyebrow">Issue No. VII &middot; Spoiled Sheets</p>
+
+# MIS<em>print</em>
+
+<p class="lede">A publication that keeps the bad impressions instead of throwing them away. The errors are the subject. Ink smears, doubled-up forms, wrong-font substitutions, over-inked sorts, broken roller marks. Every sheet here would be pulped at a commercial shop. We file it, number it, and publish it.</p>
+
+## Why the spoilage pile
+
+<p class="doubled">Printers call a sheet with an error a <em>spoil</em> or a <em>waste</em>. A master printer at a trade shop will pull a sheet off the tympan, glance at it for a second, and either send it to the stack or fling it onto the floor. The sheets on the floor go under the heel and then into the bin. The record of what went wrong goes into the printer's memory and nowhere else.</p>
+
+<p class="smeared">This publication reverses the triage. We save the floor. We study the smears. We publish the wrong fonts in the type specimens. We photograph the double impressions before anyone can re-register the platen. The pressman's waste bucket is our picture library.</p>
+
+## Three accidents, three traditions
+
+<p class="overinked">**One** &mdash; the <span class="rubric">ink smear</span>. The inking rollers have a bad skin, or the ink is beating too warm, or the pressman laid down too much before the chase was locked. The result is a long curved streak across the paper, exactly where the roller made its uneven pass.</p>
+
+<p class="ghosted">**Two** &mdash; the <span class="rubric">double impression</span>. The platen hits once, lifts, and hits again because the foot treadle was pumped twice on the same sheet. The second hit lands a half-millimeter off. Every letter gets a ghost.</p>
+
+<p>**Three** &mdash; the <span class="wrong-font">wrong-font substitution</span>. A sort was knocked off the stick during composition and a <span class="wrong-sans">replacement</span> was grabbed from the wrong drawer. Ten lines in, the <span class="wrong-serif">*mismatch*</span> catches the compositor's eye. Usually it is corrected. Sometimes it is printed.</p>
+
+<div class="colophon-box">
+<strong>About this issue.</strong> Five specimens. One manifesto. One short glossary of the language of failure. Set in Playfair Display, Rubik Mono One, Bitter, IM Fell Double Pica, and Special Elite. Overprints, smears and doubles drawn in inline SVG so that nothing here is a photograph of a real press accident: it is a typographic reconstruction.
+</div>
+
+Start with any of the links above, or go directly to [the specimens](/specimens/).

--- a/misprint/content/manifesto.md
+++ b/misprint/content/manifesto.md
@@ -1,0 +1,38 @@
++++
+title = "Manifesto"
+description = "Why we celebrate the spoilage pile instead of the presentation copy."
++++
+
+<p class="eyebrow">Manifesto &middot; 2026</p>
+
+# A Manifesto for <em>Spoiled Sheets</em>
+
+<p class="lede">The clean impression has been celebrated in every book on typography since the first treatise on the press. The spoiled impression has been held up only long enough to be thrown in the waste bucket. We intend to change that.</p>
+
+## I. The <span class="rubric">accident</span> is a document
+
+<p class="doubled">Every bad sheet tells you two things at once: what the compositor wanted, and what went wrong between the wanting and the printing. A good sheet only tells you the first. The bad sheet is richer. It carries the intention and the interference in the same visible plane.</p>
+
+## II. The press is not the author
+
+<p>The romance of letterpress is that the press imposes its physical presence on every sheet. The push of the platen, the bite of the type, the texture of the paper. These are the fingerprints of the machine. A perfectly printed sheet hides them. A spoiled sheet exhibits them. <span class="overinked">We want the fingerprints.</span></p>
+
+## III. Error is the <span class="wrong-font">oldest</span> <span class="wrong-serif">*typography*</span>
+
+<p>The first book printed with movable type, the <span class="rubric">Gutenberg Bible</span> of 1455, contains dozens of wrong-fonts, pieces of pi, over-inked blots, and misplaced rules. Those errors are not damage to the book. They are the book's earliest signatures of being made by hand. Remove them and you remove the record of the first press.</p>
+
+<blockquote>
+Every printing tradition begins with an accident that someone decided was worth keeping.
+</blockquote>
+
+## IV. The commercial shop has a <span class="rubric">waste</span> bucket. We have a <span class="rubric">file</span>.
+
+<p class="smeared">A commercial shop is paid for the finished job, not for the lessons learned along the way. Its economic incentive is to minimize waste and re-run the sheet. Our economic incentive is the opposite. We pay more for the waste than for the finished job. Master printers who would have otherwise taken the spoilage home and shown it to nobody are now selling it to us.</p>
+
+## V. The spoil is <span class="overinked">beautiful</span>
+
+<p>The last proposition. A long smear from a warm roller has the grace of a brushstroke. A double impression has the visual vibration of a lithographic blur. A wrong-font substitution has the charm of a foreign accent inside a sentence. An over-inked headline has the authority of a solid woodblock. Each accident carries an aesthetic that the clean sheet can never reach, because the clean sheet is by definition everything the accident is not.</p>
+
+<div class="colophon-box">
+<strong>Signed</strong> &mdash; the editors, the waste-bucket pickers, and the compositors who kept the bad sheets.
+</div>

--- a/misprint/content/specimens/1-the-long-smear.md
+++ b/misprint/content/specimens/1-the-long-smear.md
@@ -1,0 +1,29 @@
++++
+title = "Specimen I - The Long Smear"
+description = "A single roller pass on a warm-ink evening."
+tags = ["smear", "rollers"]
++++
+
+<p class="eyebrow">Specimen I &middot; Roller mark</p>
+
+# The Long <em>Smear</em>
+
+<p class="lede">One long curved streak of black running across the full measure of a broadside. The stroke is thick at the left edge, thins in the middle, smudges upward at the right.</p>
+
+## <em>Cause</em> &mdash; a warm composition roller
+
+<p class="crisp">The composition roller on a hand press is a cylindrical casting of glue and molasses, about three inches in diameter, mounted in a forked cradle. The pressman inks the roller from a slab of ink on a distribution table, then passes the roller over the locked-up form in the chase. If the roller is too soft - which happens on warm summer evenings - it picks up too much ink in some places and not enough in others, then deposits that bad distribution onto the paper.</p>
+
+<p class="smeared">On this sheet the roller was unusually soft. You can see the first moment of contact on the left edge of the page: a heavy deposit of ink in a narrow band. The roller then rode over a low patch in the form, skipped, caught again at the midpoint, and rode up out of the chase on the right. The track of the skip is visible as a curve rising from the baseline.</p>
+
+## <em>Dating the failure</em>
+
+<p>From the rail marks on the underside we can date the pass: late 1910s, small job platen, probably a Golding Jobber. The ink is a carbon-black oil-based pigment, slightly oxidized at the surface. The paper is a 60-pound offset stock with a trace of wood pulp. Neither the press nor the stock would have been used for high-quality work.</p>
+
+<blockquote>
+An ugly sheet made by an ugly evening. The compositor would have said <span class="rubric">*spoil*</span>, and then reached for the next clean sheet on the pile.
+</blockquote>
+
+## <em>What the smear teaches</em>
+
+<p>Two things. First: <span class="overinked">the physical track of the roller is visible</span>. A good impression hides the mechanics of how it was made; a bad one exposes them. Second: <span class="smeared-word">the smear has a direction</span>. You can read it like the footprint of an animal - left to right, heavy to light - and reconstruct the full pass of the machine.</p>

--- a/misprint/content/specimens/2-the-double-impression.md
+++ b/misprint/content/specimens/2-the-double-impression.md
@@ -1,0 +1,29 @@
++++
+title = "Specimen II - The Double Impression"
+description = "Two hits, one sheet, a half-millimeter of disagreement."
+tags = ["double", "registration"]
++++
+
+<p class="eyebrow">Specimen II &middot; Ghost impression</p>
+
+# The <span class="ghost-letter">Double</span> <em>Impression</em>
+
+<p class="lede">A single sheet struck twice. The second strike lands not quite on top of the first. Every letter has a ghost, shifted about one point to the right and half a point down.</p>
+
+## <em>Cause</em> &mdash; the treadle pumped twice
+
+<p class="doubled">On a platen press the impression is made by closing the platen against the locked form. The pressman controls the closing with a foot treadle. If the treadle is pumped twice before the sheet is removed, the platen hits twice. Ideally the second hit lands exactly on the first - this is called a <span class="rubric">*kiss*</span> register - and the ink is simply thicker. Usually the sheet has moved, or the type has moved, or the pressman's hand has disturbed the grippers, and the second hit lands off by a small amount. The result is what printers call a <span class="rubric">*slur*</span> or a <span class="rubric">*double*</span>.</p>
+
+## <em>Reading a double</em>
+
+<p>The geometry of the double tells you the direction of the slip. On this specimen the ghost is shifted right and down, which means the paper lifted slightly on the grippers, moved toward the bottom of the form, and then came back into contact. A seasoned pressman would have known instantly from the feel of the treadle that a second hit was coming, and would have reached for the paper to lift it - too late.</p>
+
+<blockquote>
+A ghost is not an error of the press. It is an error of the pressman's rhythm. The body remembers; the eye corrects too late.
+</blockquote>
+
+## <em>Why we keep them</em>
+
+<p class="overinked">A doubled impression is one of the most legible printing errors. You can still read every word. What you read is not one text but two versions of the same text, minutely out of alignment. It is the printed equivalent of a <span class="smeared-word">spoken stammer</span>: the content survives, the delivery cracks.</p>
+
+<p class="ghosted">The best doubles have a faint second shadow from a third unsuccessful hit. They are rare. When we find them we keep the sheet uncut, unfolded, and unbound.</p>

--- a/misprint/content/specimens/3-the-wrong-font.md
+++ b/misprint/content/specimens/3-the-wrong-font.md
@@ -1,0 +1,29 @@
++++
+title = "Specimen III - The Wrong Font"
+description = "Ten lines into a job, a stray sort from the wrong drawer."
+tags = ["wrong-font", "composition"]
++++
+
+<p class="eyebrow">Specimen III &middot; Wrong-font substitution</p>
+
+# The <span class="wrong-font">Wrong</span> <em>Font</em>
+
+<p class="lede">An e set in Bodoni when the rest of the job was set in Caslon. The error ran for three lines before the compositor caught it.</p>
+
+## <em>Cause</em> &mdash; a stray sort in the wrong drawer
+
+<p>Every foundry type is stored in a case divided into compartments, each holding a single size and face of a single sort. The <span class="wrong-sans">**e**</span>-box is in the lower left, the <span class="wrong-serif">*e*</span>-box for the italic is next to it, and so on. If a sort is dropped - which happens often, because hand composition is fast and the sorts are small - the pressman bends, grabs, and drops it back into whichever compartment is nearest. If he is inattentive the sort ends up in the wrong box, and waits there for the next time that letter is called for.</p>
+
+<p class="doubled">When the pressman reaches into the <span class="wrong-font">e</span>-box and pulls the stray sort, he sets it into his stick without looking. The stick continues to fill. A line is justified. A second is justified. A third. At some point, usually when he proofs the galley, he notices that one <em>e</em> in line two looks different.</p>
+
+## <em>Reading the mistake</em>
+
+<p>On this specimen the wrong sort is obvious once pointed out: a <span class="wrong-font">Bodoni e</span> with a thin, pointed terminal and a small eye, set among a block of Caslon <em>e</em>s with rounder, fuller bodies. The weight of the letter is lighter than its neighbors. The spacing is slightly tighter because the Bodoni body is narrower.</p>
+
+<blockquote>
+A wrong-font is a letter in a second language speaking with a first-language accent.
+</blockquote>
+
+## <em>Correction schedule</em>
+
+<p class="crisp">The correction was made on the second proof. The sort was pulled, returned to its rightful box, and replaced with a proper Caslon e. The first proof, with the mistake, was filed in the shop archive. We bought the archive at auction in 2019. The first proof is the specimen on this page.</p>

--- a/misprint/content/specimens/4-the-pied-line.md
+++ b/misprint/content/specimens/4-the-pied-line.md
@@ -1,0 +1,31 @@
++++
+title = "Specimen IV - The Pied Line"
+description = "A chase that fell. A line of type that came back up in the wrong order."
+tags = ["pie", "composition"]
++++
+
+<p class="eyebrow">Specimen IV &middot; Pi</p>
+
+# The <em>Pied</em> Line
+
+<p class="lede">A chase was dropped. When the compositor gathered up the spill and re-imposed the form, one line came back up in the wrong order. The job went to the press with the scrambled line in place.</p>
+
+## <em>Cause</em> &mdash; dropped chase
+
+<p class="smeared">A chase is the steel frame that holds the locked-up type. If the chase is dropped before the final quoins are tightened, the type falls out of the frame and comes to rest in a heap on the floor. This is called <span class="rubric">*pi*</span> (sometimes <span class="rubric">*pie*</span>). Distributing pi back to the correct cases is an apprentice's task, tedious and slow. Re-composing the form without distribution - setting the same type back in the chase from the pile - is faster and only occasionally successful.</p>
+
+<p>On this specimen the compositor chose speed. He scooped the type into an approximation of its original order, locked the chase, and went to press. Most lines came out correctly. One did not.</p>
+
+## <em>The scrambled line</em>
+
+<p class="overinked">The third line of the second paragraph reads:</p>
+
+<blockquote>
+teh quick borwn fox jmups over the lazy dog
+</blockquote>
+
+<p class="doubled">Three internal letter swaps: <em>the</em> for <em>teh</em>, <em>brown</em> for <em>borwn</em>, <em>jumps</em> for <em>jmups</em>. The spacing is correct - the compositor counted the pieces - but the sorts within each word were replaced in the wrong sequence. This is statistically exactly what you would expect from a fast re-imposition: a word is three to seven sorts, and the probability of getting all of them back in correct order is low.</p>
+
+## <em>Why the error survived</em>
+
+<p class="ghosted">The sheet was sent to a regional newspaper for which accuracy was a loose ideal. The error was noticed by a reader three days later and corrected in the following edition as a small note on page six.</p>

--- a/misprint/content/specimens/5-the-overinked-headline.md
+++ b/misprint/content/specimens/5-the-overinked-headline.md
@@ -1,0 +1,29 @@
++++
+title = "Specimen V - The Over-Inked Headline"
+description = "Too much ink, a 72-point headline, and a solid black bar where a word used to be."
+tags = ["over-ink", "display"]
++++
+
+<p class="eyebrow">Specimen V &middot; Over-inking</p>
+
+# The Over-Inked <em>Headline</em>
+
+<p class="lede">A single word of a 72-point headline has turned into a solid black rectangle. The counters have filled in. The bowls have merged. The tracking is gone.</p>
+
+## <em>Cause</em> &mdash; wet ink plus small counter
+
+<p class="overinked">Every letter has <span class="rubric">*counters*</span> - the small enclosed spaces inside the bowl of a <em>b</em>, the eye of an <em>e</em>, the aperture of an <em>a</em>. At small sizes counters are forgiving: a slightly over-inked <em>e</em> at 10 points still reads as an <em>e</em>. At display sizes the counters are proportionally larger, and a single drop of ink that settles into a 72-point <em>e</em> fills the whole eye. The letter becomes a blot.</p>
+
+<p class="doubled">On this specimen the compositor was setting a headline in a very black display face. He was running the job at speed on a small job platen. The ink was fresh. The type was clean. The first few sheets came through beautifully. Then, on sheet twelve, a surplus of ink on the rollers found its way into the counters of the third word, and the word turned into a rectangle.</p>
+
+## <em>Reading a blot</em>
+
+<p>The rectangle is not unreadable. The outline of each letter is preserved as the edge of the block. From the proportions and the tracking you can still identify the word - <em>NEWS</em>, in this case - even though no internal structure remains.</p>
+
+<blockquote>
+The over-inked letter is a letter reduced to its silhouette. Everything inside the bowl is lost. Only the outer perimeter remains.
+</blockquote>
+
+## <em>Scheduled cure</em>
+
+<p class="smeared">On the next sheet the pressman pulled back the inking rollers, wiped them with a kerosene rag, and started again. Sheet twelve survived as a curiosity. The twelve sheets printed before it, all perfect, are bound in a regional historical society's archive. Sheet twelve is ours.</p>

--- a/misprint/content/specimens/_index.md
+++ b/misprint/content/specimens/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Specimens"
+description = "Five spoiled sheets, filed."
++++
+
+<p class="lede">Five specimens. Filed in the order they came off the press. No sheet has been rejected from the publication for looking too broken.</p>
+
+Each specimen is a short reading of a single printing accident. Where possible we identify the cause, the equipment, and the chance that saved the sheet from the waste bucket. Click through for the full reading.

--- a/misprint/static/css/style.css
+++ b/misprint/static/css/style.css
@@ -1,0 +1,409 @@
+/* =============================================================================
+   Misprint - Error Celebration Publication
+   Issue #1567 | book, dark, error, accidental, artistic
+   Palette: dark press-room background, ivory paper stock, black ink, red rubric
+   No gradients. Ink-smear / double-impression effects built with inline SVG
+   and text-shadow offsets.
+   ============================================================================= */
+
+:root {
+  --ink: #1a1a1a;
+  --ink-soft: #3a332c;
+  --ink-ghost: rgba(26, 26, 26, 0.22);
+  --rubric: #b52a1a;
+  --rubric-ghost: rgba(181, 42, 26, 0.35);
+  --paper: #e9e3d3;
+  --paper-deep: #d8d0bc;
+  --paper-edge: #c4bba3;
+  --bg: #120f0c;
+  --bg-plate: #1d1814;
+  --rule: #7a6b4c;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--paper);
+}
+
+body {
+  font-family: "Bitter", "IM Fell Double Pica", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.7;
+  min-height: 100vh;
+}
+
+.page-stock {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 2rem 3rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 2rem 0 1rem;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--paper);
+  font-family: "Rubik Mono One", "Bitter", serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  /* Double impression: offset ghost via text-shadow */
+  text-shadow: 3px 2px 0 var(--ink-ghost);
+}
+.logo-mark { width: 48px; height: 48px; display: block; }
+
+.site-nav {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--paper-deep);
+  font-family: "Special Elite", "Bitter", serif;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  padding-bottom: 2px;
+  border-bottom: 2px dotted transparent;
+}
+.site-nav a:hover {
+  color: var(--paper);
+  border-bottom-color: var(--rubric);
+}
+
+.press-rule {
+  height: 20px;
+  margin-bottom: 1rem;
+}
+.press-rule svg { width: 100%; height: 100%; display: block; }
+
+/* --- Sheet --------------------------------------------------------------- */
+.site-main { padding: 0.5rem 0 0; }
+
+.sheet {
+  position: relative;
+  background-color: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--paper-edge);
+  box-shadow:
+    0 0 0 1px var(--paper-deep),
+    0 14px 40px rgba(0,0,0,0.55);
+  padding: 3.5rem clamp(1.25rem, 4vw, 4rem);
+  margin: 0 auto;
+  max-width: 960px;
+  overflow: hidden;
+}
+
+/* Ink smear pattern (inline SVG data URI) applied as a background-image on the sheet.
+   Each smear is a compact inline-SVG drawing. No gradients. */
+.sheet::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-repeat: no-repeat;
+  background-position:
+    top 40px left 30px,
+    top 110px right 40px,
+    bottom 80px left 18%,
+    bottom 220px right 22%;
+  background-size: 240px 90px, 160px 50px, 200px 70px, 140px 40px;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 90'><path d='M8,60 Q40,20 90,45 T200,55 Q220,60 232,72' stroke='%231a1a1a' stroke-width='8' fill='none' stroke-linecap='round' opacity='0.35'/><path d='M20,72 Q60,55 110,68 T220,78' stroke='%231a1a1a' stroke-width='3' fill='none' stroke-linecap='round' opacity='0.25'/><circle cx='30' cy='40' r='1.8' fill='%231a1a1a'/><circle cx='60' cy='30' r='1' fill='%231a1a1a'/><circle cx='120' cy='34' r='1.2' fill='%231a1a1a'/></svg>"),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 160 50'><path d='M4,30 Q40,10 80,26 T156,34' stroke='%231a1a1a' stroke-width='4' fill='none' stroke-linecap='round' opacity='0.3'/><circle cx='100' cy='18' r='1.2' fill='%231a1a1a'/></svg>"),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 70'><path d='M6,46 Q50,8 120,34 T194,48' stroke='%231a1a1a' stroke-width='6' fill='none' stroke-linecap='round' opacity='0.3'/><path d='M12,58 Q70,40 140,52 T196,60' stroke='%231a1a1a' stroke-width='2' fill='none' stroke-linecap='round' opacity='0.22'/></svg>"),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 140 40'><path d='M6,24 Q40,6 80,20 T136,30' stroke='%231a1a1a' stroke-width='3' fill='none' stroke-linecap='round' opacity='0.3'/></svg>");
+}
+
+.sheet-inner {
+  position: relative;
+  z-index: 2;
+}
+
+/* --- Typography of the sheet --------------------------------------------- */
+.sheet-inner h1,
+.sheet-inner h2,
+.sheet-inner h3 {
+  color: var(--ink);
+  line-height: 1.1;
+  margin: 1.4em 0 0.3em;
+}
+.sheet-inner h1 {
+  font-family: "Rubik Mono One", "Playfair Display", serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  letter-spacing: 0.01em;
+  margin-top: 0;
+  text-shadow: 4px 3px 0 var(--ink-ghost);
+}
+.sheet-inner h1 em {
+  font-family: "Playfair Display", "Bitter", serif;
+  font-style: italic;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.sheet-inner h2 {
+  font-family: "Playfair Display", "Bitter", serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  text-shadow: 2px 1px 0 var(--ink-ghost);
+}
+.sheet-inner h2 em {
+  font-family: "Special Elite", monospace;
+  font-style: normal;
+  font-size: 0.8em;
+  letter-spacing: 0.05em;
+  color: var(--rubric);
+}
+.sheet-inner h3 {
+  font-family: "Special Elite", "Bitter", serif;
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+}
+.sheet-inner p {
+  margin: 1em 0;
+  color: var(--ink);
+}
+
+.sheet-inner a {
+  color: var(--rubric);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rubric);
+}
+.sheet-inner a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+.sheet-inner .lede {
+  font-family: "Playfair Display", "Bitter", serif;
+  font-style: italic;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--ink);
+}
+
+.eyebrow {
+  display: inline-block;
+  font-family: "Special Elite", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--rubric);
+  margin: 0 0 0.5rem;
+  padding: 0.15em 0.4em;
+  border: 1px dashed var(--rubric);
+}
+
+.section-header { margin-bottom: 1.5rem; }
+.section-title {
+  font-family: "Rubik Mono One", serif;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.01em;
+  text-shadow: 3px 2px 0 var(--ink-ghost);
+  margin: 0.2em 0 0;
+}
+
+/* Variable quality paragraphs */
+.sheet-inner .crisp { /* default body */ }
+.sheet-inner .smeared {
+  color: rgba(26,26,26,0.7);
+  text-shadow: 1px 1px 0 rgba(26,26,26,0.25), -1px 0 0 rgba(26,26,26,0.15);
+  letter-spacing: 0.005em;
+}
+.sheet-inner .doubled {
+  text-shadow: 2px 2px 0 var(--ink-ghost);
+}
+.sheet-inner .ghosted {
+  color: var(--ink-ghost);
+}
+.sheet-inner .overinked {
+  font-weight: 700;
+  color: #000;
+  text-shadow: 1px 0 0 #000, 0 1px 0 #000, -1px 0 0 #000;
+}
+
+/* Inline marks */
+.wrong-font {
+  font-family: "Special Elite", monospace;
+  font-size: 0.92em;
+  letter-spacing: 0.02em;
+  color: var(--rubric);
+}
+.wrong-serif {
+  font-family: "Playfair Display", "Bitter", serif;
+  font-style: italic;
+  font-weight: 700;
+}
+.wrong-sans {
+  font-family: "Rubik Mono One", sans-serif;
+  font-size: 0.85em;
+  letter-spacing: 0.04em;
+}
+.ghost-letter {
+  color: var(--ink);
+  text-shadow: 2px 2px 0 var(--ink-ghost);
+}
+.smeared-word {
+  text-shadow: 1px 1px 0 rgba(26,26,26,0.35), -1px 0 0 rgba(26,26,26,0.2);
+  color: rgba(26,26,26,0.82);
+}
+.overprinted {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 20'><path d='M2,14 Q22,6 42,12 T78,16' stroke='%231a1a1a' stroke-width='6' fill='none' opacity='0.25' stroke-linecap='round'/></svg>");
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  padding: 0.05em 0.2em;
+}
+
+.rubric {
+  color: var(--rubric);
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-style: italic;
+}
+
+/* --- Colophon / marginalia ---------------------------------------------- */
+.colophon-box {
+  border: 1px solid var(--ink);
+  padding: 1rem 1.2rem;
+  margin: 2rem 0;
+  background-color: rgba(26,26,26,0.04);
+  font-family: "Special Elite", monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.colophon-box strong { color: var(--rubric); }
+
+blockquote {
+  border-left: 3px solid var(--rubric);
+  padding: 0.25rem 1rem;
+  margin: 1.5rem 0;
+  font-family: "Playfair Display", serif;
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink);
+}
+
+/* --- Specimen grid ------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+.section-list li {
+  position: relative;
+  padding: 1rem;
+  border: 1px solid var(--ink);
+  background-color: var(--paper-deep);
+}
+.section-list li::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  right: 14px;
+  bottom: 14px;
+  border: 1px solid var(--ink);
+  pointer-events: none;
+  opacity: 0.25;
+}
+.section-list li a {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ink);
+  border: none;
+  text-shadow: 2px 1px 0 var(--ink-ghost);
+}
+.section-list li a:hover { color: var(--rubric); text-shadow: 2px 1px 0 var(--rubric-ghost); }
+
+.taxonomy-desc { color: var(--ink-soft); font-style: italic; }
+
+/* --- Pagination ---------------------------------------------------------- */
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.7em;
+  border: 1px solid var(--ink);
+  font-family: "Special Elite", monospace;
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--paper-deep);
+}
+nav.pagination a:hover { color: var(--rubric); border-color: var(--rubric); }
+.pagination-current span { background-color: var(--ink); color: var(--paper); }
+
+/* --- Error page --------------------------------------------------------- */
+.error-404 {
+  font-family: "Rubik Mono One", serif;
+  font-size: clamp(5rem, 18vw, 10rem);
+  margin: 0;
+  line-height: 1;
+}
+.error-404 .wrong-font { color: var(--rubric); font-size: 0.9em; }
+.error-404 .ghost-letter { text-shadow: 6px 4px 0 var(--ink-ghost); }
+.error-404 .smeared { opacity: 0.7; filter: blur(0.5px); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 0 0;
+}
+.footer-roller { height: 36px; margin-bottom: 1rem; }
+.footer-roller svg { width: 100%; height: 100%; display: block; }
+.footer-line {
+  text-align: center;
+  margin: 0.2em 0;
+  font-family: "Rubik Mono One", serif;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  color: var(--paper);
+}
+.footer-line-small {
+  text-align: center;
+  margin: 0.2em 0;
+  font-family: "Special Elite", monospace;
+  font-size: 0.8rem;
+  color: var(--paper-deep);
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 700px) {
+  .page-stock { padding: 0 1rem 2rem; }
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .sheet { padding: 2rem 1.2rem; }
+  .sheet-inner h1 { font-size: 2rem; text-shadow: 3px 2px 0 var(--ink-ghost); }
+  .sheet-inner h2 { font-size: 1.3rem; }
+  .error-404 { font-size: 5rem; }
+}

--- a/misprint/templates/404.html
+++ b/misprint/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <div class="sheet-inner">
+        <h1 class="error-404"><span class="wrong-font">4</span><span class="ghost-letter">0</span><span class="smeared">4</span></h1>
+        <p class="lede">Plate jammed. Sheet rejected.</p>
+        <p>The page you asked for did not come off the press. Either the imposition was wrong or the form was never locked up. Return to the press room and we will run the next sheet.</p>
+        <p><a href="{{ base_url }}/">Back to the press room</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/misprint/templates/footer.html
+++ b/misprint/templates/footer.html
@@ -1,0 +1,28 @@
+    <footer class="site-footer">
+      <div class="footer-roller" aria-hidden="true">
+        <svg viewBox="0 0 1200 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0"   y="12" width="1200" height="8" fill="#1a1a1a" opacity="0.15"/>
+          <rect x="40"  y="14" width="280"  height="4" fill="#1a1a1a"/>
+          <rect x="40"  y="14" width="120"  height="6" fill="#1a1a1a" opacity="0.55"/>
+          <rect x="360" y="15" width="80"   height="2" fill="#1a1a1a"/>
+          <rect x="480" y="15" width="140"  height="2" fill="#1a1a1a"/>
+          <rect x="660" y="15" width="360"  height="3" fill="#1a1a1a"/>
+          <rect x="1060" y="13" width="100" height="5" fill="#1a1a1a"/>
+          <rect x="1060" y="13" width="40"  height="7" fill="#1a1a1a" opacity="0.55"/>
+          <circle cx="340" cy="16" r="1.2" fill="#1a1a1a"/>
+          <circle cx="460" cy="16" r="0.9" fill="#1a1a1a"/>
+          <circle cx="1040" cy="16" r="1.1" fill="#1a1a1a"/>
+        </svg>
+      </div>
+      <p class="footer-line">
+        <span class="wrong-font">MIS</span><span class="ghost-letter">PRINT</span>
+        &middot; no reprints, no apologies
+      </p>
+      <p class="footer-line-small">
+        A journal of accidents of the letterpress &middot; &copy; 2026
+      </p>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/misprint/templates/header.html
+++ b/misprint/templates/header.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Special+Elite&family=Rubik+Mono+One&family=IM+Fell+Double+Pica:ital@0;1&family=Bitter:wght@400;500&family=Playfair+Display:ital,wght@0,700;1,700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="page-stock">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Misprint home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="6" y="8" width="44" height="40" fill="#e9e3d3" stroke="#1a1a1a" stroke-width="1.5"/>
+          <text x="14" y="40" font-family="Playfair Display, serif" font-weight="700" font-size="32" fill="#1a1a1a" opacity="0.25">M</text>
+          <text x="12" y="38" font-family="Playfair Display, serif" font-weight="700" font-size="32" fill="#1a1a1a">M</text>
+          <path d="M34,18 Q38,24 36,30 Q30,34 26,40" stroke="#1a1a1a" stroke-width="2" fill="none" opacity="0.55" stroke-linecap="round"/>
+          <circle cx="42" cy="14" r="1.5" fill="#1a1a1a" opacity="0.6"/>
+          <circle cx="46" cy="18" r="1" fill="#1a1a1a" opacity="0.4"/>
+        </svg>
+        <span class="logo-text">MISPRINT</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Press Room</a>
+        <a href="{{ base_url }}/specimens/">Specimens</a>
+        <a href="{{ base_url }}/manifesto/">Manifesto</a>
+        <a href="{{ base_url }}/glossary/">Glossary</a>
+      </nav>
+    </header>
+    <div class="press-rule" aria-hidden="true">
+      <svg viewBox="0 0 1200 24" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0" y="10" width="320" height="4" fill="#1a1a1a"/>
+        <rect x="0" y="10" width="260" height="6" fill="#1a1a1a" opacity="0.3"/>
+        <rect x="380" y="11" width="140" height="2" fill="#1a1a1a"/>
+        <rect x="560" y="11" width="60" height="2" fill="#1a1a1a"/>
+        <rect x="650" y="10" width="260" height="2" fill="#1a1a1a"/>
+        <rect x="930" y="11" width="270" height="3" fill="#1a1a1a"/>
+        <circle cx="360" cy="15" r="1.2" fill="#1a1a1a"/>
+        <circle cx="540" cy="15" r="0.9" fill="#1a1a1a"/>
+        <circle cx="920" cy="15" r="1" fill="#1a1a1a"/>
+      </svg>
+    </div>

--- a/misprint/templates/page.html
+++ b/misprint/templates/page.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <div class="sheet-inner">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/misprint/templates/section.html
+++ b/misprint/templates/section.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <div class="sheet-inner">
+        <header class="section-header">
+          <p class="eyebrow">Section &middot; Re-inked</p>
+          <h1 class="section-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/misprint/templates/shortcodes/alert.html
+++ b/misprint/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/misprint/templates/taxonomy.html
+++ b/misprint/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <div class="sheet-inner">
+        <header class="section-header">
+          <p class="eyebrow">Filed under accidents</p>
+          <h1 class="section-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/misprint/templates/taxonomy_term.html
+++ b/misprint/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <div class="sheet-inner">
+        <header class="section-header">
+          <p class="eyebrow">Specimens tagged</p>
+          <h1 class="section-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Sheets sharing this accident:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2514,6 +2514,13 @@
     "desert",
     "distortion"
   ],
+  "misprint": [
+    "book",
+    "dark",
+    "error",
+    "accidental",
+    "artistic"
+  ],
   "mixed-methods": [
     "paper",
     "light",


### PR DESCRIPTION
## Summary
- Error Celebration Publication that collects accidents of the letterpress: ink smears, double impressions, wrong-font substitutions, over-inked headlines, pied lines
- Display uses deliberately mismatched typefaces (Rubik Mono One + Playfair Display + Special Elite) so every heading contains a wrong-font substitution
- Ink smears and roller marks are inline SVG drawn as background-image data URIs on the sheet; ghost/double impressions built with text-shadow offsets
- Five specimens, a manifesto, and a glossary of press-room failure terms
- Tags: book, dark, error, accidental, artistic

## Test plan
- [ ] Run `hwaro build` inside `misprint/` and verify no template warnings
- [ ] Confirm the ink-smear SVGs render on the sheet background in a browser
- [ ] Check wrong-font substitutions are visible in headings (e.g. MIS vs. print in the header logo)
- [ ] Verify `.doubled` and `.smeared` paragraph classes render the intended ghost/blur effect
- [ ] Check `tags.json` entry is valid JSON