### PR TITLE
feat: add incunabula-noir example site (closes #1566)

### DIFF
--- a/incunabula-noir/AGENTS.md
+++ b/incunabula-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/incunabula-noir/config.toml
+++ b/incunabula-noir/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Incunabula Noir - Dark Early Print Publication
+# Issue #1566 | Tags: book, dark, incunabulum, early-print, revolutionary
+# =============================================================================
+
+title = "Incunabula Noir"
+description = "A dark incunabulum for the early-print devotee: heavy blackletter display, dense roman body in tight two-column measures, deep-set metal-type impression marks, and rubricated initial letters in the hand-finishing tradition. The earliest printed books, read at midnight."
+base_url = "http://localhost:3000"
+
+sections = ["leaves"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/incunabula-noir/content/colophon.md
+++ b/incunabula-noir/content/colophon.md
@@ -1,0 +1,33 @@
++++
+title = "Colophon"
+description = "A colophon after the manner of Fust and Schoeffer."
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Colophon</p>
+<h1 class="leaf-title">Finit feliciter</h1>
+</div>
+
+<span class="rubricated">I</span>
+
+mpressum Incunabula Noir. <span class="rubric">Anno Domini</span> MMXXVI. A small edition of one, after the manner of the cradle books that the Rhine masters set at Mainz four hundred and seventy years ago.
+
+<h2>Of the type</h2>
+
+The display face on every leaf is <span class="black-letter">UnifrakturMaguntia</span>, a modern revival of a fifteenth-century Mainz textura. It is set large at the opening of each leaf, in the manner of a display hand. The rubrics and secondary headings use <span class="black-letter">UnifrakturCook</span>, a heavier cursiva that would have been set at a smaller size on a press in the same workshop.
+
+The body face is <span class="black-letter">Old Standard TT</span>, a revival of a nineteenth-century scholarly roman that reaches back in spirit to the Jenson romans of 1470. The italic and the small caps are from <span class="black-letter">EB Garamond</span>, another traditional roman with a serious manuscript ancestry. Both faces are dense and tight, the way a two-column measure on a folio sheet needs them to be.
+
+<h2>Of the colors</h2>
+
+Three inks. <span class="rubric">Iron-oxide red</span> for the initials, the rubrics, and the marginalia. <span class="rubric">Bone white</span> for the body text and the display hand. <span class="rubric">Pitch black</span> for the vellum ground. No gradients. Every rule is drawn as metal type would have drawn it: a thin stroke laid down by a raised piece of lead.
+
+<h2>Of the ornaments</h2>
+
+Every decorative element in this edition is inline SVG. The type squares on the incipit leaf are vector drawings of a single piece of metal type, with body, shoulder, shank, and raised letterform. The plate rules at the head and foot are thin SVG lines with iron-oxide dots at the corners and center. The rubricated initial at the opening of each leaf is a small panel of darker vellum set inside a thin red border, with the capital letter painted in red on top.
+
+<blockquote>
+Impressum hic liber feliciter in officina noctis, mensibus autumnalibus, per hwaroniam pressam mechanicam, ex ludo ingenioso hominis et machinae.
+</blockquote>
+
+A book printed in the workshop of the night, in autumn, by the hwaro mechanical press, from the ingenious play of man and machine.

--- a/incunabula-noir/content/history.md
+++ b/incunabula-noir/content/history.md
@@ -1,0 +1,34 @@
++++
+title = "The Cradle"
+description = "A short history of the first half-century of European print."
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Historia incunabulorum</p>
+<h1 class="leaf-title">The Cradle</h1>
+</div>
+
+<span class="rubricated">T</span>
+
+he word <span class="rubric">incunabulum</span> comes from the Latin for swaddling clothes: a book in its cradle. It is applied, by convention, to every book printed in Europe before the first of January 1501. The cutoff is arbitrary, but useful. The books printed in the half-century from 1455 to 1500 share enough visual and technical features that treating them as a single family is defensible.
+
+<div class="two-col">
+
+The earliest dated piece of European print is a 1454 indulgence issued from the press of Johannes Gutenberg at Mainz. The earliest book-length incunabulum is the 42-line Bible, also Gutenberg, from around 1455. By the 1460s presses had been established at Strasbourg, Bamberg, Cologne, and Augsburg. By 1470 Venice had become the largest printing center in Europe, a position it held for nearly half a century. By 1500 there were active presses in roughly two hundred and fifty European cities.
+
+The Incunabula Short Title Catalogue, maintained by the British Library, lists about thirty thousand editions printed before 1501, representing roughly six million physical copies. Of those, perhaps four hundred and fifty thousand copies still exist in libraries and private collections. The survival rate is about seven and a half percent, which is remarkable for books that were printed on rag paper and bound in soft leather and carried around for five hundred and seventy years.
+
+Most incunabula are religious: Bibles, Books of Hours, psalters, patristic commentaries. The second-largest category is classical: editions of Cicero, Virgil, Ovid, Aristotle. The third is legal: compendia of Roman and canon law. Vernacular literature &mdash; Chaucer, Dante, Boccaccio &mdash; represents only a small fraction of the total.
+
+The value of an incunabulum today depends less on its text than on its state. A complete copy of a well-preserved Jenson classical edition, still in its original binding and with clean rubrication, can sell at auction for the price of a small house. A fragment from the same edition, loose in an archive, is worth much less. The book as an object has become more valuable than the text it carries.
+
+</div>
+
+<h2>Significant presses, 1455-1500</h2>
+
+- <span class="rubric">Mainz</span>: Gutenberg (c.1455), Fust &amp; Schoeffer (from 1457).
+- <span class="rubric">Strasbourg</span>: Mentelin (from 1460), Heinrich Eggestein.
+- <span class="rubric">Venice</span>: Jenson (from 1470), Aldus Manutius (from 1494).
+- <span class="rubric">Paris</span>: the Sorbonne press (1470), Jean Du Pre.
+- <span class="rubric">Rome</span>: Sweynheym &amp; Pannartz (from 1467).
+- <span class="rubric">Westminster</span>: Caxton (from 1476).

--- a/incunabula-noir/content/index.md
+++ b/incunabula-noir/content/index.md
@@ -1,0 +1,66 @@
++++
+title = "Incipit"
+description = "An incipit leaf for a dark incunabulum: printed after the manner of the books made before 1501."
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Incipit liber primus</p>
+<h1 class="leaf-title">Incunabula Noir</h1>
+</div>
+
+<span class="rubricated">I</span>
+
+n the century between Gutenberg's first dated impression at Mainz and the turn of the sixteenth century, about twenty-eight thousand editions were printed in Europe. These are the <span class="rubric">incunabula</span>: the books of the cradle. They were set with hand-cast metal type, pulled sheet by sheet on wooden screw presses, and rubricated afterward by a scribe who painted the initials and headings in red ink. They are the first printed books. They are also still partly manuscripts.
+
+<div class="two-col">
+
+This publication collects the visual grammar of that first half-century of print and sets it against a black ground. Blackletter display at the head, dense roman in a two-column measure below, iron-oxide rubric for the initial and the marginalia. The paper is a deep vellum-black, the ink is bone, and every rule on the page is drawn as metal type would have drawn it: a thin stroke laid down by a raised piece of lead.
+
+The noir in the title is not a mood. It is the page. Every early printed book survives as a white rectangle of impressed ink; this edition inverts the contrast and prints in bone against black. The letterforms are unchanged. What shifts is the physical weight of the type as you look at it: the ink no longer sits on a bright field, it emerges from a dark field. You read a letterform the way a punchcutter would have seen it on the face of the matrix before the ink was ever applied.
+
+</div>
+
+<h2>What this edition contains</h2>
+
+A handful of leaves on early-print craft. A short history of the cradle. A colophon after the manner of Schoeffer. The text is not a reproduction of any specific incunabulum. It is a new composition set in the manner of one.
+
+<div class="type-grid">
+<div class="type-cell">
+<svg viewBox="0 0 120 160" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="10" y="10" width="100" height="140" fill="#181410" stroke="#7a2d1c" stroke-width="1"/>
+  <rect x="18" y="18" width="84" height="124" fill="#0a0806"/>
+  <text x="60" y="102" font-family="UnifrakturCook, serif" font-weight="700" font-size="70" fill="#d5c5a4" text-anchor="middle">A</text>
+  <line x1="10" y1="132" x2="110" y2="132" stroke="#7a2d1c" stroke-width="0.75"/>
+  <line x1="10" y1="10" x2="110" y2="10" stroke="#3a2a20" stroke-width="0.5"/>
+</svg>
+</div>
+<div class="type-cell">
+<svg viewBox="0 0 120 160" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="10" y="10" width="100" height="140" fill="#181410" stroke="#7a2d1c" stroke-width="1"/>
+  <rect x="18" y="18" width="84" height="124" fill="#0a0806"/>
+  <text x="60" y="102" font-family="UnifrakturCook, serif" font-weight="700" font-size="70" fill="#d5c5a4" text-anchor="middle">B</text>
+  <line x1="10" y1="132" x2="110" y2="132" stroke="#7a2d1c" stroke-width="0.75"/>
+  <line x1="10" y1="10" x2="110" y2="10" stroke="#3a2a20" stroke-width="0.5"/>
+</svg>
+</div>
+<div class="type-cell">
+<svg viewBox="0 0 120 160" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="10" y="10" width="100" height="140" fill="#181410" stroke="#7a2d1c" stroke-width="1"/>
+  <rect x="18" y="18" width="84" height="124" fill="#0a0806"/>
+  <text x="60" y="102" font-family="UnifrakturCook, serif" font-weight="700" font-size="70" fill="#d5c5a4" text-anchor="middle">C</text>
+  <line x1="10" y1="132" x2="110" y2="132" stroke="#7a2d1c" stroke-width="0.75"/>
+  <line x1="10" y1="10" x2="110" y2="10" stroke="#3a2a20" stroke-width="0.5"/>
+</svg>
+</div>
+<div class="type-cell">
+<svg viewBox="0 0 120 160" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="10" y="10" width="100" height="140" fill="#181410" stroke="#7a2d1c" stroke-width="1"/>
+  <rect x="18" y="18" width="84" height="124" fill="#0a0806"/>
+  <text x="60" y="102" font-family="UnifrakturCook, serif" font-weight="700" font-size="70" fill="#b5321e" text-anchor="middle">D</text>
+  <line x1="10" y1="132" x2="110" y2="132" stroke="#7a2d1c" stroke-width="0.75"/>
+  <line x1="10" y1="10" x2="110" y2="10" stroke="#3a2a20" stroke-width="0.5"/>
+</svg>
+</div>
+</div>
+
+Each square above is a single piece of <span class="rubric">metal type</span>: body, shoulder, shank, and the letterform standing proud of the face. The rubricated D is set in iron-oxide to mark where the hand-finisher would have gone to work with a small brush, after the press had done its part.

--- a/incunabula-noir/content/leaves/1-of-the-punch.md
+++ b/incunabula-noir/content/leaves/1-of-the-punch.md
@@ -1,0 +1,32 @@
++++
+title = "Of the Punch"
+description = "On the steel punch, the father of every metal letter."
+tags = ["craft", "type"]
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Leaf I</p>
+<h1 class="leaf-title">Of the Punch</h1>
+</div>
+
+<span class="rubricated">T</span>
+
+he first object in the genealogy of the metal letter is the <span class="rubric">punch</span>. It is a small bar of steel, about three inches long and a quarter-inch square, filed and engraved at one end with the negative image of a single letterform. The punchcutter's work is private: he sits at a bench with a vise, a loupe, and a set of small files, and for two or three weeks he carves a single A. When he is finished he tempers the steel and the A is permanent.
+
+<div class="two-col">
+
+A single font of pica roman requires about three hundred punches: roman upper and lower case, italic upper and lower case, numerals, punctuation, ligatures, accented letters, and the specialist sorts such as long-s and thorn. A master cutter like <span class="black-letter">Griffo</span> or <span class="black-letter">Garamont</span> could produce a fresh font of three hundred punches in eighteen months of steady work. A journeyman took three or four years.
+
+The punch is the artistic act. Every subsequent step in the manufacture of metal type is mechanical and reproducible. The letterform that the reader sees on the page is a negative of a negative of a negative: the punch is struck into soft copper to form the matrix, the matrix is clamped into the hand mold, the mold is filled with molten lead, and the cooled piece of lead is pressed into dampened paper. Four reversals between the cutter's file and the reader's eye.
+
+What makes a great punch is not the shape of the letter in isolation. It is the <span class="rubric">optical rhythm</span> of the letter next to every other letter in the font. The cutter is working with a single piece of steel, but the shape he carves must harmonize with the two hundred and ninety-nine other pieces already finished, and also with the pieces not yet cut. The earliest punchcutters kept a book of their own letters, pulled as proof on vellum, and worked with that book always at their elbow.
+
+</div>
+
+<h2>Survival</h2>
+
+Very few fifteenth-century punches survive. The Plantin-Moretus Museum in Antwerp holds the oldest intact collection: about five thousand punches from the sixteenth and seventeenth centuries, laid out in shallow wooden drawers. None of the original Mainz punches from the 1450s is known to exist. Every Gutenberg letter we have is a descendant without a surviving ancestor.
+
+<blockquote>
+A punch is a private act of craftsmanship whose entire purpose is to produce, downstream, a public artifact that does not bear the maker's name.
+</blockquote>

--- a/incunabula-noir/content/leaves/2-of-the-matrix.md
+++ b/incunabula-noir/content/leaves/2-of-the-matrix.md
@@ -1,0 +1,28 @@
++++
+title = "Of the Matrix"
+description = "On the soft copper block that holds the imprint of the letter."
+tags = ["craft", "matrix"]
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Leaf II</p>
+<h1 class="leaf-title">Of the Matrix</h1>
+</div>
+
+<span class="rubricated">T</span>
+
+he <span class="rubric">matrix</span> is the second object in the genealogy. It is a small rectangular bar of soft copper, cut to a standard size so it can be clamped into a hand mold. The punchcutter, having finished a steel punch, places the punch above the copper and hammers it into the metal with a single square blow. The impression is deep, about two millimeters, and is the negative of the letterform.
+
+<div class="two-col">
+
+Not every matrix is perfect. The blow may be struck off-axis, and the letter comes out leaning. The copper may be too hard, and the impression is shallow. The punch may be too warm from the vise, and the edges of the letter soften. A matrix that is off-axis will produce every letter from it with the same lean. A matrix that is shallow will produce every letter thin. A matrix that is softened will produce every letter slightly blurred.
+
+After the strike the matrix is <span class="rubric">justified</span>: filed on four sides to exact dimensions so that every piece of type cast from it sits level in the stick and lines up with every other piece cast from its font. Justifying is done with a toothed file and a small square, by a specialist called the justifier, who usually was not the same person as the cutter. A matrix badly justified will produce type that kerns, that is, it will overhang the body of the adjacent sort and print unevenly.
+
+A single matrix, once justified, is good for many thousands of casts. The copper is soft enough to take the punch but hard enough to endure repeated contact with molten lead. A well-kept matrix outlives its cutter. Most fifteenth-century matrices that still exist were passed down through three generations of type founders before reaching a museum.
+
+</div>
+
+<h2>Of strike hierarchies</h2>
+
+A punchcutter's output went into one of three hierarchies depending on the quality of the strike. <span class="rubric">Primary</span> matrices were his best work, reserved for prestige editions. <span class="rubric">Secondary</span> matrices were slightly off-axis or slightly shallow, sold to working printers for ordinary jobs. <span class="rubric">Tertiary</span> matrices had visible defects but were still usable, sold at a discount to provincial shops. The tertiary strike is often the only version of a given punchcutter's work that survives, because the prestige editions wore out the primary matrices and the working printers wore out the secondary, while the provincial shops kept their tertiary matrices in a drawer for fifty years.

--- a/incunabula-noir/content/leaves/3-of-the-impression.md
+++ b/incunabula-noir/content/leaves/3-of-the-impression.md
@@ -1,0 +1,32 @@
++++
+title = "Of the Impression"
+description = "On the physical bite of metal type into a dampened sheet."
+tags = ["craft", "press"]
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Leaf III</p>
+<h1 class="leaf-title">Of the Impression</h1>
+</div>
+
+<span class="rubricated">T</span>
+
+he <span class="rubric">impression</span> is what the early printed book leaves in the paper that no modern print can reproduce. At Mainz and at Venice and at Paris the sheet went into the press slightly damp, the type was inked with a firm leather ball, and the screw was turned until the type was pressed deep into the paper. When the sheet came out it carried not only the ink of the letter but a physical depression, the shape of the letter sunken into the fiber. Hold a fifteenth-century leaf to a raking light and every line of type appears as a small trench.
+
+<div class="two-col">
+
+The depth of the impression is partly a function of the pressure the pressman applied and partly a function of the paper. Fifteenth-century paper was handmade from linen rag, beaten in a stamping mill, formed on a wire screen, and pressed to a uniform thickness of about two hundred microns. It was more absorbent than modern paper and took a deep bite from the type without tearing.
+
+The impression is what the twentieth century called <span class="rubric">letterpress</span>. Revival presses like Doves and Kelmscott set out to reproduce exactly this effect, sometimes at the cost of legibility. A William Morris page has a deeper impression than a Nicolas Jenson page, because Morris wanted the reader to feel the page as a physical object. Jenson wanted the reader to read the text. Both goals are served by deep impression, but the ratio is different.
+
+For the noir incunabulum the impression is simulated typographically. The letterforms sit in a slightly recessed panel of darker vellum on each piece of the type grid. The eye reads them as sunken. No actual depression is possible in a web document, but the visual cue of the recess - the inner darker rectangle set within an outer border - does much of the same work.
+
+</div>
+
+<h2>The noir impression</h2>
+
+Where a traditional letterpress impression presses <em>into</em> the paper and leaves a small valley, a noir impression prints <em>out</em> of a dark field. The letterform rises from blackness into bone ink. The direction of the contrast is reversed. It is closer to how the punchcutter saw the letter on the face of his matrix, where the letter was always a small island of copper rising from an engraved pit.
+
+<blockquote>
+The incunabulum at midnight: the letter is a light that has just been lifted out of a darkness.
+</blockquote>

--- a/incunabula-noir/content/leaves/4-of-the-rubricator.md
+++ b/incunabula-noir/content/leaves/4-of-the-rubricator.md
@@ -1,0 +1,32 @@
++++
+title = "Of the Rubricator"
+description = "On the hand-finisher who painted the initials after the press was done."
+tags = ["craft", "rubric"]
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Leaf IV</p>
+<h1 class="leaf-title">Of the Rubricator</h1>
+</div>
+
+<span class="rubricated">A</span>
+
+n incunabulum, fresh off the press, was not a finished book. The text block was complete in black ink, but every place where a colored initial was meant to go was blank, with perhaps a small <span class="rubric">directeur</span> &mdash; a faint guide letter set in tiny type &mdash; marking which letter the rubricator should paint. The sheets were then sent to a workshop of hand-finishers, who worked leaf by leaf with brushes and small pots of red and blue pigment.
+
+<div class="two-col">
+
+The pigment was typically an iron-oxide red for the rubrics and an indigo or azurite blue for the capitals, both suspended in a gum arabic medium. The rubricator held the sheet flat on a slanted desk, consulted the directeur, and painted the initial inside the blank square that the printer had left open. The size of the initial was dictated by the number of lines the printer had <span class="rubric">skipped</span> for it: a two-line initial fits a square the height of two lines, a six-line initial the height of six.
+
+Rubricators varied widely in skill. In a Mainz workshop the initials might be precise and delicate; in a provincial job they could be blobby and uneven. In the most expensive copies the initials were not rubricated at all but illuminated &mdash; painted in gold leaf on a colored ground with decorative vines trailing into the margin. These copies were sold to wealthy patrons who wanted the book to resemble a manuscript.
+
+By the first decade of the sixteenth century the rubricator's trade was in decline. Printers began to cast their own decorative initials as woodblocks or type sorts, to be printed alongside the text in the same press run. The <span class="rubric">two-color press</span> &mdash; pulling once in black, shifting the chase, pulling again in red &mdash; was the successor technology. The hand-finisher disappeared.
+
+</div>
+
+<h2>This edition</h2>
+
+On every leaf of Incunabula Noir the opening initial is set in iron-oxide red, inside a small square panel of slightly darker vellum, with a border drawn in thin red rule. The letter itself is a UnifrakturMaguntia capital, cast in the blackletter tradition that a fifteenth-century rubricator would have painted by hand. No gold. No illumination. The square, the border, and the letter are the three devices the hand-finisher reached for most often.
+
+<blockquote>
+The rubricator is the last human touch in a book otherwise made by machine. Their absence in the later sixteenth century is one of the first signs that the press has fully separated from the scribe.
+</blockquote>

--- a/incunabula-noir/content/leaves/5-of-the-revolution.md
+++ b/incunabula-noir/content/leaves/5-of-the-revolution.md
@@ -1,0 +1,32 @@
++++
+title = "Of the Revolution"
+description = "On why the cradle books changed Europe."
+tags = ["history", "revolution"]
++++
+
+<div class="leaf-head">
+<p class="eyebrow rubric">Leaf V</p>
+<h1 class="leaf-title">Of the Revolution</h1>
+</div>
+
+<span class="rubricated">T</span>
+
+he printing press was not the most important machine of the fifteenth century. The most important machine was the <span class="rubric">hand mold</span> &mdash; the small two-piece iron caliper, invented at Mainz around 1450, which allowed molten lead to be cast in great numbers into precise standardized bodies. Without the hand mold, type would still have been whittled from wood, and a page of text would have been a one-time artifact. With it, type became a fungible commodity. A pica <em>a</em> cast in Strasbourg would line up perfectly against a pica <em>b</em> cast in Venice, because both were justified to the same body height.
+
+<div class="two-col">
+
+The hand mold made the press possible. The press made the book possible. The book made the reading public possible. And the reading public made every social and religious upheaval of the sixteenth century possible, because any pamphleteer could now set a text in type once and reprint a thousand copies cheaply.
+
+In the half-century from 1455 to 1500 the number of books produced in Europe exceeded the entire manuscript output of the preceding thousand years. The single city of Venice, in 1493, supported over two hundred active presses and produced more titles per year than the entire scribal tradition of France had produced per century. The economy of information had changed.
+
+Every early printed book shares a small set of features that mark it as transitional. The page layout is still a manuscript layout: two tight columns, rubricated initials, heavy display hand. The colophon at the end still speaks in the manuscript tradition, addressing the reader directly and naming the scribe &mdash; now called the printer. The paper stock is still the paper that scribes used. It is only in the early sixteenth century that the book begins to look modern: title page at the front, folio numbers in the corner, signatures in typed numerals instead of letters.
+
+</div>
+
+<h2>The cradle closes</h2>
+
+By 1501 the transition is complete. Historians draw an arbitrary line at that year and call every book printed before it an <span class="rubric">incunabulum</span> &mdash; a book still in its cradle. After 1501 the book is a grown child, standing on its own and ready to walk through four centuries of religious reformation, scientific revolution, colonial ambition, and national awakening. All of it made possible by that one small caliper in Mainz in 1450.
+
+<blockquote>
+Every revolution in reading was preceded by a small mechanical invention that nobody celebrated at the time.
+</blockquote>

--- a/incunabula-noir/content/leaves/_index.md
+++ b/incunabula-noir/content/leaves/_index.md
@@ -1,0 +1,6 @@
++++
+title = "The Leaves"
+description = "Leaves of the noir incunabulum."
++++
+
+<p class="taxonomy-desc">A short gathering of leaves on the craft of the early print. Each leaf is a single quarto sheet, unbound, ready for the rubricator.</p>

--- a/incunabula-noir/static/css/style.css
+++ b/incunabula-noir/static/css/style.css
@@ -1,0 +1,347 @@
+/* =============================================================================
+   Incunabula Noir - Dark Early Print Publication
+   Issue #1566 | book, dark, incunabulum, early-print, revolutionary
+   Palette: pitch-dark vellum, bone-ivory ink, iron-oxide rubric red
+   No gradients. SVG metal type and impression ornaments only.
+   ============================================================================= */
+
+:root {
+  --ink: #d5c5a4;
+  --ink-bright: #ede1c4;
+  --ink-soft: #a8976f;
+  --ink-dim: #756347;
+  --rubric: #b5321e;
+  --rubric-deep: #7a2d1c;
+  --bg: #0a0806;
+  --bg-leaf: #121010;
+  --bg-leaf-panel: #181410;
+  --rule: #3a2a20;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Old Standard TT", "EB Garamond", Georgia, serif;
+  font-size: 16px;
+  line-height: 1.62;
+  min-height: 100vh;
+}
+
+.press-plate {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem 2rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 2rem 0 1rem;
+  flex-wrap: wrap;
+}
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink-bright);
+  font-family: "UnifrakturMaguntia", "UnifrakturCook", serif;
+  font-weight: 400;
+  font-size: 2.2rem;
+  letter-spacing: 0.02em;
+}
+.logo-mark { width: 56px; height: 56px; display: block; }
+
+.site-nav {
+  display: flex;
+  gap: 1.3rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "UnifrakturCook", serif;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+}
+.site-nav a:hover {
+  color: var(--rubric);
+  border-bottom-color: var(--rubric);
+}
+
+.plate-rule { height: 14px; }
+.plate-rule svg { width: 100%; height: 100%; display: block; }
+.plate-rule-bottom { margin-top: 3rem; }
+
+/* --- Leaf ---------------------------------------------------------------- */
+.site-main { padding: 1rem 0 0; }
+
+.leaf {
+  position: relative;
+  background-color: var(--bg-leaf);
+  border: 1px solid var(--rule);
+  padding: 3rem clamp(1rem, 3vw, 3rem);
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) 40px;
+  gap: 0;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.7);
+}
+
+.leaf-margin {
+  position: relative;
+}
+.leaf-margin svg { width: 100%; height: 100%; display: block; }
+
+.leaf-inner {
+  padding: 0 clamp(0.5rem, 2vw, 2rem);
+}
+
+/* --- Leaf head ----------------------------------------------------------- */
+.leaf-head {
+  text-align: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+.leaf-head::after {
+  content: "";
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 10px;
+  height: 10px;
+  background-color: var(--bg-leaf);
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+}
+
+.eyebrow {
+  display: inline-block;
+  font-family: "UnifrakturCook", serif;
+  font-size: 1rem;
+  letter-spacing: 0.1em;
+  color: var(--rubric);
+  margin: 0 0 0.4em;
+}
+
+.leaf-title {
+  font-family: "UnifrakturMaguntia", "UnifrakturCook", serif;
+  font-weight: 400;
+  font-size: clamp(2.2rem, 5.5vw, 3.8rem);
+  line-height: 1;
+  margin: 0.2em 0 0;
+  color: var(--ink-bright);
+  letter-spacing: 0.01em;
+}
+
+/* --- Typography of body prose -------------------------------------------- */
+.leaf-inner h2 {
+  font-family: "UnifrakturCook", serif;
+  font-weight: 700;
+  font-size: 1.8rem;
+  color: var(--ink-bright);
+  margin: 2em 0 0.3em;
+  line-height: 1.15;
+}
+.leaf-inner h3 {
+  font-family: "Old Standard TT", serif;
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.1em;
+  font-size: 1.1rem;
+  color: var(--rubric);
+  margin: 1.6em 0 0.2em;
+}
+
+.leaf-inner p {
+  margin: 0.9em 0;
+  text-align: justify;
+  hyphens: auto;
+}
+.leaf-inner p + p { text-indent: 2em; }
+
+.leaf-inner .two-col {
+  column-count: 2;
+  column-gap: 2rem;
+  column-rule: 1px solid var(--rule);
+  margin: 1.5em 0;
+}
+.leaf-inner .two-col p { margin: 0 0 0.8em; text-indent: 1.5em; }
+.leaf-inner .two-col p:first-child { text-indent: 0; }
+
+.leaf-inner a {
+  color: var(--rubric);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rubric-deep);
+}
+.leaf-inner a:hover { color: var(--ink-bright); border-bottom-color: var(--ink-bright); }
+
+/* Rubricated drop capital: builds the classic hand-finished initial. */
+.rubricated {
+  position: relative;
+  float: left;
+  width: 4.5rem;
+  height: 4.5rem;
+  margin: 0.1em 0.9rem 0.1em 0;
+  font-family: "UnifrakturMaguntia", "UnifrakturCook", serif;
+  font-size: 4.4rem;
+  line-height: 1;
+  color: var(--rubric);
+  text-align: center;
+  padding-top: 0.1em;
+  background-color: var(--bg-leaf-panel);
+  border: 1px solid var(--rubric-deep);
+}
+.rubricated::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border: 1px solid var(--rubric-deep);
+  pointer-events: none;
+}
+
+.rubric {
+  color: var(--rubric);
+  font-weight: 700;
+}
+.black-letter {
+  font-family: "UnifrakturCook", serif;
+  font-weight: 700;
+}
+
+blockquote {
+  margin: 1.5rem 2rem;
+  padding: 0.25rem 1rem;
+  border-left: 2px solid var(--rubric-deep);
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  color: var(--ink);
+}
+
+.leaf-inner ul,
+.leaf-inner ol {
+  margin: 1em 0 1em 2em;
+  padding: 0;
+}
+.leaf-inner ul { list-style: "\271A  "; }
+.leaf-inner ol { list-style: lower-roman; }
+.leaf-inner li { padding: 0.2em 0; }
+
+/* --- Metal type impression grid (inline SVG as background pattern) -------- */
+.type-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+.type-cell {
+  aspect-ratio: 3 / 4;
+  background-color: var(--bg-leaf-panel);
+  border: 1px solid var(--rule);
+  position: relative;
+  overflow: hidden;
+}
+.type-cell svg { width: 100%; height: 100%; display: block; }
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--rule);
+}
+.section-list li {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.section-list li::before {
+  content: "\271A";
+  color: var(--rubric);
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-family: "Old Standard TT", serif;
+  font-weight: 700;
+  color: var(--ink-bright);
+  border: none;
+  font-size: 1.05rem;
+}
+.section-list li a:hover { color: var(--rubric); }
+
+.taxonomy-desc { color: var(--ink-soft); font-style: italic; }
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.25em 0.6em;
+  border: 1px solid var(--rule);
+  font-family: "UnifrakturCook", serif;
+  font-size: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--bg-leaf-panel);
+}
+nav.pagination a:hover { color: var(--rubric); border-color: var(--rubric); }
+.pagination-current span { color: var(--rubric); border-color: var(--rubric); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  margin-top: 2rem;
+  text-align: center;
+  padding-top: 0;
+}
+.footer-colophon {
+  font-family: "UnifrakturCook", serif;
+  font-size: 1rem;
+  color: var(--ink-bright);
+  margin: 1rem 0 0.3rem;
+}
+.footer-colophon .rubric { margin-right: 0.6em; }
+.footer-line-small {
+  color: var(--ink-dim);
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0 0 0.5rem;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .leaf {
+    grid-template-columns: 1fr;
+    padding: 2rem 1rem;
+  }
+  .leaf-margin { display: none; }
+  .leaf-inner { padding: 0; }
+  .leaf-inner .two-col { column-count: 1; }
+  .leaf-title { font-size: 2.4rem; }
+  .site-header { padding: 1.5rem 0 0.75rem; }
+  .site-logo { font-size: 1.7rem; }
+  .rubricated { width: 3.6rem; height: 3.6rem; font-size: 3.3rem; margin-right: 0.6rem; }
+}

--- a/incunabula-noir/templates/404.html
+++ b/incunabula-noir/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <div class="leaf-inner">
+        <p class="eyebrow rubric">Quaesitum</p>
+        <h1 class="leaf-title">Leaf lost</h1>
+        <p>This leaf is missing from the gathering. The binder never caught up with it, or the rubricator set the signature incorrectly, or the volume was rebound and the page was omitted. Turn back to the incipit and begin again.</p>
+        <p><a href="{{ base_url }}/">Redde ad incipit</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/incunabula-noir/templates/footer.html
+++ b/incunabula-noir/templates/footer.html
@@ -1,0 +1,24 @@
+    <footer class="site-footer">
+      <div class="plate-rule plate-rule-bottom" aria-hidden="true">
+        <svg viewBox="0 0 1200 16" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="4" x2="1200" y2="4" stroke="#7a2d1c" stroke-width="0.4"/>
+          <line x1="0" y1="8" x2="1200" y2="8" stroke="#7a2d1c" stroke-width="1"/>
+          <g fill="#7a2d1c">
+            <circle cx="8"    cy="8" r="2"/>
+            <circle cx="600"  cy="8" r="2.5"/>
+            <circle cx="1192" cy="8" r="2"/>
+          </g>
+        </svg>
+      </div>
+      <p class="footer-colophon">
+        <span class="rubric">Finit feliciter.</span>
+        Impressum MMXXVI &middot; a noir edition
+      </p>
+      <p class="footer-line-small">
+        Printed after the manner of the cradle books &middot; all rules drawn in metal
+      </p>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/incunabula-noir/templates/header.html
+++ b/incunabula-noir/templates/header.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&family=UnifrakturCook:wght@700&family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&family=EB+Garamond:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="press-plate">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Incunabula Noir home">
+        <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <!-- Metal type body, front face -->
+          <rect x="14" y="8" width="36" height="48" fill="#171310" stroke="#7a2d1c" stroke-width="1"/>
+          <!-- Deep-set letterform indent -->
+          <rect x="18" y="12" width="28" height="40" fill="#0a0806"/>
+          <!-- Raised letterform -->
+          <text x="32" y="42" font-family="UnifrakturCook, UnifrakturMaguntia, serif" font-weight="700" font-size="26" fill="#c9b591" text-anchor="middle">I</text>
+          <!-- Nick line on the shank -->
+          <line x1="14" y1="50" x2="50" y2="50" stroke="#7a2d1c" stroke-width="0.75"/>
+          <!-- Highlight edges to suggest metal -->
+          <line x1="14" y1="8" x2="50" y2="8" stroke="#3a2a20" stroke-width="0.5"/>
+        </svg>
+        <span class="logo-text">Incunabula Noir</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Incipit</a>
+        <a href="{{ base_url }}/leaves/">Leaves</a>
+        <a href="{{ base_url }}/history/">The Cradle</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+    <div class="plate-rule" aria-hidden="true">
+      <svg viewBox="0 0 1200 16" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <line x1="0" y1="8" x2="1200" y2="8" stroke="#7a2d1c" stroke-width="1"/>
+        <line x1="0" y1="12" x2="1200" y2="12" stroke="#7a2d1c" stroke-width="0.4"/>
+        <g fill="#7a2d1c">
+          <circle cx="8"    cy="8" r="2"/>
+          <circle cx="600"  cy="8" r="2.5"/>
+          <circle cx="1192" cy="8" r="2"/>
+        </g>
+      </svg>
+    </div>

--- a/incunabula-noir/templates/page.html
+++ b/incunabula-noir/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <aside class="leaf-margin leaf-margin-left" aria-hidden="true">
+        <svg viewBox="0 0 40 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="20" y1="0" x2="20" y2="600" stroke="#7a2d1c" stroke-width="1"/>
+          <line x1="26" y1="0" x2="26" y2="600" stroke="#7a2d1c" stroke-width="0.3"/>
+          <g fill="#7a2d1c" font-family="UnifrakturCook" font-size="10">
+            <text x="10" y="40"  >i</text>
+            <text x="10" y="160" >ij</text>
+            <text x="10" y="280" >iij</text>
+            <text x="10" y="400" >iv</text>
+            <text x="10" y="520" >v</text>
+          </g>
+        </svg>
+      </aside>
+      <div class="leaf-inner">
+        {{ content }}
+      </div>
+      <aside class="leaf-margin leaf-margin-right" aria-hidden="true">
+        <svg viewBox="0 0 40 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="14" y1="0" x2="14" y2="600" stroke="#7a2d1c" stroke-width="0.3"/>
+          <line x1="20" y1="0" x2="20" y2="600" stroke="#7a2d1c" stroke-width="1"/>
+        </svg>
+      </aside>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/incunabula-noir/templates/section.html
+++ b/incunabula-noir/templates/section.html
@@ -1,0 +1,29 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <aside class="leaf-margin leaf-margin-left" aria-hidden="true">
+        <svg viewBox="0 0 40 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="20" y1="0" x2="20" y2="600" stroke="#7a2d1c" stroke-width="1"/>
+          <line x1="26" y1="0" x2="26" y2="600" stroke="#7a2d1c" stroke-width="0.3"/>
+        </svg>
+      </aside>
+      <div class="leaf-inner">
+        <header class="leaf-head">
+          <p class="eyebrow rubric">Index librorum</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+      <aside class="leaf-margin leaf-margin-right" aria-hidden="true">
+        <svg viewBox="0 0 40 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="14" y1="0" x2="14" y2="600" stroke="#7a2d1c" stroke-width="0.3"/>
+          <line x1="20" y1="0" x2="20" y2="600" stroke="#7a2d1c" stroke-width="1"/>
+        </svg>
+      </aside>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/incunabula-noir/templates/shortcodes/alert.html
+++ b/incunabula-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/incunabula-noir/templates/taxonomy.html
+++ b/incunabula-noir/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <div class="leaf-inner">
+        <header class="leaf-head">
+          <p class="eyebrow rubric">Signs and subjects</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">The known subjects of this noir impression:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/incunabula-noir/templates/taxonomy_term.html
+++ b/incunabula-noir/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <div class="leaf-inner">
+        <header class="leaf-head">
+          <p class="eyebrow rubric">Under this sign</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Leaves gathered under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1909,6 +1909,13 @@
     "bold",
     "artistic"
   ],
+  "incunabula-noir": [
+    "book",
+    "dark",
+    "incunabulum",
+    "early-print",
+    "revolutionary"
+  ],
   "inferno": [
     "dark",
     "community",


### PR DESCRIPTION
## Summary
- Dark early-print publication modeled on the fifteenth-century incunabulum, inverted to print bone-ivory against pitch-dark vellum
- UnifrakturMaguntia / UnifrakturCook blackletter display; Old Standard TT + EB Garamond for the dense two-column roman body measure
- Inline SVG: metal-type impression squares (body / shoulder / shank with raised letterform), plate rules at head and foot, rubricated initial panels (iron-oxide border + bordered inset)
- Five leaves on punch, matrix, impression, rubricator, and revolution, plus a cradle history and a colophon after the manner of Fust and Schoeffer
- Tags: book, dark, incunabulum, early-print, revolutionary

## Test plan
- [ ] Run `hwaro build` inside `incunabula-noir/` and confirm zero warnings
- [ ] Check that blackletter display renders (Unifraktur fonts from Google Fonts load cleanly)
- [ ] Verify the metal-type SVG squares on the incipit leaf render at reasonable size
- [ ] Confirm rubricated drop-cap panels appear on each leaf
- [ ] Check tags.json entry is valid JSON