### PR TITLE
feat: add washi-bound example site (closes #1565)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -4372,6 +4372,13 @@
     "landing",
     "music"
   ],
+  "washi-bound": [
+    "book",
+    "light",
+    "japanese",
+    "stab-binding",
+    "paper"
+  ],
   "weathervane": [
     "light",
     "blog",

--- a/washi-bound/AGENTS.md
+++ b/washi-bound/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/washi-bound/config.toml
+++ b/washi-bound/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Washi Bound - Japanese Paper Publication
+# Issue #1565 | Tags: book, light, japanese, stab-binding, paper
+# =============================================================================
+
+title = "Washi Bound"
+description = "A light, traditionally Japanese paper publication bound in four-hole stab binding (yotsume toji). Washi paper fiber textures are drawn as inline SVG backgrounds. Noto Sans JP + Noto Serif JP and Inter + Crimson Pro hold the type down as it would lie on a handmade sheet."
+base_url = "http://localhost:3000"
+
+sections = ["chapters"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/washi-bound/content/binding.md
+++ b/washi-bound/content/binding.md
@@ -1,0 +1,39 @@
++++
+title = "Binding"
+description = "A short visual reference for the stab-binding used throughout this volume."
++++
+
+<p class="jp-label">Appendix / 綴じ方</p>
+
+# Binding <span class="jp">綴じ</span>
+
+<p class="lede">This page is a visual reference for the stab-binding that runs down the left edge of every sheet in this volume. Four evenly spaced holes, a single waxed thread, and a specific passing sequence that wraps around the head and tail.</p>
+
+## The pattern <span class="jp">図案</span>
+
+<p>On every sheet, the left margin displays the binding as it would look on the physical book. Four tea-brown stitch points are drawn as small filled circles, with connecting curves showing the path of the thread on the outside of the spine. Two additional wraps are drawn at the head and tail of the volume.</p>
+
+<h2>Materials <span class="jp">材料</span>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Thread</h3>
+<p>Waxed hemp or silk. Color is traditionally natural or dyed tea-brown for everyday volumes, indigo for scholarly books, and deep red for poetry anthologies.</p>
+</div>
+<div class="note-card">
+<h3>Needle</h3>
+<p>A blunt bookbinder's needle, slightly thicker than a sewing needle, with a rounded tip that pushes through the pre-punched holes without splitting the paper.</p>
+</div>
+<div class="note-card">
+<h3>Awl</h3>
+<p>A small awl is used to punch the four holes through the stacked sheets before sewing. Holes are punched one at a time, turning the awl to make a clean round opening.</p>
+</div>
+<div class="note-card">
+<h3>Bone folder</h3>
+<p>Used to score the binding edge and to tamp the pages flat before and during stitching. A wooden or plastic folder also works but the bone folder has the best feel.</p>
+</div>
+</div>
+
+<h2>On this website <span class="jp">このサイトで</span>
+
+<p>Every page carries the four-hole pattern as a small inline SVG along its left edge. The stitches are positioned at roughly ten, twenty, sixty, and eighty percent of the page height, with wraps added at the top and bottom edges. Because the SVG scales with the page, the binding always appears in proportion to the sheet regardless of viewport size.</p>

--- a/washi-bound/content/chapters/1-the-fiber.md
+++ b/washi-bound/content/chapters/1-the-fiber.md
@@ -1,0 +1,44 @@
++++
+title = "The Fiber"
+description = "On the long plant fibers that give washi its strength and tactility."
+tags = ["paper", "fiber"]
++++
+
+<p class="jp-label">Chapter I &middot; 第一章</p>
+
+# The Fiber <span class="jp">繊維</span>
+
+<p class="lede">What distinguishes washi from the machine-made paper of the industrial world is not the whiteness of the sheet or the price of the material, but the length of the fibers laid down on the screen.</p>
+
+## The three plants <span class="jp">三つの植物</span>
+
+<p>Traditional washi is made from the inner bark of one of three plants: <em>kozo</em> (the paper mulberry), <em>gampi</em> (a small mountain shrub), and <em>mitsumata</em> (a three-forked shrub cultivated for paper since the sixteenth century). Each yields a fiber of a different length, strength, and sheen.</p>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Kozo <span class="jp">楮</span></h3>
+<p>The strongest of the three. Fibers up to ten millimeters long. Produces a slightly rough, extremely durable sheet. Used for books that will be handled daily.</p>
+</div>
+<div class="note-card">
+<h3>Gampi <span class="jp">雁皮</span></h3>
+<p>The silkiest. Fibers three to five millimeters, with a natural luster. Produces a smooth translucent sheet used for calligraphy masterworks. Cannot be cultivated; must be harvested wild.</p>
+</div>
+<div class="note-card">
+<h3>Mitsumata <span class="jp">三椏</span></h3>
+<p>The most uniform. Fibers two to four millimeters, tightly interwoven. Produces a fine even sheet used for banknotes, government documents, and fine art prints.</p>
+</div>
+</div>
+
+## Preparation <span class="jp">処理</span>
+
+<p>The bark is harvested in winter, steamed to separate the outer bark from the inner, and then boiled in alkaline water to soften the cellulose. The fibers are beaten by hand or with a small wooden mallet on a flat stone. A skilled beater can prepare a batch of kozo in about three hours; industrial beaters take twenty minutes but shorten the fibers and weaken the finished sheet. The hand-beaten fiber is the one that makes traditional washi possible.</p>
+
+<h2>Why the long fiber matters <span class="jp">長繊維の意味</span></h2>
+
+<p>A sheet of paper is a random felt of fibers held together by nothing more than mechanical entanglement. Short fibers make a weak sheet because each fiber touches only a few neighbors before it runs out. Long fibers make a strong sheet because each fiber touches many neighbors along its length, and the entanglement is stable. A sheet of kozo washi will survive centuries of folding, handling, and transport without tearing. A sheet of machine pulp paper will split within decades.</p>
+
+<blockquote>
+Every characteristic of traditional washi - its strength, its softness, its translucency, its long life - follows from the length of its fibers.
+</blockquote>
+
+<p>On the background of every page on this site, faint long curves represent the trace of a single kozo or gampi fiber as it lies on the mold. They are drawn as inline SVG. You are looking at a schematic of a handmade sheet.</p>

--- a/washi-bound/content/chapters/2-the-stitch.md
+++ b/washi-bound/content/chapters/2-the-stitch.md
@@ -1,0 +1,57 @@
++++
+title = "The Stitch"
+description = "On the four-hole stab binding known as yotsume toji."
+tags = ["binding", "stitch"]
++++
+
+<p class="jp-label">Chapter II &middot; 第二章</p>
+
+# The Stitch <span class="jp">綴じ</span>
+
+<p class="lede">Stab binding is one of the oldest book structures in East Asia. The sheets are stacked, punched, and stitched along one long edge. There is no sewn-through spine, no glue, and no codex folding. The book is a flat packet of leaves held together by a single continuous thread.</p>
+
+## Yotsume toji <span class="jp">四つ目綴じ</span>
+
+<p>The <em>yotsume toji</em> or "four-hole stitch" is the canonical pattern. Four holes are punched in a vertical line along the binding edge, evenly spaced, about one to two centimeters from the edge. A single waxed thread is drawn through each hole in turn, with the path crossing around the head and tail of the volume so that the top and bottom holes are doubly wrapped.</p>
+
+<h2>The sewing sequence <span class="jp">縫い順序</span></h2>
+
+<ol>
+<li>Enter the needle through hole two from the back. Pull the thread almost all the way through, leaving a short tail.</li>
+<li>Bring the needle over the top edge and back through hole one from the back. This anchors the thread at the head.</li>
+<li>Pass the needle along the spine to hole one again, this time over the front. Now hole one is wrapped both top-to-bottom and front-to-back.</li>
+<li>Continue down the spine: hole two front, hole three back, hole four front, wrapping each hole in the same way.</li>
+<li>At hole four, wrap around the tail the same way you wrapped the head.</li>
+<li>Work back up the spine, reinforcing each stitch. End by knotting the two ends of the thread inside hole two and trimming short.</li>
+</ol>
+
+<p>A complete yotsume toji stitch uses about thirty centimeters of thread for a volume of fifty sheets. The thread is usually waxed silk, hemp, or - in cheaper modern books - cotton.</p>
+
+## Variations <span class="jp">変種</span>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Kikko toji <span class="jp">亀甲綴じ</span></h3>
+<p>The tortoise-shell stitch. Adds diagonal stitches across the four-hole pattern to form a hexagonal cell on the cover. Used for prestige bindings.</p>
+</div>
+<div class="note-card">
+<h3>Asa-no-ha toji <span class="jp">麻の葉綴じ</span></h3>
+<p>The hemp-leaf stitch. A more ornate pattern with six holes in two columns. Used for poetry anthologies and religious texts.</p>
+</div>
+<div class="note-card">
+<h3>Kangxi binding</h3>
+<p>The Chinese-style four-hole binding, closely related but with slightly different proportions and a different thread color convention.</p>
+</div>
+<div class="note-card">
+<h3>Korean line binding <span class="jp">線装</span></h3>
+<p>A five-hole variant common in Korean scholarly books of the Joseon period. Proportions differ; thread is usually deep red.</p>
+</div>
+</div>
+
+<h2>Why stab instead of codex <span class="jp">なぜ袋綴じ</span></h2>
+
+<p>A codex folds sheets in half and sews through the fold. The advantage is that the book opens fully and lies flat. The disadvantage is that the binding is inside the fold, where it is stressed every time the book is opened. A stab binding puts the stitch on the outside edge. The book does not open fully - the pages swing open to about one hundred and sixty degrees - but the stitch is never stressed beyond its strength. A stab-bound volume can be read, unread, and re-read for centuries without the binding failing.</p>
+
+<blockquote>
+The trade-off at the heart of yotsume toji: you lose a little convenience, and you gain a book that survives.
+</blockquote>

--- a/washi-bound/content/chapters/3-the-type.md
+++ b/washi-bound/content/chapters/3-the-type.md
@@ -1,0 +1,48 @@
++++
+title = "The Type"
+description = "On the modern type that carries a traditional binding."
+tags = ["typography", "type"]
++++
+
+<p class="jp-label">Chapter III &middot; 第三章</p>
+
+# The Type <span class="jp">書体</span>
+
+<p class="lede">A faithful reconstruction of a seventeenth-century wahon would be set in hand-brushed kanji, but this volume is not a facsimile. It is a contemporary publication in a traditional binding. The typography is deliberately modern.</p>
+
+## Display <span class="jp">見出し</span>
+
+<p>The display hand on this site is <span class="sumi">Inter</span>, a clean geometric sans designed for screens, set in the semibold weight. The English letterforms sit comfortably alongside <span class="sumi">Noto Sans JP</span>, which was designed explicitly as a companion for the Noto Latin families. The two fonts agree on x-height, stroke contrast, and overall proportion. Set side by side they read as a single typographic system.</p>
+
+<h2>Body <span class="jp">本文</span></h2>
+
+<p>The body face is <span class="sumi">Crimson Pro</span>, an old-style serif with a slightly condensed proportion that reads well at long measures. Its companion is <span class="sumi">Noto Serif JP</span>, which matches Crimson's contrast and stroke weight at common body sizes. Together they produce a page of text that is comfortable at the screen and respectful of the Japanese tradition without imitating it.</p>
+
+## Why modern type in a traditional binding <span class="jp">なぜ現代書体</span>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Legibility</h3>
+<p>A reader opening a website expects type that holds its shape at small sizes on low-resolution screens. Historical calligraphy does not meet that expectation.</p>
+</div>
+<div class="note-card">
+<h3>Honesty</h3>
+<p>A pastiche of historical brushwork in a digital document is always a little dishonest. The type was never produced by a brush. Modern type acknowledges the medium.</p>
+</div>
+<div class="note-card">
+<h3>Continuity</h3>
+<p>Traditional Japanese books were always set in the type that was current at the time. A seventeenth-century wahon used seventeenth-century calligraphy because that was the contemporary hand.</p>
+</div>
+<div class="note-card">
+<h3>Harmony</h3>
+<p>The binding, the paper, and the layout can be traditional while the type is contemporary. The two traditions coexist on the same page.</p>
+</div>
+</div>
+
+<h2>Aesthetic of restraint <span class="jp">抑制の美</span>
+
+<p>A Japanese book, traditional or modern, tends toward visual restraint. The margins are generous. The type is not too large. The color palette is narrow, often just three or four colors. This site follows the convention: paper ivory for the ground, tea-brown for the stitch and the accents, deep sumi ink for the body, and a single indigo used only for special phrases. The ratio of ink to paper is much more generous than a Western magazine would use.</p>
+
+<blockquote>
+In Japanese book design the page is not the area to be filled with content. It is the area to be approached by content.
+</blockquote>

--- a/washi-bound/content/chapters/4-the-volume.md
+++ b/washi-bound/content/chapters/4-the-volume.md
@@ -1,0 +1,50 @@
++++
+title = "The Volume"
+description = "On the wahon as an object: proportions, cover, and the cultural place of the stab-bound book."
+tags = ["book", "culture"]
++++
+
+<p class="jp-label">Chapter IV &middot; 第四章</p>
+
+# The Volume <span class="jp">本</span>
+
+<p class="lede">A wahon is a physical object before it is a text. Its proportions, its cover, and its place in the rhythm of Japanese daily life have as much to do with its identity as the words printed inside it.</p>
+
+## Proportions <span class="jp">寸法</span>
+
+<p>The classic wahon is taller than it is wide, at a ratio of roughly three to two. A typical volume is about twenty-four centimeters tall by sixteen centimeters wide - close to what a Western reader would call a small quarto. The ratio is not accidental. It matches the natural aspect ratio of handmade washi when cut from the standard mold size, and it sits comfortably on the low reading desk that was standard in a Japanese home.</p>
+
+<h2>Cover <span class="jp">表紙</span></h2>
+
+<p>The cover of a wahon was traditionally a heavier sheet of washi, often dyed with indigo or persimmon tannin, or occasionally a thin layer of silk glued to washi for prestige editions. The title was written directly on the cover in ink, usually inside a rectangular frame drawn with a brush. There was no printed title page, and there was usually no separate spine lettering, because a stab-bound volume has no spine in the Western sense. The binding edge is visible from the front, and the title sits on the front cover itself.</p>
+
+## Cultural place <span class="jp">文化的位置</span>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Tokonoma <span class="jp">床の間</span></h3>
+<p>Valuable volumes were placed in the tokonoma, the alcove reserved for art and seasonal display in a traditional room. A stab-bound book flat on its side is part of the display aesthetic.</p>
+</div>
+<div class="note-card">
+<h3>Reading desk <span class="jp">文机</span></h3>
+<p>The low desk, or <em>fumizukue</em>, was the proper place to read a wahon. Kneeling at the desk, the reader would untie the wrapping and open the volume to about a hundred and sixty degrees.</p>
+</div>
+<div class="note-card">
+<h3>Chitsu case <span class="jp">帙</span></h3>
+<p>A multi-volume set was stored in a rigid case called a <em>chitsu</em>, usually made of wood covered in silk or washi. The case protected the books from dust and kept them aligned on a shelf.</p>
+</div>
+<div class="note-card">
+<h3>Seal <span class="jp">印</span></h3>
+<p>A book belonging to a scholar was often stamped with the owner's personal seal on a fly-leaf. The seal was carved in soapstone and inked with red cinnabar. The mark was a permanent claim of ownership.</p>
+</div>
+</div>
+
+<h2>The wahon today <span class="jp">現代の和本</span>
+
+<p>The stab-bound volume has not disappeared. It is still made, by craft publishers and by individual bookbinders, for poetry, for photography, and for artisanal small-press work. The binding is slow - a skilled binder can produce about ten volumes per day - but the finished object has a presence that no commercially bound book can match. Every page turns easily. The volume lies flat without stress on the thread. The cover, once softened by use, develops a warmth that industrial materials cannot imitate.</p>
+
+<blockquote>
+A wahon is a book that rewards the reader who has time for it. Which, in the end, describes every book that has ever mattered.
+</blockquote>
+
+<p><span class="seal">印</span> Filed: 2026 spring. Next printing: unscheduled.</p>

--- a/washi-bound/content/chapters/_index.md
+++ b/washi-bound/content/chapters/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Chapters"
+description = "The four chapters of this stab-bound volume."
++++
+
+<p class="lede">Four chapters, stitched together in a single volume. Each is a single leaf of washi paper, bound at the left edge.</p>
+
+<p>A traditional wahon was often a volume of poetry, a manual, or a ledger. This one is a set of short notes on the paper itself, the binding, the calligraphy it was designed to carry, and the broader book culture that depended on handmade sheets.</p>

--- a/washi-bound/content/index.md
+++ b/washi-bound/content/index.md
@@ -1,0 +1,43 @@
++++
+title = "Washi Bound"
+description = "A Japanese paper publication, stitched in four-hole stab binding."
++++
+
+<p class="jp-label">表紙 / Cover</p>
+
+# Washi Bound <span class="jp">和紙綴本</span>
+
+<p class="lede">A publication laid out the way a small Japanese book would be laid out: a single stitched volume of handmade paper, bound along the left edge in the four-hole stab tradition known as <em>yotsume toji</em>, with a clean modern typography that does not try to imitate the calligraphy of the original.</p>
+
+## The idea of the volume <span class="jp">本の考え</span>
+
+<p>This site is structured like a small <em>wahon</em>, a traditional Japanese stitched book. Each page is a single sheet of washi paper with a stab binding running down the left edge. The binding is visible on every page, because in a stab-bound volume the spine is the first thing the reader sees. The typography is modern - <span class="sumi">Inter</span> for the display hand and <span class="sumi">Crimson Pro</span> with Noto Serif JP for the body - because the aim is not a facsimile but a contemporary reading of the tradition.</p>
+
+## The four-hole stitch <span class="jp">四つ目綴じ</span>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Four holes <span class="jp">四目</span></h3>
+<p>The classic stab-binding pattern punches four holes along the binding edge, evenly spaced. Each hole is about two centimeters in from the edge.</p>
+</div>
+<div class="note-card">
+<h3>Single thread <span class="jp">一本糸</span></h3>
+<p>A single length of waxed hemp or silk thread is drawn through all four holes in a specific sequence, with the ends wrapping around the head and tail to anchor the stitch.</p>
+</div>
+<div class="note-card">
+<h3>No glue <span class="jp">糊なし</span></h3>
+<p>A properly sewn yotsume toji uses no adhesive. The thread holds the volume closed. The book can be taken apart at any time by cutting and re-sewing a single knot.</p>
+</div>
+<div class="note-card">
+<h3>Visible binding <span class="jp">見える綴じ</span></h3>
+<p>Because the stitch is on the outside of the spine, the reader always sees the binding. The book does not hide its construction. This is part of the aesthetic.</p>
+</div>
+</div>
+
+## How to read this volume <span class="jp">読み方</span>
+
+<p>Turn the pages in sequence. Each chapter is a single leaf. The binding runs continuously down the left edge from cover to cover, with the four stitches visible as small dots and connecting segments. The fiber texture of the washi paper is suggested by soft long curves drawn into the background of every sheet.</p>
+
+<p class="sumi">Four chapters are bound into this volume. Begin with <a href="/chapters/">the index</a>, or follow the links in the navigation above.</p>
+
+<p><span class="seal">印</span> An authentic wahon is stamped with the binder's seal on the final page. This site honors that tradition with a small red seal glyph on the colophon.</p>

--- a/washi-bound/content/paper.md
+++ b/washi-bound/content/paper.md
@@ -1,0 +1,41 @@
++++
+title = "Paper"
+description = "A short note on the washi paper simulated on every sheet of this volume."
++++
+
+<p class="jp-label">Appendix / 紙</p>
+
+# Paper <span class="jp">紙</span>
+
+<p class="lede">The background of every sheet on this site is a schematic of a handmade washi paper, drawn with inline SVG as a set of long soft curves and small dots suggesting the trace of fibers on the mold.</p>
+
+## The mould <span class="jp">漉簀</span>
+
+<p>Washi is formed on a <em>sukisu</em>, a screen of fine bamboo rods held between wooden frames. The papermaker dips the screen into a vat of fiber suspended in water, lifts it out with a steady rocking motion, and drains the water through the bamboo. What remains on the screen is a thin web of entangled fibers, ready to be couched onto a stack of freshly made sheets.</p>
+
+<h2>Fiber patterns <span class="jp">繊維模様</span>
+
+<p>The long curves on every page of this site trace the characteristic direction of fibers as they lie on the screen. The rocking motion of the papermaker aligns many fibers in a single direction; a small cross-rocking spreads others across it; a few fibers lie at wild angles because the vat was not quite even. All of this is what the paper looks like when you hold a sheet up to the light.</p>
+
+<div class="note-grid">
+<div class="note-card">
+<h3>Primary curves</h3>
+<p>Long horizontal curves drawn at 35% opacity represent the dominant fiber direction from the rocking motion.</p>
+</div>
+<div class="note-card">
+<h3>Secondary curves</h3>
+<p>Thinner, slightly lower-opacity curves at offset positions represent the cross-rocking direction that interlocks the sheet.</p>
+</div>
+<div class="note-card">
+<h3>Fiber knots</h3>
+<p>Small dots scattered across the sheet are nub knots where fibers clumped during beating. They are cosmetic features of a hand-beaten batch.</p>
+</div>
+<div class="note-card">
+<h3>Sheet tone</h3>
+<p>The base color of the sheet is a warm ivory, the natural tone of unbleached kozo after boiling and beating. No dye has been added. This is the paper at rest.</p>
+</div>
+</div>
+
+<h2>Aging <span class="jp">経年</span>
+
+<p>Washi darkens slightly over years in light and gains a faint yellow cast over decades. It does not yellow the way wood-pulp paper does, because it has almost no lignin. A well-kept wahon from the Edo period can still be read comfortably today. The paper simulated on this site is approximately the tone of a seventy-year-old kozo sheet stored away from direct light: still ivory, with a hint of cha.</p>

--- a/washi-bound/static/css/style.css
+++ b/washi-bound/static/css/style.css
@@ -1,0 +1,377 @@
+/* =============================================================================
+   Washi Bound - Japanese Paper Publication
+   Issue #1565 | book, light, japanese, stab-binding, paper
+   Palette: warm natural-paper ivory, soft cha (tea) ink, deep aizome (indigo) accents
+   No gradients. Stab binding + washi fibers drawn as inline SVG.
+   ============================================================================= */
+
+:root {
+  --paper: #f5ecd9;
+  --paper-soft: #efe6d4;
+  --paper-deep: #e2d6ba;
+  --paper-edge: #c4b48c;
+  --ink: #2a241b;
+  --ink-soft: #574b36;
+  --ink-dim: #8a7d62;
+  --cha: #6e3826;         /* tea-brown stab thread */
+  --cha-soft: #a06a4f;
+  --indigo: #2b4563;      /* aizome indigo accent */
+  --sumi: #0f0d0a;        /* deep sumi ink */
+  --bg: #f8f2e3;          /* outer background, soft paper */
+  --fiber: rgba(181, 159, 114, 0.35);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Crimson Pro", "Noto Serif JP", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.book-shell {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--paper-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 52px; height: 52px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Noto Serif JP", serif;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--cha);
+  letter-spacing: 0.1em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--cha); border-bottom-color: var(--cha); }
+
+/* --- Sheet (page) -------------------------------------------------------- */
+.site-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.sheet {
+  position: relative;
+  background-color: var(--paper);
+  border: 1px solid var(--paper-edge);
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  min-height: 640px;
+  box-shadow:
+    0 1px 0 var(--paper-deep),
+    0 18px 36px rgba(110, 56, 38, 0.10);
+  overflow: hidden;
+}
+
+.sheet-narrow {
+  grid-template-columns: 1fr;
+}
+
+.stab-spine {
+  background-color: var(--paper-soft);
+  border-right: 1px solid var(--paper-edge);
+}
+.stab-spine svg { width: 100%; height: 100%; display: block; }
+
+.sheet-fiber {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+.sheet-fiber svg { width: 100%; height: 100%; display: block; }
+
+.sheet-body {
+  position: relative;
+  z-index: 2;
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1rem, 4vw, 3.5rem);
+}
+
+/* --- Typography in the sheet ------------------------------------------- */
+.sheet-body h1,
+.sheet-body h2,
+.sheet-body h3 {
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  color: var(--ink);
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 600;
+}
+.sheet-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0 0 0.2em;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+.sheet-body h2 {
+  font-size: 1.45rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--paper-edge);
+}
+.sheet-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--cha);
+}
+.sheet-body h2 .jp,
+.sheet-body h1 .jp,
+.sheet-body h3 .jp {
+  font-family: "Noto Sans JP", sans-serif;
+  font-weight: 500;
+  color: var(--ink-soft);
+  font-size: 0.8em;
+  margin-left: 0.5em;
+}
+
+.sheet-body p {
+  margin: 1em 0;
+  color: var(--ink);
+  font-family: "Crimson Pro", "Noto Serif JP", Georgia, serif;
+}
+.sheet-body p.lede {
+  font-family: "Crimson Pro", "Noto Serif JP", serif;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  font-style: italic;
+}
+
+.jp-label {
+  display: inline-block;
+  font-family: "Noto Sans JP", "Inter", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--cha);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.6em;
+  background-color: var(--paper-soft);
+  border: 1px solid var(--paper-edge);
+}
+
+.jp { font-family: "Noto Serif JP", "Noto Sans JP", serif; }
+.sumi { color: var(--sumi); font-weight: 500; }
+
+.chapter-head { margin-bottom: 2rem; }
+.chapter-title {
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+
+.sheet-body a {
+  color: var(--cha);
+  text-decoration: none;
+  border-bottom: 1px solid var(--cha-soft);
+}
+.sheet-body a:hover { color: var(--indigo); border-bottom-color: var(--indigo); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--cha);
+  background-color: var(--paper-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Crimson Pro", "Noto Serif JP", serif;
+  font-size: 1.05rem;
+}
+
+.sheet-body ul,
+.sheet-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.sheet-body ul { list-style: "\25E6  "; }
+.sheet-body ol { list-style: decimal; }
+.sheet-body li { padding: 0.2em 0; }
+
+/* --- Ruled two-column note grid ----------------------------------------- */
+.note-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.note-card {
+  background-color: var(--paper-soft);
+  border: 1px solid var(--paper-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.note-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--indigo);
+  font-size: 1rem;
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+}
+.note-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+.seal {
+  display: inline-block;
+  color: var(--cha);
+  font-family: "Noto Serif JP", serif;
+  font-weight: 700;
+  font-size: 1.1em;
+  padding: 0.05em 0.3em;
+  border: 2px solid var(--cha);
+  margin: 0 0.1em;
+  background-color: var(--paper-soft);
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--paper-edge);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--paper-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+}
+.section-list li::before {
+  content: "\4E00";                /* Japanese "one" */
+  color: var(--cha);
+  font-family: "Noto Serif JP", serif;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 1.02rem;
+}
+.section-list li a:hover { color: var(--cha); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--paper-edge);
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--paper-soft);
+}
+nav.pagination a:hover { color: var(--cha); border-color: var(--cha); }
+.pagination-current span { color: var(--cha); border-color: var(--cha); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--paper-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-weight: 500;
+  color: var(--ink);
+  margin: 0.2em 0;
+  letter-spacing: 0.02em;
+}
+.footer-line .jp { margin-right: 0.4em; color: var(--cha); }
+.footer-line-small {
+  font-family: "Crimson Pro", "Noto Serif JP", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .sheet { grid-template-columns: 40px minmax(0, 1fr); }
+  .sheet-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .chapter-title, .sheet-body h1 { font-size: 1.9rem; }
+  .sheet-body h2 { font-size: 1.2rem; }
+}

--- a/washi-bound/templates/404.html
+++ b/washi-bound/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet sheet-narrow">
+      <div class="sheet-body">
+        <header class="chapter-head">
+          <p class="jp-label">404 / 迷い</p>
+          <h1 class="chapter-title">Page not bound</h1>
+        </header>
+        <p>This chapter was never stitched into the volume, or the thread has come loose and the leaf has wandered. Please return to the cover and find another chapter.</p>
+        <p><a href="{{ base_url }}/">Back to the cover / 表紙へ</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/washi-bound/templates/footer.html
+++ b/washi-bound/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line"><span class="jp">和紙綴本</span> Washi Bound</p>
+      <p class="footer-line-small">A publication bound in the four-hole stab (yotsume toji) tradition.</p>
+      <p class="footer-line-small">© 2026 &middot; printed on the idea of handmade paper</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/washi-bound/templates/header.html
+++ b/washi-bound/templates/header.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;700&family=Inter:wght@400;500;600&family=Crimson+Pro:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="book-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Washi Bound home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="8" y="6" width="40" height="44" fill="#f6f1e4" stroke="#3a352b" stroke-width="1"/>
+          <rect x="10" y="8" width="38" height="42" fill="none" stroke="#c5b088" stroke-width="0.4"/>
+          <g fill="#7a3a26">
+            <circle cx="14" cy="14" r="1.3"/>
+            <circle cx="14" cy="22" r="1.3"/>
+            <circle cx="14" cy="34" r="1.3"/>
+            <circle cx="14" cy="42" r="1.3"/>
+          </g>
+          <g stroke="#7a3a26" stroke-width="0.8" fill="none" stroke-linecap="round">
+            <path d="M14,14 L14,22"/>
+            <path d="M14,22 Q30,20 14,34"/>
+            <path d="M14,34 L14,42"/>
+          </g>
+          <line x1="24" y1="18" x2="42" y2="18" stroke="#3a352b" stroke-width="0.6"/>
+          <line x1="24" y1="28" x2="42" y2="28" stroke="#3a352b" stroke-width="0.6"/>
+          <line x1="24" y1="38" x2="36" y2="38" stroke="#3a352b" stroke-width="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Washi Bound</span>
+          <span class="logo-sub">和紙綴本</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home / 表紙</a>
+        <a href="{{ base_url }}/chapters/">Chapters / 章</a>
+        <a href="{{ base_url }}/binding/">Binding / 綴</a>
+        <a href="{{ base_url }}/paper/">Paper / 紙</a>
+      </nav>
+    </header>
+  </div>

--- a/washi-bound/templates/page.html
+++ b/washi-bound/templates/page.html
@@ -1,0 +1,70 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <aside class="stab-spine" aria-hidden="true">
+        <svg viewBox="0 0 48 640" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="48" height="640" fill="#efe6d4"/>
+          <rect x="38" y="0" width="4" height="640" fill="#d8c9a6"/>
+          <g stroke="#6e3826" stroke-width="2" stroke-linecap="round" fill="none">
+            <line x1="24" y1="40"  x2="24" y2="120"/>
+            <line x1="24" y1="120" x2="24" y2="240"/>
+            <line x1="24" y1="240" x2="24" y2="380"/>
+            <line x1="24" y1="380" x2="24" y2="520"/>
+            <line x1="24" y1="520" x2="24" y2="600"/>
+            <path d="M24,120 C36,130 36,232 24,240" />
+            <path d="M24,240 C12,252 12,368 24,380" />
+            <path d="M24,380 C36,390 36,510 24,520" />
+          </g>
+          <g fill="#6e3826">
+            <circle cx="24" cy="40"  r="3"/>
+            <circle cx="24" cy="120" r="3"/>
+            <circle cx="24" cy="240" r="3"/>
+            <circle cx="24" cy="380" r="3"/>
+            <circle cx="24" cy="520" r="3"/>
+            <circle cx="24" cy="600" r="3"/>
+          </g>
+          <g fill="#0a0a0a" opacity="0.9" font-family="Noto Serif JP, serif" font-size="12" text-anchor="middle">
+            <text x="24" y="185" transform="rotate(-90,24,185)">四</text>
+            <text x="24" y="310" transform="rotate(-90,24,310)">目</text>
+            <text x="24" y="440" transform="rotate(-90,24,440)">綴</text>
+          </g>
+        </svg>
+      </aside>
+      <div class="sheet-fiber" aria-hidden="true">
+        <svg viewBox="0 0 600 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <g stroke="#b59f72" stroke-width="0.35" fill="none" opacity="0.35">
+            <path d="M-20,60 Q120,40 260,70 T540,50 T620,80"/>
+            <path d="M-20,140 Q140,120 280,150 T560,130 T620,150"/>
+            <path d="M-20,240 Q160,210 320,250 T580,220 T620,240"/>
+            <path d="M-20,320 Q140,300 300,330 T540,310 T620,340"/>
+            <path d="M-20,420 Q160,390 320,420 T580,400 T620,430"/>
+            <path d="M-20,500 Q120,480 260,510 T540,490 T620,520"/>
+            <path d="M-20,580 Q160,550 320,580 T580,560 T620,600"/>
+          </g>
+          <g stroke="#b59f72" stroke-width="0.22" fill="none" opacity="0.25">
+            <path d="M-20,20 Q140,10 300,30 T560,20 T620,40"/>
+            <path d="M-20,100 Q120,90 260,110 T540,100 T620,120"/>
+            <path d="M-20,200 Q160,180 320,210 T580,190 T620,220"/>
+            <path d="M-20,280 Q140,260 280,290 T540,270 T620,290"/>
+            <path d="M-20,380 Q120,360 260,390 T540,370 T620,400"/>
+            <path d="M-20,460 Q160,440 320,470 T580,450 T620,480"/>
+            <path d="M-20,540 Q140,520 300,550 T560,540 T620,570"/>
+          </g>
+          <g fill="#b59f72" opacity="0.4">
+            <circle cx="82"  cy="88"  r="0.6"/>
+            <circle cx="230" cy="156" r="0.5"/>
+            <circle cx="430" cy="112" r="0.6"/>
+            <circle cx="540" cy="260" r="0.7"/>
+            <circle cx="134" cy="312" r="0.5"/>
+            <circle cx="330" cy="404" r="0.6"/>
+            <circle cx="490" cy="460" r="0.6"/>
+            <circle cx="210" cy="512" r="0.5"/>
+          </g>
+        </svg>
+      </div>
+      <div class="sheet-body">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/washi-bound/templates/section.html
+++ b/washi-bound/templates/section.html
@@ -1,0 +1,53 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet">
+      <aside class="stab-spine" aria-hidden="true">
+        <svg viewBox="0 0 48 640" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="48" height="640" fill="#efe6d4"/>
+          <rect x="38" y="0" width="4" height="640" fill="#d8c9a6"/>
+          <g stroke="#6e3826" stroke-width="2" stroke-linecap="round" fill="none">
+            <line x1="24" y1="40"  x2="24" y2="120"/>
+            <line x1="24" y1="120" x2="24" y2="240"/>
+            <line x1="24" y1="240" x2="24" y2="380"/>
+            <line x1="24" y1="380" x2="24" y2="520"/>
+            <line x1="24" y1="520" x2="24" y2="600"/>
+            <path d="M24,120 C36,130 36,232 24,240" />
+            <path d="M24,240 C12,252 12,368 24,380" />
+            <path d="M24,380 C36,390 36,510 24,520" />
+          </g>
+          <g fill="#6e3826">
+            <circle cx="24" cy="40"  r="3"/>
+            <circle cx="24" cy="120" r="3"/>
+            <circle cx="24" cy="240" r="3"/>
+            <circle cx="24" cy="380" r="3"/>
+            <circle cx="24" cy="520" r="3"/>
+            <circle cx="24" cy="600" r="3"/>
+          </g>
+        </svg>
+      </aside>
+      <div class="sheet-fiber" aria-hidden="true">
+        <svg viewBox="0 0 600 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <g stroke="#b59f72" stroke-width="0.35" fill="none" opacity="0.35">
+            <path d="M-20,60 Q120,40 260,70 T540,50 T620,80"/>
+            <path d="M-20,160 Q140,130 280,160 T560,140 T620,160"/>
+            <path d="M-20,260 Q160,230 320,260 T580,240 T620,260"/>
+            <path d="M-20,360 Q140,330 300,360 T540,340 T620,360"/>
+            <path d="M-20,460 Q160,430 320,460 T580,440 T620,460"/>
+            <path d="M-20,560 Q120,540 260,570 T540,550 T620,580"/>
+          </g>
+        </svg>
+      </div>
+      <div class="sheet-body">
+        <header class="chapter-head">
+          <p class="jp-label">章 / Chapter index</p>
+          <h1 class="chapter-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/washi-bound/templates/shortcodes/alert.html
+++ b/washi-bound/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/washi-bound/templates/taxonomy.html
+++ b/washi-bound/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet sheet-narrow">
+      <div class="sheet-body">
+        <header class="chapter-head">
+          <p class="jp-label">索引 / Index</p>
+          <h1 class="chapter-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Subjects of this bound volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/washi-bound/templates/taxonomy_term.html
+++ b/washi-bound/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="sheet sheet-narrow">
+      <div class="sheet-body">
+        <header class="chapter-head">
+          <p class="jp-label">主題 / Subject</p>
+          <h1 class="chapter-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Chapters filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
## Summary
- Light Japanese paper publication bound in four-hole stab (yotsume toji) style
- Stab-binding stitch pattern (four stitch points, connecting thread curves, head/tail wraps) runs down the left margin of every sheet as inline SVG
- Washi paper fiber texture rendered behind the body column as long soft curves with scattered fiber-knot dots - all inline SVG
- Typography pairs Inter + Noto Sans JP for display, Crimson Pro + Noto Serif JP for body; bilingual labels throughout
- Four chapters on fiber, stitch, type, and the wahon as an object, plus Binding and Paper appendices
- Tags: book, light, japanese, stab-binding, paper

## Test plan
- [ ] Run `hwaro build` inside `washi-bound/` and confirm no template warnings
- [ ] Check that the stab-binding stitches render along the left edge of each page
- [ ] Verify the washi fiber SVG sits behind the body text without obscuring it
- [ ] Confirm bilingual JP / EN labels render cleanly (Noto JP fonts load)
- [ ] Check `tags.json` entry is valid JSON