### PR TITLE
feat: add pop-up-page example site (closes #1559)

### DIFF
--- a/pop-up-page/AGENTS.md
+++ b/pop-up-page/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/pop-up-page/config.toml
+++ b/pop-up-page/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Pop-Up Page - Dimensional Publication
+# Issue #1559 | Tags: book, light, dimensional, paper-engineering, interactive
+# =============================================================================
+
+title = "Pop-Up Page"
+description = "A light, dimensional publication inspired by paper engineering and pop-up book mechanics. SVG fold diagrams and tab-and-slot connection patterns bring the page to life. Montserrat Bold and Outfit Bold stand up from the page while Inter and Noto Sans lie flat on the surface."
+base_url = "http://localhost:3000"
+
+sections = ["spreads"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/pop-up-page/content/about.md
+++ b/pop-up-page/content/about.md
@@ -1,0 +1,45 @@
++++
+title = "Mechanics"
+description = "The fundamental mechanisms of pop-up paper engineering."
++++
+
+<p class="spread-label">Reference</p>
+
+# Mechanics of Paper Engineering
+
+<p class="lede">Every pop-up book relies on a small set of fundamental mechanisms. The complexity of the finished spread comes from combining these mechanisms, not from inventing new ones.</p>
+
+## The gutter fold
+
+<p>The gutter is the central fold of the spread. Every pop-up mechanism is driven by the opening of this fold. When the reader opens the spread from zero degrees (closed) to one hundred and eighty degrees (flat), the gutter fold acts as a hinge that transfers motion to every attached panel. The gutter is the engine of the pop-up.</p>
+
+## Parallel folds and angle folds
+
+<p>There are two families of pop-up mechanism. In a <strong>parallel fold</strong>, the creases of the pop-up panel run parallel to the gutter. The panel rises straight up as the spread opens. In an <strong>angle fold</strong>, the creases run at an angle to the gutter. The panel rises and rotates simultaneously, creating a more dynamic motion. Most commercial pop-ups combine both families on a single spread.</p>
+
+## Adhesive points
+
+<p>The pop-up structure is attached to the base page at specific adhesive points. These are small areas of glue that anchor the mechanism. The placement of these points determines the geometry of the pop-up: move an adhesive point one centimeter to the left and the entire structure changes its angle of rise, its height, and its stability.</p>
+
+<div class="mech-grid">
+<div class="mech-card">
+<h3>Mountain fold</h3>
+<p>A fold that creates a ridge when viewed from the front. The paper rises toward the viewer. Indicated by a dash-dot line on engineering diagrams.</p>
+</div>
+<div class="mech-card">
+<h3>Valley fold</h3>
+<p>A fold that creates a trough. The paper falls away from the viewer. Indicated by a dashed line. Mountain and valley folds always alternate across a pop-up structure.</p>
+</div>
+<div class="mech-card">
+<h3>Score line</h3>
+<p>A partial cut through the paper that weakens the fiber along a straight line, making it fold cleanly. Without scoring, thick paper buckles and tears instead of folding.</p>
+</div>
+<div class="mech-card">
+<h3>Die cut</h3>
+<p>A full cut through the paper, shaped by a metal die. Used to create tabs, slots, and shaped edges. The precision of the die determines the tightness of the mechanical fit.</p>
+</div>
+</div>
+
+## Materials
+
+<p>Pop-up engineering requires stiff, resilient paper. Most commercial pop-ups use 200-300 gsm card stock. The paper must hold a crease without splitting, spring back without warping, and accept adhesive without buckling. Coated stocks are preferred for printing but uncoated stocks fold more cleanly. The best pop-up books use a combination: coated outer surfaces for color and uncoated inner panels for structure.</p>

--- a/pop-up-page/content/construction.md
+++ b/pop-up-page/content/construction.md
@@ -1,0 +1,49 @@
++++
+title = "Construction"
+description = "How pop-up books are constructed from flat sheets."
++++
+
+<p class="spread-label">Workshop</p>
+
+# Construction
+
+<p class="lede">A pop-up book is built in reverse: the engineer begins with the finished three-dimensional form and works backward to a flat pattern that can be printed, cut, scored, folded, and glued on a production line.</p>
+
+## The white dummy
+
+<p>Before any artwork is drawn, the engineer builds a white dummy: a full-size prototype made from plain white card. The white dummy is the proof of concept. It tests whether every mechanism works, whether the spread closes flat without jamming, and whether the paper can withstand repeated opening and closing. A commercial pop-up book may go through twenty or more white dummies before the design is approved for production.</p>
+
+## Flat pattern layout
+
+<p>Every three-dimensional pop-up structure can be unfolded into a flat two-dimensional pattern. The flat pattern includes:</p>
+
+<ul>
+<li>Cut lines (solid) that define the outer shape of each panel</li>
+<li>Mountain fold lines (dash-dot) that fold toward the viewer</li>
+<li>Valley fold lines (dashed) that fold away from the viewer</li>
+<li>Glue tabs marked with hatching or a specific color</li>
+<li>Registration marks that align the printed artwork to the mechanical structure</li>
+</ul>
+
+## Assembly sequence
+
+<p>A complex pop-up spread may contain twenty or more individual pieces that must be assembled in a precise order. The assembly sequence is written by the engineer and followed exactly by the production team. A single piece glued out of order can jam the entire mechanism. In high-volume production, each assembly step is assigned to a different worker on a hand-assembly line. Pop-up books cannot be assembled by machine: the three-dimensional folding requires human dexterity.</p>
+
+<div class="mech-grid">
+<div class="mech-card">
+<h3>Step 1: Base page</h3>
+<p>The printed base page is scored along the gutter fold and any secondary fold lines. Die-cut slots are punched for tab insertion.</p>
+</div>
+<div class="mech-card">
+<h3>Step 2: Sub-assemblies</h3>
+<p>Small groups of panels are pre-folded and glued together off the base page. These sub-assemblies are the building blocks of the final spread.</p>
+</div>
+<div class="mech-card">
+<h3>Step 3: Attachment</h3>
+<p>Sub-assemblies are glued to the base page at the marked adhesive points. The spread is checked for clean folding after each attachment.</p>
+</div>
+<div class="mech-card">
+<h3>Step 4: Final check</h3>
+<p>The completed spread is opened and closed several times to verify that all mechanisms operate smoothly and the spread lies flat when closed.</p>
+</div>
+</div>

--- a/pop-up-page/content/index.md
+++ b/pop-up-page/content/index.md
@@ -1,0 +1,76 @@
++++
+title = "Pop-Up Page"
+description = "A dimensional publication where every spread rises from the gutter."
++++
+
+<p class="spread-label">Cover</p>
+
+# Pop-Up Page
+
+<p class="lede">A publication engineered like a pop-up book: every spread contains a mechanism that lifts the content off the flat page. Fold lines, tab-and-slot joints, and V-fold scaffolds turn a bound volume into a three-dimensional reading experience.</p>
+
+## The dimensional page
+
+<p>Open any pop-up book and the first thing you notice is that the page does not stay flat. A system of folded panels, glued tabs, and hidden slots converts the simple act of turning a page into a mechanical event. The spread opens, and a structure rises from the gutter. Close the spread, and the structure collapses back into two dimensions. This publication takes the same principle and applies it to the layout of a website: the gutter fold runs down the left edge, fold lines are indicated by dashed rules, and every piece of content sits on a panel that appears to stand up from the surface.</p>
+
+## Mechanisms
+
+<div class="mech-grid">
+<div class="mech-card">
+<div class="mech-diagram" aria-hidden="true">
+<svg viewBox="0 0 120 80" xmlns="http://www.w3.org/2000/svg">
+<line x1="60" y1="80" x2="60" y2="0" stroke="#c9bfae" stroke-width="0.5" stroke-dasharray="3,2"/>
+<polygon points="60,10 90,50 30,50" fill="none" stroke="#c4561a" stroke-width="1"/>
+<circle cx="60" cy="10" r="2" fill="#c4561a"/>
+<rect x="42" y="50" width="36" height="6" fill="#f0ebe2" stroke="#3a3530" stroke-width="0.5"/>
+</svg>
+</div>
+<h3>V-Fold</h3>
+<p>The simplest pop-up: a single panel folded along the gutter rises as the spread opens. The angle of the fold determines how far the panel stands up.</p>
+</div>
+<div class="mech-card">
+<div class="mech-diagram" aria-hidden="true">
+<svg viewBox="0 0 120 80" xmlns="http://www.w3.org/2000/svg">
+<line x1="60" y1="80" x2="60" y2="0" stroke="#c9bfae" stroke-width="0.5" stroke-dasharray="3,2"/>
+<rect x="25" y="20" width="30" height="40" fill="none" stroke="#c4561a" stroke-width="1"/>
+<rect x="65" y="20" width="30" height="40" fill="none" stroke="#c4561a" stroke-width="1"/>
+<line x1="55" y1="40" x2="65" y2="40" stroke="#c4561a" stroke-width="1.2"/>
+<circle cx="55" cy="40" r="1.5" fill="#c4561a"/>
+<circle cx="65" cy="40" r="1.5" fill="#c4561a"/>
+</svg>
+</div>
+<h3>Tab-and-Slot</h3>
+<p>A tab cut into one panel slides into a slot cut into another. The joint locks the two panels at a fixed angle, creating a rigid three-dimensional form.</p>
+</div>
+<div class="mech-card">
+<div class="mech-diagram" aria-hidden="true">
+<svg viewBox="0 0 120 80" xmlns="http://www.w3.org/2000/svg">
+<line x1="60" y1="80" x2="60" y2="0" stroke="#c9bfae" stroke-width="0.5" stroke-dasharray="3,2"/>
+<path d="M30,60 L30,20 L60,10 L90,20 L90,60" fill="none" stroke="#c4561a" stroke-width="1"/>
+<line x1="30" y1="60" x2="90" y2="60" stroke="#3a3530" stroke-width="0.5"/>
+<line x1="60" y1="10" x2="60" y2="60" stroke="#c9bfae" stroke-width="0.4" stroke-dasharray="2,2"/>
+</svg>
+</div>
+<h3>Tent Fold</h3>
+<p>Two panels joined at the peak and glued at the base on opposite pages. When the spread opens, the tent rises along the gutter line.</p>
+</div>
+<div class="mech-card">
+<div class="mech-diagram" aria-hidden="true">
+<svg viewBox="0 0 120 80" xmlns="http://www.w3.org/2000/svg">
+<line x1="60" y1="80" x2="60" y2="0" stroke="#c9bfae" stroke-width="0.5" stroke-dasharray="3,2"/>
+<rect x="20" y="15" width="80" height="50" fill="none" stroke="#3a3530" stroke-width="0.5"/>
+<rect x="35" y="25" width="20" height="30" fill="none" stroke="#c4561a" stroke-width="1"/>
+<line x1="35" y1="55" x2="55" y2="55" stroke="#c4561a" stroke-width="1.2"/>
+<line x1="35" y1="25" x2="35" y2="55" stroke="#c4561a" stroke-width="0.5" stroke-dasharray="2,1"/>
+</svg>
+</div>
+<h3>Pull-Strip</h3>
+<p>A hidden strip attached to the page edge. Pulling the strip slides a panel across the surface or lifts a flap to reveal content beneath.</p>
+</div>
+</div>
+
+## Reading this volume
+
+<p>Each spread in this publication is laid out on a flat page surface with a fold gutter running down the left edge. The gutter shows fold-line chevrons at regular intervals, indicating where the paper would crease if this were a physical pop-up. The background carries faint score lines and tab outlines as reminders that every element on the page is part of a mechanical system.</p>
+
+<p>Navigate to the <a href="/spreads/">spreads index</a> to open each dimensional chapter, or use the links in the header above.</p>

--- a/pop-up-page/content/spreads/1-the-v-fold.md
+++ b/pop-up-page/content/spreads/1-the-v-fold.md
@@ -1,0 +1,40 @@
++++
+title = "The V-Fold"
+description = "The simplest pop-up mechanism: a single panel rising from the gutter."
+tags = ["v-fold", "parallel"]
++++
+
+<p class="spread-label">Spread I</p>
+
+# The V-Fold
+
+<p class="lede">One fold, one crease, one rising panel. The V-fold is the atom of paper engineering: the smallest mechanism that produces three-dimensional motion from a flat sheet.</p>
+
+## How it works
+
+<p>A V-fold is a single piece of card with a central crease. The two halves of the card are glued to opposite sides of the gutter. When the spread opens, the gutter pulls the two glue points apart, and the crease in the middle forces the card to rise. The angle of rise depends on the angle of the crease relative to the gutter: a crease parallel to the gutter produces a panel that rises straight up; a crease at forty-five degrees produces a panel that rises and rotates.</p>
+
+<div class="popup-diagram" aria-hidden="true">
+<svg viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="100" width="400" height="100" fill="#f5f0e6" stroke="#c9bfae" stroke-width="0.5"/>
+<line x1="200" y1="0" x2="200" y2="200" stroke="#c9bfae" stroke-width="1" stroke-dasharray="6,4"/>
+<polygon points="200,20 300,100 100,100" fill="#fff7ee" stroke="#c4561a" stroke-width="1.5"/>
+<line x1="200" y1="20" x2="200" y2="100" stroke="#c4561a" stroke-width="0.8" stroke-dasharray="3,2"/>
+<circle cx="100" cy="100" r="3" fill="#c4561a"/>
+<circle cx="300" cy="100" r="3" fill="#c4561a"/>
+<circle cx="200" cy="20" r="3" fill="#3a3530"/>
+<text x="105" y="95" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62">glue point</text>
+<text x="245" y="95" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62">glue point</text>
+<text x="208" y="18" font-family="Inter, sans-serif" font-size="9" fill="#3a3530">peak</text>
+</svg>
+</div>
+
+## Variations
+
+<p>The basic V-fold can be modified in several ways. A <strong>truncated V-fold</strong> has the peak cut off, creating a flat platform at the top that can support a secondary element. An <strong>asymmetric V-fold</strong> has panels of different sizes, causing the structure to lean to one side as it rises. A <strong>compound V-fold</strong> has a smaller V-fold glued on top of a larger one, creating a two-tier structure.</p>
+
+## In this publication
+
+<p>The gutter fold running down the left edge of every page represents the central crease of a V-fold spread. The chevron markers along the gutter indicate the fold points where a physical pop-up panel would be attached. The page itself is the base surface from which the content rises.</p>
+
+<blockquote>The V-fold teaches the fundamental lesson of paper engineering: three dimensions are always hiding inside two. You only need a fold to find them.</blockquote>

--- a/pop-up-page/content/spreads/2-the-box.md
+++ b/pop-up-page/content/spreads/2-the-box.md
@@ -1,0 +1,36 @@
++++
+title = "The Box"
+description = "A four-sided structure that rises from the page surface."
+tags = ["box", "parallel"]
++++
+
+<p class="spread-label">Spread II</p>
+
+# The Box
+
+<p class="lede">Four walls, four folds, one right angle. The box is the first pop-up mechanism that encloses a volume of space above the page surface.</p>
+
+## How it works
+
+<p>A box pop-up is made from a single strip of card with four parallel fold lines. The two outer panels are glued to the base page on opposite sides of the gutter. When the spread opens, the strip is forced into a rectangular cross-section: the two side panels become walls, the top panel becomes a ceiling, and the interior is empty space. The height of the box is determined by the width of the side panels. The width of the box is determined by the distance between the two glue points.</p>
+
+<div class="popup-diagram" aria-hidden="true">
+<svg viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="120" width="400" height="80" fill="#f5f0e6" stroke="#c9bfae" stroke-width="0.5"/>
+<line x1="200" y1="0" x2="200" y2="200" stroke="#c9bfae" stroke-width="1" stroke-dasharray="6,4"/>
+<rect x="120" y="40" width="160" height="80" fill="#fff7ee" stroke="#c4561a" stroke-width="1.5"/>
+<line x1="120" y1="40" x2="120" y2="120" stroke="#c4561a" stroke-width="0.8" stroke-dasharray="3,2"/>
+<line x1="280" y1="40" x2="280" y2="120" stroke="#c4561a" stroke-width="0.8" stroke-dasharray="3,2"/>
+<circle cx="120" cy="120" r="3" fill="#c4561a"/>
+<circle cx="280" cy="120" r="3" fill="#c4561a"/>
+<text x="170" y="85" font-family="Inter, sans-serif" font-size="10" fill="#8a7d62">enclosed space</text>
+</svg>
+</div>
+
+## Applications
+
+<p>The box mechanism is the basis for buildings, furniture, vehicles, and any other pop-up element that needs to look solid. A row of boxes along the gutter creates a street scene. A single tall box with a peaked top becomes a tower. Boxes can be nested inside each other to create rooms within buildings, drawers within cabinets, and any other structure that requires interior subdivisions.</p>
+
+## Structural considerations
+
+<p>The box is stronger than the V-fold because it has four fold lines instead of one. The rectangular cross-section resists compression from above. However, the box requires more precise alignment of fold lines and glue points. If the folds are not exactly parallel, the box will twist as it rises, and the top panel will not lie flat. Paper engineers test box mechanisms by pressing down on the top panel: a well-made box springs back to its full height; a poorly made box stays partially collapsed.</p>

--- a/pop-up-page/content/spreads/3-the-pull-tab.md
+++ b/pop-up-page/content/spreads/3-the-pull-tab.md
@@ -1,0 +1,39 @@
++++
+title = "The Pull-Tab"
+description = "A sliding mechanism that reveals hidden content."
+tags = ["pull-tab", "interactive"]
++++
+
+<p class="spread-label">Spread III</p>
+
+# The Pull-Tab
+
+<p class="lede">Not all pop-up mechanisms rely on the opening of the spread. The pull-tab is reader-driven: the viewer reaches in and pulls a paper strip to set the mechanism in motion.</p>
+
+## How it works
+
+<p>A pull-tab mechanism has three components: the <strong>tab</strong> itself (a strip of card extending from the edge of the page), a <strong>guide channel</strong> (a slit or pair of slits that constrains the tab to move in a straight line), and a <strong>connected element</strong> (a panel, flap, or rotating disc attached to the tab by a paper linkage). When the reader pulls the tab, the linkage converts the linear motion of the tab into the desired motion of the connected element: a sliding panel, a rotating arm, a rising figure.</p>
+
+<div class="popup-diagram" aria-hidden="true">
+<svg viewBox="0 0 400 160" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="400" height="160" fill="#f5f0e6" stroke="#c9bfae" stroke-width="0.5"/>
+<rect x="30" y="60" width="140" height="40" fill="#fff7ee" stroke="#3a3530" stroke-width="0.8"/>
+<rect x="170" y="70" width="80" height="20" fill="#c4561a" opacity="0.15" stroke="#c4561a" stroke-width="0.8"/>
+<line x1="250" y1="80" x2="340" y2="80" stroke="#c4561a" stroke-width="1.5"/>
+<polygon points="340,74 355,80 340,86" fill="#c4561a"/>
+<text x="55" y="84" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62">hidden panel</text>
+<text x="180" y="84" font-family="Inter, sans-serif" font-size="8" fill="#c4561a">guide slot</text>
+<text x="280" y="74" font-family="Inter, sans-serif" font-size="9" fill="#3a3530">pull</text>
+<circle cx="170" cy="80" r="2" fill="#c4561a"/>
+</svg>
+</div>
+
+## Durability
+
+<p>Pull-tabs are the most vulnerable mechanism in a pop-up book. Unlike spread-driven mechanisms, which are protected by the covers when the book is closed, pull-tabs are exposed and handled directly. The guide channel wears out with repeated use, and the tab itself can tear if pulled too hard or at the wrong angle. Commercial pop-up books reinforce pull-tabs with a second layer of card and use rounded corners on guide slots to reduce stress concentrations.</p>
+
+## Design principle
+
+<p>The pull-tab is the only pop-up mechanism that requires the reader to make a choice. The spread opens passively, but the pull-tab must be discovered, understood, and operated. This makes it the most interactive mechanism in the paper engineer's toolkit. A well-designed pull-tab invites the reader to participate in the construction of the page.</p>
+
+<blockquote>A pop-up that opens itself is a spectacle. A pop-up that waits for the reader's hand is a conversation.</blockquote>

--- a/pop-up-page/content/spreads/4-the-layer.md
+++ b/pop-up-page/content/spreads/4-the-layer.md
@@ -1,0 +1,42 @@
++++
+title = "The Layer"
+description = "Stacked planes creating depth and parallax."
+tags = ["layer", "dimensional"]
++++
+
+<p class="spread-label">Spread IV</p>
+
+# The Layer
+
+<p class="lede">Depth without mechanics. The layer technique stacks flat panels at different distances from the base page, creating the illusion of three-dimensional space through parallax alone.</p>
+
+## How it works
+
+<p>A layered pop-up uses spacer strips to hold flat panels at fixed distances above the base page. Each panel is cut with openings that reveal the panels behind it. The foreground panel is closest to the viewer and has the largest openings; the background panel is closest to the base page and provides the most distant scenery. When the reader looks at the spread from different angles, the panels shift relative to each other, producing a parallax effect that mimics natural depth perception.</p>
+
+<div class="popup-diagram" aria-hidden="true">
+<svg viewBox="0 0 400 180" xmlns="http://www.w3.org/2000/svg">
+<rect x="20" y="140" width="360" height="30" fill="#f5f0e6" stroke="#c9bfae" stroke-width="0.5"/>
+<rect x="40" y="100" width="320" height="30" fill="#fff7ee" stroke="#3a3530" stroke-width="0.8" opacity="0.9"/>
+<rect x="60" y="60" width="280" height="30" fill="#fff7ee" stroke="#3a3530" stroke-width="0.8" opacity="0.8"/>
+<rect x="80" y="20" width="240" height="30" fill="#fff7ee" stroke="#c4561a" stroke-width="1" opacity="0.9"/>
+<line x1="40" y1="130" x2="40" y2="140" stroke="#c4561a" stroke-width="1"/>
+<line x1="360" y1="130" x2="360" y2="140" stroke="#c4561a" stroke-width="1"/>
+<line x1="60" y1="90" x2="60" y2="100" stroke="#c4561a" stroke-width="1"/>
+<line x1="340" y1="90" x2="340" y2="100" stroke="#c4561a" stroke-width="1"/>
+<line x1="80" y1="50" x2="80" y2="60" stroke="#c4561a" stroke-width="1"/>
+<line x1="320" y1="50" x2="320" y2="60" stroke="#c4561a" stroke-width="1"/>
+<text x="130" y="38" font-family="Inter, sans-serif" font-size="9" fill="#c4561a">foreground</text>
+<text x="140" y="78" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62">mid-ground</text>
+<text x="150" y="118" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62">background</text>
+<text x="160" y="158" font-family="Inter, sans-serif" font-size="9" fill="#c9bfae">base page</text>
+</svg>
+</div>
+
+## The tunnel book
+
+<p>The most extreme application of the layer technique is the tunnel book (also called a peep show). A tunnel book is a series of panels connected by accordion-folded side strips. The viewer looks through a hole in the front panel and sees a deep scene receding into the distance. Tunnel books have been made since the eighteenth century, originally as souvenirs of theatrical performances and architectural views.</p>
+
+## Depth on a screen
+
+<p>The layer technique translates naturally to screen-based design. CSS stacking contexts, z-index values, and subtle shadow offsets can reproduce the same layered depth that a physical pop-up achieves with spacer strips. This publication uses background SVG planes at different opacities to suggest layered depth on every page.</p>

--- a/pop-up-page/content/spreads/5-the-carousel.md
+++ b/pop-up-page/content/spreads/5-the-carousel.md
@@ -1,0 +1,57 @@
++++
+title = "The Carousel"
+description = "A multi-spread compound mechanism that creates a panoramic scene."
+tags = ["carousel", "compound"]
++++
+
+<p class="spread-label">Spread V</p>
+
+# The Carousel
+
+<p class="lede">The most ambitious pop-up mechanism: multiple spreads joined at the spine to form a three-hundred-and-sixty-degree panoramic scene. The carousel is the pop-up as architecture.</p>
+
+## How it works
+
+<p>A carousel pop-up is made by joining the front and back covers of a book so that the pages fan out in a complete circle. Each spread contributes one sector of the panorama. The spines act as structural ribs, and the pages between them act as walls. When viewed from above, the opened book forms a star shape. When viewed from inside the circle, the reader is surrounded by a continuous scene.</p>
+
+<div class="popup-diagram" aria-hidden="true">
+<svg viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(200,100)">
+<polygon points="0,-70 49,-49 70,0 49,49 0,70 -49,49 -70,0 -49,-49" fill="none" stroke="#c9bfae" stroke-width="0.5"/>
+<line x1="0" y1="-70" x2="0" y2="70" stroke="#c9bfae" stroke-width="0.4" stroke-dasharray="3,2"/>
+<line x1="-70" y1="0" x2="70" y2="0" stroke="#c9bfae" stroke-width="0.4" stroke-dasharray="3,2"/>
+<g fill="none" stroke="#c4561a" stroke-width="1.2">
+<line x1="0" y1="-70" x2="49" y2="-49"/>
+<line x1="49" y1="-49" x2="70" y2="0"/>
+<line x1="70" y1="0" x2="49" y2="49"/>
+<line x1="49" y1="49" x2="0" y2="70"/>
+<line x1="0" y1="70" x2="-49" y2="49"/>
+<line x1="-49" y1="49" x2="-70" y2="0"/>
+<line x1="-70" y1="0" x2="-49" y2="-49"/>
+<line x1="-49" y1="-49" x2="0" y2="-70"/>
+</g>
+<g fill="#c4561a">
+<circle cx="0" cy="-70" r="2.5"/>
+<circle cx="49" cy="-49" r="2.5"/>
+<circle cx="70" cy="0" r="2.5"/>
+<circle cx="49" cy="49" r="2.5"/>
+<circle cx="0" cy="70" r="2.5"/>
+<circle cx="-49" cy="49" r="2.5"/>
+<circle cx="-70" cy="0" r="2.5"/>
+<circle cx="-49" cy="-49" r="2.5"/>
+</g>
+<circle cx="0" cy="0" r="4" fill="#3a3530"/>
+</g>
+<text x="200" y="190" font-family="Inter, sans-serif" font-size="9" fill="#8a7d62" text-anchor="middle">top view: eight-spread carousel</text>
+</svg>
+</div>
+
+## Historical examples
+
+<p>Carousel pop-ups have been made since the mid-nineteenth century. The most famous early example is Dean and Son's "New Scenic Books" from the 1860s, which used three spreads joined at the covers to create a six-panel theater scene. Modern carousel books by artists like David Carter and Robert Sabuda use four or five spreads with additional V-fold and box elements rising from each panel.</p>
+
+## Engineering challenges
+
+<p>The carousel is the most difficult mechanism to engineer because every spread must fold flat independently and also work as part of the circular assembly. The cover-to-cover connection must be strong enough to hold the circle open but flexible enough to allow the book to close. Most carousel books solve this with a ribbon tie: the front and back covers are joined by a ribbon that the reader ties to hold the carousel open and unties to close the book flat.</p>
+
+<blockquote>The carousel turns the book inside out. The reader is no longer looking at the page; the page is looking at the reader.</blockquote>

--- a/pop-up-page/content/spreads/_index.md
+++ b/pop-up-page/content/spreads/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Spreads"
+description = "The dimensional spreads of this pop-up publication."
++++
+
+<p class="lede">Five spreads, each demonstrating a different pop-up mechanism. Open each spread to see the structure rise from the flat page.</p>
+
+<p>A pop-up book is read one spread at a time. Each spread is a self-contained mechanical scene that deploys when the page is opened and collapses when it is closed. The spreads below progress from the simplest mechanism to the most complex.</p>

--- a/pop-up-page/static/css/style.css
+++ b/pop-up-page/static/css/style.css
@@ -1,0 +1,375 @@
+/* =============================================================================
+   Pop-Up Page - Dimensional Publication
+   Issue #1559 | book, light, dimensional, paper-engineering, interactive
+   Palette: warm cream page surface, burnt-orange fold accents, charcoal structure
+   No gradients. Fold diagrams + tab-and-slot patterns drawn as inline SVG.
+   ============================================================================= */
+
+:root {
+  --page: #faf6ef;
+  --page-soft: #f0ebe2;
+  --page-deep: #e4ddd0;
+  --page-edge: #c9bfae;
+  --ink: #3a3530;
+  --ink-soft: #5c554c;
+  --ink-dim: #8a7d62;
+  --fold: #c4561a;        /* burnt-orange fold accent */
+  --fold-soft: #d88a5e;
+  --tab: #2b5e4a;         /* deep green tab accent */
+  --charcoal: #1e1c1a;    /* deep structural ink */
+  --bg: #fdfaf4;          /* outer background */
+  --score: rgba(201, 191, 174, 0.3);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Noto Sans", "Inter", system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.book-shell {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--page-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 52px; height: 52px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 800;
+  font-size: 1.25rem;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 0.82rem;
+  color: var(--fold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--fold); border-bottom-color: var(--fold); }
+
+/* --- Spread (page) ------------------------------------------------------- */
+.site-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.spread {
+  position: relative;
+  background-color: var(--page);
+  border: 1px solid var(--page-edge);
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  min-height: 640px;
+  box-shadow:
+    0 1px 0 var(--page-deep),
+    0 18px 36px rgba(196, 86, 26, 0.08);
+  overflow: hidden;
+}
+
+.spread-narrow {
+  grid-template-columns: 1fr;
+}
+
+.fold-gutter {
+  background-color: var(--page-soft);
+  border-right: 1px dashed var(--page-edge);
+}
+.fold-gutter svg { width: 100%; height: 100%; display: block; }
+
+.spread-surface {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+.spread-surface svg { width: 100%; height: 100%; display: block; }
+
+.spread-body {
+  position: relative;
+  z-index: 2;
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1rem, 4vw, 3.5rem);
+}
+
+/* --- Typography in the spread -------------------------------------------- */
+.spread-body h1,
+.spread-body h2,
+.spread-body h3 {
+  font-family: "Montserrat", "Outfit", sans-serif;
+  color: var(--ink);
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 700;
+}
+.spread-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0 0 0.2em;
+  font-weight: 800;
+  letter-spacing: -0.005em;
+}
+.spread-body h2 {
+  font-size: 1.45rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--page-edge);
+}
+.spread-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--fold);
+}
+
+.spread-body p {
+  margin: 1em 0;
+  color: var(--ink);
+  font-family: "Noto Sans", "Inter", sans-serif;
+}
+.spread-body p.lede {
+  font-family: "Noto Sans", "Inter", sans-serif;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  font-style: italic;
+}
+
+.spread-label {
+  display: inline-block;
+  font-family: "Outfit", "Montserrat", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fold);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.6em;
+  background-color: var(--page-soft);
+  border: 1px solid var(--page-edge);
+}
+
+.spread-head { margin-bottom: 2rem; }
+.spread-title {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 800;
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+
+.spread-body a {
+  color: var(--fold);
+  text-decoration: none;
+  border-bottom: 1px solid var(--fold-soft);
+}
+.spread-body a:hover { color: var(--tab); border-bottom-color: var(--tab); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--fold);
+  background-color: var(--page-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Noto Sans", "Inter", sans-serif;
+  font-size: 1.05rem;
+}
+
+.spread-body ul,
+.spread-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.spread-body ul { list-style: disc; }
+.spread-body ol { list-style: decimal; }
+.spread-body li { padding: 0.2em 0; }
+
+/* --- Mechanism card grid ------------------------------------------------- */
+.mech-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.mech-card {
+  background-color: var(--page-soft);
+  border: 1px solid var(--page-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.mech-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--tab);
+  font-size: 1rem;
+  font-family: "Outfit", "Montserrat", sans-serif;
+  font-weight: 600;
+}
+.mech-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+.mech-diagram {
+  margin-bottom: 0.75rem;
+}
+.mech-diagram svg {
+  width: 100%;
+  max-height: 80px;
+  display: block;
+}
+
+/* --- Pop-up diagrams ----------------------------------------------------- */
+.popup-diagram {
+  margin: 1.5rem 0;
+  background-color: var(--page-soft);
+  border: 1px solid var(--page-edge);
+  padding: 1rem;
+}
+.popup-diagram svg {
+  width: 100%;
+  max-height: 200px;
+  display: block;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--page-edge);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--page-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Outfit", "Montserrat", sans-serif;
+}
+.section-list li::before {
+  content: "\25B3";               /* triangle up - fold marker */
+  color: var(--fold);
+  font-size: 0.8em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 1.02rem;
+}
+.section-list li a:hover { color: var(--fold); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--page-edge);
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--page-soft);
+}
+nav.pagination a:hover { color: var(--fold); border-color: var(--fold); }
+.pagination-current span { color: var(--fold); border-color: var(--fold); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--page-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0.2em 0;
+  letter-spacing: 0.02em;
+}
+.footer-line-small {
+  font-family: "Noto Sans", "Inter", sans-serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .spread { grid-template-columns: 32px minmax(0, 1fr); }
+  .spread-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .spread-title, .spread-body h1 { font-size: 1.9rem; }
+  .spread-body h2 { font-size: 1.2rem; }
+  .popup-diagram svg { max-height: 140px; }
+}

--- a/pop-up-page/templates/404.html
+++ b/pop-up-page/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">404</p>
+          <h1 class="spread-title">Spread not found</h1>
+        </header>
+        <p>This page has collapsed flat. The tab that held it in place must have slipped. Return to the cover and try another spread.</p>
+        <p><a href="{{ base_url }}/">Back to the cover</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/pop-up-page/templates/footer.html
+++ b/pop-up-page/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line">Pop-Up Page</p>
+      <p class="footer-line-small">A dimensional publication where every spread rises from the gutter.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; engineered on paper, assembled in code</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/pop-up-page/templates/header.html
+++ b/pop-up-page/templates/header.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;800&family=Outfit:wght@400;500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="book-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Pop-Up Page home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="4" y="28" width="48" height="24" fill="#f0ebe2" stroke="#3a3530" stroke-width="0.8"/>
+          <polygon points="28,6 48,28 8,28" fill="#fff7ee" stroke="#3a3530" stroke-width="0.8"/>
+          <line x1="28" y1="6" x2="28" y2="28" stroke="#c4561a" stroke-width="0.6" stroke-dasharray="2,2"/>
+          <line x1="18" y1="17" x2="18" y2="28" stroke="#8a7d62" stroke-width="0.5" stroke-dasharray="1.5,1.5"/>
+          <line x1="38" y1="17" x2="38" y2="28" stroke="#8a7d62" stroke-width="0.5" stroke-dasharray="1.5,1.5"/>
+          <circle cx="28" cy="28" r="1.5" fill="#c4561a"/>
+          <rect x="12" y="34" width="14" height="2" rx="0.5" fill="#c9bfae"/>
+          <rect x="30" y="38" width="16" height="2" rx="0.5" fill="#c9bfae"/>
+          <rect x="12" y="42" width="20" height="2" rx="0.5" fill="#c9bfae"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Pop-Up Page</span>
+          <span class="logo-sub">Dimensional Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/spreads/">Spreads</a>
+        <a href="{{ base_url }}/mechanics/">Mechanics</a>
+        <a href="{{ base_url }}/construction/">Construction</a>
+      </nav>
+    </header>
+  </div>

--- a/pop-up-page/templates/page.html
+++ b/pop-up-page/templates/page.html
@@ -1,0 +1,47 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread">
+      <div class="fold-gutter" aria-hidden="true">
+        <svg viewBox="0 0 40 800" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="20" y1="0" x2="20" y2="800" stroke="#c9bfae" stroke-width="1" stroke-dasharray="6,4"/>
+          <g fill="none" stroke="#c4561a" stroke-width="0.7">
+            <path d="M10,60 L20,40 L30,60"/>
+            <path d="M10,180 L20,160 L30,180"/>
+            <path d="M10,300 L20,280 L30,300"/>
+            <path d="M10,420 L20,400 L30,420"/>
+            <path d="M10,540 L20,520 L30,540"/>
+            <path d="M10,660 L20,640 L30,660"/>
+          </g>
+          <g fill="#c4561a">
+            <circle cx="20" cy="40" r="1.5"/>
+            <circle cx="20" cy="160" r="1.5"/>
+            <circle cx="20" cy="280" r="1.5"/>
+            <circle cx="20" cy="400" r="1.5"/>
+            <circle cx="20" cy="520" r="1.5"/>
+            <circle cx="20" cy="640" r="1.5"/>
+          </g>
+        </svg>
+      </div>
+      <div class="spread-surface" aria-hidden="true">
+        <svg viewBox="0 0 600 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <g stroke="#c9bfae" stroke-width="0.3" fill="none" opacity="0.3">
+            <line x1="0" y1="100" x2="600" y2="100"/>
+            <line x1="0" y1="200" x2="600" y2="200"/>
+            <line x1="0" y1="300" x2="600" y2="300"/>
+            <line x1="0" y1="400" x2="600" y2="400"/>
+            <line x1="0" y1="500" x2="600" y2="500"/>
+          </g>
+          <g fill="none" stroke="#d4c9b5" stroke-width="0.25" opacity="0.2">
+            <rect x="40" y="80" width="60" height="40" rx="2"/>
+            <rect x="480" y="260" width="80" height="50" rx="2"/>
+            <rect x="60" y="440" width="70" height="45" rx="2"/>
+            <rect x="440" y="480" width="60" height="35" rx="2"/>
+          </g>
+        </svg>
+      </div>
+      <div class="spread-body">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/pop-up-page/templates/section.html
+++ b/pop-up-page/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread">
+      <div class="fold-gutter" aria-hidden="true">
+        <svg viewBox="0 0 40 800" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="20" y1="0" x2="20" y2="800" stroke="#c9bfae" stroke-width="1" stroke-dasharray="6,4"/>
+          <g fill="none" stroke="#c4561a" stroke-width="0.7">
+            <path d="M10,60 L20,40 L30,60"/>
+            <path d="M10,180 L20,160 L30,180"/>
+            <path d="M10,300 L20,280 L30,300"/>
+            <path d="M10,420 L20,400 L30,420"/>
+          </g>
+          <g fill="#c4561a">
+            <circle cx="20" cy="40" r="1.5"/>
+            <circle cx="20" cy="160" r="1.5"/>
+            <circle cx="20" cy="280" r="1.5"/>
+            <circle cx="20" cy="400" r="1.5"/>
+          </g>
+        </svg>
+      </div>
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">Spread Index</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/pop-up-page/templates/shortcodes/alert.html
+++ b/pop-up-page/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #c4561a; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/pop-up-page/templates/taxonomy.html
+++ b/pop-up-page/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">Index</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All mechanisms catalogued in this volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/pop-up-page/templates/taxonomy_term.html
+++ b/pop-up-page/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">Mechanism</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Spreads using this mechanism:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2051,19 +2051,19 @@
     "psychedelic",
     "pattern"
   ],
-  "keynote-blast": [
-    "event",
-    "dark",
-    "conference",
-    "keynote",
-    "explosive"
-  ],
   "ketubah": [
     "book",
     "light",
     "ceremonial",
     "decorated",
     "formal"
+  ],
+  "keynote-blast": [
+    "event",
+    "dark",
+    "conference",
+    "keynote",
+    "explosive"
   ],
   "keystone": [
     "light",
@@ -3184,6 +3184,13 @@
     "elegant",
     "surreal",
     "trendy"
+  ],
+  "pop-up-page": [
+    "book",
+    "light",
+    "dimensional",
+    "paper-engineering",
+    "interactive"
   ],
   "portfolio-blog": [
     "dark",
@@ -4387,18 +4394,18 @@
     "warp",
     "gaming"
   ],
-  "wavelength": [
-    "audio",
-    "dark",
-    "landing",
-    "music"
-  ],
   "washi-bound": [
     "book",
     "light",
     "japanese",
     "stab-binding",
     "paper"
+  ],
+  "wavelength": [
+    "audio",
+    "dark",
+    "landing",
+    "music"
   ],
   "weathervane": [
     "light",


### PR DESCRIPTION
Closes #1559

## Summary
- Adds pop-up-page example site: a dimensional publication inspired by paper engineering and pop-up book mechanics
- SVG fold diagrams showing V-fold, box, tent fold, and pull-strip mechanisms; tab-and-slot connection patterns for dimensional elements
- Typography: Montserrat Bold / Outfit Bold for display type appearing to stand up from the page; Inter / Noto Sans for flat body text on the page surface
- Full content with 5 spread chapters covering V-fold, box, pull-tab, layer, and carousel mechanisms, plus mechanics reference and construction guide
- Tags: book, light, dimensional, paper-engineering, interactive

## Test plan
- [ ] Run `hwaro build` in `pop-up-page/` directory
- [ ] Run `hwaro serve` and verify all pages render correctly
- [ ] Verify no CSS gradients are used
- [ ] Verify all decorative visuals use inline SVG
- [ ] Verify no emojis in any files
- [ ] Verify tags.json is updated with the new entry