### PR TITLE
feat: add gilt-edge example site (closes #1554)

### DIFF
--- a/gilt-edge/AGENTS.md
+++ b/gilt-edge/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/gilt-edge/config.toml
+++ b/gilt-edge/config.toml
@@ -1,0 +1,85 @@
+# =============================================================================
+# Gilt-Edge - A Gold-Edged Publication
+# Issue #1554 | Tags: book, dark, luxury, gilded, opulent
+# =============================================================================
+
+title = "GILT-EDGE - A Study in Gold-Edged Binding"
+description = "A survey of the gilt-edged book - gold leaf applied to page edges, gold tooling upon covers and spines, and the opulent binding traditions of the eighteenth and nineteenth centuries. High-contrast Didone type in gold on deep navy."
+base_url = "http://localhost:3000"
+
+sections = ["plates"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "binding"
+paginate_by = 10
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "monthly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A study of gilt-edged binding traditions. Scholarly use; please cite if used."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["plates"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/gilt-edge/content/colophon.md
+++ b/gilt-edge/content/colophon.md
@@ -1,0 +1,24 @@
++++
+title = "Colophon"
+description = "Particulars of this edition: the types, the design, and the tools used in its production."
+template = "page"
+tags = ["colophon"]
++++
+
+## Particulars of This Edition
+
+This study of gilt-edged binding has been composed and typeset with the Hwaro static site generator. The design is original, conceived to evoke the dark luxury of a gold-tooled binding viewed by candlelight.
+
+### The Typography
+
+The display type is **Bodoni Moda**, a variable optical-size interpretation of the Didone faces cut by Giambattista Bodoni at his press in Parma in the late eighteenth century. The high contrast between thick and thin strokes, the flat unbracketed serifs, and the vertical axis of the round letters are characteristic of the Didone style and recall the age in which gilt-edge binding reached its greatest refinement.
+
+The body text is set in **Cormorant**, a digital type designed by Christian Thalmann after the tradition of Claude Garamond. The proportions are those of a Renaissance Garalde, lighter and more open than the Didone display, and the italic is a true chancery cursive. The secondary display and navigation text is set in **EB Garamond**, a digital cutting of the types of Claude Garamond by Georg Duffner.
+
+### The Colour
+
+The palette is drawn from the materials of the gilder's craft: the deep navy (#0B1126) of a morocco cover viewed in low light; the gold (#C9A84C) of the leaf itself; the dimmer gold (#8B7332) of a tooling impression seen at an angle; and the cream (#F2EACC) of the paper visible between the gilded edges.
+
+### The Ornament
+
+All decorative elements are rendered as inline SVG. The gilt border patterns along the page edges evoke the gold tooling on covers and spines. The plate illustrations are schematic representations of binding designs, not photographic reproductions, and are intended to convey the structural principles of each style.

--- a/gilt-edge/content/index.md
+++ b/gilt-edge/content/index.md
@@ -1,0 +1,171 @@
++++
+title = "Title Page"
+description = "A survey of the gilt-edged book - gold leaf applied to page edges, gold tooling upon covers and spines, and the opulent binding traditions of the eighteenth and nineteenth centuries."
+template = "page"
++++
+
+<div class="frontispiece">
+  <p class="kicker">A Study in Gold-Edged Binding</p>
+  <h1>Gilt-Edge</h1>
+  <p class="sub"><em>Gold leaf upon the edges of the book, tooled covers in the opulent tradition of the eighteenth and nineteenth centuries.</em></p>
+</div>
+
+<div class="front-plate">
+  <div class="front-plate-inner">
+    <svg viewBox="0 0 560 360" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="560" height="360" fill="#0B1126" stroke="#C9A84C" stroke-width="1.5"/>
+      <rect x="8" y="8" width="544" height="344" fill="none" stroke="#8B7332" stroke-width="0.6"/>
+      <!-- Book cover with gold tooling pattern -->
+      <g transform="translate(40,30)">
+        <!-- Cover rectangle -->
+        <rect x="0" y="0" width="220" height="300" fill="#1C2A50" stroke="#C9A84C" stroke-width="1"/>
+        <!-- Gold border frame on cover -->
+        <rect x="10" y="10" width="200" height="280" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+        <rect x="16" y="16" width="188" height="268" fill="none" stroke="#8B7332" stroke-width="0.4"/>
+        <!-- Central cartouche -->
+        <rect x="50" y="80" width="120" height="140" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+        <rect x="56" y="86" width="108" height="128" fill="none" stroke="#8B7332" stroke-width="0.4"/>
+        <!-- Corner ornaments -->
+        <g fill="#C9A84C">
+          <path d="M 22 22 L 32 22 L 22 32 Z"/>
+          <path d="M 198 22 L 188 22 L 198 32 Z"/>
+          <path d="M 22 278 L 32 278 L 22 268 Z"/>
+          <path d="M 198 278 L 188 278 L 198 268 Z"/>
+        </g>
+        <!-- Title text -->
+        <text x="110" y="130" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="16" font-weight="900" fill="#C9A84C">GILT</text>
+        <text x="110" y="155" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="16" font-weight="900" fill="#C9A84C">EDGE</text>
+        <line x1="70" y1="165" x2="150" y2="165" stroke="#C9A84C" stroke-width="0.6"/>
+        <text x="110" y="185" text-anchor="middle" font-family="EB Garamond, serif" font-size="10" fill="#8B7332">A STUDY</text>
+        <!-- Spine dots -->
+        <g fill="#C9A84C">
+          <circle cx="110" cy="40" r="2"/>
+          <circle cx="110" cy="260" r="2"/>
+        </g>
+      </g>
+      <!-- Gilt page edges (fore-edge) -->
+      <g transform="translate(280,30)">
+        <rect x="0" y="0" width="240" height="300" fill="#C9A84C"/>
+        <!-- Individual page lines -->
+        <g stroke="#8B7332" stroke-width="0.3">
+          <line x1="0" y1="3" x2="240" y2="3"/>
+          <line x1="0" y1="6" x2="240" y2="6"/>
+          <line x1="0" y1="9" x2="240" y2="9"/>
+          <line x1="0" y1="12" x2="240" y2="12"/>
+          <line x1="0" y1="15" x2="240" y2="15"/>
+          <line x1="0" y1="18" x2="240" y2="18"/>
+          <line x1="0" y1="21" x2="240" y2="21"/>
+          <line x1="0" y1="24" x2="240" y2="24"/>
+          <line x1="0" y1="27" x2="240" y2="27"/>
+          <line x1="0" y1="30" x2="240" y2="30"/>
+        </g>
+        <!-- Gilt edge shine highlights -->
+        <g fill="#E2CC7E" opacity="0.4">
+          <rect x="0" y="0" width="240" height="1.5"/>
+          <rect x="0" y="50" width="240" height="0.8"/>
+          <rect x="0" y="100" width="240" height="1"/>
+          <rect x="0" y="150" width="240" height="0.8"/>
+          <rect x="0" y="200" width="240" height="1"/>
+          <rect x="0" y="250" width="240" height="0.8"/>
+          <rect x="0" y="299" width="240" height="1"/>
+        </g>
+        <!-- "GILT EDGES" label -->
+        <text x="120" y="155" text-anchor="middle" font-family="EB Garamond, serif" font-size="14" fill="#0B1126" letter-spacing="6" opacity="0.4">GILT EDGES</text>
+      </g>
+    </svg>
+  </div>
+  <p class="front-cap"><em>Title plate.</em> A bound volume with gold-tooled cover (left) and gilt fore-edge (right) showing the characteristic gold-leaf finish on the page edges.</p>
+</div>
+
+<p class="front-lede">This study treats the art of gilt-edging and gold tooling upon books - the application of gold leaf to the three exposed edges of the text block, and the decoration of covers and spines with heated finishing tools impressed through gold foil. From the early Venetian bindings of the fifteenth century through the magnificent productions of the Georgian and Victorian bookbinders, the gilt-edged book represents the summit of the binder's art.</p>
+
+<div class="two-col-wrap">
+  <div class="divider" aria-hidden="true">
+    <svg viewBox="0 0 44 400" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+      <line x1="22" y1="10" x2="22" y2="390" stroke="#C9A84C" stroke-width="0.6"/>
+      <g transform="translate(22,60)">
+        <path d="M 0 -8 L 8 0 L 0 8 L -8 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.7"/>
+        <circle r="2" fill="#C9A84C"/>
+      </g>
+      <g transform="translate(22,200)">
+        <path d="M 0 -8 L 8 0 L 0 8 L -8 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.7"/>
+        <circle r="2" fill="#C9A84C"/>
+      </g>
+      <g transform="translate(22,340)">
+        <path d="M 0 -8 L 8 0 L 0 8 L -8 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.7"/>
+        <circle r="2" fill="#C9A84C"/>
+      </g>
+    </svg>
+  </div>
+
+<div class="two-col">
+
+<p class="illum-para">The practice of gilding the edges of a book has its origins in the manuscript era, when gold leaf or gold paint was applied to the fore-edge of a volume to protect the pages from dust and to signal the value of the contents within. With the advent of printing, the technique was refined and systematised: the text block was trimmed flush by the plough, the edges burnished smooth with a polishing tool, and thin leaves of beaten gold laid upon a bed of Armenian bole and adhesive, then burnished to a brilliant finish with an agate or bloodstone.</p>
+
+<p>The gold-tooled cover - that second great province of the gilder's art - arrived in Western Europe from the Islamic East in the late fifteenth century. The Venetian binders were the first to adopt the technique of impressing heated brass tools through gold foil onto leather, and by the middle of the sixteenth century the practice had spread to France, where it reached its first great flowering under the patronage of Jean Grolier and the French royal collectors.</p>
+
+<p>The plates that follow in this study survey the principal traditions of gilt-edge binding from the Venetian Renaissance through the English Regency. Each plate presents a representative example of the binding style, with notes upon the materials, the tooling patterns, the binder where known, and the provenance of the copy examined. The reader will find the plates arranged by period and school, with the earliest Venetian work first and the latest English commercial bindings last.</p>
+
+<p>The present edition is typeset in Bodoni Moda for the display headings - a high-contrast Didone face whose sharp serifs and dramatic thick-thin strokes recall the printer Giambattista Bodoni's own magnificent publications of the late eighteenth century - and in Cormorant for the body text, a refined serif whose proportions complement the Didone display without competing with it.</p>
+
+</div>
+</div>
+
+## The Plates in Brief
+
+<ul class="featured-plates">
+  <li class="featured-plate">
+    <a href="{{ base_url }}/plates/the-venetian-aldine/">
+      <div class="featured-init">
+        <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="72" height="72" fill="#1C2A50" stroke="#C9A84C" stroke-width="1"/>
+          <rect x="10" y="10" width="60" height="60" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+          <text x="40" y="52" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="36" font-weight="900" fill="#C9A84C">V</text>
+        </svg>
+      </div>
+      <span class="featured-plate-title">The Venetian Aldine</span>
+      <span class="featured-plate-dek">Venice, c. 1500</span>
+    </a>
+  </li>
+  <li class="featured-plate">
+    <a href="{{ base_url }}/plates/the-grolier-binding/">
+      <div class="featured-init">
+        <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="72" height="72" fill="#1C2A50" stroke="#C9A84C" stroke-width="1"/>
+          <rect x="10" y="10" width="60" height="60" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+          <text x="40" y="52" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="36" font-weight="900" fill="#C9A84C">G</text>
+        </svg>
+      </div>
+      <span class="featured-plate-title">The Grolier Binding</span>
+      <span class="featured-plate-dek">Paris, c. 1540</span>
+    </a>
+  </li>
+  <li class="featured-plate">
+    <a href="{{ base_url }}/plates/the-harleian-style/">
+      <div class="featured-init">
+        <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="72" height="72" fill="#1C2A50" stroke="#C9A84C" stroke-width="1"/>
+          <rect x="10" y="10" width="60" height="60" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+          <text x="40" y="52" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="36" font-weight="900" fill="#C9A84C">H</text>
+        </svg>
+      </div>
+      <span class="featured-plate-title">The Harleian Style</span>
+      <span class="featured-plate-dek">London, c. 1720</span>
+    </a>
+  </li>
+  <li class="featured-plate">
+    <a href="{{ base_url }}/plates/the-edwards-of-halifax/">
+      <div class="featured-init">
+        <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="72" height="72" fill="#1C2A50" stroke="#C9A84C" stroke-width="1"/>
+          <rect x="10" y="10" width="60" height="60" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+          <text x="40" y="52" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="36" font-weight="900" fill="#C9A84C">E</text>
+        </svg>
+      </div>
+      <span class="featured-plate-title">Edwards of Halifax</span>
+      <span class="featured-plate-dek">Halifax, c. 1790</span>
+    </a>
+  </li>
+</ul>
+
+Turn to [the full catalogue of plates](/plates/) for the complete programme, to [techniques](/techniques/) for a survey of gilding methods, or to [the colophon](/colophon/) for particulars of this edition.

--- a/gilt-edge/content/plates/_index.md
+++ b/gilt-edge/content/plates/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Plates"
+description = "A catalogue of ten plates surveying the principal traditions of gilt-edge binding from the Venetian Renaissance to the Victorian era."
+template = "section"
+sort_by = "weight"
+transparent = false
++++
+
+The plates are arranged chronologically by period and school, from the earliest Venetian arabesque bindings of the late fifteenth century through the commercial gilt-cloth bindings of the Victorian book trade. Each plate gives a description of the binding, the tooling patterns, the materials, and the provenance where known.

--- a/gilt-edge/content/plates/the-cathedral-binding.md
+++ b/gilt-edge/content/plates/the-cathedral-binding.md
@@ -1,0 +1,71 @@
++++
+title = "The Cathedral Binding"
+description = "The architectural gold-tooled bindings of the Romantic period with their Gothic window tracery designs."
+date = "2026-04-10"
+template = "plate"
+weight = 9
+tags = ["english", "romantic"]
+[taxonomies]
+binding = ["Cathedral"]
+[extra]
+plate_no = "IX"
+binding_style = "Cathedral Gothic"
+binder = "Joseph Thouvenin, Paris, and English followers"
+date_bound = "c. 1820-1840"
+materials = "Dark blue or green goatskin; gold-tooled Gothic tracery in the cathedral style"
+dimensions = "Octavo, 220 x 140 mm"
+provenance = "Bodleian Library, Oxford"
+gilding = "All edges gilt with bright finish"
+plate_caption = "Schematic of a cathedral binding with a pointed-arch tracery design on the front cover."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#0F1F3A" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="114" y="34" width="372" height="332" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Gothic pointed arch -->
+  <g stroke="#C9A84C" stroke-width="1" fill="none">
+    <path d="M 180 330 L 180 120 Q 180 50 300 40 Q 420 50 420 120 L 420 330"/>
+    <path d="M 195 325 L 195 125 Q 195 65 300 55 Q 405 65 405 125 L 405 325"/>
+  </g>
+  <!-- Tracery within the arch -->
+  <g stroke="#C9A84C" stroke-width="0.8" fill="none">
+    <!-- Central mullion -->
+    <line x1="300" y1="55" x2="300" y2="330"/>
+    <!-- Left sub-arch -->
+    <path d="M 200 200 Q 200 130 250 110 Q 295 100 295 130"/>
+    <!-- Right sub-arch -->
+    <path d="M 400 200 Q 400 130 350 110 Q 305 100 305 130"/>
+    <!-- Trefoil at top -->
+    <circle cx="300" cy="85" r="15" fill="none"/>
+    <circle cx="275" cy="105" r="10" fill="none"/>
+    <circle cx="325" cy="105" r="10" fill="none"/>
+  </g>
+  <!-- Rose window element -->
+  <g transform="translate(300,85)" stroke="#C9A84C" stroke-width="0.5" fill="none">
+    <circle r="8"/>
+    <line x1="-8" y1="0" x2="8" y2="0"/>
+    <line x1="0" y1="-8" x2="0" y2="8"/>
+    <line x1="-6" y1="-6" x2="6" y2="6"/>
+    <line x1="-6" y1="6" x2="6" y2="-6"/>
+  </g>
+  <!-- Pinnacle finials -->
+  <g fill="#C9A84C">
+    <path d="M 180 120 L 175 108 L 185 108 Z"/>
+    <path d="M 420 120 L 415 108 L 425 108 Z"/>
+    <path d="M 300 40 L 295 28 L 305 28 Z"/>
+  </g>
+</svg>
+'''
++++
+
+## The Style
+
+The cathedral binding emerged in the 1820s as an expression of the Gothic Revival which swept through European architecture and design in the early nineteenth century. The design imitates the tracery of a Gothic church window: pointed arches, trefoils, mullions, and rose windows, all rendered in gold tooling upon the cover of the book. The effect is architectural rather than purely decorative, and the best examples achieve a genuine sense of the soaring verticality of the Gothic style.
+
+## The Origins
+
+The style is generally attributed to the Parisian binder Joseph Thouvenin, who produced the first cathedral bindings in the early 1820s for books with Gothic or medieval subjects. The design was quickly taken up by English binders, who adapted it to their own taste, and cathedral bindings became a fashionable style for gift books, annuals, and religious works throughout the 1830s and 1840s.
+
+## The Technique
+
+The cathedral binding demands careful planning, as the architectural elements must be accurately proportioned to achieve the desired effect. The pointed arches are formed with curved gouges (arc-shaped tools) of various radii, the tracery with small straight fillets and circle tools, and the finials with pointed stamps. The entire design is impressed through gold foil in the usual manner, but the number of individual tool impressions required is very large - a single cathedral binding may require several hundred separate strikes of the finishing tool.

--- a/gilt-edge/content/plates/the-cosway-binding.md
+++ b/gilt-edge/content/plates/the-cosway-binding.md
@@ -1,0 +1,68 @@
++++
+title = "The Cosway Binding"
+description = "The jewelled bindings of Riviere and Son featuring miniature portrait paintings set into the covers."
+date = "2026-04-10"
+template = "plate"
+weight = 8
+tags = ["english", "edwardian"]
+[taxonomies]
+binding = ["Cosway"]
+[extra]
+plate_no = "VIII"
+binding_style = "Cosway Jewelled"
+binder = "Riviere and Son, London, for Henry Sotheran Ltd"
+date_bound = "c. 1905-1920"
+materials = "Full green goatskin; miniature portrait painting on ivory set under glass in a gold-tooled frame"
+dimensions = "Octavo, 220 x 140 mm"
+provenance = "Private collection"
+gilding = "All edges gilt; dentelles of gold tooling on the turn-ins; silk doublures"
+plate_caption = "Schematic of a Cosway binding with an oval miniature portrait set into the front cover."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#1C3A2A" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="114" y="34" width="372" height="332" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <rect x="122" y="42" width="356" height="316" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+  <!-- Central oval frame for miniature -->
+  <g transform="translate(300,190)">
+    <ellipse rx="55" ry="70" fill="#D4C9A0" stroke="#C9A84C" stroke-width="2"/>
+    <ellipse rx="48" ry="63" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+    <!-- Simplified portrait silhouette -->
+    <ellipse cx="0" cy="-15" rx="18" ry="22" fill="#8B7332" opacity="0.4"/>
+    <ellipse cx="0" cy="20" rx="28" ry="22" fill="#8B7332" opacity="0.3"/>
+  </g>
+  <!-- Gold tooled border decorations -->
+  <g fill="#C9A84C">
+    <circle cx="140" cy="60" r="3"/>
+    <circle cx="460" cy="60" r="3"/>
+    <circle cx="140" cy="340" r="3"/>
+    <circle cx="460" cy="340" r="3"/>
+    <circle cx="300" cy="50" r="3"/>
+    <circle cx="300" cy="345" r="3"/>
+  </g>
+  <!-- Decorative scroll tools -->
+  <g stroke="#C9A84C" stroke-width="0.6" fill="none">
+    <path d="M 160 60 Q 220 50 280 55"/>
+    <path d="M 320 55 Q 380 50 440 60"/>
+    <path d="M 160 340 Q 220 350 280 345"/>
+    <path d="M 320 345 Q 380 350 440 340"/>
+  </g>
+  <!-- Title below miniature -->
+  <text x="300" y="310" text-anchor="middle" font-family="Bodoni Moda, serif" font-size="12" font-weight="700" fill="#C9A84C" letter-spacing="3">COSWAY</text>
+</svg>
+'''
++++
+
+## The Invention
+
+The Cosway binding was invented as a commercial venture by the London bookseller Henry Sotheran Ltd around 1905. The idea was simple but striking: a fine binding in full morocco by Riviere and Son, one of London's best trade binderies, with a miniature portrait painting on ivory set into an oval recess in the front cover, protected by a thin sheet of glass and framed by gold tooling. The bindings were named after Richard Cosway (1742-1821), the celebrated miniature painter of the Georgian era, though Cosway himself had nothing to do with them.
+
+## The Execution
+
+The miniature portraits were painted by Miss C. B. Currie, an accomplished miniaturist who worked exclusively for Sotheran's for some twenty years. The subjects were typically the author of the book, or a figure related to its contents: Shakespeare for a Shakespeare, Dr. Johnson for a Boswell, and so on. The portraits were painted on thin slices of ivory in the traditional manner of the English miniature school, and the detail achieved in a space no larger than a few centimetres is remarkable.
+
+The bindings themselves were of the highest quality. Riviere and Son used full goatskin in green, red, blue, or brown, tooled with borders and corner ornaments in gold. The turn-ins were decorated with elaborate dentelles (tooled inner borders), and the endpapers were of watered silk. The entire production was lavish and expensive, intended for the wealthy collectors of the Edwardian era.
+
+## The Gilt Edges
+
+The Cosway bindings were invariably gilt on all three edges, the gilding done to the highest standard with a mirror-bright burnished finish. The fore-edge was sometimes gauffered with a repeating pattern of small tools, and in a few cases a concealed fore-edge painting was added in the manner of Edwards of Halifax - a book within a book, as it were, with the painting revealed only when the pages were fanned.

--- a/gilt-edge/content/plates/the-cottage-roof.md
+++ b/gilt-edge/content/plates/the-cottage-roof.md
@@ -1,0 +1,67 @@
++++
+title = "The Cottage-Roof Binding"
+description = "The English cottage-roof design with its peaked centre panel, a distinctive seventeenth-century development."
+date = "2026-04-10"
+template = "plate"
+weight = 6
+tags = ["english", "stuart"]
+[taxonomies]
+binding = ["Cottage"]
+[extra]
+plate_no = "VI"
+binding_style = "English Cottage-Roof"
+binder = "Samuel Mearne and workshop, London"
+date_bound = "c. 1665-1680"
+materials = "Red goatskin over pasteboards; gold-tooled cottage-roof panel with drawer-handle corner tools"
+dimensions = "Octavo, 200 x 120 mm"
+provenance = "Royal Library of Charles II; British Library"
+gilding = "All edges gilt; gauffered with small tulip and leaf tools"
+plate_caption = "Schematic of a cottage-roof binding showing the peaked centre panel and corner ornaments."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#3A0A0A" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="114" y="34" width="372" height="332" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Cottage-roof centre panel -->
+  <g stroke="#C9A84C" stroke-width="1" fill="none">
+    <path d="M 180 100 L 300 50 L 420 100 L 420 300 L 300 350 L 180 300 Z"/>
+    <path d="M 192 108 L 300 64 L 408 108 L 408 292 L 300 338 L 192 292 Z"/>
+  </g>
+  <!-- Inner decorative fillets -->
+  <g stroke="#8B7332" stroke-width="0.5" fill="none">
+    <path d="M 204 116 L 300 78 L 396 116 L 396 284 L 300 326 L 204 284 Z"/>
+  </g>
+  <!-- Small floral tools along the peaked lines -->
+  <g fill="#C9A84C">
+    <circle cx="220" cy="95" r="2.5"/>
+    <circle cx="260" cy="75" r="2.5"/>
+    <circle cx="340" cy="75" r="2.5"/>
+    <circle cx="380" cy="95" r="2.5"/>
+    <circle cx="220" cy="305" r="2.5"/>
+    <circle cx="260" cy="325" r="2.5"/>
+    <circle cx="340" cy="325" r="2.5"/>
+    <circle cx="380" cy="305" r="2.5"/>
+    <circle cx="300" cy="200" r="4"/>
+  </g>
+  <!-- Drawer-handle corner tools -->
+  <g stroke="#C9A84C" stroke-width="0.8" fill="none">
+    <path d="M 130 50 Q 145 55 155 70"/>
+    <path d="M 470 50 Q 455 55 445 70"/>
+    <path d="M 130 350 Q 145 345 155 330"/>
+    <path d="M 470 350 Q 455 345 445 330"/>
+  </g>
+</svg>
+'''
++++
+
+## The Design
+
+The cottage-roof binding takes its name from the distinctive peaked shape of the central panel on each board: the top and bottom edges of the panel are not straight but angled upward (or downward) to a point at the centre, like the gable end of a cottage. The design is unique to English binding and appears to have originated in the workshop of Samuel Mearne, binder to Charles II, in the 1660s.
+
+The peaked panel is outlined by two or three gold fillets, with small floral or leaf tools struck at intervals along the lines. The corners outside the panel are filled with "drawer-handle" tools - small curved stamps so called because of their resemblance to the handles on furniture drawers. The spine is gilt in compartments with the usual small tools.
+
+## Samuel Mearne
+
+Samuel Mearne (c. 1624-1683) served as Royal Bookbinder to Charles II from the Restoration of 1660 until his death. His workshop in Little Britain, near St. Paul's, produced bindings of exceptional quality and originality, and the cottage-roof design is his most famous contribution to the history of the craft. Mearne's bindings are found in red, blue, and olive goatskin, always of the finest quality, and the gold tooling is notable for its precision and restraint.
+
+The cottage-roof design persisted in English binding well into the eighteenth century, and was revived by the Victorian bookbinders of the Arts and Crafts movement. T. J. Cobden-Sanderson, the founder of the Doves Bindery, admired Mearne's work and produced several bindings in the cottage-roof manner.

--- a/gilt-edge/content/plates/the-edwards-of-halifax.md
+++ b/gilt-edge/content/plates/the-edwards-of-halifax.md
@@ -1,0 +1,76 @@
++++
+title = "Edwards of Halifax"
+description = "The celebrated fore-edge painters and transparent-vellum binders of Halifax, pioneers of the painted gilt edge."
+date = "2026-04-10"
+template = "plate"
+weight = 4
+tags = ["english", "fore-edge"]
+[taxonomies]
+binding = ["Edwards"]
+[extra]
+plate_no = "IV"
+binding_style = "Edwards Fore-Edge"
+binder = "Edwards of Halifax (James Edwards and workshop)"
+date_bound = "c. 1785-1800"
+materials = "Transparent vellum over painted paper boards; gilt edges with concealed fore-edge painting"
+dimensions = "Octavo, 210 x 130 mm"
+provenance = "Private collection; exhibited at the Grolier Club, 1990"
+gilding = "All edges gilt; fore-edge concealing a watercolour landscape visible when pages are fanned"
+plate_caption = "Schematic of an Edwards of Halifax binding showing gilt fore-edge with concealed painting revealed by fanning."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <!-- Closed book with gilt edge -->
+  <g transform="translate(50,40)">
+    <rect x="0" y="0" width="220" height="320" fill="#D4C9A0" stroke="#C9A84C" stroke-width="1"/>
+    <rect x="8" y="8" width="204" height="304" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+    <text x="110" y="150" text-anchor="middle" font-family="Bodoni Moda, serif" font-size="14" font-weight="700" fill="#0B1126">EDWARDS</text>
+    <text x="110" y="170" text-anchor="middle" font-family="EB Garamond, serif" font-size="10" fill="#8B7332">of Halifax</text>
+    <!-- Gilt edge (closed) -->
+    <rect x="220" y="0" width="16" height="320" fill="#C9A84C"/>
+    <g stroke="#8B7332" stroke-width="0.2">
+      <line x1="220" y1="4" x2="236" y2="4"/>
+      <line x1="220" y1="8" x2="236" y2="8"/>
+      <line x1="220" y1="12" x2="236" y2="12"/>
+    </g>
+    <text x="228" y="165" text-anchor="middle" font-family="EB Garamond, serif" font-size="7" fill="#0B1126" transform="rotate(-90 228 165)" letter-spacing="3">GILT</text>
+  </g>
+  <!-- Fanned book revealing painting -->
+  <g transform="translate(320,40)">
+    <text x="110" y="-10" text-anchor="middle" font-family="EB Garamond, serif" font-size="10" fill="#8B7332" letter-spacing="2">FANNED TO REVEAL</text>
+    <!-- Fanned pages showing painting -->
+    <g transform="skewX(-15)">
+      <rect x="0" y="0" width="220" height="320" fill="#C9A84C" stroke="#8B7332" stroke-width="0.5"/>
+      <!-- Watercolour landscape (simplified) -->
+      <rect x="10" y="100" width="200" height="140" fill="#1C2A50" opacity="0.6"/>
+      <!-- Sky -->
+      <rect x="10" y="100" width="200" height="60" fill="#2E4A6E" opacity="0.5"/>
+      <!-- Hills -->
+      <path d="M 10 160 Q 60 130 110 155 Q 160 130 210 160 L 210 200 L 10 200 Z" fill="#2E4A2E" opacity="0.4"/>
+      <!-- Water reflection -->
+      <rect x="10" y="200" width="200" height="40" fill="#1C2A50" opacity="0.3"/>
+      <!-- Trees -->
+      <g fill="#1A3A1A" opacity="0.5">
+        <ellipse cx="50" cy="148" rx="12" ry="18"/>
+        <ellipse cx="160" cy="142" rx="10" ry="15"/>
+      </g>
+      <text x="110" y="270" text-anchor="middle" font-family="EB Garamond, serif" font-size="9" fill="#0B1126" letter-spacing="2">CONCEALED PAINTING</text>
+    </g>
+  </g>
+</svg>
+'''
++++
+
+## The Firm
+
+Edwards of Halifax was a firm of booksellers and binders founded by William Edwards in Halifax, Yorkshire, in the mid-eighteenth century and continued by his sons, of whom James Edwards (1757-1816) was the most celebrated. The firm is best known for two innovations in the binder's art: the transparent vellum binding and the concealed fore-edge painting.
+
+## The Fore-Edge Painting
+
+The concealed fore-edge painting is the most famous production of the Edwards workshop. The technique is deceptively simple in description: the pages of the book are fanned open and clamped, a watercolour scene is painted upon the angled surface of the page edges, the pages are released and the edges gilded in the usual manner. When the book is closed, the painting is entirely concealed beneath the gold; when the pages are fanned open again, the painting reappears.
+
+The subjects of Edwards fore-edge paintings are typically English landscapes, country houses, or scenes from the text of the book itself. The painting is executed in transparent watercolour washes which allow the gold beneath to shimmer through, giving the image a luminous quality quite unlike any other form of painting.
+
+## The Transparent Vellum Binding
+
+The second innovation of the Edwards workshop was the binding in transparent vellum over painted paper boards. The vellum was prepared to an exceptional thinness, almost translucent, and laid over boards which had been decorated with painted or printed designs. The design showed through the vellum as if behind a veil, and was protected from wear by the tough outer skin. The effect was unlike anything produced by other binders, and Edwards vellum bindings remain among the most distinctive and recognisable of all English binding styles.

--- a/gilt-edge/content/plates/the-fanfare-style.md
+++ b/gilt-edge/content/plates/the-fanfare-style.md
@@ -1,0 +1,63 @@
++++
+title = "The Fanfare Style"
+description = "The French fanfare bindings of the late sixteenth century with their spiralling branches and laurel compartments."
+date = "2026-04-10"
+template = "plate"
+weight = 7
+tags = ["french", "renaissance"]
+[taxonomies]
+binding = ["Fanfare"]
+[extra]
+plate_no = "VII"
+binding_style = "French Fanfare"
+binder = "Attributed to the atelier of Nicolas Eve, Paris"
+date_bound = "c. 1580-1600"
+materials = "Olive calf over pasteboards; gold-tooled spiralling branches with laurel-leaf compartments"
+dimensions = "Quarto, 260 x 180 mm"
+provenance = "Bibliotheque Nationale de France"
+gilding = "All edges gilt and gauffered with a repeating palmette"
+plate_caption = "Schematic of a fanfare binding with spiralling tendrils and interlocking compartments."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#1C2A50" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="114" y="34" width="372" height="332" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Spiralling branches -->
+  <g stroke="#C9A84C" stroke-width="0.8" fill="none">
+    <path d="M 140 60 Q 200 100 240 80 Q 280 60 300 100 Q 320 140 280 160 Q 240 180 260 220 Q 280 260 240 280 Q 200 300 220 340"/>
+    <path d="M 460 60 Q 400 100 360 80 Q 320 60 300 100 Q 280 140 320 160 Q 360 180 340 220 Q 320 260 360 280 Q 400 300 380 340"/>
+    <path d="M 160 200 Q 200 180 240 200 Q 280 220 300 200 Q 320 180 360 200 Q 400 220 440 200"/>
+  </g>
+  <!-- Laurel-leaf tools at intersections -->
+  <g fill="#C9A84C">
+    <ellipse cx="300" cy="100" rx="6" ry="3"/>
+    <ellipse cx="280" cy="160" rx="6" ry="3"/>
+    <ellipse cx="320" cy="160" rx="6" ry="3"/>
+    <ellipse cx="260" cy="220" rx="6" ry="3"/>
+    <ellipse cx="340" cy="220" rx="6" ry="3"/>
+    <ellipse cx="300" cy="200" rx="8" ry="4"/>
+  </g>
+  <!-- Small dot tools filling spaces -->
+  <g fill="#8B7332">
+    <circle cx="200" cy="140" r="1.5"/>
+    <circle cx="400" cy="140" r="1.5"/>
+    <circle cx="200" cy="260" r="1.5"/>
+    <circle cx="400" cy="260" r="1.5"/>
+    <circle cx="300" cy="60" r="1.5"/>
+    <circle cx="300" cy="340" r="1.5"/>
+  </g>
+</svg>
+'''
++++
+
+## The Style
+
+The fanfare style is the name given to a group of French bindings from the late sixteenth century characterised by an all-over design of spiralling branches which divide the cover into interlocking compartments. The branches are formed of gold fillets, often dotted, and the compartments are filled with small tools: laurel leaves, sprigs, and tiny circles. The effect is one of extraordinary density and movement, the eye following the spiral branches as they wind across the cover.
+
+The name "fanfare" is something of a misnomer: it was applied retrospectively by the nineteenth-century bibliographer Charles Nodier, who gave the style its name after the title of the first book he found in such a binding. The original binders would not have recognised the term.
+
+## The Technique
+
+The fanfare binding represents the most technically demanding form of gold tooling. The interlocking spirals must be planned with great care to ensure that the branches meet correctly at each intersection, and the small filling tools must be struck with uniform pressure and spacing across the entire cover. The gold leaf must be applied in multiple stages, as the heated tools cannot reach all areas of the cover in a single pass.
+
+The best fanfare bindings exhibit a quality of workmanship that is almost impossible to reproduce today. The fillets are struck with absolute uniformity, the intersections are clean, and the small tools are spaced with mathematical regularity. The work is attributed to the atelier of Nicolas Eve, binder to Henri III, though the evidence for this attribution is largely circumstantial.

--- a/gilt-edge/content/plates/the-french-royal.md
+++ b/gilt-edge/content/plates/the-french-royal.md
@@ -1,0 +1,71 @@
++++
+title = "The French Royal Binding"
+description = "The armorial bindings of the French kings from Francis I to Louis XVI, the summit of European gold tooling."
+date = "2026-04-10"
+template = "plate"
+weight = 5
+tags = ["french", "royal"]
+[taxonomies]
+binding = ["Royal"]
+[extra]
+plate_no = "V"
+binding_style = "French Royal"
+binder = "Royal Binders to the Crown of France"
+date_bound = "c. 1550-1780"
+materials = "Red or blue goatskin over pasteboards; arms of France gilt on both covers; fleur-de-lis corner tools"
+dimensions = "Various formats"
+provenance = "Bibliotheque Nationale de France"
+gilding = "All edges gilt; gauffered with the royal cipher and fleur-de-lis"
+plate_caption = "Schematic of a French royal binding with armorial centre and semis of fleur-de-lis."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#1C2A50" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="114" y="34" width="372" height="332" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Semis of fleur-de-lis -->
+  <g fill="#C9A84C" opacity="0.5">
+    <g transform="translate(160,80)"><path d="M 0 -8 C 4 -4 4 0 0 4 C -4 0 -4 -4 0 -8 M -4 0 C -6 4 -2 6 0 4 C 2 6 6 4 4 0" stroke="#C9A84C" stroke-width="0.5" fill="none"/></g>
+    <g transform="translate(240,80)"><circle r="2"/></g>
+    <g transform="translate(360,80)"><circle r="2"/></g>
+    <g transform="translate(440,80)"><circle r="2"/></g>
+    <g transform="translate(160,140)"><circle r="2"/></g>
+    <g transform="translate(440,140)"><circle r="2"/></g>
+    <g transform="translate(160,260)"><circle r="2"/></g>
+    <g transform="translate(440,260)"><circle r="2"/></g>
+    <g transform="translate(160,320)"><circle r="2"/></g>
+    <g transform="translate(240,320)"><circle r="2"/></g>
+    <g transform="translate(360,320)"><circle r="2"/></g>
+    <g transform="translate(440,320)"><circle r="2"/></g>
+  </g>
+  <!-- Royal arms centre -->
+  <g transform="translate(300,200)">
+    <ellipse rx="70" ry="85" fill="none" stroke="#C9A84C" stroke-width="1.5"/>
+    <ellipse rx="55" ry="70" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+    <!-- Shield shape -->
+    <path d="M -30 -40 L 30 -40 L 30 10 Q 30 40 0 50 Q -30 40 -30 10 Z" fill="none" stroke="#C9A84C" stroke-width="1"/>
+    <!-- Three fleur-de-lis in shield -->
+    <g fill="#C9A84C">
+      <circle cx="-10" cy="-20" r="4"/>
+      <circle cx="10" cy="-20" r="4"/>
+      <circle cx="0" cy="10" r="4"/>
+    </g>
+    <!-- Crown above -->
+    <path d="M -20 -50 L -15 -60 L -5 -52 L 0 -65 L 5 -52 L 15 -60 L 20 -50 Z" fill="#C9A84C"/>
+  </g>
+</svg>
+'''
++++
+
+## The Tradition
+
+The French royal library was the greatest repository of fine bindings in Europe, and the kings of France maintained a succession of official binders whose work set the standard for the entire continent. From the reign of Francis I (1515-1547), who established the practice of binding his books in goatskin tooled with the royal arms, through the elaborate productions of the seventeenth and eighteenth centuries, the French royal binding represents the continuous refinement of gold tooling over three centuries.
+
+## The Design
+
+The typical French royal binding bears the royal arms of France - three fleur-de-lis upon a shield beneath a crown - at the centre of each cover, surrounded by an oval frame of laurel or palm branches. The corners bear either the royal cipher (two interlaced letters, such as the double L of Louis XIV) or sprays of fleur-de-lis tools. The border is formed of one or more gilt fillets, sometimes enriched with a roll of small ornamental tools.
+
+In the grander productions, particularly those of the reign of Louis XIV, the entire field of the cover is strewn with a semis (scattered pattern) of small fleur-de-lis tools, each individually impressed in gold. The effect is one of extraordinary richness, the gold catching the light from every angle as the book is handled.
+
+## The Binders
+
+Among the most celebrated of the French royal binders were the Eves (Clovis and Nicolas), who worked for Henri III and Henri IV in the late sixteenth century; Le Gascon, the anonymous master of the mid-seventeenth century whose work for Richelieu and Mazarin represents perhaps the finest gold tooling ever executed; and the Deromes (Nicolas-Denis and his son), who served Louis XV and Louis XVI in the eighteenth century.

--- a/gilt-edge/content/plates/the-grolier-binding.md
+++ b/gilt-edge/content/plates/the-grolier-binding.md
@@ -1,0 +1,71 @@
++++
+title = "The Grolier Binding"
+description = "The painted and gold-tooled bindings of Jean Grolier de Servier, the greatest French bibliophile of the sixteenth century."
+date = "2026-04-10"
+template = "plate"
+weight = 2
+tags = ["french", "renaissance"]
+[taxonomies]
+binding = ["Grolier"]
+[extra]
+plate_no = "II"
+binding_style = "French Grolier"
+binder = "Atelier of Jean Picard, Paris, for Jean Grolier"
+date_bound = "c. 1535-1545"
+materials = "Olive-brown calf over pasteboards; gilt interlace with painted compartments in black, red, and green"
+dimensions = "Folio, 340 x 220 mm"
+provenance = "Jean Grolier; thence to the Bibliotheque Nationale de France"
+gilding = "All edges gilt and gauffered with a running vine-leaf pattern"
+plate_caption = "Schematic of a Grolier binding with interlaced ribbons and painted compartments."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <!-- Book cover -->
+  <rect x="80" y="20" width="440" height="360" fill="#1C2A50" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="92" y="32" width="416" height="336" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Grolier interlacing ribbons -->
+  <g stroke="#C9A84C" stroke-width="1.2" fill="none">
+    <path d="M 120 60 C 200 60 200 140 300 140 C 400 140 400 60 480 60"/>
+    <path d="M 120 340 C 200 340 200 260 300 260 C 400 260 400 340 480 340"/>
+    <path d="M 120 60 C 120 160 180 200 120 340"/>
+    <path d="M 480 60 C 480 160 420 200 480 340"/>
+  </g>
+  <!-- Central title cartouche -->
+  <rect x="220" y="170" width="160" height="60" fill="none" stroke="#C9A84C" stroke-width="1"/>
+  <text x="300" y="195" text-anchor="middle" font-family="EB Garamond, serif" font-size="10" fill="#C9A84C" letter-spacing="2">IO. GROLIERII</text>
+  <text x="300" y="215" text-anchor="middle" font-family="EB Garamond, serif" font-size="9" fill="#8B7332" letter-spacing="2">ET AMICORVM</text>
+  <!-- Painted compartments (as colored fills) -->
+  <g opacity="0.3">
+    <circle cx="180" cy="100" r="20" fill="#8B0000"/>
+    <circle cx="420" cy="100" r="20" fill="#2E4A2E"/>
+    <circle cx="180" cy="300" r="20" fill="#2E4A2E"/>
+    <circle cx="420" cy="300" r="20" fill="#8B0000"/>
+  </g>
+  <!-- Corner tools -->
+  <g fill="#C9A84C">
+    <path d="M 110 52 L 120 42 L 130 52 L 120 62 Z"/>
+    <path d="M 470 52 L 480 42 L 490 52 L 480 62 Z"/>
+    <path d="M 110 348 L 120 338 L 130 348 L 120 358 Z"/>
+    <path d="M 470 348 L 480 338 L 490 348 L 480 358 Z"/>
+  </g>
+</svg>
+'''
++++
+
+## The Collector
+
+Jean Grolier de Servier (1489-1565) was Treasurer-General of France and the most celebrated bibliophile of the sixteenth century. His library of some three thousand volumes was bound to his order in a distinctive style which has been the admiration and the model of collectors ever since. The bindings were executed by several workshops in Paris and Lyon over a period of some forty years, and they exhibit a progression from the early arabesque patterns derived from the Venetian models to the fully developed French style of interlaced ribbons and painted compartments.
+
+## The Style
+
+The characteristic Grolier binding is covered in smooth calf - olive, brown, or citron - tooled in gold with interlacing ribbon patterns that divide the cover into compartments. The compartments are painted in solid colours: black, dark green, red, or occasionally blue. The central feature is a cartouche bearing the inscription "IO. GROLIERII ET AMICORVM" (belonging to Jean Grolier and his friends), a motto which reflects the collector's generous habit of lending his books freely.
+
+The gold tooling is of the highest quality. The fillets which form the ribbon interlace are impressed with great precision, the intersections clearly defined, and the small tools which fill the spaces between the ribbons - acorns, leaves, and tiny flowers - are struck with uniform depth and clarity.
+
+## The Edge Gilding
+
+Grolier's binders gilded the edges of his books with particular care, and many of them exhibit gauffered edges - that is, edges which have been decorated by impressing heated tools into the gold surface to create a repeating pattern. The gauffering on Grolier bindings typically consists of a running vine-leaf or arabesque pattern, and the effect when the book is closed is of a shimmering band of ornament framing the text block.
+
+## The Legacy
+
+Approximately six hundred Grolier bindings survive, distributed among the major libraries and private collections of Europe and North America. The Bibliotheque Nationale holds the largest single group, followed by the British Library and the Morgan Library in New York. The Grolier Club of New York, founded in 1884 and named in his honour, continues to promote the art of the book and the tradition of fine binding.

--- a/gilt-edge/content/plates/the-harleian-style.md
+++ b/gilt-edge/content/plates/the-harleian-style.md
@@ -1,0 +1,71 @@
++++
+title = "The Harleian Style"
+description = "The distinctive diamond-centre gold-tooled bindings produced for the library of Robert Harley, Earl of Oxford."
+date = "2026-04-10"
+template = "plate"
+weight = 3
+tags = ["english", "georgian"]
+[taxonomies]
+binding = ["Harleian"]
+[extra]
+plate_no = "III"
+binding_style = "English Harleian"
+binder = "Thomas Elliott and John Chapman, London, for Robert Harley"
+date_bound = "c. 1715-1730"
+materials = "Red goatskin over pasteboards; gold-tooled centre-and-corner design with Harleian diamond lozenge"
+dimensions = "Quarto, 280 x 200 mm"
+provenance = "Robert Harley, 1st Earl of Oxford; Harleian Collection; British Museum (1753)"
+gilding = "All edges gilt with bright finish; spine gilt in six compartments with floral tools"
+plate_caption = "Schematic of a Harleian binding with the characteristic diamond centre lozenge and corner fan tools."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#3A0A0A" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="112" y="32" width="376" height="336" fill="none" stroke="#C9A84C" stroke-width="1"/>
+  <rect x="120" y="40" width="360" height="320" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+  <!-- Harleian diamond centre -->
+  <g transform="translate(300,200)">
+    <path d="M 0 -80 L 80 0 L 0 80 L -80 0 Z" fill="none" stroke="#C9A84C" stroke-width="1.2"/>
+    <path d="M 0 -60 L 60 0 L 0 60 L -60 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+    <path d="M 0 -40 L 40 0 L 0 40 L -40 0 Z" fill="none" stroke="#8B7332" stroke-width="0.6"/>
+    <circle r="8" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+    <circle r="3" fill="#C9A84C"/>
+  </g>
+  <!-- Corner fan tools -->
+  <g stroke="#C9A84C" stroke-width="0.6" fill="none">
+    <path d="M 130 50 Q 160 50 170 70"/>
+    <path d="M 130 50 Q 150 60 155 80"/>
+    <path d="M 130 50 Q 140 70 140 90"/>
+    <path d="M 470 50 Q 440 50 430 70"/>
+    <path d="M 470 50 Q 450 60 445 80"/>
+    <path d="M 470 50 Q 460 70 460 90"/>
+    <path d="M 130 350 Q 160 350 170 330"/>
+    <path d="M 130 350 Q 150 340 155 320"/>
+    <path d="M 130 350 Q 140 330 140 310"/>
+    <path d="M 470 350 Q 440 350 430 330"/>
+    <path d="M 470 350 Q 450 340 445 320"/>
+    <path d="M 470 350 Q 460 330 460 310"/>
+  </g>
+  <g fill="#C9A84C">
+    <circle cx="130" cy="50" r="3"/>
+    <circle cx="470" cy="50" r="3"/>
+    <circle cx="130" cy="350" r="3"/>
+    <circle cx="470" cy="350" r="3"/>
+  </g>
+</svg>
+'''
++++
+
+## The Collection
+
+Robert Harley, first Earl of Oxford (1661-1724), and his son Edward, second Earl (1689-1741), assembled one of the greatest libraries in English history. The collection encompassed some fifty thousand printed books and seven thousand manuscripts, and the bindings executed for the Harleys by their binders Thomas Elliott and John Chapman established a distinctive English style which has been admired and imitated ever since.
+
+## The Design
+
+The Harleian binding is characterised by its centre-and-corner design. The centre of each board bears a large diamond-shaped lozenge formed of concentric frames of gold fillets and rolls, with a small central ornament. The corners are filled with fan-shaped sprays of curving lines and small tools. The overall effect is one of restrained opulence: the gold tooling is rich but orderly, the symmetry exact, the workmanship impeccable.
+
+The spine is divided into six compartments by raised bands, each compartment filled with a small symmetrical arrangement of floral and leaf tools. The title is lettered in gold on a dark label in the second compartment, and the Harley coat of arms is sometimes tooled in the lowest compartment.
+
+## The Materials
+
+The Harleian binders worked almost exclusively in red goatskin - the material known in the trade as Turkey morocco, imported from the Levant and finished in England. The skins were of the highest quality, close-grained and supple, and they took the gold tooling with great clarity. The gold leaf was of standard thickness, applied through a thin film of egg-white adhesive (glaire) and impressed with brass tools heated to the correct temperature.

--- a/gilt-edge/content/plates/the-venetian-aldine.md
+++ b/gilt-edge/content/plates/the-venetian-aldine.md
@@ -1,0 +1,76 @@
++++
+title = "The Venetian Aldine"
+description = "The arabesque gold-tooled bindings produced for Aldus Manutius and the Venetian collectors, c. 1490-1520."
+date = "2026-04-10"
+template = "plate"
+weight = 1
+tags = ["venetian", "renaissance"]
+[taxonomies]
+binding = ["Arabesque"]
+[extra]
+plate_no = "I"
+binding_style = "Venetian Arabesque"
+binder = "Workshop of Aldus Manutius, Venice"
+date_bound = "c. 1495-1510"
+materials = "Brown goatskin over pasteboards; gold-tooled arabesque interlace on both covers"
+dimensions = "Octavo, 160 x 100 mm"
+provenance = "Biblioteca Marciana, Venice; acquired from the Contarini collection"
+gilding = "All edges gilt; fore-edge lightly gauffered with small floral tools"
+plate_caption = "Schematic of a Venetian arabesque binding with interlaced strap-work and central medallion."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <!-- Book cover outline -->
+  <rect x="100" y="20" width="400" height="360" fill="#1C2A50" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="112" y="32" width="376" height="336" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <rect x="120" y="40" width="360" height="320" fill="none" stroke="#8B7332" stroke-width="0.5"/>
+  <!-- Central medallion -->
+  <ellipse cx="300" cy="200" rx="60" ry="80" fill="none" stroke="#C9A84C" stroke-width="1.2"/>
+  <ellipse cx="300" cy="200" rx="45" ry="65" fill="none" stroke="#8B7332" stroke-width="0.6"/>
+  <!-- Arabesque interlace straps -->
+  <g stroke="#C9A84C" stroke-width="0.8" fill="none">
+    <path d="M 140 60 Q 200 100 200 200 Q 200 300 140 340"/>
+    <path d="M 460 60 Q 400 100 400 200 Q 400 300 460 340"/>
+    <path d="M 160 50 Q 300 80 440 50"/>
+    <path d="M 160 350 Q 300 320 440 350"/>
+  </g>
+  <!-- Corner fleurons -->
+  <g fill="#C9A84C">
+    <circle cx="140" cy="60" r="4"/>
+    <circle cx="460" cy="60" r="4"/>
+    <circle cx="140" cy="340" r="4"/>
+    <circle cx="460" cy="340" r="4"/>
+    <circle cx="300" cy="200" r="5"/>
+  </g>
+  <!-- Gold leaf edge indicator -->
+  <rect x="502" y="20" width="20" height="360" fill="#C9A84C" opacity="0.8"/>
+  <g stroke="#8B7332" stroke-width="0.3">
+    <line x1="502" y1="24" x2="522" y2="24"/>
+    <line x1="502" y1="28" x2="522" y2="28"/>
+    <line x1="502" y1="32" x2="522" y2="32"/>
+    <line x1="502" y1="36" x2="522" y2="36"/>
+  </g>
+  <text x="512" y="210" text-anchor="middle" font-family="EB Garamond, serif" font-size="9" fill="#0B1126" transform="rotate(-90 512 210)" letter-spacing="4">GILT EDGE</text>
+</svg>
+'''
++++
+
+## The Setting
+
+The Venetian bindings of the late fifteenth and early sixteenth centuries represent the first systematic application of gold tooling to European bookbinding. The technique arrived in Venice from the Ottoman East - probably through the trade in Islamic manuscripts and luxury goods which flowed through the Venetian lagoon - and was adopted by the binders working in the vicinity of the Aldine press and the great Venetian libraries.
+
+## The Tooling
+
+The characteristic feature of the Venetian arabesque binding is the interlaced strap-work which covers both boards. The straps are formed of narrow fillets impressed through gold foil, interlacing in geometric patterns derived from Islamic prototypes. At the centre of each board is a medallion - usually an oval or a pointed oval - and at each corner a triangular fleuron. The spaces between the straps are often filled with small punched tools: stars, circles, and tiny leaves.
+
+The tools themselves were cut in brass and heated over a small charcoal brazier before being pressed into the dampened leather through a sheet of gold leaf. The skill required was considerable: too much heat would scorch the leather; too little would leave a faint impression; an unsteady hand would blur the line of the fillet.
+
+## The Gilding of Edges
+
+The Venetian binders gilded the edges of their books as a matter of course for any volume of quality. The method was that which persisted with little change for three centuries thereafter: the text block was pressed firmly in a lying press, the edges scraped smooth with a sharp plane, a thin layer of Armenian bole (a fine red clay) applied as a ground, and sheets of gold leaf laid upon the prepared surface and burnished to brilliance with an agate tool.
+
+{{ alert(type="note", body="The Aldine octavo format - the small, portable book which Aldus Manutius introduced for his editions of the Greek and Latin classics - was particularly suited to gilt-edge treatment, as the small page size made the gilding economical and the book was often carried in the pocket, where the gold edges protected the pages from wear.") }}
+
+## The Survival
+
+Venetian arabesque bindings survive in relatively small numbers, as many were rebound in later centuries when the taste changed. The finest surviving examples are in the Biblioteca Marciana in Venice, the Bibliotheque Nationale in Paris, and the British Library in London. The binding illustrated in this plate is after a copy of the Aldine Virgil of 1501, one of the earliest books to be issued in the new octavo format.

--- a/gilt-edge/content/plates/the-victorian-cloth-gilt.md
+++ b/gilt-edge/content/plates/the-victorian-cloth-gilt.md
@@ -1,0 +1,75 @@
++++
+title = "The Victorian Cloth Gilt"
+description = "The mass-produced gilt-stamped cloth bindings of the Victorian book trade, bringing gold to the common reader."
+date = "2026-04-10"
+template = "plate"
+weight = 10
+tags = ["english", "victorian"]
+[taxonomies]
+binding = ["Cloth"]
+[extra]
+plate_no = "X"
+binding_style = "Victorian Cloth Gilt"
+binder = "Trade binderies of London and Edinburgh"
+date_bound = "c. 1840-1900"
+materials = "Bookcloth over mill-board; brass-die stamping in gold and blind on covers and spine"
+dimensions = "Crown octavo, 190 x 125 mm"
+provenance = "General trade; numerous institutional collections"
+gilding = "Top edge gilt; fore-edge and tail uncut or stained"
+plate_caption = "Schematic of a Victorian cloth-gilt binding with a pictorial brass-die stamp on the front cover."
+plate_svg = '''
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="400" fill="#0B1126"/>
+  <rect x="100" y="20" width="400" height="360" fill="#2A1A3A" stroke="#C9A84C" stroke-width="1"/>
+  <!-- Embossed texture pattern -->
+  <g stroke="#3A2A4A" stroke-width="0.3" opacity="0.5">
+    <line x1="100" y1="40" x2="500" y2="40"/>
+    <line x1="100" y1="60" x2="500" y2="60"/>
+    <line x1="100" y1="80" x2="500" y2="80"/>
+    <line x1="100" y1="100" x2="500" y2="100"/>
+    <line x1="100" y1="300" x2="500" y2="300"/>
+    <line x1="100" y1="320" x2="500" y2="320"/>
+    <line x1="100" y1="340" x2="500" y2="340"/>
+    <line x1="100" y1="360" x2="500" y2="360"/>
+  </g>
+  <!-- Gilt frame on cover -->
+  <rect x="130" y="50" width="340" height="300" fill="none" stroke="#C9A84C" stroke-width="1.5"/>
+  <rect x="140" y="60" width="320" height="280" fill="none" stroke="#8B7332" stroke-width="0.6"/>
+  <!-- Central pictorial stamp area -->
+  <rect x="180" y="100" width="240" height="180" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+  <!-- Simplified floral/botanical design -->
+  <g stroke="#C9A84C" stroke-width="0.6" fill="none">
+    <path d="M 300 140 Q 280 160 280 180 Q 280 200 300 220"/>
+    <path d="M 300 140 Q 320 160 320 180 Q 320 200 300 220"/>
+    <ellipse cx="280" cy="170" rx="15" ry="10"/>
+    <ellipse cx="320" cy="170" rx="15" ry="10"/>
+    <path d="M 300 220 L 300 260"/>
+    <path d="M 280 240 Q 300 230 320 240"/>
+    <path d="M 270 250 Q 300 240 330 250"/>
+  </g>
+  <g fill="#C9A84C">
+    <circle cx="300" cy="160" r="4"/>
+    <circle cx="280" cy="195" r="2"/>
+    <circle cx="320" cy="195" r="2"/>
+  </g>
+  <!-- Title -->
+  <text x="300" y="80" text-anchor="middle" font-family="Bodoni Moda, serif" font-size="16" font-weight="700" fill="#C9A84C">VICTORIAN</text>
+  <text x="300" y="325" text-anchor="middle" font-family="EB Garamond, serif" font-size="12" fill="#8B7332" letter-spacing="3">CLOTH GILT</text>
+  <!-- Top edge gilt indicator -->
+  <rect x="502" y="20" width="16" height="8" fill="#C9A84C" opacity="0.8"/>
+  <text x="510" y="46" text-anchor="middle" font-family="EB Garamond, serif" font-size="7" fill="#8B7332">t.e.g.</text>
+</svg>
+'''
++++
+
+## The Revolution
+
+The introduction of bookcloth in the late 1820s and the development of brass-die stamping in the 1830s transformed the economics of bookbinding. For the first time it was possible to produce decorated bindings by machine, in large editions, at a fraction of the cost of hand-tooled leather. The gilt-stamped cloth binding became the standard dress of the English book from the 1840s until the end of the century, and the designs produced by the Victorian trade binderies constitute one of the most prolific and varied bodies of decorative art in the history of the book.
+
+## The Process
+
+The Victorian cloth-gilt binding was produced by a fundamentally different process from the hand-tooled leather binding. A brass die was engraved with the design for the entire cover in reverse - a process which might take a skilled engraver several days - and mounted in an arming press. The cloth case was positioned on the bed of the press, a sheet of gold foil laid over it, and the heated die brought down under heavy pressure. A single pull of the press produced the entire cover design in one operation, where a hand finisher would have required hundreds of individual tool impressions.
+
+## The Gilt Edge
+
+The Victorian trade practice distinguished three levels of edge treatment: "gilt" (all three edges gilt); "top edge gilt" (abbreviated t.e.g., with the top edge gilt and the fore-edge and tail left uncut or stained); and "uncut" (no gilding). The first was reserved for the most expensive gift editions, the second became the standard for quality trade books, and the third was the cheapest option. The gilding was done by machine, the text blocks clamped in stacks and the gold leaf applied to the trimmed edges with hydraulic pressure.

--- a/gilt-edge/content/techniques.md
+++ b/gilt-edge/content/techniques.md
@@ -1,0 +1,30 @@
++++
+title = "Techniques of Gilt-Edging"
+description = "A survey of the principal methods used to apply gold leaf to the edges of books and to tool gold upon their covers."
+template = "page"
+tags = ["technique", "craft"]
++++
+
+## The Art of Gilding
+
+The gilding of book edges and the tooling of gold upon leather covers are two distinct but related crafts, both practised within the binder's workshop and both requiring the manipulation of gold leaf under controlled conditions of heat and pressure.
+
+### Edge Gilding
+
+The process of gilding the edges of a book has changed little since the sixteenth century. The text block is removed from its boards (or, in modern practice, gilded before casing-in) and placed in a lying press with the edge to be gilded uppermost. The edge is scraped perfectly smooth with a sharp plane or paring knife, then burnished with a polishing tool to close the fibres of the paper.
+
+A thin layer of Armenian bole - a fine red clay mixed with egg-white - is applied as a ground. The bole serves two purposes: it provides a smooth, slightly tacky surface to which the gold will adhere, and its red colour gives warmth and depth to the finished gilding, visible as a faint glow beneath the gold when the light catches the edge at an angle.
+
+Sheets of gold leaf - beaten to a thickness of approximately 0.1 microns - are laid upon the prepared edge with a gilder's tip (a flat brush of squirrel hair charged with static from the gilder's cheek) and gently pressed into place. The gold is then burnished to a high polish with an agate or bloodstone burnisher, the smooth stone drawn repeatedly across the surface until the gold is compacted and brilliant.
+
+### Gold Tooling on Leather
+
+The tooling of gold upon leather requires a different set of skills but the same basic principle: gold leaf is made to adhere to a prepared surface under the influence of heat and pressure. The binder first marks out the design upon the dampened leather, then applies a thin film of egg-white adhesive (glaire) to the areas which are to receive gold. The gold leaf is laid over the glaired area, and the heated brass tool - whether a fillet, a gouge, a roll, or a small hand stamp - is pressed firmly into the leather through the gold.
+
+The heat activates the protein in the glaire, bonding the gold permanently to the leather. The surplus gold around the impression is wiped away with an oiled rag, leaving a clean, bright line or stamp of gold upon the cover. The skill lies in the control of temperature, pressure, and timing: too much heat will scorch the leather and produce a dull, brownish impression; too little will leave the gold unbonded and it will brush away.
+
+### Gauffering
+
+Gauffering is the technique of impressing a decorative pattern into the gilt edges of a book after the gilding has been completed. Small heated tools - typically floral, leaf, or geometric stamps - are pressed into the gold surface to create a repeating pattern. The gauffered pattern appears as a slightly darkened impression against the bright gold ground, and the effect when the book is closed is of an ornamental band running around the three edges of the text block.
+
+Gauffering was practised from the sixteenth century onward and was particularly popular in the eighteenth century, when elaborate gauffered edges were a standard feature of presentation and luxury bindings. The technique requires considerable skill, as the tools must be applied with uniform pressure and spacing to produce a regular pattern, and any error is permanent - there is no way to remove a gauffered impression once it has been made.

--- a/gilt-edge/static/css/style.css
+++ b/gilt-edge/static/css/style.css
@@ -1,0 +1,601 @@
+/* ============================================================
+   GILT-EDGE - Gold-Edged Publication
+   A dark, opulent design with gold leaf and Didone typography
+   ============================================================ */
+
+/* --- Reset & Base --- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --gold: #C9A84C;
+  --gold-light: #E2CC7E;
+  --gold-dim: #8B7332;
+  --navy: #0B1126;
+  --navy-mid: #141E3C;
+  --navy-light: #1C2A50;
+  --cream: #F2EACC;
+  --cream-dim: #D4C9A0;
+  --white: #FDFBF2;
+  --text-body: #E8E0C8;
+  --text-muted: #9E9478;
+  --border-gold: rgba(201, 168, 76, 0.3);
+}
+
+html { font-size: 16px; scroll-behavior: smooth; }
+body {
+  font-family: 'Cormorant', 'EB Garamond', 'Georgia', serif;
+  line-height: 1.7;
+  color: var(--text-body);
+  background: var(--navy);
+}
+
+a { color: var(--gold); text-decoration: none; }
+a:hover { color: var(--gold-light); }
+
+/* --- Gilt Border Frame --- */
+.gilt-frame {
+  position: relative;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.gilt-border {
+  position: fixed;
+  pointer-events: none;
+  z-index: 100;
+}
+.gilt-border-top,
+.gilt-border-bottom {
+  left: 0; right: 0; height: 20px;
+}
+.gilt-border-top { top: 0; }
+.gilt-border-bottom { bottom: 0; }
+.gilt-border-left,
+.gilt-border-right {
+  top: 0; bottom: 0; width: 20px;
+}
+.gilt-border-left { left: 0; }
+.gilt-border-right { right: 0; }
+
+.gilt-border svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* --- Header --- */
+.gilt-header {
+  text-align: center;
+  padding: 40px 20px 30px;
+  border-bottom: 1px solid var(--border-gold);
+  margin-bottom: 40px;
+}
+
+.gilt-brand {
+  display: inline-block;
+  color: var(--gold);
+  text-decoration: none;
+}
+.gilt-brand:hover { color: var(--gold-light); }
+
+.gilt-brand-svg { max-width: 480px; width: 100%; height: auto; }
+
+.gilt-sub {
+  font-family: 'EB Garamond', 'Georgia', serif;
+  font-size: 0.8rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-top: 8px;
+}
+
+.gilt-nav {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+.gilt-nav a {
+  font-family: 'EB Garamond', 'Georgia', serif;
+  font-size: 0.85rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--cream-dim);
+  position: relative;
+  padding-bottom: 4px;
+}
+.gilt-nav a:hover { color: var(--gold); }
+.gilt-nav a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 25%; right: 25%;
+  height: 1px;
+  background: var(--gold);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.gilt-nav a:hover::after { opacity: 1; }
+
+.gilt-rule {
+  display: block;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* --- Main Content --- */
+.gilt-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 20px 60px;
+}
+
+/* --- Frontispiece --- */
+.frontispiece {
+  text-align: center;
+  padding: 40px 0 30px;
+}
+.frontispiece .kicker {
+  font-family: 'EB Garamond', 'Georgia', serif;
+  font-size: 0.8rem;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-bottom: 12px;
+}
+.frontispiece h1 {
+  font-family: 'Bodoni Moda', 'Didot', 'Georgia', serif;
+  font-size: 3rem;
+  font-weight: 900;
+  color: var(--gold);
+  letter-spacing: 2px;
+  line-height: 1.15;
+  margin-bottom: 16px;
+}
+.frontispiece .sub {
+  font-family: 'Cormorant', 'EB Garamond', serif;
+  font-size: 1.15rem;
+  color: var(--cream-dim);
+  font-style: italic;
+}
+
+/* --- Front Plate --- */
+.front-plate {
+  margin: 40px auto;
+  max-width: 640px;
+}
+.front-plate-inner {
+  border: 2px solid var(--gold-dim);
+  padding: 6px;
+  background: var(--navy-mid);
+}
+.front-plate-inner svg { display: block; width: 100%; height: auto; }
+.front-cap {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 10px;
+  font-style: italic;
+}
+
+/* --- Body Prose --- */
+.front-lede {
+  font-family: 'Cormorant', 'EB Garamond', serif;
+  font-size: 1.2rem;
+  line-height: 1.8;
+  color: var(--cream);
+  text-align: center;
+  max-width: 640px;
+  margin: 30px auto;
+  padding: 20px 0;
+  border-top: 1px solid var(--border-gold);
+  border-bottom: 1px solid var(--border-gold);
+}
+
+.two-col-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  margin: 30px 0;
+}
+.two-col-wrap .divider { flex: 0 0 44px; }
+.two-col-wrap .divider svg { display: block; width: 44px; height: 400px; }
+.two-col {
+  flex: 1;
+  columns: 2;
+  column-gap: 2rem;
+}
+.two-col p {
+  font-size: 0.95rem;
+  margin-bottom: 1em;
+  text-align: justify;
+  color: var(--text-body);
+  break-inside: avoid;
+}
+.two-col .illum-para::first-letter {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 3.5rem;
+  float: left;
+  line-height: 1;
+  margin-right: 6px;
+  color: var(--gold);
+}
+
+/* --- Featured Plates --- */
+.featured-plates {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 20px;
+  margin: 30px 0;
+}
+.featured-plate a {
+  display: block;
+  text-align: center;
+  padding: 20px 10px;
+  border: 1px solid var(--border-gold);
+  background: var(--navy-mid);
+  transition: border-color 0.3s, background 0.3s;
+}
+.featured-plate a:hover {
+  border-color: var(--gold);
+  background: var(--navy-light);
+}
+.featured-init svg { display: block; width: 80px; height: 80px; margin: 0 auto 12px; }
+.featured-plate-title {
+  display: block;
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--gold);
+}
+.featured-plate-dek {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+/* --- Section Head --- */
+.section-head {
+  text-align: center;
+  margin-bottom: 40px;
+}
+.section-head .kicker {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.8rem;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-bottom: 8px;
+}
+.section-head .section-title {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 2.2rem;
+  font-weight: 900;
+  color: var(--gold);
+  letter-spacing: 1px;
+}
+.section-head .section-lede {
+  font-size: 1rem;
+  color: var(--cream-dim);
+  margin-top: 10px;
+  font-style: italic;
+}
+
+.section-intro {
+  max-width: 640px;
+  margin: 0 auto 30px;
+  font-size: 0.95rem;
+  text-align: center;
+  color: var(--text-body);
+}
+
+/* --- Plate Table (Section Listing) --- */
+.plate-table {
+  list-style: none;
+  margin: 20px 0;
+  border-top: 1px solid var(--border-gold);
+}
+.plate-row {
+  border-bottom: 1px solid var(--border-gold);
+}
+.plate-link {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 12px;
+  transition: background 0.2s;
+}
+.plate-link:hover { background: var(--navy-mid); }
+.plate-no {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--gold);
+  min-width: 48px;
+  text-align: center;
+}
+.plate-title-wrap { flex: 1; }
+.plate-title-bl {
+  display: block;
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--cream);
+}
+.plate-dek {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.plate-binding {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.75rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+}
+
+/* --- Plate Page (Individual Article) --- */
+.plate-page { margin-bottom: 40px; }
+
+.plate-head {
+  text-align: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-gold);
+}
+.plate-head .kicker {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.8rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-bottom: 8px;
+}
+.plate-head .plate-title {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 2.4rem;
+  font-weight: 900;
+  color: var(--gold);
+  line-height: 1.2;
+}
+.plate-head .plate-lede {
+  font-size: 1rem;
+  color: var(--cream-dim);
+  margin-top: 10px;
+  font-style: italic;
+}
+
+/* --- Plate Specs --- */
+.plate-specs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 20px;
+  margin: 0 0 30px;
+  padding: 20px;
+  border: 1px solid var(--border-gold);
+  background: var(--navy-mid);
+  font-size: 0.9rem;
+}
+.plate-specs dt {
+  font-family: 'EB Garamond', serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 0.78rem;
+  color: var(--gold-dim);
+}
+.plate-specs dd {
+  color: var(--cream-dim);
+}
+
+/* --- Plate Figure --- */
+.plate-figure {
+  margin: 30px 0;
+}
+.plate-frame {
+  border: 2px solid var(--gold-dim);
+  padding: 6px;
+  background: var(--navy-mid);
+}
+.plate-frame svg { display: block; width: 100%; height: auto; }
+.plate-figcap {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 10px;
+  font-style: italic;
+}
+
+/* --- Plate Prose --- */
+.plate-prose {
+  font-size: 1rem;
+  line-height: 1.8;
+}
+.plate-prose h2 {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--gold);
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-gold);
+}
+.plate-prose h3 {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.15rem;
+  color: var(--cream);
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+.plate-prose p {
+  margin-bottom: 1em;
+  text-align: justify;
+}
+.plate-prose blockquote {
+  border-left: 3px solid var(--gold-dim);
+  padding-left: 20px;
+  margin: 1.5em 0;
+  color: var(--cream-dim);
+  font-style: italic;
+}
+.plate-prose code {
+  background: var(--navy-mid);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: ui-monospace, Consolas, monospace;
+  color: var(--gold-light);
+}
+.plate-prose pre {
+  background: var(--navy-mid);
+  padding: 1rem;
+  border: 1px solid var(--border-gold);
+  overflow-x: auto;
+  margin: 1.5em 0;
+}
+.plate-prose pre code { background: none; padding: 0; }
+
+.plate-foot {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-gold);
+}
+.back-link {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+  color: var(--gold-dim);
+}
+.back-link:hover { color: var(--gold); }
+
+/* --- Footer --- */
+.gilt-foot {
+  text-align: center;
+  padding: 40px 20px;
+  border-top: 1px solid var(--border-gold);
+  margin-top: 40px;
+}
+.gilt-foot-ornament { max-width: 600px; margin: 0 auto 24px; }
+.gilt-foot-ornament svg { display: block; width: 100%; height: auto; }
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  max-width: 640px;
+  margin: 0 auto 24px;
+  text-align: center;
+}
+.foot-head {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.72rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 6px;
+}
+.foot-col p:last-child {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.foot-stamp {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.72rem;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-top: 20px;
+}
+
+/* --- Error Page --- */
+.error-page {
+  text-align: center;
+  padding: 80px 0;
+}
+.error-page .kicker {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.8rem;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+  margin-bottom: 12px;
+}
+.error-page h1 {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 2rem;
+  color: var(--gold);
+  margin-bottom: 16px;
+}
+.error-page p {
+  color: var(--cream-dim);
+  margin-bottom: 12px;
+}
+
+/* --- Alert Shortcode --- */
+.alert {
+  padding: 1rem;
+  border: 1px solid var(--border-gold);
+  border-left: 4px solid var(--gold);
+  background: var(--navy-mid);
+  margin: 1.5em 0;
+  font-size: 0.9rem;
+  color: var(--cream-dim);
+}
+.alert strong {
+  color: var(--gold);
+  font-family: 'EB Garamond', serif;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+/* --- Markdown Content Defaults --- */
+.gilt-main h1 {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 2rem;
+  color: var(--gold);
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+.gilt-main h2 {
+  font-family: 'Bodoni Moda', 'Didot', serif;
+  font-size: 1.5rem;
+  color: var(--gold);
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+.gilt-main h3 {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.15rem;
+  color: var(--cream);
+  margin-top: 1.3em;
+  margin-bottom: 0.5em;
+}
+.gilt-main p { margin-bottom: 1em; }
+.gilt-main ul, .gilt-main ol {
+  margin: 1em 0;
+  padding-left: 1.5em;
+}
+.gilt-main li { margin-bottom: 0.5em; }
+
+/* --- Responsive --- */
+@media (max-width: 700px) {
+  .frontispiece h1 { font-size: 2rem; }
+  .two-col { columns: 1; }
+  .two-col-wrap .divider { display: none; }
+  .foot-grid { grid-template-columns: 1fr; gap: 16px; }
+  .gilt-nav { gap: 1rem; }
+  .plate-head .plate-title { font-size: 1.8rem; }
+  .plate-specs { grid-template-columns: 1fr; }
+  .featured-plates { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 480px) {
+  .gilt-frame { padding: 12px; }
+  .featured-plates { grid-template-columns: 1fr; }
+}

--- a/gilt-edge/templates/404.html
+++ b/gilt-edge/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    <div class="error-page">
+      <p class="kicker">A LEAF UNGILDED</p>
+      <h1>404 - The Sought Page Is Wanting</h1>
+      <p>This leaf has not been pressed with gold. Perhaps the folio reference is mistaken; perhaps the plate was never bound into this edition.</p>
+      <p><a href="{{ base_url }}/" class="back-link">&larr; Return to the Title Page</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/gilt-edge/templates/footer.html
+++ b/gilt-edge/templates/footer.html
@@ -1,0 +1,36 @@
+    <footer class="gilt-foot" role="contentinfo">
+      <div class="gilt-foot-ornament" aria-hidden="true">
+        <svg viewBox="0 0 600 50" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <g stroke="#C9A84C" stroke-width="0.8" fill="none">
+            <path d="M 20 25 Q 100 8 180 25 Q 260 42 280 25"/>
+            <path d="M 320 25 Q 340 8 420 25 Q 500 42 580 25"/>
+          </g>
+          <g transform="translate(300,25)">
+            <path d="M 0 -12 L 12 0 L 0 12 L -12 0 Z" fill="none" stroke="#C9A84C" stroke-width="1"/>
+            <path d="M 0 -6 L 6 0 L 0 6 L -6 0 Z" fill="#C9A84C"/>
+          </g>
+          <circle cx="10" cy="25" r="2" fill="#8B7332"/>
+          <circle cx="590" cy="25" r="2" fill="#8B7332"/>
+        </svg>
+      </div>
+      <div class="foot-grid">
+        <div class="foot-col">
+          <p class="foot-head">THE BINDER</p>
+          <p>Compiled by the Gilt-Edge Bindery from exemplars in the Rare Books collection.</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">CITATION</p>
+          <p>Cite as "Gilt-Edge: A Study in Gold-Edged Binding, Anno MMXXVI" with the plate reference.</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">LICENCE</p>
+          <p>Commentary under Creative Commons. Binding photographs remain the property of the source institutions.</p>
+        </div>
+      </div>
+      <p class="foot-stamp">FINIS - AURUM FOLIUM - TYPESET WITH HWARO - Anno Domini MMXXVI</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/gilt-edge/templates/header.html
+++ b/gilt-edge/templates/header.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:ital,opsz,wght@0,6..96,400;0,6..96,700;0,6..96,900;1,6..96,400&family=Cormorant:ital,wght@0,400;0,500;0,600;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <!-- Gilt border edges -->
+  <div class="gilt-border gilt-border-top" aria-hidden="true">
+    <svg viewBox="0 0 1200 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+      <rect x="0" y="0" width="1200" height="20" fill="#0B1126"/>
+      <line x1="0" y1="4" x2="1200" y2="4" stroke="#C9A84C" stroke-width="1"/>
+      <line x1="0" y1="8" x2="1200" y2="8" stroke="#8B7332" stroke-width="0.5"/>
+      <line x1="0" y1="16" x2="1200" y2="16" stroke="#C9A84C" stroke-width="1"/>
+      <g fill="#C9A84C">
+        <rect x="96" y="6" width="8" height="8" transform="rotate(45 100 10)"/>
+        <rect x="296" y="6" width="8" height="8" transform="rotate(45 300 10)"/>
+        <rect x="496" y="6" width="8" height="8" transform="rotate(45 500 10)"/>
+        <rect x="696" y="6" width="8" height="8" transform="rotate(45 700 10)"/>
+        <rect x="896" y="6" width="8" height="8" transform="rotate(45 900 10)"/>
+        <rect x="1096" y="6" width="8" height="8" transform="rotate(45 1100 10)"/>
+      </g>
+    </svg>
+  </div>
+  <div class="gilt-border gilt-border-bottom" aria-hidden="true">
+    <svg viewBox="0 0 1200 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+      <rect x="0" y="0" width="1200" height="20" fill="#0B1126"/>
+      <line x1="0" y1="4" x2="1200" y2="4" stroke="#C9A84C" stroke-width="1"/>
+      <line x1="0" y1="12" x2="1200" y2="12" stroke="#8B7332" stroke-width="0.5"/>
+      <line x1="0" y1="16" x2="1200" y2="16" stroke="#C9A84C" stroke-width="1"/>
+      <g fill="#C9A84C">
+        <rect x="196" y="6" width="8" height="8" transform="rotate(45 200 10)"/>
+        <rect x="396" y="6" width="8" height="8" transform="rotate(45 400 10)"/>
+        <rect x="596" y="6" width="8" height="8" transform="rotate(45 600 10)"/>
+        <rect x="796" y="6" width="8" height="8" transform="rotate(45 800 10)"/>
+        <rect x="996" y="6" width="8" height="8" transform="rotate(45 1000 10)"/>
+      </g>
+    </svg>
+  </div>
+  <div class="gilt-border gilt-border-left" aria-hidden="true">
+    <svg viewBox="0 0 20 800" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+      <rect x="0" y="0" width="20" height="800" fill="#0B1126"/>
+      <line x1="4" y1="0" x2="4" y2="800" stroke="#C9A84C" stroke-width="1"/>
+      <line x1="8" y1="0" x2="8" y2="800" stroke="#8B7332" stroke-width="0.5"/>
+      <line x1="16" y1="0" x2="16" y2="800" stroke="#C9A84C" stroke-width="1"/>
+    </svg>
+  </div>
+  <div class="gilt-border gilt-border-right" aria-hidden="true">
+    <svg viewBox="0 0 20 800" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+      <rect x="0" y="0" width="20" height="800" fill="#0B1126"/>
+      <line x1="4" y1="0" x2="4" y2="800" stroke="#C9A84C" stroke-width="1"/>
+      <line x1="12" y1="0" x2="12" y2="800" stroke="#8B7332" stroke-width="0.5"/>
+      <line x1="16" y1="0" x2="16" y2="800" stroke="#C9A84C" stroke-width="1"/>
+    </svg>
+  </div>
+
+  <div class="gilt-frame" role="document">
+    <header class="gilt-header" role="banner">
+      <div class="gilt-rule" aria-hidden="true">
+        <svg viewBox="0 0 600 16" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="20" y1="8" x2="260" y2="8" stroke="#C9A84C" stroke-width="0.8"/>
+          <line x1="340" y1="8" x2="580" y2="8" stroke="#C9A84C" stroke-width="0.8"/>
+          <g transform="translate(300,8)">
+            <path d="M 0 -7 L 7 0 L 0 7 L -7 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+            <circle r="2" fill="#C9A84C"/>
+          </g>
+        </svg>
+      </div>
+      <a href="{{ base_url }}/" class="gilt-brand" aria-label="Gilt-Edge home">
+        <svg viewBox="0 0 480 80" xmlns="http://www.w3.org/2000/svg" class="gilt-brand-svg" aria-hidden="true">
+          <!-- Gold tooling monogram -->
+          <g transform="translate(36,40)">
+            <rect x="-20" y="-20" width="40" height="40" fill="none" stroke="#C9A84C" stroke-width="1.2"/>
+            <rect x="-14" y="-14" width="28" height="28" fill="none" stroke="#8B7332" stroke-width="0.6"/>
+            <text x="0" y="8" text-anchor="middle" font-family="Bodoni Moda, Didot, serif" font-size="24" font-weight="900" fill="#C9A84C">G</text>
+          </g>
+          <text x="76" y="36" font-family="Bodoni Moda, Didot, serif" font-size="32" font-weight="900" fill="#C9A84C" letter-spacing="3">GILT-EDGE</text>
+          <text x="76" y="62" font-family="EB Garamond, serif" font-size="14" fill="#8B7332" letter-spacing="4">A STUDY IN GOLD-EDGED BINDING</text>
+        </svg>
+      </a>
+      <p class="gilt-sub">GOLD LEAF UPON THE EDGES OF THE BOOK - TOOLED COVERS AND SPINES IN THE OPULENT TRADITION</p>
+      <nav class="gilt-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Title Page</a>
+        <a href="{{ base_url }}/plates/">The Plates</a>
+        <a href="{{ base_url }}/techniques/">Techniques</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+      <div class="gilt-rule" aria-hidden="true" style="margin-top: 20px;">
+        <svg viewBox="0 0 600 16" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="20" y1="8" x2="260" y2="8" stroke="#C9A84C" stroke-width="0.8"/>
+          <line x1="340" y1="8" x2="580" y2="8" stroke="#C9A84C" stroke-width="0.8"/>
+          <g transform="translate(300,8)">
+            <path d="M 0 -7 L 7 0 L 0 7 L -7 0 Z" fill="none" stroke="#C9A84C" stroke-width="0.8"/>
+            <circle r="2" fill="#C9A84C"/>
+          </g>
+        </svg>
+      </div>
+    </header>

--- a/gilt-edge/templates/page.html
+++ b/gilt-edge/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/gilt-edge/templates/plate.html
+++ b/gilt-edge/templates/plate.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    <article class="plate-page">
+      <header class="plate-head">
+        <p class="kicker">{% if page.extra.plate_no %}PLATE {{ page.extra.plate_no | e }}{% endif %}{% if page.extra.binding_style %} - {{ page.extra.binding_style | upper }}{% endif %}</p>
+        <h1 class="plate-title">{{ page.title | e }}</h1>
+        {% if page.description %}<p class="plate-lede">{{ page.description | e }}</p>{% endif %}
+      </header>
+
+      {% if page.extra.binder or page.extra.date_bound or page.extra.materials or page.extra.provenance %}
+      <dl class="plate-specs">
+        {% if page.extra.binder %}<dt>Binder</dt><dd>{{ page.extra.binder | e }}</dd>{% endif %}
+        {% if page.extra.date_bound %}<dt>Date</dt><dd>{{ page.extra.date_bound | e }}</dd>{% endif %}
+        {% if page.extra.materials %}<dt>Materials</dt><dd>{{ page.extra.materials | e }}</dd>{% endif %}
+        {% if page.extra.dimensions %}<dt>Dimensions</dt><dd>{{ page.extra.dimensions | e }}</dd>{% endif %}
+        {% if page.extra.provenance %}<dt>Provenance</dt><dd>{{ page.extra.provenance | e }}</dd>{% endif %}
+        {% if page.extra.gilding %}<dt>Gilding</dt><dd>{{ page.extra.gilding | e }}</dd>{% endif %}
+      </dl>
+      {% endif %}
+
+      {% if page.extra.plate_svg %}
+      <figure class="plate-figure">
+        <div class="plate-frame">
+          {{ page.extra.plate_svg | safe }}
+        </div>
+        {% if page.extra.plate_caption %}<figcaption class="plate-figcap">{{ page.extra.plate_caption | e }}</figcaption>{% endif %}
+      </figure>
+      {% endif %}
+
+      <div class="plate-prose">
+        {{ content }}
+      </div>
+
+      <footer class="plate-foot">
+        <a href="{{ base_url }}/plates/" class="back-link">&larr; Return to the catalogue</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/gilt-edge/templates/section.html
+++ b/gilt-edge/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    <header class="section-head">
+      <p class="kicker">THE CATALOGUE</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+      {% if page.description %}<p class="section-lede">{{ page.description | e }}</p>{% endif %}
+    </header>
+    <div class="section-intro">
+      {{ content }}
+    </div>
+    <ol class="plate-table">
+      {% for pl in section.pages %}
+      <li class="plate-row">
+        <a href="{{ pl.url }}" class="plate-link">
+          <span class="plate-no">{% if pl.extra.plate_no %}{{ pl.extra.plate_no | e }}{% else %}{{ loop.index }}{% endif %}</span>
+          <span class="plate-title-wrap">
+            <span class="plate-title-bl">{{ pl.title | e }}</span>
+            {% if pl.description %}<span class="plate-dek">{{ pl.description | e }}</span>{% endif %}
+          </span>
+          {% if pl.extra.binding_style %}<span class="plate-binding">{{ pl.extra.binding_style | upper }}</span>{% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/gilt-edge/templates/shortcodes/alert.html
+++ b/gilt-edge/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/gilt-edge/templates/taxonomy.html
+++ b/gilt-edge/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    <header class="section-head">
+      <p class="kicker">INDEX</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/gilt-edge/templates/taxonomy_term.html
+++ b/gilt-edge/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="gilt-main" role="main">
+    <header class="section-head">
+      <p class="kicker">CLASSIFIED AS</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1589,6 +1589,13 @@
     "blog",
     "editorial"
   ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
+  ],
   "generative-art": [
     "dark",
     "portfolio",


### PR DESCRIPTION
Closes #1554

## Summary
- Add gilt-edge example site: a gold-edged publication study with dark navy background and gold (#C9A84C) Didone typography
- 10 plates covering binding traditions from Venetian Aldine to Victorian cloth gilt, plus techniques and colophon pages
- SVG gilded edge patterns along all page borders; SVG gold tooling patterns on cover/spine sections
- Custom plate template with specs display, inline SVG figures, and binding taxonomy

## Test plan
- [ ] Verify `hwaro build` succeeds in gilt-edge directory
- [ ] Verify all 14 pages render correctly
- [ ] Check tags.json includes gilt-edge entry
- [ ] Confirm no CSS gradients or emojis present