### PR TITLE
feat: add cuneiform-tablet example site (closes #1558)

### DIFF
--- a/cuneiform-tablet/AGENTS.md
+++ b/cuneiform-tablet/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/cuneiform-tablet/config.toml
+++ b/cuneiform-tablet/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Cuneiform Tablet - Clay Impression Publication
+# Issue #1558 | Tags: book, dark, ancient, impressed, archaeological
+# =============================================================================
+
+title = "Cuneiform Tablet"
+description = "A dark, archaeological publication inspired by clay tablet impressions and cuneiform writing. SVG wedge-mark patterns and clay tablet rounded-rectangle frames evoke ancient Mesopotamian records. Rajdhani and Orbitron mimic wedge impressions while Share Tech and Exo 2 provide cuneiform-inspired body text."
+base_url = "http://localhost:3000"
+
+sections = ["tablets"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/cuneiform-tablet/content/about.md
+++ b/cuneiform-tablet/content/about.md
@@ -1,0 +1,41 @@
++++
+title = "Writing"
+description = "The cuneiform writing system of ancient Mesopotamia."
++++
+
+<p class="tablet-label">Reference</p>
+
+# The Cuneiform Writing System
+
+<p class="lede">Cuneiform was not a single language but a script used to write many languages over three millennia: Sumerian, Akkadian, Babylonian, Assyrian, Hittite, Elamite, and others. The script evolved from pictographic origins into an abstract system of wedge impressions.</p>
+
+## Origins in accounting
+
+<p>The earliest cuneiform tablets, from Uruk around 3400 BCE, are not literature but accounting records. They track quantities of grain, heads of livestock, and measures of beer. The writing system was invented not to record speech but to record numbers and commodities. The transition from pictographic tokens to abstract wedge marks happened gradually over five centuries, driven by the need to write faster and on smaller tablets.</p>
+
+## The reed stylus
+
+<p>The writing instrument was a length of reed, cut at an angle to produce a triangular cross-section. The scribe held the stylus between thumb and forefinger and pressed it into a pad of wet clay at different angles to produce the four basic mark types: vertical, horizontal, diagonal, and the circular Winkelhaken. A skilled scribe could write a standard administrative tablet in under five minutes.</p>
+
+## Scribal education
+
+<p>Scribes trained for years in the edubba, the tablet house. Students began by copying simple sign lists and progressed through increasingly complex literary and administrative texts. The edubba curriculum has survived because students practiced on clay tablets that were fired or sun-dried and then discarded in rubbish heaps. Archaeologists have recovered thousands of these school tablets, giving us a detailed picture of ancient education.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Old Babylonian period</h3>
+<p>The golden age of cuneiform literature. The Epic of Gilgamesh, the Code of Hammurabi, and extensive mathematical texts were composed or copied during this period (2000-1600 BCE).</p>
+</div>
+<div class="tablet-card">
+<h3>Neo-Assyrian period</h3>
+<p>King Ashurbanipal assembled the great library at Nineveh, collecting copies of every known text. Over 30,000 tablets survived the fall of the city in 612 BCE and now reside in the British Museum.</p>
+</div>
+<div class="tablet-card">
+<h3>Late period</h3>
+<p>Cuneiform persisted into the first century CE for astronomical records. The last known cuneiform tablet dates to 75 CE. The script was then forgotten until its decipherment in the nineteenth century.</p>
+</div>
+</div>
+
+## Decipherment
+
+<p>The decipherment of cuneiform began with the trilingual inscription at Behistun, carved into a cliff face in western Iran by order of Darius I around 520 BCE. Henry Rawlinson, hanging from ropes on the cliff face in the 1830s and 1840s, copied the Old Persian, Elamite, and Babylonian versions. The Old Persian was cracked first, providing the key to the Babylonian, which in turn unlocked the entire cuneiform tradition.</p>

--- a/cuneiform-tablet/content/excavation.md
+++ b/cuneiform-tablet/content/excavation.md
@@ -1,0 +1,41 @@
++++
+title = "Excavation"
+description = "The archaeology of cuneiform tablet recovery."
++++
+
+<p class="tablet-label">Field Notes</p>
+
+# Excavation
+
+<p class="lede">A cuneiform tablet survives because clay is nearly indestructible. Fired tablets last millennia. Even unfired tablets, if buried in dry soil, can survive three thousand years and emerge legible.</p>
+
+## Finding the tablets
+
+<p>Cuneiform tablets are found in archaeological excavations of ancient Mesopotamian cities, primarily in modern-day Iraq, Syria, Turkey, and Iran. The tablets are usually found in collapsed rooms, rubbish dumps, or purpose-built archive chambers. A single room in the palace at Nineveh yielded over twenty thousand tablets. The temple of Bau at Girsu produced six thousand. Most sites yield a few dozen to a few hundred.</p>
+
+## Conservation
+
+<p>A freshly excavated tablet is fragile. Unfired tablets may be damp and soft. Sun-dried tablets crack easily. Even fire-hardened tablets may have salt deposits that expand and flake the surface. The conservator's first task is to stabilize the tablet: cleaning the surface with soft brushes, consolidating cracks with dilute adhesive, and allowing the tablet to dry slowly under controlled conditions.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Nineveh</h3>
+<p>Ashurbanipal's library. The single most important source of cuneiform literature. Excavated by Austen Henry Layard and Hormuzd Rassam in the 1840s-1850s.</p>
+</div>
+<div class="tablet-card">
+<h3>Ur</h3>
+<p>The great Sumerian city-state. Leonard Woolley's excavations (1922-1934) revealed the Royal Tombs and thousands of administrative tablets documenting daily life.</p>
+</div>
+<div class="tablet-card">
+<h3>Ebla</h3>
+<p>A surprise discovery in 1974-75: an archive of 17,000 tablets from a previously unknown Bronze Age kingdom in Syria, written in a language no one had ever seen.</p>
+</div>
+<div class="tablet-card">
+<h3>Persepolis</h3>
+<p>The Persepolis Fortification Archive: over 30,000 tablets and fragments recording the administration of the Persian Empire under Darius I, found in 1933.</p>
+</div>
+</div>
+
+## Reading a tablet
+
+<p>A cuneiform tablet is read from left to right, top to bottom, in horizontal registers separated by incised lines. The reverse side is read by rotating the tablet along its bottom edge, so that the text on the reverse continues from where the obverse ended. Some large tablets have text on all six surfaces: obverse, reverse, top edge, bottom edge, left edge, and right edge. The colophon, a summary of the tablet's contents and the scribe's name, is usually found at the end of the reverse.</p>

--- a/cuneiform-tablet/content/index.md
+++ b/cuneiform-tablet/content/index.md
@@ -1,0 +1,75 @@
++++
+title = "Cuneiform Tablet"
+description = "An archaeological archive of clay tablet impressions from the ancient world."
++++
+
+<p class="tablet-label">Archive Entry</p>
+
+# Cuneiform Tablet
+
+<p class="lede">A publication pressed into clay: each page is a fired tablet bearing the wedge-shaped impressions of a reed stylus. The oldest writing system known to civilization, rendered in modern typography that recalls the angular geometry of the original marks.</p>
+
+## The clay archive
+
+<p>For three thousand years, the civilizations of Mesopotamia recorded their laws, their commerce, their literature, and their prayers by pressing a cut reed into a pad of wet clay. The resulting marks, triangular wedge shapes with thin tails, are called cuneiform, from the Latin <em>cuneus</em>, meaning wedge. This publication takes the form of a cuneiform archive: a collection of tablets, each containing a single record, stored in a digital equivalent of the great library at Nineveh.</p>
+
+## The wedge impression
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<div class="wedge-demo" aria-hidden="true">
+<svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+<g stroke="#a89272" stroke-width="1.5" stroke-linecap="round">
+<line x1="20" y1="30" x2="40" y2="30"/>
+<line x1="20" y1="30" x2="20" y2="45"/>
+</g>
+</svg>
+</div>
+<h3>Vertical wedge</h3>
+<p>The basic mark of cuneiform. The stylus is pressed into the clay at an angle, creating a deep triangular head that tapers into a thin vertical tail.</p>
+</div>
+<div class="tablet-card">
+<div class="wedge-demo" aria-hidden="true">
+<svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+<g stroke="#a89272" stroke-width="1.5" stroke-linecap="round">
+<line x1="20" y1="30" x2="50" y2="30"/>
+<line x1="20" y1="30" x2="25" y2="40"/>
+</g>
+</svg>
+</div>
+<h3>Horizontal wedge</h3>
+<p>The stylus is rotated ninety degrees. The triangular head points left and the tail extends to the right. Used for vowel signs and determinatives.</p>
+</div>
+<div class="tablet-card">
+<div class="wedge-demo" aria-hidden="true">
+<svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+<g stroke="#a89272" stroke-width="1.5" stroke-linecap="round">
+<line x1="20" y1="20" x2="40" y2="40"/>
+<line x1="20" y1="20" x2="30" y2="18"/>
+</g>
+</svg>
+</div>
+<h3>Diagonal wedge</h3>
+<p>An angled impression used in compound signs. The combination of vertical, horizontal, and diagonal wedges creates the full cuneiform syllabary of over six hundred signs.</p>
+</div>
+<div class="tablet-card">
+<div class="wedge-demo" aria-hidden="true">
+<svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+<g fill="#a89272">
+<circle cx="30" cy="30" r="4"/>
+</g>
+<g stroke="#a89272" stroke-width="0.5" stroke-linecap="round">
+<line x1="30" y1="30" x2="50" y2="30"/>
+</g>
+</svg>
+</div>
+<h3>Winkelhaken</h3>
+<p>A corner impression made by pressing the end of the stylus straight into the clay. Used for numerals and as a component in complex signs. The oldest numeral system in the world.</p>
+</div>
+</div>
+
+## Reading the archive
+
+<p>Each tablet in this archive is presented within a rounded-rectangle frame that echoes the shape of an actual clay tablet: thick edges, slightly convex surface, and visible clay texture in the background. The wedge-mark patterns that appear faintly behind the text are schematic cuneiform impressions, drawn as inline SVG.</p>
+
+<p>Navigate to the <a href="/tablets/">tablet index</a> to browse the collection, or use the links above to explore the writing system and the archaeology of excavation.</p>

--- a/cuneiform-tablet/content/tablets/1-the-royal-inscription.md
+++ b/cuneiform-tablet/content/tablets/1-the-royal-inscription.md
@@ -1,0 +1,32 @@
++++
+title = "The Royal Inscription"
+description = "A proclamation of kingship and conquest pressed into clay."
+tags = ["royal", "inscription"]
++++
+
+<p class="tablet-label">Tablet I</p>
+
+# The Royal Inscription
+
+<p class="lede">When a Mesopotamian king built a temple, dug a canal, or conquered a city, he recorded the deed on clay. The royal inscription is the most formal category of cuneiform text: large tablets, carefully written, with deep clear impressions meant to last forever.</p>
+
+## Purpose
+
+<p>Royal inscriptions served three audiences. The first was the gods: the inscription was buried in the foundation of the building as a message to the divine patron, explaining who built the temple and why. The second audience was future kings: the inscription established precedent and warned successors not to alter or demolish the building. The third audience was eternity itself: the king's name and deeds would survive as long as the clay endured.</p>
+
+## Form
+
+<p>A royal inscription typically begins with the king's titles and genealogy, proceeds through a narrative of the deed being commemorated, and ends with blessings on those who preserve the inscription and curses on those who deface it. The script is large and formal, with each sign carefully impressed. The tablet itself is often larger than standard administrative tablets, sometimes taking the form of a clay prism or a barrel-shaped cylinder.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Foundation deposits</h3>
+<p>Small tablets or cones buried in the foundations of buildings. The most common type of royal inscription, found at almost every major Mesopotamian site.</p>
+</div>
+<div class="tablet-card">
+<h3>Prisms</h3>
+<p>Multi-sided clay objects, usually six or eight faces, inscribed with extended royal annals. The most famous is the Taylor Prism of Sennacherib, recording his military campaigns.</p>
+</div>
+</div>
+
+<blockquote>I am Ashurbanipal, king of the world, king of Assyria, on whom the gods have bestowed intelligence, who has acquired keen understanding. I learned the craft of the sage Adapa, the hidden treasure of all scribal knowledge.</blockquote>

--- a/cuneiform-tablet/content/tablets/2-the-administrative-record.md
+++ b/cuneiform-tablet/content/tablets/2-the-administrative-record.md
@@ -1,0 +1,36 @@
++++
+title = "The Administrative Record"
+description = "Everyday accounting and bureaucracy on clay."
+tags = ["administrative", "accounting"]
++++
+
+<p class="tablet-label">Tablet II</p>
+
+# The Administrative Record
+
+<p class="lede">The vast majority of cuneiform tablets are not literature or law but the mundane records of bureaucracy: receipts, inventories, ration lists, and labor accounts. The clay archive is, above all, an accounting archive.</p>
+
+## The Ur III bureaucracy
+
+<p>The Third Dynasty of Ur (2112-2004 BCE) produced the most extensive bureaucratic archive in the ancient world. Tens of thousands of tablets record every detail of the state economy: how many workers were assigned to each canal project, how many liters of barley each worker received, how many sheep were delivered to each temple, and how many days each laborer was absent. The level of detail is extraordinary. Modern historians have been able to reconstruct the daily operations of individual workshops, farms, and temples from these records.</p>
+
+## Format
+
+<p>Administrative tablets are small, typically fitting in the palm of the hand. The obverse records the transaction: quantities, commodities, names of parties. The reverse records the date, the name of the responsible official, and sometimes a seal impression. The writing is rapid and abbreviated, using shorthand forms of common signs. A single scribe might produce dozens of these tablets in a day.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Receipt</h3>
+<p>Confirms that goods were delivered. The most common tablet type. "Received: 30 liters of barley from Ur-Namma for the temple of Nanna."</p>
+</div>
+<div class="tablet-card">
+<h3>Ration list</h3>
+<p>Records the allocation of food and supplies to workers. Listed by name, with quantities of barley, oil, and wool.</p>
+</div>
+<div class="tablet-card">
+<h3>Labor account</h3>
+<p>Tracks worker-days on construction projects. Distinguishes between full days, half days, and absences. The earliest timesheets.</p>
+</div>
+</div>
+
+<blockquote>One ox, fed barley; one ox, fed grass. Delivered to the house of the governor. Month of the harvest festival, year Amar-Sin became king.</blockquote>

--- a/cuneiform-tablet/content/tablets/3-the-literary-text.md
+++ b/cuneiform-tablet/content/tablets/3-the-literary-text.md
@@ -1,0 +1,32 @@
++++
+title = "The Literary Text"
+description = "Epic poetry and wisdom literature preserved in clay."
+tags = ["literary", "epic"]
++++
+
+<p class="tablet-label">Tablet III</p>
+
+# The Literary Text
+
+<p class="lede">The greatest works of ancient literature survive because they were copied onto clay tablets by generations of scribes. The Epic of Gilgamesh, the Enuma Elish, and the Descent of Ishtar are all cuneiform texts.</p>
+
+## The Epic of Gilgamesh
+
+<p>The oldest surviving work of literature is the Epic of Gilgamesh, composed in Sumerian around 2100 BCE and later expanded into a twelve-tablet Akkadian version by the scholar Sin-leqi-unninni around 1200 BCE. The epic tells the story of Gilgamesh, king of Uruk, and his quest for immortality after the death of his companion Enkidu. The eleventh tablet contains a flood narrative that closely parallels the story of Noah in Genesis, a discovery that caused a sensation when George Smith published his translation in 1872.</p>
+
+## Scribal copying
+
+<p>Literary texts were preserved through scribal copying. Each generation of scribes learned the great texts by copying them in the edubba. The copies were not always faithful: scribes added lines, omitted passages, and introduced errors. By comparing tablets from different cities and periods, modern scholars can reconstruct the history of each text and identify the layers of editorial intervention.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Colophon</h3>
+<p>The note at the end of a literary tablet identifying the text, the scribe, and the date of copying. "Tablet 11 of the series 'He who saw the deep.' Written by Nabu-zuqup-kenu, son of Marduk-shumu-iqisha."</p>
+</div>
+<div class="tablet-card">
+<h3>Catch-line</h3>
+<p>The first line of the next tablet, written at the end of the current one. The ancient equivalent of a page number, linking tablets in sequence.</p>
+</div>
+</div>
+
+<blockquote>He who saw the deep, the foundation of the country, who knew everything, was wise in all matters. Gilgamesh, who saw the deep, the foundation of the country, who knew everything, was wise in all matters.</blockquote>

--- a/cuneiform-tablet/content/tablets/4-the-legal-document.md
+++ b/cuneiform-tablet/content/tablets/4-the-legal-document.md
@@ -1,0 +1,36 @@
++++
+title = "The Legal Document"
+description = "Contracts, deeds, and laws impressed into clay."
+tags = ["legal", "contract"]
++++
+
+<p class="tablet-label">Tablet IV</p>
+
+# The Legal Document
+
+<p class="lede">Mesopotamian law was written in clay. Contracts of sale, deeds of property, marriage agreements, and slave manumissions were all recorded on tablets, sealed by witnesses, and stored in archives that served as ancient registries.</p>
+
+## The envelope tablet
+
+<p>Important legal documents were enclosed in a clay envelope: a second layer of clay wrapped around the original tablet and inscribed with a copy of the text. If a dispute arose, the outer envelope could be broken open to reveal the unaltered original inside. The envelope also carried the seal impressions of the witnesses, pressed into the wet clay with cylinder seals. This double-document system is the ancestor of modern notarization.</p>
+
+## The Code of Hammurabi
+
+<p>The most famous legal text in cuneiform is the Code of Hammurabi, inscribed on a basalt stela around 1754 BCE. The code contains 282 laws covering property, commerce, family, and criminal matters. Although it was carved in stone rather than pressed into clay, it was composed in cuneiform script and distributed to the provinces on clay tablets. The laws reveal a complex society with detailed provisions for contracts, wages, liability, and the rights of different social classes.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Sale contract</h3>
+<p>Records the sale of land, houses, or slaves. Includes the price, the names of buyer and seller, the names of witnesses, and the date. Often sealed in an envelope.</p>
+</div>
+<div class="tablet-card">
+<h3>Loan agreement</h3>
+<p>Records a loan of silver or barley with the interest rate, repayment date, and penalty for default. Interest rates in Old Babylonian period: 20% on silver, 33% on barley.</p>
+</div>
+<div class="tablet-card">
+<h3>Adoption record</h3>
+<p>Legal tablet recording the adoption of a child, specifying the rights and obligations of the adoptive parents and the consequences of repudiation.</p>
+</div>
+</div>
+
+<blockquote>If a man has purchased a slave or slave-girl and the seller has not disclosed a pre-existing claim, the buyer may return the slave within one month.</blockquote>

--- a/cuneiform-tablet/content/tablets/5-the-mathematical-tablet.md
+++ b/cuneiform-tablet/content/tablets/5-the-mathematical-tablet.md
@@ -1,0 +1,36 @@
++++
+title = "The Mathematical Tablet"
+description = "Arithmetic, geometry, and astronomy computed on clay."
+tags = ["mathematical", "astronomy"]
++++
+
+<p class="tablet-label">Tablet V</p>
+
+# The Mathematical Tablet
+
+<p class="lede">Mesopotamian mathematics was remarkably advanced. The scribes of Babylon worked in a base-60 number system, solved quadratic equations, computed square roots, and understood the relationship between the sides of a right triangle a thousand years before Pythagoras.</p>
+
+## The sexagesimal system
+
+<p>Cuneiform mathematics uses a base-60 (sexagesimal) positional number system. The two basic numerals are the vertical wedge (value 1) and the Winkelhaken (value 10). These are combined to write numbers from 1 to 59, and then the position of the numeral group determines its power of 60. The system survives today in our division of the hour into 60 minutes and the circle into 360 degrees.</p>
+
+## Plimpton 322
+
+<p>The most famous mathematical tablet is Plimpton 322, a small clay tablet from the Old Babylonian period now in Columbia University. It contains a table of fifteen rows of numbers that represent Pythagorean triples: sets of three integers that satisfy the equation a-squared plus b-squared equals c-squared. The tablet demonstrates that Babylonian mathematicians understood this relationship more than a thousand years before the Greek tradition attributes the discovery to Pythagoras.</p>
+
+<div class="tablet-grid">
+<div class="tablet-card">
+<h3>Multiplication tables</h3>
+<p>The most common mathematical tablets. Students memorized tables for every integer from 1 to 60 and their reciprocals. These formed the basis for all computation.</p>
+</div>
+<div class="tablet-card">
+<h3>Problem texts</h3>
+<p>Worked examples of mathematical problems: finding the area of irregular fields, computing the volume of excavated canals, calculating the labor required for construction projects.</p>
+</div>
+<div class="tablet-card">
+<h3>Astronomical tables</h3>
+<p>Late Babylonian tablets recording the positions of planets, the timing of eclipses, and the rising and setting of stars. The foundation of Western astronomy and astrology.</p>
+</div>
+</div>
+
+<blockquote>I found the length to be four rods and the width to be three rods. The diagonal I computed: five rods. The field is twelve sar. This is the procedure.</blockquote>

--- a/cuneiform-tablet/content/tablets/_index.md
+++ b/cuneiform-tablet/content/tablets/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Tablets"
+description = "The tablet collection of this cuneiform archive."
++++
+
+<p class="lede">Five tablets from the archive, each representing a different category of cuneiform record. From royal inscriptions to humble receipts, the clay remembers what paper would have forgotten.</p>
+
+<p>The tablets are arranged by type, following the cataloguing conventions of modern Assyriology. Each tablet is identified by its content type and a brief description of the impression pattern on its surface.</p>

--- a/cuneiform-tablet/static/css/style.css
+++ b/cuneiform-tablet/static/css/style.css
@@ -1,0 +1,372 @@
+/* =============================================================================
+   Cuneiform Tablet - Clay Impression Publication
+   Issue #1558 | book, dark, ancient, impressed, archaeological
+   Palette: dark clay browns, warm ochre accents, aged parchment text
+   No gradients. Cuneiform wedge patterns + clay tablet frames as inline SVG.
+   ============================================================================= */
+
+:root {
+  --clay: #2e2720;
+  --clay-soft: #3d3328;
+  --clay-deep: #221c17;
+  --clay-edge: #5a4d3c;
+  --text: #c4b394;
+  --text-soft: #a89272;
+  --text-dim: #7a6b54;
+  --ochre: #c8943e;       /* warm ochre accent */
+  --ochre-soft: #a67c35;
+  --sand: #d4c1a0;        /* light sand for emphasis */
+  --char: #1a1510;        /* deepest charcoal */
+  --bg: #1e1a15;          /* outer background */
+  --wedge: rgba(168, 146, 114, 0.12);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: "Exo 2", "Share Tech", system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.archive-shell {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--clay-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 52px; height: 52px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.04em;
+  color: var(--sand);
+  text-transform: uppercase;
+}
+.logo-sub {
+  font-family: "Share Tech", sans-serif;
+  font-weight: 400;
+  font-size: 0.82rem;
+  color: var(--text-soft);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Share Tech", sans-serif;
+  font-size: 0.88rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--ochre); border-bottom-color: var(--ochre); }
+
+/* --- Tablet (page) ------------------------------------------------------- */
+.site-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.tablet {
+  position: relative;
+  background-color: var(--clay);
+  border: 2px solid var(--clay-edge);
+  border-radius: 12px;
+  min-height: 640px;
+  box-shadow:
+    0 2px 0 var(--clay-deep),
+    0 18px 36px rgba(30, 26, 21, 0.5);
+  overflow: hidden;
+}
+
+.tablet-narrow {
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tablet-edge-top {
+  height: 12px;
+}
+.tablet-edge-top svg { width: 100%; height: 100%; display: block; }
+
+.tablet-surface {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+.tablet-surface svg { width: 100%; height: 100%; display: block; }
+
+.tablet-body {
+  position: relative;
+  z-index: 2;
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.tablet-body h1,
+.tablet-body h2,
+.tablet-body h3 {
+  font-family: "Rajdhani", "Orbitron", sans-serif;
+  color: var(--sand);
+  line-height: 1.25;
+  letter-spacing: 0.02em;
+  font-weight: 700;
+}
+.tablet-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0 0 0.2em;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.tablet-body h2 {
+  font-size: 1.45rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--clay-edge);
+}
+.tablet-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--ochre);
+}
+
+.tablet-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Exo 2", "Share Tech", sans-serif;
+}
+.tablet-body p.lede {
+  font-family: "Exo 2", sans-serif;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--text-soft);
+  font-style: italic;
+}
+
+.tablet-label {
+  display: inline-block;
+  font-family: "Orbitron", "Rajdhani", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ochre);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.7em;
+  background-color: var(--clay-deep);
+  border: 1px solid var(--clay-edge);
+  border-radius: 3px;
+}
+
+.tablet-head { margin-bottom: 2rem; }
+.tablet-title {
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  margin: 0;
+  letter-spacing: 0.03em;
+  color: var(--sand);
+  text-transform: uppercase;
+}
+
+.tablet-body a {
+  color: var(--ochre);
+  text-decoration: none;
+  border-bottom: 1px solid var(--ochre-soft);
+}
+.tablet-body a:hover { color: var(--sand); border-bottom-color: var(--sand); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--ochre);
+  background-color: var(--clay-deep);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "Exo 2", sans-serif;
+  font-size: 1.05rem;
+  border-radius: 0 4px 4px 0;
+}
+
+.tablet-body ul,
+.tablet-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.tablet-body ul { list-style: disc; }
+.tablet-body ol { list-style: decimal; }
+.tablet-body li { padding: 0.2em 0; }
+
+/* --- Tablet card grid ---------------------------------------------------- */
+.tablet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.tablet-card {
+  background-color: var(--clay-deep);
+  border: 1px solid var(--clay-edge);
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.tablet-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--ochre);
+  font-size: 1rem;
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.tablet-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+
+.wedge-demo {
+  margin-bottom: 0.5rem;
+}
+.wedge-demo svg {
+  width: 80px;
+  height: 48px;
+  display: block;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--clay-edge);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--clay-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Rajdhani", sans-serif;
+}
+.section-list li::before {
+  content: "\25C6";               /* diamond - clay seal mark */
+  color: var(--ochre);
+  font-size: 0.7em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--sand);
+  border: none;
+  font-size: 1.02rem;
+  letter-spacing: 0.02em;
+}
+.section-list li a:hover { color: var(--ochre); }
+
+.taxonomy-desc {
+  color: var(--text-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--clay-edge);
+  border-radius: 3px;
+  font-family: "Share Tech", sans-serif;
+  font-size: 0.85rem;
+  color: var(--text);
+  text-decoration: none;
+  background-color: var(--clay-deep);
+}
+nav.pagination a:hover { color: var(--ochre); border-color: var(--ochre); }
+.pagination-current span { color: var(--ochre); border-color: var(--ochre); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--clay-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 700;
+  color: var(--sand);
+  margin: 0.2em 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.footer-line-small {
+  font-family: "Exo 2", sans-serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .tablet { border-radius: 8px; }
+  .tablet-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .tablet-title, .tablet-body h1 { font-size: 1.9rem; }
+  .tablet-body h2 { font-size: 1.2rem; }
+}

--- a/cuneiform-tablet/templates/404.html
+++ b/cuneiform-tablet/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tablet tablet-narrow">
+      <div class="tablet-body">
+        <header class="tablet-head">
+          <p class="tablet-label">404</p>
+          <h1 class="tablet-title">Tablet not found</h1>
+        </header>
+        <p>This tablet has crumbled or was never fired. The clay has returned to dust. Please return to the archive and select another record.</p>
+        <p><a href="{{ base_url }}/">Back to the archive</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cuneiform-tablet/templates/footer.html
+++ b/cuneiform-tablet/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line">Cuneiform Tablet</p>
+      <p class="footer-line-small">An archaeological archive of clay impressions from the ancient world.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; pressed into wet clay, fired in digital kilns</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cuneiform-tablet/templates/header.html
+++ b/cuneiform-tablet/templates/header.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700&family=Share+Tech&family=Exo+2:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="archive-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Cuneiform Tablet home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="6" y="4" width="44" height="48" rx="6" fill="#3d3328" stroke="#6b5d4a" stroke-width="0.8"/>
+          <rect x="9" y="7" width="38" height="42" rx="4" fill="none" stroke="#5a4d3c" stroke-width="0.4"/>
+          <g stroke="#a89272" stroke-width="1.4" stroke-linecap="round">
+            <line x1="16" y1="16" x2="22" y2="16"/>
+            <line x1="16" y1="16" x2="16" y2="22"/>
+            <line x1="28" y1="16" x2="34" y2="16"/>
+            <line x1="28" y1="16" x2="28" y2="20"/>
+            <line x1="16" y1="28" x2="22" y2="28"/>
+            <line x1="16" y1="28" x2="18" y2="34"/>
+            <line x1="28" y1="28" x2="34" y2="28"/>
+            <line x1="34" y1="28" x2="34" y2="34"/>
+            <line x1="38" y1="16" x2="42" y2="16"/>
+            <line x1="38" y1="16" x2="38" y2="20"/>
+            <line x1="16" y1="40" x2="24" y2="40"/>
+            <line x1="30" y1="40" x2="36" y2="40"/>
+          </g>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Cuneiform Tablet</span>
+          <span class="logo-sub">Clay Impression Archive</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/tablets/">Tablets</a>
+        <a href="{{ base_url }}/writing/">Writing</a>
+        <a href="{{ base_url }}/excavation/">Excavation</a>
+      </nav>
+    </header>
+  </div>

--- a/cuneiform-tablet/templates/page.html
+++ b/cuneiform-tablet/templates/page.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tablet">
+      <div class="tablet-edge tablet-edge-top" aria-hidden="true">
+        <svg viewBox="0 0 800 12" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="800" height="12" fill="#3d3328" rx="4"/>
+          <g stroke="#5a4d3c" stroke-width="0.4" opacity="0.5">
+            <line x1="60" y1="4" x2="60" y2="8"/>
+            <line x1="160" y1="3" x2="160" y2="9"/>
+            <line x1="300" y1="4" x2="300" y2="8"/>
+            <line x1="440" y1="3" x2="440" y2="9"/>
+            <line x1="580" y1="4" x2="580" y2="8"/>
+            <line x1="720" y1="3" x2="720" y2="9"/>
+          </g>
+        </svg>
+      </div>
+      <div class="tablet-surface" aria-hidden="true">
+        <svg viewBox="0 0 600 600" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <g stroke="#5a4d3c" stroke-width="0.6" stroke-linecap="round" opacity="0.12">
+            <line x1="40" y1="80" x2="52" y2="80"/>
+            <line x1="40" y1="80" x2="40" y2="88"/>
+            <line x1="120" y1="160" x2="132" y2="160"/>
+            <line x1="120" y1="160" x2="122" y2="168"/>
+            <line x1="480" y1="120" x2="492" y2="120"/>
+            <line x1="480" y1="120" x2="480" y2="128"/>
+            <line x1="300" y1="280" x2="312" y2="280"/>
+            <line x1="300" y1="280" x2="302" y2="288"/>
+            <line x1="540" y1="360" x2="552" y2="360"/>
+            <line x1="540" y1="360" x2="540" y2="368"/>
+            <line x1="80" y1="440" x2="92" y2="440"/>
+            <line x1="80" y1="440" x2="82" y2="448"/>
+            <line x1="420" y1="500" x2="432" y2="500"/>
+            <line x1="420" y1="500" x2="420" y2="508"/>
+            <line x1="200" y1="540" x2="212" y2="540"/>
+            <line x1="200" y1="540" x2="200" y2="548"/>
+          </g>
+        </svg>
+      </div>
+      <div class="tablet-body">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cuneiform-tablet/templates/section.html
+++ b/cuneiform-tablet/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tablet">
+      <div class="tablet-edge tablet-edge-top" aria-hidden="true">
+        <svg viewBox="0 0 800 12" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="800" height="12" fill="#3d3328" rx="4"/>
+        </svg>
+      </div>
+      <div class="tablet-body">
+        <header class="tablet-head">
+          <p class="tablet-label">Tablet Index</p>
+          <h1 class="tablet-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cuneiform-tablet/templates/shortcodes/alert.html
+++ b/cuneiform-tablet/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #5a4d3c; background-color: #2e2720; border-left: 5px solid #a89272; margin: 1rem 0; color: #c4b394;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/cuneiform-tablet/templates/taxonomy.html
+++ b/cuneiform-tablet/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tablet tablet-narrow">
+      <div class="tablet-body">
+        <header class="tablet-head">
+          <p class="tablet-label">Catalogue</p>
+          <h1 class="tablet-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subject classifications in this archive:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cuneiform-tablet/templates/taxonomy_term.html
+++ b/cuneiform-tablet/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tablet tablet-narrow">
+      <div class="tablet-body">
+        <header class="tablet-head">
+          <p class="tablet-label">Subject</p>
+          <h1 class="tablet-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Tablets filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1017,6 +1017,13 @@
     "crystal",
     "faceted"
   ],
+  "cuneiform-tablet": [
+    "book",
+    "dark",
+    "ancient",
+    "impressed",
+    "archaeological"
+  ],
   "curator": [
     "light",
     "portfolio",
@@ -1589,13 +1596,6 @@
     "blog",
     "editorial"
   ],
-  "gilt-edge": [
-    "book",
-    "dark",
-    "luxury",
-    "gilded",
-    "opulent"
-  ],
   "generative-art": [
     "dark",
     "portfolio",
@@ -1619,6 +1619,13 @@
     "blog",
     "luxury",
     "gold"
+  ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
   ],
   "glacial-blog": [
     "blog",


### PR DESCRIPTION
Closes #1558

## Summary
- Adds cuneiform-tablet example site: a dark, archaeological publication inspired by clay tablet impressions and cuneiform writing
- SVG cuneiform wedge-mark patterns as decorative background elements; clay tablet rounded-rectangle frames for content blocks
- Typography: Rajdhani / Orbitron for angular display type mimicking wedge impressions; Share Tech / Exo 2 for cuneiform-inspired body text
- Full content with 5 tablet chapters covering royal inscriptions, administrative records, literary texts, legal documents, and mathematical tablets, plus writing system reference and excavation guide
- Tags: book, dark, ancient, impressed, archaeological

## Test plan
- [ ] Run `hwaro build` in `cuneiform-tablet/` directory
- [ ] Run `hwaro serve` and verify all pages render correctly
- [ ] Verify no CSS gradients are used
- [ ] Verify all decorative visuals use inline SVG
- [ ] Verify no emojis in any files
- [ ] Verify tags.json is updated with the new entry