### PR TITLE
feat: add bastard-title example site (closes #1557)

### DIFF
--- a/bastard-title/AGENTS.md
+++ b/bastard-title/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/bastard-title/config.toml
+++ b/bastard-title/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Bastard Title - Half-Title Publication
+# Issue #1557 | Tags: book, light, preliminary, ceremonial, typography
+# =============================================================================
+
+title = "Bastard Title"
+description = "A light, typographically refined publication modeled on the preliminary pages of a fine book. SVG ornamental rules and a publisher's device mark frame each page in the tradition of the half-title, title page, and colophon. Playfair Display and Cormorant for display, Crimson Pro and EB Garamond for body."
+base_url = "http://localhost:3000"
+
+sections = ["leaves"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/bastard-title/content/about.md
+++ b/bastard-title/content/about.md
@@ -1,0 +1,41 @@
++++
+title = "Preliminaries"
+description = "The structure and conventions of preliminary pages in bookmaking."
++++
+
+<p class="leaf-label">Reference</p>
+
+# The Preliminary Pages
+
+<p class="lede">Every element of the preliminary sequence has a purpose, a position, and a typographic style that has been refined over centuries of bookmaking tradition.</p>
+
+## Recto and verso
+
+<p>In book terminology, the recto is the right-hand page (odd-numbered) and the verso is the left-hand page (even-numbered). The preliminary pages follow a strict recto/verso assignment: the half-title falls on the first recto, the title page on the second recto, and the dedication on the third recto. Versos are typically blank or carry secondary material like the frontispiece (verso of the half-title) or the copyright notice (verso of the title page).</p>
+
+## The title page
+
+<p>The title page is the most important typographic composition in the book. It must convey the full title, subtitle, author name, publisher name, and date of publication in a balanced, hierarchical arrangement. The best title pages achieve this with nothing but type, carefully chosen and carefully spaced. The great title pages of the sixteenth and seventeenth centuries are masterworks of typographic design, using only roman and italic type, rules, and the occasional printer's ornament.</p>
+
+## The colophon
+
+<p>The colophon appears at the end of the book rather than the beginning, but it belongs to the same family of ceremonial pages. In fine printing, the colophon records the typeface, paper, printer, binder, and edition size. It is the bookmaker's signature, placed at the very end as a final mark of craft.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>Typeface notice</h3>
+<p>"This volume is set in Caslon Old Face, designed by William Caslon in 1722." The colophon names the type as a craftsman names tools.</p>
+</div>
+<div class="prelim-card">
+<h3>Paper notice</h3>
+<p>"Printed on Mohawk Superfine, eggshell finish, 80 lb text." The paper is the body of the book; the colophon acknowledges it.</p>
+</div>
+<div class="prelim-card">
+<h3>Edition statement</h3>
+<p>"First edition. 500 copies printed, of which 50 are signed and numbered." The colophon defines the book as an object.</p>
+</div>
+</div>
+
+## The publisher's device
+
+<p>A small emblem or mark identifying the publisher, traditionally placed on the title page or colophon. The device is the publisher's signature: Aldus Manutius used a dolphin and anchor, the Elzevirs used a solitary figure with a vine, and modern publishers continue the tradition with logo marks. In this publication, a simple circular device with the initials "BT" appears in the footer of every page.</p>

--- a/bastard-title/content/colophon.md
+++ b/bastard-title/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "The colophon of this publication: type, design, and construction."
++++
+
+<div class="colophon-page">
+<p class="leaf-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="ornamental-divider" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<line x1="30" y1="8" x2="170" y2="8" stroke="#c4b594" stroke-width="0.5"/>
+<circle cx="100" cy="8" r="2.5" fill="none" stroke="#8c7b64" stroke-width="0.8"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of the preliminary pages of the bound book: the half-title, the title page, the dedication, the colophon, and the other ceremonial leaves that precede and follow the main text.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Playfair Display and Cormorant, refined display serifs chosen for their elegance at large sizes and their compatibility with the centered, symmetrical layouts of traditional title pages.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in Crimson Pro and EB Garamond, text faces that carry long passages with ease and pair naturally with the display type above.</p>
+
+<p class="colophon-detail"><strong>Ornamental rules</strong> are drawn as inline SVG, following the restrained tradition of typographic ornament: a centered arrangement of dots, circles, and thin rules, never competing with the type for attention.</p>
+
+<p class="colophon-detail"><strong>The publisher's device</strong> appears in the footer: a simple circular mark bearing the initials "BT" for Bastard Title, in the tradition of the printer's mark on the colophon page.</p>
+
+<div class="ornamental-divider" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<circle cx="90" cy="8" r="1.5" fill="#8c7b64"/>
+<circle cx="100" cy="8" r="1.5" fill="#8c7b64"/>
+<circle cx="110" cy="8" r="1.5" fill="#8c7b64"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First digital edition, 2026.</p>
+</div>

--- a/bastard-title/content/index.md
+++ b/bastard-title/content/index.md
@@ -1,0 +1,63 @@
++++
+title = "Bastard Title"
+description = "A half-title publication in the tradition of the preliminary pages."
++++
+
+<div class="half-title-page">
+<p class="leaf-label">Half-Title</p>
+<h1 class="half-title-display">Bastard Title</h1>
+<p class="half-title-subtitle">A Study of the Preliminary Pages</p>
+</div>
+
+<div class="ornamental-divider" aria-hidden="true">
+<svg viewBox="0 0 200 24" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="12" x2="80" y2="12" stroke="#c4b594" stroke-width="0.5"/>
+<circle cx="90" cy="12" r="2" fill="#8c7b64"/>
+<circle cx="100" cy="12" r="3" fill="none" stroke="#8c7b64" stroke-width="0.8"/>
+<circle cx="110" cy="12" r="2" fill="#8c7b64"/>
+<line x1="120" y1="12" x2="180" y2="12" stroke="#c4b594" stroke-width="0.5"/>
+</svg>
+</div>
+
+## On the bastard title
+
+<p class="lede">The bastard title -- properly called the half-title -- is the first printed page of a bound book. It carries nothing but the title of the work, set in modest type, centered on the page with vast whitespace above and below. No author name, no publisher, no date. Just the title, standing alone, announcing the volume before the full title page arrives.</p>
+
+## Why it exists
+
+<p>The half-title serves a protective function. In the hand-press era, books were sold as unbound text blocks, and the buyer took them to a binder of their choosing. The half-title was the outermost printed leaf, shielding the full title page from damage during transport and binding. It was also a placeholder: if the binder trimmed the edges too aggressively, the half-title absorbed the cut and the title page survived intact.</p>
+
+## The preliminary sequence
+
+<p>A formally structured book follows a strict sequence of preliminary pages before the main text begins. Each page has a name, a function, and a set of typographic conventions that have barely changed in five centuries.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>Half-title (bastard title)</h3>
+<p>The first printed leaf. Title only, centered, in a smaller size than the full title page. Often in small capitals or italic.</p>
+</div>
+<div class="prelim-card">
+<h3>Frontispiece</h3>
+<p>An illustration facing the title page, usually on the verso of the half-title. In fine books, an engraved plate tipped in by hand.</p>
+</div>
+<div class="prelim-card">
+<h3>Title page</h3>
+<p>The full title, subtitle, author, publisher, and date. The most carefully designed page in the book. The face of the volume.</p>
+</div>
+<div class="prelim-card">
+<h3>Copyright page</h3>
+<p>The verso of the title page. Publishing details, copyright notice, ISBN, edition statement, printer's name, and paper stock.</p>
+</div>
+<div class="prelim-card">
+<h3>Dedication</h3>
+<p>A brief inscription to a person or cause, set in italic, centered on an otherwise blank page. Traditionally restrained and formal.</p>
+</div>
+<div class="prelim-card">
+<h3>Epigraph</h3>
+<p>A quotation that sets the tone for the work. Set in a smaller size than body text, with the author's name below.</p>
+</div>
+</div>
+
+## The typography of ceremony
+
+<p>The preliminary pages are the most typographically conservative part of any book. They follow conventions established in the sixteenth century and maintained through five hundred years of changing fashion. The type is centered. The leading is generous. The ornaments, if any, are restrained: a simple rule, a small device, a row of dots. The preliminary pages are a ceremony of introduction, and ceremony demands decorum.</p>

--- a/bastard-title/content/leaves/1-the-half-title.md
+++ b/bastard-title/content/leaves/1-the-half-title.md
@@ -1,0 +1,32 @@
++++
+title = "The Half-Title"
+description = "The first printed leaf of a bound book."
+tags = ["half-title", "preliminary"]
++++
+
+<p class="leaf-label">Leaf I</p>
+
+# The Half-Title
+
+<p class="lede">The half-title is the quietest page in the book. It speaks only the title, in a modest size, centered on an expanse of white paper. Everything else -- the author, the publisher, the date, the subtitle -- waits for the title page. The half-title is an announcement, not an introduction.</p>
+
+## Origin
+
+<p>The half-title emerged in the late seventeenth century as a protective wrapper for the title page. Books were sold as unbound sheets, and the outermost leaves were vulnerable to soiling, tearing, and handling damage during transport. A simple leaf bearing only the title could be sacrificed to protect the more elaborate title page behind it. Over time, the half-title became conventional rather than functional, but its form -- title only, centered, restrained -- has never changed.</p>
+
+## Typography
+
+<p>The half-title is traditionally set in a smaller size than the title page, often in small capitals or a light italic. The positioning is centered both horizontally and vertically, with generous margins on all sides. The effect is one of restraint and anticipation: the reader knows the title of the book but must turn the page to learn anything more.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>Small capitals</h3>
+<p>The classic choice for the half-title. Small capitals are formal, restrained, and unobtrusive. They set the title apart from running text without competing with the full title page.</p>
+</div>
+<div class="prelim-card">
+<h3>Italic</h3>
+<p>An alternative for the half-title, especially in literary works. Italic conveys a sense of intimacy and anticipation that suits the introductory function of the page.</p>
+</div>
+</div>
+
+<blockquote>The half-title says: here begins the book. It does not say: here is what the book contains, who wrote it, or why you should read it. That is the work of the title page.</blockquote>

--- a/bastard-title/content/leaves/2-the-title-page.md
+++ b/bastard-title/content/leaves/2-the-title-page.md
@@ -1,0 +1,36 @@
++++
+title = "The Title Page"
+description = "The face of the book: title, author, publisher, and date."
+tags = ["title-page", "design"]
++++
+
+<p class="leaf-label">Leaf II</p>
+
+# The Title Page
+
+<p class="lede">The title page is the most carefully designed page in any book. It is the face of the volume, the first full statement of what the book is, who made it, and when it was made. Five centuries of typographic tradition have refined the title page into a composition of extraordinary precision.</p>
+
+## Elements
+
+<p>A complete title page contains, in descending order of prominence: the full title of the work, the subtitle (if any), the author's name, the publisher's name or device, the place of publication, and the date. Each element is set in a different size, weight, or style to create a clear hierarchy. The title is the largest element; the date is the smallest. The arrangement is centered on the vertical axis, with each line balanced on the midpoint of the measure.</p>
+
+## Historical evolution
+
+<p>The earliest printed books had no title page. The text began on the first leaf with an incipit: "Here begins the book of..." The title page as a separate leaf appeared around 1480 and became standard by 1520. Early title pages were elaborate, with woodcut borders, printer's devices, and long descriptive titles. By the eighteenth century, the title page had been stripped to its essentials: type, rules, and whitespace. The modern title page inherits this classical restraint.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>The Aldine title page</h3>
+<p>Aldus Manutius established the modern title page form in Venice around 1500: centered type, a simple rule, the printer's device, and the date in Roman numerals.</p>
+</div>
+<div class="prelim-card">
+<h3>The baroque title page</h3>
+<p>Seventeenth-century title pages became theatrical: engraved architectural frames, allegorical figures, and long descriptive titles. Beautiful but difficult to read.</p>
+</div>
+<div class="prelim-card">
+<h3>The modern title page</h3>
+<p>The return to simplicity in the eighteenth and nineteenth centuries. Clean type, generous spacing, and no ornament beyond a thin rule or a small device.</p>
+</div>
+</div>
+
+<blockquote>A great title page is a composition in which every element -- title, author, publisher, date -- finds its natural position through the weight and rhythm of the type alone.</blockquote>

--- a/bastard-title/content/leaves/3-the-dedication.md
+++ b/bastard-title/content/leaves/3-the-dedication.md
@@ -1,0 +1,32 @@
++++
+title = "The Dedication"
+description = "A brief inscription to a person, cause, or ideal."
+tags = ["dedication", "ceremony"]
++++
+
+<p class="leaf-label">Leaf III</p>
+
+# The Dedication
+
+<p class="lede">The dedication is the most personal page in the book. It is a brief inscription, rarely more than a few lines, addressed to a specific person or cause. It occupies a full recto page, centered, with more whitespace than any other page in the volume.</p>
+
+## Convention
+
+<p>The dedication is set in italic, centered on the page, with wide margins. It traditionally begins with "To" or "For" followed by the dedicatee's name. The tone is formal and restrained. Effusive dedications went out of fashion in the eighteenth century; modern dedications are brief, sometimes cryptic, and always sincere.</p>
+
+## Historical role
+
+<p>In the era of patronage, the dedication was a political act. Authors dedicated their books to wealthy patrons in exchange for financial support, protection, or social advancement. The dedication could be fulsome, running to several pages of elaborate praise. Samuel Johnson, in the preface to his Dictionary, famously addressed his patron Lord Chesterfield with barely concealed contempt after Chesterfield had ignored him during the years of composition. The modern dedication has shed this transactional function and become a private gesture within a public object.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>The simple dedication</h3>
+<p>"For my mother." Three words on a full page. The most powerful form of the dedication: extreme brevity against extreme whitespace.</p>
+</div>
+<div class="prelim-card">
+<h3>The cryptic dedication</h3>
+<p>"For E.H., who knows why." The dedication as private code. The dedicatee understands; the reader wonders.</p>
+</div>
+</div>
+
+<blockquote>The dedication is the one page in the book where the author speaks as a person rather than a writer. It is the only page that is not about the book.</blockquote>

--- a/bastard-title/content/leaves/4-the-epigraph.md
+++ b/bastard-title/content/leaves/4-the-epigraph.md
@@ -1,0 +1,36 @@
++++
+title = "The Epigraph"
+description = "A quotation that sets the tone for the work."
+tags = ["epigraph", "quotation"]
++++
+
+<p class="leaf-label">Leaf IV</p>
+
+# The Epigraph
+
+<p class="lede">The epigraph is a quotation placed after the dedication and before the main text. It borrows a voice from another writer to set the tone, establish a theme, or signal the intellectual tradition to which the book belongs.</p>
+
+## Function
+
+<p>The epigraph does not summarize the book. It resonates with it. A well-chosen epigraph creates a harmonic between the quoted text and the work that follows, so that the reader encounters the quotation again in memory while reading the main text. The epigraph is a tuning fork: it establishes the pitch before the music begins.</p>
+
+## Typography
+
+<p>The epigraph is set in a smaller size than body text, often in italic, and indented from both margins. The author of the quotation is given below, typically in small capitals or roman, preceded by a dash. The epigraph occupies a full page, centered vertically, with generous whitespace. Like the dedication, it is a page of few words and much silence.</p>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>The literary epigraph</h3>
+<p>A quotation from another literary work. The most common type. It signals the genre, the tradition, and the ambition of the book.</p>
+</div>
+<div class="prelim-card">
+<h3>The philosophical epigraph</h3>
+<p>A quotation from a philosopher or thinker. It frames the book as an argument or an inquiry, placing it in an intellectual lineage.</p>
+</div>
+<div class="prelim-card">
+<h3>The ironic epigraph</h3>
+<p>A quotation that contradicts or subverts the book's apparent subject. The reader discovers the irony only after finishing the work.</p>
+</div>
+</div>
+
+<blockquote>The epigraph is the author's confession of influence. It says: I have read this, and it changed what I wrote.</blockquote>

--- a/bastard-title/content/leaves/5-the-colophon-leaf.md
+++ b/bastard-title/content/leaves/5-the-colophon-leaf.md
@@ -1,0 +1,45 @@
++++
+title = "The Colophon"
+description = "The maker's mark at the end of the volume."
+tags = ["colophon", "craft"]
++++
+
+<p class="leaf-label">Leaf V</p>
+
+# The Colophon
+
+<p class="lede">The colophon is the last ceremonial page. It appears at the end of the volume, often on the final verso, and records the details of the book's physical making: the type, the paper, the printer, the binder, the edition size, and the date of completion.</p>
+
+## The printer's signature
+
+<p>The colophon predates the title page. The earliest printed books identified themselves only through a colophon at the end of the text: "Printed in the city of Mainz by Johann Fust and Peter Schoeffer, in the year of our Lord 1457." As the title page took over the function of identification, the colophon evolved into a craftsman's record: a place to name the materials and methods that brought the text into physical form.</p>
+
+## Content of the colophon
+
+<p>A fine-press colophon typically records the following details, each on its own line or paragraph:</p>
+
+<ul>
+<li>The name of the typeface and its designer</li>
+<li>The name and weight of the paper</li>
+<li>The name of the printer and the press</li>
+<li>The name of the binder (if hand-bound)</li>
+<li>The edition size and any limitation</li>
+<li>The date of completion</li>
+</ul>
+
+<div class="prelim-grid">
+<div class="prelim-card">
+<h3>Fine-press colophon</h3>
+<p>The most elaborate form. Names every material and craftsperson. Common in limited editions, letterpress books, and artist's books.</p>
+</div>
+<div class="prelim-card">
+<h3>Trade colophon</h3>
+<p>A simpler form found in commercial books. Names the typeface and sometimes the paper, but omits the printer and binder.</p>
+</div>
+<div class="prelim-card">
+<h3>The printer's device</h3>
+<p>A small emblem or mark placed on the colophon page. The visual equivalent of the printer's signature, linking the physical object to its maker.</p>
+</div>
+</div>
+
+<blockquote>The colophon is the bookmaker's handshake with the reader. It says: this is what I made, and this is how I made it.</blockquote>

--- a/bastard-title/content/leaves/_index.md
+++ b/bastard-title/content/leaves/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Leaves"
+description = "The leaves of this half-title publication."
++++
+
+<p class="lede">Five leaves, each examining a different aspect of the preliminary pages. From the half-title to the colophon, the ceremonial structure of the book has been refined over five centuries of printing.</p>
+
+<p>The leaves are arranged in the order they would appear in a bound volume, following the traditional sequence of the preliminary pages.</p>

--- a/bastard-title/static/css/style.css
+++ b/bastard-title/static/css/style.css
@@ -1,0 +1,425 @@
+/* =============================================================================
+   Bastard Title - Half-Title Publication
+   Issue #1557 | book, light, preliminary, ceremonial, typography
+   Palette: warm ivory, aged gold accents, deep ink
+   No gradients. Ornamental rules + publisher's device as inline SVG.
+   ============================================================================= */
+
+:root {
+  --ivory: #faf7f0;
+  --ivory-soft: #f2ede3;
+  --ivory-deep: #e6dfd2;
+  --ivory-edge: #c4b594;
+  --ink: #3a3530;
+  --ink-soft: #5c554c;
+  --ink-dim: #8c7b64;
+  --gold: #8c7b64;         /* aged gold accent */
+  --gold-light: #c4b594;
+  --wine: #6b3a3a;         /* deep wine for emphasis */
+  --charcoal: #1e1c1a;
+  --bg: #fdfbf6;           /* outer background */
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Crimson Pro", "EB Garamond", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.76;
+  min-height: 100vh;
+}
+
+.volume-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--ivory-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 48px; height: 48px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Cormorant", serif;
+  font-weight: 500;
+  font-size: 0.88rem;
+  color: var(--gold);
+  letter-spacing: 0.06em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--wine); border-bottom-color: var(--wine); }
+
+/* --- Leaf (page) --------------------------------------------------------- */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.leaf {
+  position: relative;
+  background-color: var(--ivory);
+  border: 1px solid var(--ivory-edge);
+  min-height: 640px;
+  box-shadow:
+    0 1px 0 var(--ivory-deep),
+    0 12px 32px rgba(140, 123, 100, 0.08);
+}
+
+.leaf-narrow {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ornamental-rule { text-align: center; }
+.ornamental-rule svg { max-width: 100%; height: 20px; display: block; margin: 0 auto; }
+.ornamental-rule-top { padding: 1.5rem 2rem 0; }
+.ornamental-rule-bottom { padding: 0 2rem 1.5rem; }
+
+.leaf-body {
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 5vw, 4rem);
+  text-align: center;
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.leaf-body h1,
+.leaf-body h2,
+.leaf-body h3 {
+  font-family: "Playfair Display", "Cormorant", serif;
+  color: var(--ink);
+  line-height: 1.25;
+  font-weight: 600;
+}
+.leaf-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0 0 0.3em;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+.leaf-body h2 {
+  font-size: 1.4rem;
+  margin: 2.5em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--ivory-edge);
+  text-align: left;
+}
+.leaf-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--wine);
+  text-align: left;
+}
+
+.leaf-body p {
+  margin: 1em 0;
+  color: var(--ink);
+  font-family: "Crimson Pro", "EB Garamond", serif;
+  text-align: left;
+}
+.leaf-body p.lede {
+  font-family: "Cormorant", serif;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 36em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.leaf-label {
+  display: inline-block;
+  font-family: "Crimson Pro", serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin: 0 0 0.5em;
+}
+
+.leaf-head { margin-bottom: 2rem; text-align: center; }
+.leaf-title {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+
+.leaf-body a {
+  color: var(--wine);
+  text-decoration: none;
+  border-bottom: 1px solid var(--gold-light);
+}
+.leaf-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+blockquote {
+  margin: 2rem auto;
+  padding: 0.5rem 1.5rem;
+  border-left: 2px solid var(--gold);
+  background-color: var(--ivory-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Cormorant", serif;
+  font-size: 1.1rem;
+  text-align: left;
+  max-width: 32em;
+}
+
+.leaf-body ul,
+.leaf-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  text-align: left;
+}
+.leaf-body ul { list-style: disc; }
+.leaf-body ol { list-style: decimal; }
+.leaf-body li { padding: 0.2em 0; }
+
+/* --- Half-title display -------------------------------------------------- */
+.half-title-page {
+  padding: clamp(4rem, 10vw, 8rem) 0;
+  text-align: center;
+}
+.half-title-display {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  margin: 0 0 0.2em;
+}
+.half-title-subtitle {
+  font-family: "Cormorant", serif;
+  font-size: 1.2rem;
+  font-style: italic;
+  color: var(--gold);
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+/* --- Ornamental divider -------------------------------------------------- */
+.ornamental-divider {
+  text-align: center;
+  margin: 2rem 0;
+}
+.ornamental-divider svg {
+  max-width: 200px;
+  height: 24px;
+  display: inline-block;
+}
+
+/* --- Preliminary card grid ----------------------------------------------- */
+.prelim-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+.prelim-card {
+  background-color: var(--ivory-soft);
+  border: 1px solid var(--ivory-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.prelim-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--wine);
+  font-size: 1rem;
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-style: italic;
+}
+.prelim-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2rem 0;
+}
+.colophon-page h1 {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: 2rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+}
+.colophon-detail strong {
+  color: var(--ink);
+  font-family: "Crimson Pro", serif;
+}
+.colophon-imprint {
+  font-family: "Cormorant", serif;
+  font-style: italic;
+  color: var(--gold);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--ivory-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--ivory-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Crimson Pro", serif;
+}
+.section-list li::before {
+  content: "\00B7";               /* middle dot */
+  color: var(--gold);
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 1.02rem;
+}
+.section-list li a:hover { color: var(--wine); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  text-align: left;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--ivory-edge);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--ivory-soft);
+}
+nav.pagination a:hover { color: var(--wine); border-color: var(--wine); }
+.pagination-current span { color: var(--wine); border-color: var(--wine); }
+
+/* --- Publisher's device (footer) ----------------------------------------- */
+.publisher-device {
+  margin: 0 auto 1rem;
+}
+.publisher-device svg {
+  width: 48px;
+  height: 48px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--ivory-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Playfair Display", serif;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0.2em 0;
+  letter-spacing: 0.02em;
+}
+.footer-line-small {
+  font-family: "Cormorant", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .leaf-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .leaf-title, .leaf-body h1, .half-title-display { font-size: 1.9rem; }
+  .leaf-body h2 { font-size: 1.2rem; }
+  .half-title-page { padding: 3rem 0; }
+}

--- a/bastard-title/templates/404.html
+++ b/bastard-title/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf leaf-narrow">
+      <div class="leaf-body">
+        <header class="leaf-head">
+          <p class="leaf-label">404</p>
+          <h1 class="leaf-title">Leaf not found</h1>
+        </header>
+        <p>This preliminary page was never bound into the volume. It may have been a cancel, removed before publication. Please return to the half-title.</p>
+        <p><a href="{{ base_url }}/">Back to the half-title</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bastard-title/templates/footer.html
+++ b/bastard-title/templates/footer.html
@@ -1,0 +1,21 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="publisher-device" aria-hidden="true">
+        <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="30" cy="30" r="22" fill="none" stroke="#8c7b64" stroke-width="0.8"/>
+          <circle cx="30" cy="30" r="18" fill="none" stroke="#c4b594" stroke-width="0.4"/>
+          <text x="30" y="34" font-family="serif" font-size="14" fill="#3a3530" text-anchor="middle" font-weight="600">BT</text>
+          <line x1="14" y1="30" x2="18" y2="30" stroke="#8c7b64" stroke-width="0.5"/>
+          <line x1="42" y1="30" x2="46" y2="30" stroke="#8c7b64" stroke-width="0.5"/>
+          <line x1="30" y1="14" x2="30" y2="18" stroke="#8c7b64" stroke-width="0.5"/>
+          <line x1="30" y1="42" x2="30" y2="46" stroke="#8c7b64" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <p class="footer-line">Bastard Title</p>
+      <p class="footer-line-small">A publication in the tradition of the half-title page.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; set in type, bound in convention</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/bastard-title/templates/header.html
+++ b/bastard-title/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Cormorant:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="volume-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Bastard Title home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="8" y="4" width="40" height="48" fill="none" stroke="#3a3530" stroke-width="0.8"/>
+          <line x1="14" y1="14" x2="42" y2="14" stroke="#8c7b64" stroke-width="0.6"/>
+          <line x1="14" y1="42" x2="42" y2="42" stroke="#8c7b64" stroke-width="0.6"/>
+          <text x="28" y="31" font-family="serif" font-size="12" fill="#3a3530" text-anchor="middle" font-weight="600">B</text>
+          <circle cx="20" cy="14" r="1" fill="#8c7b64"/>
+          <circle cx="28" cy="14" r="1" fill="#8c7b64"/>
+          <circle cx="36" cy="14" r="1" fill="#8c7b64"/>
+          <circle cx="20" cy="42" r="1" fill="#8c7b64"/>
+          <circle cx="28" cy="42" r="1" fill="#8c7b64"/>
+          <circle cx="36" cy="42" r="1" fill="#8c7b64"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Bastard Title</span>
+          <span class="logo-sub">Half-Title Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Half-Title</a>
+        <a href="{{ base_url }}/leaves/">Leaves</a>
+        <a href="{{ base_url }}/preliminaries/">Preliminaries</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/bastard-title/templates/page.html
+++ b/bastard-title/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <div class="ornamental-rule ornamental-rule-top" aria-hidden="true">
+        <svg viewBox="0 0 600 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="10" x2="260" y2="10" stroke="#c4b594" stroke-width="0.5"/>
+          <circle cx="270" cy="10" r="2" fill="#8c7b64"/>
+          <circle cx="284" cy="10" r="1.2" fill="#c4b594"/>
+          <circle cx="300" cy="10" r="3" fill="#8c7b64"/>
+          <circle cx="316" cy="10" r="1.2" fill="#c4b594"/>
+          <circle cx="330" cy="10" r="2" fill="#8c7b64"/>
+          <line x1="340" y1="10" x2="600" y2="10" stroke="#c4b594" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="leaf-body">
+        {{ content }}
+      </div>
+      <div class="ornamental-rule ornamental-rule-bottom" aria-hidden="true">
+        <svg viewBox="0 0 600 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="100" y1="10" x2="500" y2="10" stroke="#c4b594" stroke-width="0.5"/>
+          <circle cx="100" cy="10" r="1.5" fill="#8c7b64"/>
+          <circle cx="300" cy="10" r="1.5" fill="#8c7b64"/>
+          <circle cx="500" cy="10" r="1.5" fill="#8c7b64"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bastard-title/templates/section.html
+++ b/bastard-title/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf">
+      <div class="ornamental-rule ornamental-rule-top" aria-hidden="true">
+        <svg viewBox="0 0 600 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="10" x2="260" y2="10" stroke="#c4b594" stroke-width="0.5"/>
+          <circle cx="270" cy="10" r="2" fill="#8c7b64"/>
+          <circle cx="300" cy="10" r="3" fill="#8c7b64"/>
+          <circle cx="330" cy="10" r="2" fill="#8c7b64"/>
+          <line x1="340" y1="10" x2="600" y2="10" stroke="#c4b594" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <div class="leaf-body">
+        <header class="leaf-head">
+          <p class="leaf-label">Contents</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bastard-title/templates/shortcodes/alert.html
+++ b/bastard-title/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #c4b594; background-color: #faf7f0; border-left: 5px solid #8c7b64; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/bastard-title/templates/taxonomy.html
+++ b/bastard-title/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf leaf-narrow">
+      <div class="leaf-body">
+        <header class="leaf-head">
+          <p class="leaf-label">Index</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/bastard-title/templates/taxonomy_term.html
+++ b/bastard-title/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf leaf-narrow">
+      <div class="leaf-body">
+        <header class="leaf-head">
+          <p class="leaf-label">Subject</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Leaves filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -301,6 +301,13 @@
     "artistic",
     "minimal"
   ],
+  "bastard-title": [
+    "book",
+    "light",
+    "preliminary",
+    "ceremonial",
+    "typography"
+  ],
   "bastion": [
     "dark",
     "docs",


### PR DESCRIPTION
Closes #1557

## Summary
- Adds bastard-title example site: a light, typographically refined publication modeled on the preliminary pages of a fine book
- SVG ornamental rule arrangements for each preliminary page type; publisher's device mark (circular BT monogram) in footer
- Typography: Playfair Display / Cormorant for refined display serif centered with vast whitespace; Crimson Pro / EB Garamond for subsidiary body text
- Full content with 5 leaf chapters covering the half-title, title page, dedication, epigraph, and colophon, plus preliminaries reference and colophon page
- Tags: book, light, preliminary, ceremonial, typography

## Test plan
- [ ] Run `hwaro build` in `bastard-title/` directory
- [ ] Run `hwaro serve` and verify all pages render correctly
- [ ] Verify no CSS gradients are used
- [ ] Verify all decorative visuals use inline SVG
- [ ] Verify no emojis in any files
- [ ] Verify tags.json is updated with the new entry