### PR TITLE
feat: add cancel-leaf example site (closes #1556)

### DIFF
--- a/cancel-leaf/AGENTS.md
+++ b/cancel-leaf/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/cancel-leaf/config.toml
+++ b/cancel-leaf/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Cancel Leaf - Replacement Page Publication
+# Issue #1556 | Tags: book, light, correction, repair, visible
+# =============================================================================
+
+title = "Cancel Leaf"
+description = "A light publication about the practice of cancelling and replacing pages in bound books. SVG cancelled page stub illustrations and tipped-in leaf adhesive strip marks evoke the visible repair work of bookbinders. Inter Bold for new replacement text on bright white, EB Garamond Light for faded original text on yellowed stock."
+base_url = "http://localhost:3000"
+
+sections = ["cancels"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/cancel-leaf/content/about.md
+++ b/cancel-leaf/content/about.md
@@ -1,0 +1,37 @@
++++
+title = "Process"
+description = "How cancel leaves are made and inserted into bound books."
++++
+
+<p class="leaf-label">Workshop</p>
+
+# The Cancelling Process
+
+<p class="lede">Cancelling a leaf is delicate work. The binder must remove the defective page without damaging the adjacent leaves, then insert the replacement so cleanly that only a careful examiner will notice the correction.</p>
+
+## Why pages are cancelled
+
+<p>Pages are cancelled for many reasons. The most common is a printing error: a misspelled word, a transposed illustration, or an incorrect page number discovered after the sheets have been printed but before (or sometimes after) binding. Legal reasons also drive cancellation: a libelous passage, a withdrawn dedication, or a copyright dispute may require specific pages to be replaced in copies already distributed. Occasionally, cancellation is performed at the author's request to revise a passage that has caused embarrassment or controversy.</p>
+
+## The cutting
+
+<p>The original leaf is removed by cutting it close to the gutter with a sharp knife or razor. The cut is made about three to five millimeters from the fold, leaving a narrow stub attached to the sewing. The cut must be clean and straight; a ragged edge will show through the replacement leaf. In volumes where the original leaf was part of a conjugate pair (two leaves printed on a single sheet and folded), only one leaf of the pair can be cancelled -- the other must remain to anchor the stub.</p>
+
+## The tipping
+
+<p>The replacement leaf is attached by applying a thin line of paste along its inner edge and pressing it onto the stub. The paste line is typically two to three millimeters wide. Too much paste and the leaf cockles; too little and it falls out. The tipped leaf must align precisely with the adjacent pages in both height and fore-edge margin. A skilled binder can tip in a cancel leaf that is virtually undetectable without magnification.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-new">
+<h3>Pre-binding cancel</h3>
+<p>The easiest type. The defective leaf is replaced before the book is bound. The cancel is simply substituted in the gathered signatures.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Post-binding cancel</h3>
+<p>More difficult. The book must be opened at the relevant point, the leaf cut out, and the replacement tipped in without disturbing the binding.</p>
+</div>
+<div class="cancel-card cancel-card-old">
+<h3>Pasted-over cancel</h3>
+<p>An alternative to cutting: the corrected text is printed on a slip and pasted directly over the erroneous passage. Visible as a raised patch on the page surface.</p>
+</div>
+</div>

--- a/cancel-leaf/content/cancels/1-the-shakespeare-first-folio.md
+++ b/cancel-leaf/content/cancels/1-the-shakespeare-first-folio.md
@@ -1,0 +1,32 @@
++++
+title = "The Shakespeare First Folio"
+description = "Cancel leaves in the 1623 First Folio of Shakespeare's plays."
+tags = ["literary", "seventeenth-century"]
++++
+
+<p class="leaf-label">Cancel I</p>
+
+# The Shakespeare First Folio
+
+<p class="lede">The First Folio of Shakespeare's plays, printed in 1623, contains several cancel leaves inserted to correct errors discovered during the printing process. These cancels are among the most studied pages in bibliographic history.</p>
+
+## The problem
+
+<p>The First Folio was a massive production: 36 plays printed in a single volume of nearly 900 pages. The printing took almost two years, with multiple compositors setting type simultaneously. Errors were inevitable. When an error was discovered after a sheet had been printed, the publishers had three options: reprint the entire sheet, cancel the defective leaf and print a replacement, or issue the book with the error uncorrected.</p>
+
+## The cancels
+
+<p>Bibliographers have identified cancel leaves in several locations in the First Folio. The most famous is in <em>Troilus and Cressida</em>, which was added to the volume late in the printing process and required significant rearrangement of the preliminary pages. The cancel leaves in surviving copies show different states of the text, allowing scholars to reconstruct the order of printing and the decisions made in the print shop.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>The cancelled state</h3>
+<p>The original text as first printed. Surviving in only a few copies where the cancel was not executed. These uncancelled copies are extremely valuable to bibliographers.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>The corrected state</h3>
+<p>The replacement leaf bearing the corrected text. Present in the majority of surviving copies. The corrected state became the standard reading for three centuries.</p>
+</div>
+</div>
+
+<blockquote>The cancel leaves of the First Folio remind us that even the most sacred text in the English language was, at the moment of its creation, a commercial product subject to the practical constraints of the printing house.</blockquote>

--- a/cancel-leaf/content/cancels/2-the-darwin-origin.md
+++ b/cancel-leaf/content/cancels/2-the-darwin-origin.md
@@ -1,0 +1,32 @@
++++
+title = "The Darwin Origin of Species"
+description = "A last-minute cancel leaf in the first edition of Darwin's Origin."
+tags = ["scientific", "nineteenth-century"]
++++
+
+<p class="leaf-label">Cancel II</p>
+
+# The Darwin Origin of Species
+
+<p class="lede">The first edition of Charles Darwin's On the Origin of Species, published in November 1859, contains a cancel leaf that was inserted to correct a factual error discovered just before publication.</p>
+
+## The error
+
+<p>Darwin had written that a particular species of bear had been observed swimming for hours with its mouth open, catching insects on the water surface, and speculated that natural selection might transform such a creature into a whale-like animal. The passage was criticized by his friends and reviewers as absurd, and Darwin instructed the publisher, John Murray, to cancel the leaf and replace it with a revised version that softened the language.</p>
+
+## The bibliographic evidence
+
+<p>The cancel is detectable in first-edition copies by the presence of a stub at the inner margin where the original leaf was cut away. The replacement leaf is printed on paper that matches the rest of the volume but shows a slightly different impression depth, suggesting it was printed on a different press run. Copies with the uncancelled leaf are extremely rare and command high prices at auction.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>Original passage</h3>
+<p>The unrevised text speculating about bears evolving into whale-like creatures. Preserved in a handful of uncancelled copies distributed before the correction was made.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Corrected passage</h3>
+<p>The softened text, present in the vast majority of first-edition copies. Darwin later removed the passage entirely from subsequent editions.</p>
+</div>
+</div>
+
+<blockquote>Even the most revolutionary ideas are subject to second thoughts. The cancel leaf is the physical evidence of revision, doubt, and the courage to correct.</blockquote>

--- a/cancel-leaf/content/cancels/3-the-withdrawn-dedication.md
+++ b/cancel-leaf/content/cancels/3-the-withdrawn-dedication.md
@@ -1,0 +1,32 @@
++++
+title = "The Withdrawn Dedication"
+description = "Cancel leaves inserted to remove dedications from published books."
+tags = ["dedication", "political"]
++++
+
+<p class="leaf-label">Cancel III</p>
+
+# The Withdrawn Dedication
+
+<p class="lede">The most politically charged cancel leaves are those inserted to remove a dedication. A dedication is a public gesture of allegiance, and when that allegiance becomes inconvenient, the page must be replaced.</p>
+
+## The problem of patronage
+
+<p>In the era of literary patronage, dedications were transactional: the author praised the patron, and the patron provided financial support. When a patron fell from grace -- through political disgrace, criminal conviction, or simple falling-out with the author -- the dedication became a liability. Publishers responded by cancelling the dedication leaf and replacing it with a blank page, a new dedication, or a revised version that omitted the offending name.</p>
+
+## Famous withdrawals
+
+<p>One of the most dramatic examples occurred in 1791, when Thomas Paine's Rights of Man was first dedicated to George Washington. When the second part was published, Paine had quarreled with Washington and the dedication was cancelled in favor of a more general address to the people of France. Copies with the original Washington dedication are now rare collector's items.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>The original dedication</h3>
+<p>The cancelled leaf bearing the patron's name. Often destroyed during the cancellation process. Surviving examples are rare and historically significant.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>The replacement</h3>
+<p>Sometimes a new dedication, sometimes a blank page. The absence of a dedication can itself be a statement: the author has severed the connection.</p>
+</div>
+</div>
+
+<blockquote>A cancelled dedication is a broken promise made visible. The stub of the original leaf remains in the gutter, a physical trace of the relationship that was severed.</blockquote>

--- a/cancel-leaf/content/cancels/4-the-legal-suppression.md
+++ b/cancel-leaf/content/cancels/4-the-legal-suppression.md
@@ -1,0 +1,32 @@
++++
+title = "The Legal Suppression"
+description = "Cancel leaves required by legal action against published text."
+tags = ["legal", "censorship"]
++++
+
+<p class="leaf-label">Cancel IV</p>
+
+# The Legal Suppression
+
+<p class="lede">When a published book contains material that a court orders removed -- a libelous passage, a copyright infringement, or an official secret -- the publisher must cancel the offending pages in every copy still in stock or in bookshops.</p>
+
+## The mechanics of suppression
+
+<p>Legal cancellation is the most urgent form of the practice. The publisher must act quickly, often within days of the court order. Every copy in the warehouse must be opened, the offending leaf cut out, and a replacement tipped in. Copies already in bookshops must be recalled or corrected in place. The expense is enormous, and the process is rarely perfect: some copies escape correction, and these uncancelled copies become prized by collectors precisely because they contain the suppressed text.</p>
+
+## The Streisand effect in print
+
+<p>The paradox of legal cancellation is that it draws attention to the very passage it seeks to suppress. Bibliographers, collectors, and the curious public seek out uncancelled copies specifically because they contain the forbidden text. The cancel leaf, intended to erase, instead preserves the evidence of erasure.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>Suppressed text</h3>
+<p>The original passage ordered removed. Preserved in copies that escaped the recall. These copies become the most sought-after state of the edition.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Replacement text</h3>
+<p>Sometimes a rewritten passage, sometimes a blank page with a notice of removal. The replacement text is the publisher's compliance made visible.</p>
+</div>
+</div>
+
+<blockquote>Every act of suppression creates an artifact. The cancelled leaf is the physical evidence that someone tried to unsay what had been said.</blockquote>

--- a/cancel-leaf/content/cancels/5-the-errata-cancel.md
+++ b/cancel-leaf/content/cancels/5-the-errata-cancel.md
@@ -1,0 +1,36 @@
++++
+title = "The Errata Cancel"
+description = "Cancel leaves used to correct typographical errors discovered after printing."
+tags = ["errata", "correction"]
++++
+
+<p class="leaf-label">Cancel V</p>
+
+# The Errata Cancel
+
+<p class="lede">The most common reason for cancellation is the simplest: a typographical error. A misspelled name, a transposed numeral, a missing line of verse -- any error serious enough to justify the cost of reprinting a leaf and tipping it into every copy of the edition.</p>
+
+## The economics of correction
+
+<p>Cancellation is expensive. The publisher must pay for composition, presswork, paper, and the hand labor of cutting and tipping in every copy. For a small error, an errata slip -- a loose sheet listing corrections -- is cheaper and faster. The decision to cancel rather than errata depends on the severity of the error, the prestige of the publication, and the number of copies already bound. A misspelled word on page 200 of a novel might warrant only an errata slip; a misspelled name on the title page demands cancellation.</p>
+
+## The errata slip as alternative
+
+<p>Before cancellation became standard practice, printers dealt with errors by inserting a loose errata slip -- a small piece of paper listing the corrections. The reader was expected to note the corrections and mentally emend the text. Errata slips survive in many early printed books, though they are easily lost. The cancel leaf replaced the errata slip for serious errors because it presented the corrected text in its proper place, requiring nothing of the reader.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>Errata slip</h3>
+<p>A loose sheet listing corrections. Cheap to produce but easily lost. Requires the reader to find and correct each error. The traditional alternative to cancellation.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Cancel leaf</h3>
+<p>A replacement page bearing the corrected text. Expensive but permanent. The reader encounters the correct text without knowing a correction was made.</p>
+</div>
+<div class="cancel-card cancel-card-old">
+<h3>Stop-press correction</h3>
+<p>The cheapest fix: correcting the type while the press is still running. Early copies have the error; later copies are correct. Both states exist in the same edition.</p>
+</div>
+</div>
+
+<blockquote>The cancel leaf is the publisher's admission that perfection is impossible. Every book contains errors; the question is only whether the publisher considers them worth the cost of correction.</blockquote>

--- a/cancel-leaf/content/cancels/_index.md
+++ b/cancel-leaf/content/cancels/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Cancels"
+description = "The cancel leaves of this replacement page publication."
++++
+
+<p class="lede">Five cancel leaves, each describing a famous instance of page cancellation in the history of printing. From Shakespeare to Darwin, the practice of correcting the printed word has shaped the books we read.</p>
+
+<p>Each cancel is presented as a replacement page: new text on white paper, tipped onto the stub of the original.</p>

--- a/cancel-leaf/content/detection.md
+++ b/cancel-leaf/content/detection.md
@@ -1,0 +1,41 @@
++++
+title = "Detection"
+description = "How bibliographers identify cancel leaves in printed books."
++++
+
+<p class="leaf-label">Examination</p>
+
+# Detecting Cancel Leaves
+
+<p class="lede">A well-executed cancel is almost invisible to the casual reader. But bibliographers have developed a set of techniques for detecting cancellation, based on the physical evidence that even the most careful repair leaves behind.</p>
+
+## The stub test
+
+<p>The most reliable sign of cancellation is the stub. When a leaf has been cut from the binding and replaced, the narrow strip of the original leaf remains visible in the gutter. Holding the book open and looking into the gutter reveals the stub as a thin line of paper that does not match the replacement leaf in color or texture. The stub is often slightly yellowed relative to the cancellans, because the original leaf was exposed to light and air before being cut.</p>
+
+## The paper test
+
+<p>A cancel leaf is often printed on different paper from the rest of the book. Even when the publisher used the same stock, different printing sessions may produce sheets with slightly different thickness, texture, or chain-line spacing. Holding the leaf up to the light and comparing it with adjacent leaves reveals differences in translucency and watermark position.</p>
+
+## The adhesive strip
+
+<p>The line of paste used to attach the cancellans to the stub leaves a visible mark on the inner margin. Under raking light (light held at a low angle to the page surface), the adhesive strip appears as a slightly darker or shinier band along the gutter edge. The width and regularity of the strip indicate whether the work was done by a professional binder or an amateur.</p>
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>Color mismatch</h3>
+<p>The original stub has aged differently from the cancellans. The stub is yellowed; the replacement may be whiter or may have aged at a different rate.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Alignment error</h3>
+<p>Even skilled binders occasionally tip in a cancel leaf slightly out of register. The text block may be a millimeter higher or lower than adjacent pages.</p>
+</div>
+<div class="cancel-card cancel-card-old">
+<h3>Sewing evidence</h3>
+<p>In pre-binding cancels, the replacement leaf passes through the sewing. In post-binding cancels, the leaf is attached only by paste. The sewing pattern tells the story.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Bibliographic record</h3>
+<p>Publishers sometimes recorded which pages were cancelled in their printing ledgers. Comparing copies from different states reveals the original and corrected readings.</p>
+</div>
+</div>

--- a/cancel-leaf/content/index.md
+++ b/cancel-leaf/content/index.md
@@ -1,0 +1,69 @@
++++
+title = "Cancel Leaf"
+description = "A publication about the practice of cancelling and replacing pages in bound books."
++++
+
+<p class="leaf-label">Replacement Page</p>
+
+# Cancel Leaf
+
+<p class="lede">In bookmaking, a cancel is a leaf that has been removed from a bound volume and replaced with a corrected version. The original leaf is cut away, leaving only a narrow stub at the inner margin. The new leaf is tipped in -- pasted along its inner edge onto the stub -- so that the book appears whole but bears the mark of its correction.</p>
+
+## The visible repair
+
+<p>This publication takes the cancel leaf as its subject and its form. Every page is presented as a replacement: clean new text on bright white paper, tipped onto the remnant of an older, yellowed sheet. The stub of the original page is visible at the inner margin as a narrow strip with faint adhesive marks. The design makes the correction visible rather than hiding it.</p>
+
+<div class="cancel-diagram" aria-hidden="true">
+<svg viewBox="0 0 500 160" xmlns="http://www.w3.org/2000/svg">
+<rect x="10" y="10" width="220" height="140" fill="#f5f0e4" stroke="#b0a48a" stroke-width="0.8" rx="2"/>
+<line x1="115" y1="40" x2="200" y2="40" stroke="#9a8e78" stroke-width="0.4"/>
+<line x1="115" y1="55" x2="190" y2="55" stroke="#9a8e78" stroke-width="0.4"/>
+<line x1="115" y1="70" x2="195" y2="70" stroke="#9a8e78" stroke-width="0.4"/>
+<line x1="115" y1="85" x2="180" y2="85" stroke="#9a8e78" stroke-width="0.4"/>
+<line x1="115" y1="100" x2="190" y2="100" stroke="#9a8e78" stroke-width="0.4"/>
+<line x1="100" y1="10" x2="220" y2="150" stroke="#c85040" stroke-width="0.6" opacity="0.4"/>
+<line x1="220" y1="10" x2="100" y2="150" stroke="#c85040" stroke-width="0.6" opacity="0.4"/>
+<text x="150" y="130" font-family="serif" font-size="8" fill="#9a8e78" text-anchor="middle" font-style="italic">cancellandum (original)</text>
+<rect x="270" y="10" width="220" height="140" fill="#ffffff" stroke="#2a2a2a" stroke-width="0.8" rx="1"/>
+<rect x="270" y="10" width="16" height="140" fill="#f5f0e4" stroke="none" opacity="0.5"/>
+<g fill="#d4c8ae" opacity="0.6">
+<rect x="273" y="30" width="8" height="2" rx="0.5"/>
+<rect x="273" y="60" width="8" height="2" rx="0.5"/>
+<rect x="273" y="90" width="8" height="2" rx="0.5"/>
+<rect x="273" y="120" width="8" height="2" rx="0.5"/>
+</g>
+<line x1="300" y1="40" x2="460" y2="40" stroke="#2a2a2a" stroke-width="0.5"/>
+<line x1="300" y1="55" x2="450" y2="55" stroke="#2a2a2a" stroke-width="0.5"/>
+<line x1="300" y1="70" x2="455" y2="70" stroke="#2a2a2a" stroke-width="0.5"/>
+<line x1="300" y1="85" x2="440" y2="85" stroke="#2a2a2a" stroke-width="0.5"/>
+<line x1="300" y1="100" x2="450" y2="100" stroke="#2a2a2a" stroke-width="0.5"/>
+<text x="380" y="130" font-family="sans-serif" font-size="8" fill="#2a2a2a" text-anchor="middle">cancellans (replacement)</text>
+<path d="M235,80 L265,80" stroke="#2a2a2a" stroke-width="1" fill="none" marker-end="url(#arrowhead)"/>
+<defs><marker id="arrowhead" markerWidth="6" markerHeight="4" refX="5" refY="2" orient="auto"><polygon points="0,0 6,2 0,4" fill="#2a2a2a"/></marker></defs>
+</svg>
+</div>
+
+## Terminology
+
+<div class="cancel-grid">
+<div class="cancel-card cancel-card-old">
+<h3>Cancellandum</h3>
+<p>The original leaf to be removed. From the Latin "that which is to be cancelled." The cancellandum is cut out, leaving only a stub at the gutter.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Cancellans</h3>
+<p>The replacement leaf, printed with corrected text. From the Latin "that which cancels." The cancellans is tipped onto the stub of the original.</p>
+</div>
+<div class="cancel-card cancel-card-old">
+<h3>Stub</h3>
+<p>The narrow strip of the original leaf that remains after cutting. Typically three to five millimeters wide. The stub holds the cancellans in place.</p>
+</div>
+<div class="cancel-card cancel-card-new">
+<h3>Tipping in</h3>
+<p>The process of attaching the cancellans to the stub with a thin line of paste along the inner margin. The adhesive strip is often visible on close examination.</p>
+</div>
+</div>
+
+## Reading this volume
+
+<p>Each page in this publication is displayed as a cancellans: new text on clean white paper, with a visible stub strip at the inner margin showing where the original leaf was cut away. The adhesive marks on the stub are drawn as small rectangular patches. Navigate to the <a href="/cancels/">cancels index</a> to browse the collection of replacement pages.</p>

--- a/cancel-leaf/static/css/style.css
+++ b/cancel-leaf/static/css/style.css
@@ -1,0 +1,384 @@
+/* =============================================================================
+   Cancel Leaf - Replacement Page Publication
+   Issue #1556 | book, light, correction, repair, visible
+   Palette: bright white (new text), yellowed ivory (old text), red cancel marks
+   No gradients. Cancelled page stubs + adhesive strip marks as inline SVG.
+   ============================================================================= */
+
+:root {
+  --white: #ffffff;
+  --white-soft: #faf8f3;
+  --yellowed: #f5f0e4;
+  --yellowed-deep: #e8dfc9;
+  --stub: #d4c8ae;
+  --ink-new: #2a2a2a;
+  --ink-new-soft: #4a4a4a;
+  --ink-old: #9a8e78;
+  --ink-old-soft: #b0a48a;
+  --cancel-red: #c85040;    /* cancel mark red */
+  --cancel-soft: #d4887e;
+  --adhesive: #c4baa4;      /* adhesive strip color */
+  --border: #ddd8cc;
+  --bg: #f0ece4;            /* outer background, aged paper */
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink-new);
+}
+
+body {
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.book-shell {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--adhesive);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink-new);
+}
+.logo-mark { width: 52px; height: 52px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  color: var(--ink-new);
+}
+.logo-sub {
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  color: var(--cancel-red);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-new-soft);
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--cancel-red); border-bottom-color: var(--cancel-red); }
+
+/* --- Leaf page ----------------------------------------------------------- */
+.site-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.leaf-page {
+  position: relative;
+  background-color: var(--white);
+  border: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  min-height: 640px;
+  box-shadow:
+    0 1px 0 var(--yellowed-deep),
+    0 12px 32px rgba(200, 80, 64, 0.06);
+  overflow: hidden;
+}
+
+.leaf-narrow {
+  grid-template-columns: 1fr;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.stub-mark {
+  background-color: var(--yellowed);
+  border-right: 1px dashed var(--adhesive);
+}
+.stub-mark svg { width: 100%; height: 100%; display: block; }
+
+.leaf-body {
+  position: relative;
+  z-index: 2;
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3.5rem);
+}
+
+/* --- New text typography (cancellans) ------------------------------------ */
+.new-text h1,
+.new-text h2,
+.new-text h3 {
+  font-family: "Inter", sans-serif;
+  color: var(--ink-new);
+  line-height: 1.25;
+  font-weight: 700;
+}
+.new-text h1 {
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0 0 0.2em;
+  letter-spacing: -0.01em;
+}
+.new-text h2 {
+  font-size: 1.4rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--border);
+}
+.new-text h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--cancel-red);
+}
+
+.new-text p {
+  margin: 1em 0;
+  color: var(--ink-new);
+  font-family: "Inter", sans-serif;
+  font-weight: 400;
+}
+.new-text p.lede {
+  font-family: "EB Garamond", serif;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--ink-new-soft);
+  font-style: italic;
+}
+
+.leaf-label {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cancel-red);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.6em;
+  background-color: var(--white-soft);
+  border: 1px solid var(--border);
+}
+
+.leaf-head { margin-bottom: 2rem; }
+.leaf-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--ink-new);
+}
+
+.new-text a {
+  color: var(--cancel-red);
+  text-decoration: none;
+  border-bottom: 1px solid var(--cancel-soft);
+}
+.new-text a:hover { color: var(--ink-new); border-bottom-color: var(--ink-new); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--cancel-red);
+  background-color: var(--white-soft);
+  font-style: italic;
+  color: var(--ink-new-soft);
+  font-family: "EB Garamond", serif;
+  font-size: 1.1rem;
+}
+
+.new-text ul,
+.new-text ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.new-text ul { list-style: disc; }
+.new-text ol { list-style: decimal; }
+.new-text li { padding: 0.2em 0; }
+
+/* --- Cancel diagram ------------------------------------------------------ */
+.cancel-diagram {
+  margin: 1.5rem 0;
+  background-color: var(--white-soft);
+  border: 1px solid var(--border);
+  padding: 1rem;
+}
+.cancel-diagram svg {
+  width: 100%;
+  max-height: 160px;
+  display: block;
+}
+
+/* --- Cancel card grid ---------------------------------------------------- */
+.cancel-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.cancel-card {
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.cancel-card-new {
+  background-color: var(--white);
+  border: 1px solid var(--border);
+}
+.cancel-card-old {
+  background-color: var(--yellowed);
+  border: 1px solid var(--adhesive);
+}
+.cancel-card h3 {
+  margin: 0 0 0.3em;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.cancel-card-new h3 {
+  color: var(--ink-new);
+  font-family: "Inter", sans-serif;
+}
+.cancel-card-old h3 {
+  color: var(--ink-old);
+  font-family: "EB Garamond", serif;
+  font-weight: 500;
+  font-style: italic;
+}
+.cancel-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.cancel-card-new p {
+  color: var(--ink-new-soft);
+  font-family: "Inter", sans-serif;
+}
+.cancel-card-old p {
+  color: var(--ink-old);
+  font-family: "EB Garamond", serif;
+  font-weight: 300;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--border);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Inter", sans-serif;
+}
+.section-list li::before {
+  content: "\2717";               /* ballot X - cancel mark */
+  color: var(--cancel-red);
+  font-size: 0.8em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink-new);
+  border: none;
+  font-size: 1.02rem;
+}
+.section-list li a:hover { color: var(--cancel-red); }
+
+.taxonomy-desc {
+  color: var(--ink-new-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--border);
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink-new);
+  text-decoration: none;
+  background-color: var(--white-soft);
+}
+nav.pagination a:hover { color: var(--cancel-red); border-color: var(--cancel-red); }
+.pagination-current span { color: var(--cancel-red); border-color: var(--cancel-red); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--adhesive);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--ink-new);
+  margin: 0.2em 0;
+  letter-spacing: -0.01em;
+}
+.footer-line-small {
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  color: var(--ink-old);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .leaf-page { grid-template-columns: 14px minmax(0, 1fr); }
+  .leaf-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .leaf-title, .new-text h1 { font-size: 1.9rem; }
+  .new-text h2 { font-size: 1.2rem; }
+  .cancel-diagram svg { max-height: 120px; }
+}

--- a/cancel-leaf/templates/404.html
+++ b/cancel-leaf/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf-page leaf-narrow">
+      <div class="leaf-body new-text">
+        <header class="leaf-head">
+          <p class="leaf-label">404</p>
+          <h1 class="leaf-title">Page cancelled</h1>
+        </header>
+        <p>This leaf has been cut from the volume and no replacement was tipped in. Only the stub remains. Return to the binding and select another page.</p>
+        <p><a href="{{ base_url }}/">Back to the volume</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cancel-leaf/templates/footer.html
+++ b/cancel-leaf/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line">Cancel Leaf</p>
+      <p class="footer-line-small">A publication where every page is a correction.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; cut, replaced, tipped in</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cancel-leaf/templates/header.html
+++ b/cancel-leaf/templates/header.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="book-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Cancel Leaf home">
+        <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="8" y="4" width="40" height="48" fill="#f5f0e4" stroke="#b0a48a" stroke-width="0.6"/>
+          <rect x="12" y="8" width="32" height="40" fill="#faf8f3" stroke="#c4baa4" stroke-width="0.4"/>
+          <line x1="12" y1="8" x2="44" y2="48" stroke="#c85040" stroke-width="0.8" opacity="0.5"/>
+          <line x1="44" y1="8" x2="12" y2="48" stroke="#c85040" stroke-width="0.8" opacity="0.5"/>
+          <rect x="16" y="18" width="24" height="20" fill="#ffffff" stroke="#2a2a2a" stroke-width="0.6"/>
+          <line x1="20" y1="24" x2="36" y2="24" stroke="#2a2a2a" stroke-width="0.5"/>
+          <line x1="20" y1="28" x2="34" y2="28" stroke="#2a2a2a" stroke-width="0.5"/>
+          <line x1="20" y1="32" x2="30" y2="32" stroke="#2a2a2a" stroke-width="0.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Cancel Leaf</span>
+          <span class="logo-sub">Replacement Page Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/cancels/">Cancels</a>
+        <a href="{{ base_url }}/process/">Process</a>
+        <a href="{{ base_url }}/detection/">Detection</a>
+      </nav>
+    </header>
+  </div>

--- a/cancel-leaf/templates/page.html
+++ b/cancel-leaf/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf-page">
+      <div class="stub-mark" aria-hidden="true">
+        <svg viewBox="0 0 20 800" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="20" height="800" fill="#f5f0e4"/>
+          <line x1="18" y1="0" x2="18" y2="800" stroke="#c4baa4" stroke-width="0.5" stroke-dasharray="4,8"/>
+          <g fill="#d4c8ae" opacity="0.6">
+            <rect x="6" y="30" width="8" height="3" rx="1"/>
+            <rect x="6" y="120" width="8" height="3" rx="1"/>
+            <rect x="6" y="240" width="8" height="3" rx="1"/>
+            <rect x="6" y="360" width="8" height="3" rx="1"/>
+            <rect x="6" y="480" width="8" height="3" rx="1"/>
+            <rect x="6" y="600" width="8" height="3" rx="1"/>
+            <rect x="6" y="720" width="8" height="3" rx="1"/>
+          </g>
+        </svg>
+      </div>
+      <div class="leaf-body new-text">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cancel-leaf/templates/section.html
+++ b/cancel-leaf/templates/section.html
@@ -1,0 +1,23 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf-page">
+      <div class="stub-mark" aria-hidden="true">
+        <svg viewBox="0 0 20 800" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="20" height="800" fill="#f5f0e4"/>
+          <line x1="18" y1="0" x2="18" y2="800" stroke="#c4baa4" stroke-width="0.5" stroke-dasharray="4,8"/>
+        </svg>
+      </div>
+      <div class="leaf-body new-text">
+        <header class="leaf-head">
+          <p class="leaf-label">Contents</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cancel-leaf/templates/shortcodes/alert.html
+++ b/cancel-leaf/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #c4baa4; background-color: #faf8f3; border-left: 5px solid #c85040; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/cancel-leaf/templates/taxonomy.html
+++ b/cancel-leaf/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf-page leaf-narrow">
+      <div class="leaf-body new-text">
+        <header class="leaf-head">
+          <p class="leaf-label">Index</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All correction types in this volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/cancel-leaf/templates/taxonomy_term.html
+++ b/cancel-leaf/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="leaf-page leaf-narrow">
+      <div class="leaf-body new-text">
+        <header class="leaf-head">
+          <p class="leaf-label">Type</p>
+          <h1 class="leaf-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Cancels of this type:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -586,6 +586,13 @@
     "blog",
     "storytelling"
   ],
+  "cancel-leaf": [
+    "book",
+    "light",
+    "correction",
+    "repair",
+    "visible"
+  ],
   "canopy": [
     "light",
     "blog",


### PR DESCRIPTION
Closes #1556

## Summary
- Adds cancel-leaf example site: a light publication about the practice of cancelling and replacing pages in bound books
- SVG cancelled page stub illustrations showing cut edges; tipped-in leaf adhesive strip marks at inner margins
- Typography: Inter Bold for new replacement text on bright white; EB Garamond Light for faded original text on yellowed stock
- Full content with 5 cancel chapters covering the Shakespeare First Folio, Darwin's Origin, withdrawn dedications, legal suppressions, and errata cancels, plus process and detection reference pages
- Tags: book, light, correction, repair, visible

## Test plan
- [ ] Run `hwaro build` in `cancel-leaf/` directory
- [ ] Run `hwaro serve` and verify all pages render correctly
- [ ] Verify no CSS gradients are used
- [ ] Verify all decorative visuals use inline SVG
- [ ] Verify no emojis in any files
- [ ] Verify tags.json is updated with the new entry