### PR TITLE
feat: add oblong-quarto example site (closes #1555)

### DIFF
--- a/oblong-quarto/AGENTS.md
+++ b/oblong-quarto/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/oblong-quarto/config.toml
+++ b/oblong-quarto/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Oblong Quarto - Landscape Publication
+# Issue #1555 | Tags: book, light, landscape, panoramic, unusual
+# =============================================================================
+
+title = "Oblong Quarto"
+description = "A light, landscape-format publication inspired by the oblong quarto book format. SVG panoramic landscape illustrations span full spreads and wide-format decorative headers fit the landscape proportions. Oswald and Barlow for extended wide display type, Lora and Source Serif Pro for readable body text in wide columns."
+base_url = "http://localhost:3000"
+
+sections = ["views"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/oblong-quarto/content/about.md
+++ b/oblong-quarto/content/about.md
@@ -1,0 +1,37 @@
++++
+title = "Format"
+description = "The oblong quarto format and its place in book history."
++++
+
+<p class="spread-label">Reference</p>
+
+# The Oblong Format
+
+<p class="lede">The oblong format has a long and distinguished history in specialized publishing. From Renaissance sketchbooks to Victorian railway panoramas, the landscape page has served artists, architects, cartographers, and travelers.</p>
+
+## Book formats and paper folding
+
+<p>Traditional book formats are defined by how many times a sheet of paper is folded. A folio is folded once (two leaves, four pages). A quarto is folded twice (four leaves, eight pages). An octavo is folded three times (eight leaves, sixteen pages). Each fold halves the page size and reverses the proportion from landscape to portrait. The oblong quarto is a quarto sheet folded so that the page remains wider than it is tall -- the fold runs along the long edge rather than the short edge.</p>
+
+## Practical considerations
+
+<p>The oblong format presents several practical challenges. Shelving is difficult: most bookshelves are designed for portrait-format books, and an oblong volume either projects beyond the shelf edge or must be shelved spine-up. Binding is more complex: the spine runs along the short edge, which puts more stress on the sewing. Reading ergonomics are different: the reader must either rest the book on a table or hold it with both hands spread wide.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Top-bound</h3>
+<p>The spine runs along the top edge. The pages flip upward like a calendar. Common for sketch pads and small-format albums.</p>
+</div>
+<div class="view-card">
+<h3>Left-bound</h3>
+<p>The spine runs along the left (short) edge. The pages turn like a standard book but the spread is landscape. The most common oblong binding for formal publications.</p>
+</div>
+<div class="view-card">
+<h3>Concertina fold</h3>
+<p>An alternative to conventional binding: the pages are folded in a zigzag and can be extended to display the full panorama as a continuous strip.</p>
+</div>
+</div>
+
+## Typography in landscape
+
+<p>Setting type for the oblong page requires a different approach. The measure (line length) is naturally wider, which can make text difficult to read if not carefully managed. The standard solution is to use two or three columns, keeping each column to a comfortable measure of 60-75 characters. Display type can be set across the full width, taking advantage of the panoramic proportion to use extended, wide typefaces like Oswald and Barlow that would feel compressed on a portrait page.</p>

--- a/oblong-quarto/content/index.md
+++ b/oblong-quarto/content/index.md
@@ -1,0 +1,59 @@
++++
+title = "Oblong Quarto"
+description = "A landscape publication wider than it is tall."
++++
+
+<p class="spread-label">Panorama</p>
+
+# Oblong Quarto
+
+<p class="lede">A publication in the landscape format: wider than it is tall, bound along the short edge, opened to reveal a panoramic spread that extends across the full width of the reader's field of vision. The oblong quarto is the book turned sideways.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 140" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="140" fill="#eae5da"/>
+<g fill="none" stroke="#5a7a5c" stroke-width="1.5" opacity="0.4">
+<path d="M0,120 Q60,80 120,100 Q200,50 300,80 Q400,30 500,60 Q580,40 660,55 Q740,45 800,50"/>
+<path d="M0,130 Q100,105 200,115 Q300,85 400,100 Q500,70 600,90 Q700,75 800,80"/>
+</g>
+<g fill="none" stroke="#8a8474" stroke-width="0.6" opacity="0.25">
+<path d="M0,110 Q150,80 300,95 Q450,55 600,75 Q700,60 800,65"/>
+</g>
+<g fill="#5a7a5c" opacity="0.15">
+<path d="M100,120 Q120,90 140,120 Z"/>
+<path d="M300,120 Q330,70 360,120 Z"/>
+<path d="M500,120 Q520,85 540,120 Z"/>
+<path d="M680,120 Q700,80 720,120 Z"/>
+</g>
+<circle cx="80" cy="25" r="16" fill="#d4a843" opacity="0.15"/>
+</svg>
+</div>
+
+## The landscape format
+
+<p>Most books are portrait-format: taller than they are wide. The oblong quarto reverses this proportion. The page is wider than it is tall, and the binding runs along the short edge (either the top or the left side). This format is unusual in publishing because it does not fit standard shelving, it is awkward to hold in one hand, and it wastes paper on the press. But for certain subjects -- landscapes, panoramas, architectural views, maps, and wide-format illustrations -- the oblong format is the only one that does justice to the content.</p>
+
+## Why landscape matters
+
+<div class="view-grid">
+<div class="view-card">
+<h3>The horizon line</h3>
+<p>A landscape illustration needs horizontal space. A portrait page forces the landscape into a narrow strip with wasted space above and below. An oblong page gives the horizon room to breathe.</p>
+</div>
+<div class="view-card">
+<h3>The panoramic spread</h3>
+<p>When an oblong book is opened flat, the double-page spread has an extreme landscape proportion. This is ideal for panoramic views that sweep across the reader's full field of vision.</p>
+</div>
+<div class="view-card">
+<h3>Wide columns</h3>
+<p>Text set in the oblong format uses wide columns with generous leading. The eye travels a longer horizontal distance, requiring careful typographic treatment to maintain readability.</p>
+</div>
+<div class="view-card">
+<h3>Unusual proportion</h3>
+<p>The oblong quarto signals to the reader that this is not an ordinary book. The format itself communicates that the content demands a different way of seeing.</p>
+</div>
+</div>
+
+## Reading this volume
+
+<p>Each page in this publication is laid out in landscape proportion with a panoramic illustration header spanning the full width. The text is set in wide columns below the illustration. Navigate to the <a href="/views/">views index</a> to browse the panoramic spreads, or use the links above.</p>

--- a/oblong-quarto/content/tradition.md
+++ b/oblong-quarto/content/tradition.md
@@ -1,0 +1,41 @@
++++
+title = "Tradition"
+description = "The history of landscape-format publications."
++++
+
+<p class="spread-label">History</p>
+
+# The Landscape Tradition
+
+<p class="lede">The oblong format has been used for specialized publications since the Renaissance. Each era has found new subjects that demand the panoramic page.</p>
+
+## Renaissance sketchbooks
+
+<p>Italian artists of the fifteenth and sixteenth centuries used oblong sketchbooks for landscape studies. The horizontal page matched the natural proportion of a view across open country. Leonardo da Vinci's notebooks include oblong pages used for wide architectural plans and panoramic landscape drawings. The format was practical for field use: an oblong book could be held in one hand while sketching with the other.</p>
+
+## Topographical views
+
+<p>The eighteenth and nineteenth centuries saw a boom in topographical publications: illustrated books showing views of cities, buildings, and landscapes. Many of these were published in oblong format to accommodate the wide copper-plate engravings. The aquatint views of London, Rome, and Paris published by Rudolph Ackermann in the early nineteenth century are classic oblong quartos, with each plate spanning the full width of the page.</p>
+
+## Railway panoramas
+
+<p>The most dramatic use of the landscape format was the railway panorama: a continuous strip showing the view from a train window, published as a concertina-folded book. The most famous example is John C. Bourne's "The History and Description of the Great Western Railway" (1846), which includes fold-out plates spanning several feet. These publications exploited the oblong format to its logical extreme: the page became a window onto a moving landscape.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Ackermann's views</h3>
+<p>Rudolph Ackermann's topographical publications (1808-1830) established the oblong quarto as the standard format for illustrated views of cities and architecture.</p>
+</div>
+<div class="view-card">
+<h3>Turner's Liber Studiorum</h3>
+<p>J.M.W. Turner published his landscape studies in oblong format (1807-1819), using the wide page to reproduce his compositions at a proportion close to the originals.</p>
+</div>
+<div class="view-card">
+<h3>Japanese woodblock books</h3>
+<p>The yokohon (horizontal book) is the Japanese equivalent of the oblong quarto, used for landscape prints and panoramic views since the Edo period.</p>
+</div>
+<div class="view-card">
+<h3>Modern photobooks</h3>
+<p>Contemporary photobooks frequently use the oblong format for landscape photography, aerial views, and architectural documentation.</p>
+</div>
+</div>

--- a/oblong-quarto/content/views/1-the-river-valley.md
+++ b/oblong-quarto/content/views/1-the-river-valley.md
@@ -1,0 +1,47 @@
++++
+title = "The River Valley"
+description = "A panoramic view of a lowland river winding through meadows."
+tags = ["river", "lowland"]
++++
+
+<p class="spread-label">View I</p>
+
+# The River Valley
+
+<p class="lede">The first view is the gentlest: a lowland river winding through meadows, with willows along the banks and a distant line of hills on the horizon. The oblong format gives the river room to meander across the full width of the page.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#eae5da"/>
+<g fill="none" stroke="#5a7a5c" stroke-width="0.8" opacity="0.3">
+<path d="M0,80 Q100,70 200,75 Q350,65 500,72 Q650,60 800,68"/>
+</g>
+<path d="M0,90 Q80,75 160,85 Q280,70 400,82 Q520,68 640,78 Q720,72 800,80 L800,100 L0,100 Z" fill="#6a9a7c" opacity="0.12"/>
+<path d="M50,95 Q150,80 250,90 Q400,75 550,88 Q700,78 800,85" fill="none" stroke="#4a7a9c" stroke-width="1.5" opacity="0.25"/>
+</svg>
+</div>
+
+## The horizontal eye
+
+<p>A river valley is one of the few landscapes that is naturally panoramic. The river runs from horizon to horizon, and the eye follows it in a continuous horizontal sweep. A portrait page would force the viewer to look at the river through a narrow window. The oblong page opens the window to the full width of the scene.</p>
+
+## Composition
+
+<p>The panoramic landscape is composed in horizontal bands. The foreground meadow occupies the lower third of the page. The river runs across the middle third, curving from one edge to the other. The distant hills and sky fill the upper third. Each band is a different value: dark foreground, middle-toned water, light sky. The eye reads the landscape from bottom to top, from near to far, following the natural recession of space.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Foreground</h3>
+<p>Meadow grasses, wildflowers, and the occasional fence post. Dark values and strong detail anchor the composition at the bottom edge.</p>
+</div>
+<div class="view-card">
+<h3>Middle ground</h3>
+<p>The river itself, with willows and alders along the banks. The water reflects the sky, creating a horizontal band of light that draws the eye across the page.</p>
+</div>
+<div class="view-card">
+<h3>Background</h3>
+<p>A line of low hills fading into atmospheric haze. The lightest values and the softest edges. The background establishes the depth of the panorama.</p>
+</div>
+</div>
+
+<blockquote>The river valley is the landscape that teaches the eye to read horizontally. Every element runs from side to side, and the oblong page follows the natural direction of the view.</blockquote>

--- a/oblong-quarto/content/views/2-the-coastal-cliff.md
+++ b/oblong-quarto/content/views/2-the-coastal-cliff.md
@@ -1,0 +1,47 @@
++++
+title = "The Coastal Cliff"
+description = "A panoramic view of chalk cliffs meeting the sea."
+tags = ["coastal", "cliff"]
++++
+
+<p class="spread-label">View II</p>
+
+# The Coastal Cliff
+
+<p class="lede">The second view is dramatic: a line of chalk cliffs falling vertically into the sea, with surf breaking at their base and seabirds wheeling above. The oblong format stretches the cliff line across the page, emphasizing its relentless horizontal extent.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#e8e3d8"/>
+<rect x="0" y="60" width="800" height="40" fill="#7a9aaa" opacity="0.15"/>
+<path d="M0,55 L80,52 L160,58 L240,50 L320,56 L400,48 L480,54 L560,46 L640,52 L720,44 L800,50 L800,60 L0,60 Z" fill="#d4cdb8" opacity="0.8"/>
+<g fill="none" stroke="#8a8474" stroke-width="0.4" opacity="0.4">
+<line x1="100" y1="52" x2="100" y2="60"/>
+<line x1="250" y1="50" x2="250" y2="60"/>
+<line x1="400" y1="48" x2="400" y2="60"/>
+<line x1="550" y1="46" x2="550" y2="60"/>
+<line x1="700" y1="44" x2="700" y2="60"/>
+</g>
+</svg>
+</div>
+
+## The cliff as line
+
+<p>A coastal cliff is a landscape defined by a single strong horizontal line: the edge where land meets air. Below the line, the cliff face drops vertically to the sea. Above the line, the sky opens. In a portrait format, the cliff line would cross the page as a short horizontal mark. In the oblong format, the line extends from edge to edge, and its authority over the composition is complete.</p>
+
+## The sea below
+
+<p>The sea at the base of the cliffs provides the second horizontal element. Its surface is a plane of reflected light that extends to the horizon. The interaction between the cliff line above and the sea surface below creates a composition of parallel horizontals that is perfectly suited to the landscape format.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Cliff face</h3>
+<p>Vertical striations of chalk and flint. The cliff face is the only strong vertical element in an otherwise horizontal composition, creating dramatic tension.</p>
+</div>
+<div class="view-card">
+<h3>Wave break</h3>
+<p>White surf at the cliff base. A thin, bright horizontal line that defines the meeting of sea and rock.</p>
+</div>
+</div>
+
+<blockquote>The coastal cliff is a landscape reduced to its essentials: a horizontal line, a vertical drop, and the immense horizontal plane of the sea. The oblong page is the natural frame.</blockquote>

--- a/oblong-quarto/content/views/3-the-open-plain.md
+++ b/oblong-quarto/content/views/3-the-open-plain.md
@@ -1,0 +1,47 @@
++++
+title = "The Open Plain"
+description = "A panoramic view of a treeless plain stretching to the horizon."
+tags = ["plain", "horizon"]
++++
+
+<p class="spread-label">View III</p>
+
+# The Open Plain
+
+<p class="lede">The third view is the most extreme test of the landscape format: a treeless plain stretching to the horizon in every direction, with nothing to interrupt the line between earth and sky. The oblong page becomes a window into infinite horizontal space.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 80" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="80" fill="#eae5da"/>
+<line x1="0" y1="45" x2="800" y2="45" stroke="#8a8474" stroke-width="0.5"/>
+<g fill="none" stroke="#8a8474" stroke-width="0.3" opacity="0.2">
+<line x1="0" y1="50" x2="800" y2="50"/>
+<line x1="0" y1="55" x2="800" y2="56"/>
+<line x1="0" y1="62" x2="800" y2="64"/>
+</g>
+<g fill="#5a7a5c" opacity="0.06">
+<rect x="0" y="45" width="800" height="35"/>
+</g>
+</svg>
+</div>
+
+## The dominance of the horizon
+
+<p>On the open plain, the horizon line is the only compositional element. There is no foreground detail, no middle-ground feature, no background landmark. The horizon divides the page into earth and sky, and the proportional relationship between the two halves determines the mood of the image. A high horizon emphasizes the earth and makes the viewer feel grounded. A low horizon emphasizes the sky and makes the viewer feel exposed.</p>
+
+## The problem of emptiness
+
+<p>The open plain is the most difficult landscape to represent in any format. There is nothing to draw. The entire composition consists of a single horizontal line and two flat tones. The oblong format helps by extending the horizon line across a wide page, giving it visual authority. But the real challenge is tonal: the subtle variations of color and value across the plain and sky must carry all the visual interest. This is landscape reduced to abstraction.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>High horizon</h3>
+<p>Two-thirds earth, one-third sky. The viewer's attention is on the land surface: the texture of the grass, the pattern of the soil, the distant road.</p>
+</div>
+<div class="view-card">
+<h3>Low horizon</h3>
+<p>One-third earth, two-thirds sky. The viewer's attention is on the atmosphere: the cloud formations, the quality of the light, the immensity of the air.</p>
+</div>
+</div>
+
+<blockquote>The open plain is the landscape that needs the oblong format most and rewards it least. There is nothing to see -- and everything to feel.</blockquote>

--- a/oblong-quarto/content/views/4-the-mountain-ridge.md
+++ b/oblong-quarto/content/views/4-the-mountain-ridge.md
@@ -1,0 +1,47 @@
++++
+title = "The Mountain Ridge"
+description = "A panoramic view along a mountain ridge above the tree line."
+tags = ["mountain", "alpine"]
++++
+
+<p class="spread-label">View IV</p>
+
+# The Mountain Ridge
+
+<p class="lede">The fourth view is elevated: a mountain ridge seen from above the tree line, with successive ranges receding into atmospheric haze. The oblong format captures the full lateral extent of the ridge as it traces a jagged line from one edge of the page to the other.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#e8e3d8"/>
+<path d="M0,70 Q40,50 80,60 Q120,30 180,50 Q220,20 280,45 Q340,15 400,40 Q460,10 520,35 Q580,20 640,30 Q700,15 740,25 Q780,20 800,30 L800,100 L0,100 Z" fill="#8a8474" opacity="0.08"/>
+<path d="M0,80 Q60,60 120,70 Q200,40 280,55 Q360,25 440,48 Q520,30 600,42 Q680,28 760,38 Q800,32 800,40 L800,100 L0,100 Z" fill="#5a7a5c" opacity="0.1"/>
+<g fill="none" stroke="#5a7a5c" stroke-width="1.2" opacity="0.3">
+<path d="M0,85 Q50,65 100,75 Q180,45 260,60 Q340,30 420,52 Q500,35 580,45 Q660,30 740,40 Q800,35 800,38"/>
+</g>
+</svg>
+</div>
+
+## Successive ranges
+
+<p>Mountain landscapes are naturally layered. Each range of hills or mountains stands behind the one in front of it, and the atmospheric perspective makes each successive range lighter and bluer. In a portrait format, these layers stack vertically and compress the depth. In the oblong format, the layers extend horizontally, and the eye can follow each ridge line from side to side, comparing its contour with the ridges in front and behind.</p>
+
+## The ridge line
+
+<p>The ridge line -- the skyline of the mountains against the sky -- is the defining feature of the alpine panorama. It is irregular, jagged, and endlessly varied: peaks, saddles, notches, and shoulders creating a complex silhouette that changes with every step along the ridge. The oblong page gives this silhouette the horizontal space it needs to develop its full character.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Foreground ridge</h3>
+<p>Dark, sharp, detailed. The ridge on which the viewer stands. Rock texture, lichen, and the occasional alpine flower.</p>
+</div>
+<div class="view-card">
+<h3>Middle ranges</h3>
+<p>Progressively lighter and less detailed. The forest line is visible as a dark band below the rock. Snow patches mark the highest peaks.</p>
+</div>
+<div class="view-card">
+<h3>Distant ranges</h3>
+<p>Pale blue-grey silhouettes against the sky. No detail, only contour. The furthest ranges are barely distinguishable from the atmosphere.</p>
+</div>
+</div>
+
+<blockquote>The mountain panorama is a lesson in atmospheric perspective. Each successive range fades a little more, until the most distant mountains are indistinguishable from the sky. The oblong page gives the eye room to follow this recession from near to far.</blockquote>

--- a/oblong-quarto/content/views/5-the-city-skyline.md
+++ b/oblong-quarto/content/views/5-the-city-skyline.md
@@ -1,0 +1,63 @@
++++
+title = "The City Skyline"
+description = "A panoramic view of a city skyline at dusk."
+tags = ["city", "skyline"]
++++
+
+<p class="spread-label">View V</p>
+
+# The City Skyline
+
+<p class="lede">The final view is urban: a city skyline seen from across a river at dusk, with towers, domes, and rooftops silhouetted against the fading light. The oblong format captures the full lateral extent of the city, from the industrial margins to the historic center.</p>
+
+<div class="panorama-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#e8e3d8"/>
+<rect x="0" y="70" width="800" height="30" fill="#7a9aaa" opacity="0.1"/>
+<g fill="#3a3832" opacity="0.15">
+<rect x="60" y="45" width="15" height="25"/>
+<rect x="90" y="40" width="20" height="30"/>
+<rect x="130" y="50" width="12" height="20"/>
+<rect x="180" y="35" width="25" height="35"/>
+<rect x="220" y="42" width="18" height="28"/>
+<rect x="280" y="30" width="12" height="40"/>
+<rect x="310" y="38" width="30" height="32"/>
+<rect x="370" y="25" width="8" height="45"/>
+<rect x="400" y="40" width="22" height="30"/>
+<rect x="450" y="32" width="15" height="38"/>
+<rect x="490" y="45" width="20" height="25"/>
+<rect x="540" y="38" width="25" height="32"/>
+<rect x="590" y="42" width="12" height="28"/>
+<rect x="630" y="48" width="18" height="22"/>
+<rect x="680" y="44" width="15" height="26"/>
+<rect x="720" y="50" width="20" height="20"/>
+<rect x="760" y="46" width="12" height="24"/>
+</g>
+<path d="M350,25 L356,15 L362,25" fill="#3a3832" opacity="0.15"/>
+</svg>
+</div>
+
+## The skyline as portrait
+
+<p>A city skyline is a portrait of a place. Every city has a unique silhouette defined by its tallest buildings, its church spires, its bridges, and its terrain. The skyline of London is different from the skyline of Manhattan, which is different from the skyline of Istanbul. The oblong format allows the full skyline to be presented as a continuous silhouette, so that the viewer can read the city's character from left to right, identifying landmarks and tracing the rhythm of high and low elements.</p>
+
+## Dusk light
+
+<p>The skyline is most dramatic at dusk, when the buildings become dark silhouettes against a bright sky. The loss of surface detail reduces the architecture to pure form: rectangles, triangles, domes, and spires. The oblong page at this moment becomes a stage for the play of dark shapes against light, and the panoramic width of the format gives every building its place in the composition.</p>
+
+<div class="view-grid">
+<div class="view-card">
+<h3>Industrial edge</h3>
+<p>Low buildings, chimneys, and cranes at the margins of the city. The horizontal emphasis of warehouses and wharves suits the oblong format.</p>
+</div>
+<div class="view-card">
+<h3>Historic center</h3>
+<p>The tallest spires and domes mark the historic core. These vertical elements punctuate the horizontal skyline, creating the rhythm that makes each city recognizable.</p>
+</div>
+<div class="view-card">
+<h3>Modern towers</h3>
+<p>Glass and steel towers in the commercial district. Their rectangular silhouettes create a different rhythm from the pointed spires of the old city.</p>
+</div>
+</div>
+
+<blockquote>The city skyline is the landscape of human making. It has the same horizontal extent as a mountain range, but every element was placed by decision rather than geology. The oblong page is the format of that decision made visible.</blockquote>

--- a/oblong-quarto/content/views/_index.md
+++ b/oblong-quarto/content/views/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Views"
+description = "The panoramic views of this landscape publication."
++++
+
+<p class="lede">Five views, each spanning the full width of the page. From river valleys to mountain ridges, the oblong format gives each landscape the horizontal space it demands.</p>
+
+<p>The views are arranged as a journey across different terrain, from lowland waterways to high alpine passes.</p>

--- a/oblong-quarto/static/css/style.css
+++ b/oblong-quarto/static/css/style.css
@@ -1,0 +1,363 @@
+/* =============================================================================
+   Oblong Quarto - Landscape Publication
+   Issue #1555 | book, light, landscape, panoramic, unusual
+   Palette: warm parchment, sage green landscape accents, muted gold
+   No gradients. Panoramic landscapes + wide-format headers as inline SVG.
+   ============================================================================= */
+
+:root {
+  --parchment: #faf7f0;
+  --parchment-soft: #f2ede3;
+  --parchment-deep: #eae5da;
+  --parchment-edge: #c4bda8;
+  --ink: #3a3832;
+  --ink-soft: #5c5850;
+  --ink-dim: #8a8474;
+  --sage: #5a7a5c;         /* landscape green accent */
+  --sage-soft: #7a9a7c;
+  --gold: #d4a843;         /* muted gold accent */
+  --gold-soft: #c4983a;
+  --sky: #7a9aaa;          /* muted sky blue */
+  --bg: #f6f2ea;           /* outer background */
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Lora", "Source Serif 4", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.76;
+  min-height: 100vh;
+}
+
+.landscape-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--parchment-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 72px; height: 40px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Barlow", sans-serif;
+  font-weight: 500;
+  font-size: 0.82rem;
+  color: var(--sage);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Barlow", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--sage); border-bottom-color: var(--sage); }
+
+/* --- Spread (page) ------------------------------------------------------- */
+.site-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.spread {
+  position: relative;
+  background-color: var(--parchment);
+  border: 1px solid var(--parchment-edge);
+  min-height: 480px;
+  box-shadow:
+    0 1px 0 var(--parchment-deep),
+    0 12px 32px rgba(90, 122, 92, 0.06);
+  overflow: hidden;
+}
+
+.spread-narrow {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.panorama-header {
+  width: 100%;
+}
+.panorama-header svg { width: 100%; display: block; }
+
+.spread-body {
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1.25rem, 4vw, 4rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.spread-body h1,
+.spread-body h2,
+.spread-body h3 {
+  font-family: "Oswald", "Barlow", sans-serif;
+  color: var(--ink);
+  line-height: 1.25;
+  letter-spacing: 0.02em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.spread-body h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0 0 0.2em;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.spread-body h2 {
+  font-size: 1.35rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--parchment-edge);
+  letter-spacing: 0.03em;
+}
+.spread-body h3 {
+  font-size: 1rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--sage);
+  letter-spacing: 0.02em;
+}
+
+.spread-body p {
+  margin: 1em 0;
+  color: var(--ink);
+  font-family: "Lora", "Source Serif 4", serif;
+  max-width: 70ch;
+}
+.spread-body p.lede {
+  font-family: "Source Serif 4", "Lora", serif;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  font-style: italic;
+  max-width: 60ch;
+}
+
+.spread-label {
+  display: inline-block;
+  font-family: "Oswald", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sage);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.7em;
+  background-color: var(--parchment-soft);
+  border: 1px solid var(--parchment-edge);
+}
+
+.spread-head { margin-bottom: 2rem; }
+.spread-title {
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+.spread-body a {
+  color: var(--sage);
+  text-decoration: none;
+  border-bottom: 1px solid var(--sage-soft);
+}
+.spread-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--sage);
+  background-color: var(--parchment-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Source Serif 4", "Lora", serif;
+  font-size: 1.05rem;
+  max-width: 60ch;
+}
+
+.spread-body ul,
+.spread-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.spread-body ul { list-style: disc; }
+.spread-body ol { list-style: decimal; }
+.spread-body li { padding: 0.2em 0; max-width: 70ch; }
+
+/* --- Panorama illustrations ---------------------------------------------- */
+.panorama-illustration {
+  margin: 1.5rem 0;
+  border: 1px solid var(--parchment-edge);
+}
+.panorama-illustration svg {
+  width: 100%;
+  display: block;
+}
+
+/* --- View card grid ------------------------------------------------------ */
+.view-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.view-card {
+  background-color: var(--parchment-soft);
+  border: 1px solid var(--parchment-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.view-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--sage);
+  font-size: 0.95rem;
+  font-family: "Oswald", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+.view-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--parchment-edge);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--parchment-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Barlow", sans-serif;
+}
+.section-list li::before {
+  content: "\2014";               /* em dash - wide format marker */
+  color: var(--sage);
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 1.02rem;
+  letter-spacing: 0.01em;
+}
+.section-list li a:hover { color: var(--sage); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--parchment-edge);
+  font-family: "Barlow", sans-serif;
+  font-size: 0.85rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--parchment-soft);
+}
+nav.pagination a:hover { color: var(--sage); border-color: var(--sage); }
+.pagination-current span { color: var(--sage); border-color: var(--sage); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--parchment-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Oswald", sans-serif;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0.2em 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.footer-line-small {
+  font-family: "Lora", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .spread-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .spread-title, .spread-body h1 { font-size: 1.8rem; }
+  .spread-body h2 { font-size: 1.15rem; }
+  .spread-body p, .spread-body li { max-width: none; }
+  .landscape-shell { max-width: 100%; }
+}

--- a/oblong-quarto/templates/404.html
+++ b/oblong-quarto/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">404</p>
+          <h1 class="spread-title">View not found</h1>
+        </header>
+        <p>This panorama has slipped beyond the horizon. The landscape extends, but this page does not. Return to the volume and select another view.</p>
+        <p><a href="{{ base_url }}/">Back to the volume</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/oblong-quarto/templates/footer.html
+++ b/oblong-quarto/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line">Oblong Quarto</p>
+      <p class="footer-line-small">A landscape publication wider than it is tall.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; bound sideways, read across</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/oblong-quarto/templates/header.html
+++ b/oblong-quarto/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Barlow:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Source+Serif+4:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="landscape-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Oblong Quarto home">
+        <svg viewBox="0 0 72 40" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="68" height="36" fill="#faf7f0" stroke="#3a3832" stroke-width="0.8" rx="2"/>
+          <line x1="10" y1="14" x2="62" y2="14" stroke="#8a8474" stroke-width="0.5"/>
+          <line x1="10" y1="26" x2="52" y2="26" stroke="#8a8474" stroke-width="0.5"/>
+          <g fill="none" stroke="#5a7a5c" stroke-width="0.8">
+            <path d="M10,32 Q20,22 30,30 Q40,18 50,28 Q58,22 62,26"/>
+          </g>
+          <circle cx="16" cy="10" r="2.5" fill="#d4a843" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Oblong Quarto</span>
+          <span class="logo-sub">Landscape Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/views/">Views</a>
+        <a href="{{ base_url }}/format/">Format</a>
+        <a href="{{ base_url }}/tradition/">Tradition</a>
+      </nav>
+    </header>
+  </div>

--- a/oblong-quarto/templates/page.html
+++ b/oblong-quarto/templates/page.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread">
+      <div class="panorama-header" aria-hidden="true">
+        <svg viewBox="0 0 1200 120" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="1200" height="120" fill="#eae5da"/>
+          <g fill="none" stroke="#5a7a5c" stroke-width="1.2" opacity="0.3">
+            <path d="M0,100 Q100,60 200,80 Q350,40 500,70 Q650,30 800,60 Q950,40 1050,55 Q1150,50 1200,65"/>
+            <path d="M0,110 Q150,85 300,95 Q450,70 600,90 Q750,65 900,80 Q1050,70 1200,85"/>
+          </g>
+          <g fill="none" stroke="#8a8474" stroke-width="0.5" opacity="0.2">
+            <path d="M0,95 Q200,70 400,85 Q600,50 800,75 Q1000,55 1200,70"/>
+          </g>
+          <circle cx="100" cy="30" r="20" fill="#d4a843" opacity="0.12"/>
+        </svg>
+      </div>
+      <div class="spread-body">
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/oblong-quarto/templates/section.html
+++ b/oblong-quarto/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread">
+      <div class="panorama-header" aria-hidden="true">
+        <svg viewBox="0 0 1200 80" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="1200" height="80" fill="#eae5da"/>
+          <g fill="none" stroke="#5a7a5c" stroke-width="1" opacity="0.25">
+            <path d="M0,60 Q200,30 400,50 Q600,20 800,40 Q1000,25 1200,35"/>
+          </g>
+        </svg>
+      </div>
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">View Index</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/oblong-quarto/templates/shortcodes/alert.html
+++ b/oblong-quarto/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #c4bda8; background-color: #faf7f0; border-left: 5px solid #5a7a5c; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/oblong-quarto/templates/taxonomy.html
+++ b/oblong-quarto/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">Index</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this landscape volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/oblong-quarto/templates/taxonomy_term.html
+++ b/oblong-quarto/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="spread spread-narrow">
+      <div class="spread-body">
+        <header class="spread-head">
+          <p class="spread-label">Subject</p>
+          <h1 class="spread-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Views filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2860,6 +2860,13 @@
     "bold",
     "angular"
   ],
+  "oblong-quarto": [
+    "book",
+    "light",
+    "landscape",
+    "panoramic",
+    "unusual"
+  ],
   "observatory": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1555

## Summary
- Adds oblong-quarto example site: a light, landscape-format publication inspired by the oblong quarto book format
- SVG panoramic landscape illustrations spanning full spreads; wide-format decorative headers fitting landscape proportions
- Typography: Oswald / Barlow for extended wide display type matching landscape proportions; Lora / Source Serif Pro for readable body text in wide columns
- Full content with 5 view chapters covering river valley, coastal cliff, open plain, mountain ridge, and city skyline panoramas, plus format reference and landscape tradition history
- Tags: book, light, landscape, panoramic, unusual

## Test plan
- [ ] Run `hwaro build` in `oblong-quarto/` directory
- [ ] Run `hwaro serve` and verify all pages render correctly
- [ ] Verify no CSS gradients are used
- [ ] Verify all decorative visuals use inline SVG
- [ ] Verify no emojis in any files
- [ ] Verify tags.json is updated with the new entry