### PR TITLE
feat: add annotation-layer example site (closes #1553)

### DIFF
--- a/annotation-layer/AGENTS.md
+++ b/annotation-layer/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/annotation-layer/config.toml
+++ b/annotation-layer/config.toml
@@ -1,0 +1,85 @@
+# =============================================================================
+# Annotation-Layer - A Study in Deep Commentary
+# Issue #1553 | Tags: book, light, scholarly, annotated, dense
+# =============================================================================
+
+title = "ANNOTATION-LAYER - A Study in Deep Commentary"
+description = "A scholarly publication in the tradition of the apparatus criticus - original texts displayed above dense commentary annotations, with variant readings, stemma codicum diagrams, and layered editorial notes filling the margins."
+base_url = "http://localhost:3000"
+
+sections = ["texts"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "tradition"
+paginate_by = 10
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "monthly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A scholarly apparatus criticus publication. Academic use; please cite if referenced."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["texts"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/annotation-layer/content/apparatus.md
+++ b/annotation-layer/content/apparatus.md
@@ -1,0 +1,61 @@
++++
+title = "The Apparatus Criticus"
+description = "A guide to the method and conventions of this edition's critical apparatus - the notation of variant readings, the construction of stemmata, and the principles of editorial decision."
+template = "page"
++++
+
+<div class="section-head">
+  <p class="kicker">METHODOLOGICAL NOTE</p>
+  <h1>The Apparatus Criticus</h1>
+  <p>On the conventions, notation, and editorial principles employed in this edition.</p>
+</div>
+
+## Purpose of the Apparatus
+
+The apparatus criticus is the engine of a critical edition. It records the evidence upon which the established text is founded: the readings of the manuscript witnesses, the conjectures of earlier scholars, and the editorial decisions of the present editors. Without the apparatus, the text is an assertion; with it, the text becomes an argument, subject to verification and challenge by any reader who possesses the skill to evaluate the evidence.
+
+The apparatus in this edition follows the conventions established in classical philology and adapted for medieval vernacular texts. The format is positive: for each lemma (the reading adopted in the text), all significant variant readings are listed with their manuscript sigla. Where the reading is unanimous across all witnesses, no apparatus entry is given.
+
+## Conventions
+
+The following conventions are employed throughout:
+
+- **Lemma** ] **Variant reading** *siglum* -- The lemma (the adopted reading) is followed by a right bracket, then the variant reading with the siglum of the manuscript or manuscripts that attest it.
+- **om.** -- The reading is omitted in the designated witness.
+- **add.** -- The designated witness adds words not found in the lemma text.
+- **transp.** -- The designated witness transposes the word order.
+- **corr.** -- A correction, either by the original scribe (corr. prima manu) or by a later hand (corr. secunda manu).
+- **coni.** -- A conjectural emendation, attributed to the scholar who proposed it.
+- **del.** -- Deleted by the designated scholar or scribe.
+
+## The Stemma Codicum
+
+Each text in this edition is accompanied by a stemma codicum - a diagram showing the hypothetical relationships among the manuscript witnesses. The stemma is constructed by identifying shared errors: if two or more manuscripts share an error that cannot have arisen independently, those manuscripts are assumed to derive from a common ancestor (a hyparchetype) that contained the error. By analysing the patterns of shared error across the entire text, the editor builds a genealogical tree of the manuscripts.
+
+The stemmata in this edition use the following conventions:
+
+- **Capital Roman letters** (A, B, C, etc.) designate extant manuscripts.
+- **Lowercase Greek or Roman letters** (alpha, beta, or a, b, etc.) designate hypothetical ancestors (hyparchetypes) that are no longer extant.
+- **O** designates the archetype - the earliest recoverable ancestor of all surviving manuscripts.
+- **Solid lines** indicate descent (the manuscript below was copied from the manuscript or ancestor above).
+- **Dashed lines** indicate hypothetical or uncertain relationships.
+- **Red dashed lines** indicate contamination - the borrowing of readings from a manuscript outside the direct line of descent.
+
+## Principles of Editorial Decision
+
+The editorial method employed in this edition follows the genealogical principles of Karl Lachmann, as refined by Paul Maas (*Textkritik*, 1927) and further developed by the scholars of the twentieth century. The fundamental principle is that shared errors reveal shared descent: manuscripts that share the same errors derive from a common ancestor.
+
+Where the stemma is established, the text of the archetype can be reconstructed mechanically: at each point of variation, the reading supported by the majority of independent branches is adopted. Where the stemma is uncertain or where contamination has obscured the genealogical relationships, the editor must resort to internal criteria: the reading that best explains the origin of the variants (the *lectio difficilior* principle), the reading that conforms to the author's established style and usage, and the reading that makes the best sense in context.
+
+## Limitations
+
+No critical edition is definitive. The stemmata presented here are hypotheses, subject to revision as new manuscripts are discovered or as existing evidence is reinterpreted. The editorial decisions recorded in the apparatus represent the best judgement of the present editors, but they are judgements nonetheless, and reasonable scholars may and do disagree. The apparatus is provided precisely so that the reader may form an independent opinion.
+
+## Further Reading
+
+The following works are fundamental to the theory and practice of textual criticism as employed in this edition:
+
+- Paul Maas, *Textkritik* (4th ed., Leipzig, 1960)
+- Martin L. West, *Textual Criticism and Editorial Technique* (Stuttgart, 1973)
+- L. D. Reynolds and N. G. Wilson, *Scribes and Scholars* (4th ed., Oxford, 2013)
+- E. J. Kenney, *The Classical Text* (Berkeley, 1974)

--- a/annotation-layer/content/colophon.md
+++ b/annotation-layer/content/colophon.md
@@ -1,0 +1,46 @@
++++
+title = "Colophon"
+description = "Particulars of this edition - the typefaces, the tools, and the editorial conventions employed in the production of Annotation-Layer."
+template = "page"
++++
+
+<div class="section-head">
+  <p class="kicker">PARTICULARS OF THIS EDITION</p>
+  <h1>Colophon</h1>
+  <p>On the design, typography, and production of this scholarly apparatus.</p>
+</div>
+
+## The Edition
+
+This edition of *Annotation-Layer: A Study in Deep Commentary* was prepared for the web and typeset with Hwaro, a static site generator. The texts presented here are drawn from the standard critical editions cited in the apparatus of each text page; the editorial commentary is original to this edition. The stemmata codicum have been constructed from the published findings of the scholars cited in the apparatus and represent a synthesis of current scholarly opinion rather than original collation.
+
+## Typography
+
+The display type is set in **Cormorant**, a typeface designed by Christian Thalmann after the models of Claude Garamond. For secondary display, **EB Garamond** is employed, a digital cutting by Georg Duffner after the types of Garamond as preserved in the specimen of the Egenolff-Berner foundry (1592). The body text is set in **Crimson Pro**, designed by Jacques Le Bailly, a serif type intended for dense scholarly composition. For secondary body text and notes, **Noto Serif** provides a reliable complement.
+
+These faces were chosen for their legibility at small sizes (essential for the dense apparatus text), their historical sympathy with the scholarly tradition (all are rooted in the humanist types of the fifteenth and sixteenth centuries), and their availability as web fonts through Google Fonts.
+
+## Design Principles
+
+The page layout follows the conventions of the apparatus criticus as developed in the printed editions of the nineteenth and twentieth centuries:
+
+- The **original text** occupies the upper portion of the page, set in a larger size and a display typeface to distinguish it from the editorial matter.
+- The **apparatus** fills the lower portion, set in a smaller size in dense columns, with variant readings keyed to the lemma text by line number and catchword.
+- The **stemma codicum** is presented as an inline SVG diagram, following the conventions of manuscript genealogy established by Karl Lachmann and refined by Paul Maas.
+
+The colour palette is deliberately restrained: a cream ground (#FAFAF5) with dark brown text (#2C2416), scholarly red (#8B2500) for apparatus markers and critical notation, and deep blue (#1B3A5C) for editorial sigla and cross-references. No gradients are employed; all decorative elements are inline SVG.
+
+## Technical Particulars
+
+- **Generator:** Hwaro
+- **Markup:** Markdown with TOML front matter
+- **Templates:** Crinja (Jinja2-compatible)
+- **Fonts:** Cormorant, EB Garamond, Crimson Pro, Noto Serif (Google Fonts)
+- **Syntax Highlighting:** github theme (light)
+- **Decorative Elements:** Inline SVG throughout; no external image files
+
+## Acknowledgements
+
+This edition draws upon the labours of generations of textual scholars, from the Alexandrian grammarians to the digital humanists of the twenty-first century. The specific debts are recorded in the apparatus of each text page. The editors acknowledge with gratitude the open-access digital facsimiles provided by the British Library, the Bibliotheque Nationale de France, the Bodleian Library, and the Biblioteca Apostolica Vaticana, which have made the study of manuscripts accessible to a wider community of scholars than was previously possible.
+
+<p class="foot-stamp" style="margin-top: 3rem;">ANNOTATION-LAYER - A STUDY IN DEEP COMMENTARY - ANNO DOMINI MMXXVI</p>

--- a/annotation-layer/content/index.md
+++ b/annotation-layer/content/index.md
@@ -1,0 +1,218 @@
++++
+title = "Frontispiece"
+description = "A scholarly publication in the tradition of the apparatus criticus - original texts displayed above dense commentary annotations, with variant readings, stemma codicum diagrams, and layered editorial notes."
+template = "page"
++++
+
+<div class="frontispiece">
+  <p class="kicker">A Study in Deep Commentary</p>
+  <h1>Annotation-Layer</h1>
+  <p class="sub"><em>Original texts displayed above dense apparatus criticus, with variant readings, stemma codicum, and layered editorial notes filling the margins.</em></p>
+</div>
+
+<div class="front-plate">
+  <div class="front-plate-inner">
+    <svg viewBox="0 0 560 420" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="560" height="420" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="1.2"/>
+      <rect x="8" y="8" width="544" height="404" fill="none" stroke="#DDD8CC" stroke-width="0.6"/>
+      <!-- Original text area: top 1/3 -->
+      <rect x="20" y="20" width="520" height="120" fill="#FFFFFF" stroke="#C8C0AE" stroke-width="0.5"/>
+      <text x="280" y="48" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="14" fill="#8B2500" letter-spacing="0.15em">TEXTUS</text>
+      <g fill="#2C2416">
+        <rect x="40" y="60" width="480" height="4" rx="1"/>
+        <rect x="40" y="72" width="460" height="4" rx="1"/>
+        <rect x="40" y="84" width="475" height="4" rx="1"/>
+        <rect x="40" y="96" width="440" height="4" rx="1"/>
+        <rect x="40" y="108" width="470" height="4" rx="1"/>
+        <rect x="40" y="120" width="420" height="4" rx="1"/>
+      </g>
+      <!-- Dividing rule -->
+      <line x1="30" y1="150" x2="530" y2="150" stroke="#8B2500" stroke-width="1.5"/>
+      <circle cx="280" cy="150" r="3" fill="#8B2500"/>
+      <circle cx="260" cy="150" r="1.5" fill="#C8C0AE"/>
+      <circle cx="300" cy="150" r="1.5" fill="#C8C0AE"/>
+      <!-- Dense commentary area: bottom 2/3 -->
+      <rect x="20" y="160" width="520" height="245" fill="#FFFFFF" stroke="#C8C0AE" stroke-width="0.5"/>
+      <text x="280" y="180" text-anchor="middle" font-family="Crimson Pro, Noto Serif, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">APPARATUS CRITICUS</text>
+      <!-- Left column of commentary -->
+      <g fill="#4A3F30">
+        <rect x="35" y="190" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="199" width="220" height="3" rx="0.5"/>
+        <rect x="35" y="208" width="228" height="3" rx="0.5"/>
+        <rect x="35" y="217" width="215" height="3" rx="0.5"/>
+        <rect x="35" y="226" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="235" width="225" height="3" rx="0.5"/>
+        <rect x="35" y="244" width="218" height="3" rx="0.5"/>
+        <rect x="35" y="253" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="262" width="210" height="3" rx="0.5"/>
+        <rect x="35" y="271" width="226" height="3" rx="0.5"/>
+        <rect x="35" y="280" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="289" width="220" height="3" rx="0.5"/>
+        <rect x="35" y="298" width="225" height="3" rx="0.5"/>
+        <rect x="35" y="307" width="214" height="3" rx="0.5"/>
+        <rect x="35" y="316" width="228" height="3" rx="0.5"/>
+        <rect x="35" y="325" width="218" height="3" rx="0.5"/>
+        <rect x="35" y="334" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="343" width="222" height="3" rx="0.5"/>
+        <rect x="35" y="352" width="212" height="3" rx="0.5"/>
+        <rect x="35" y="361" width="226" height="3" rx="0.5"/>
+        <rect x="35" y="370" width="230" height="3" rx="0.5"/>
+        <rect x="35" y="379" width="216" height="3" rx="0.5"/>
+        <rect x="35" y="388" width="224" height="3" rx="0.5"/>
+      </g>
+      <!-- Divider between columns -->
+      <line x1="280" y1="190" x2="280" y2="395" stroke="#C8C0AE" stroke-width="0.5"/>
+      <!-- Right column of commentary -->
+      <g fill="#4A3F30">
+        <rect x="295" y="190" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="199" width="218" height="3" rx="0.5"/>
+        <rect x="295" y="208" width="226" height="3" rx="0.5"/>
+        <rect x="295" y="217" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="226" width="215" height="3" rx="0.5"/>
+        <rect x="295" y="235" width="228" height="3" rx="0.5"/>
+        <rect x="295" y="244" width="220" height="3" rx="0.5"/>
+        <rect x="295" y="253" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="262" width="222" height="3" rx="0.5"/>
+        <rect x="295" y="271" width="212" height="3" rx="0.5"/>
+        <rect x="295" y="280" width="226" height="3" rx="0.5"/>
+        <rect x="295" y="289" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="298" width="218" height="3" rx="0.5"/>
+        <rect x="295" y="307" width="225" height="3" rx="0.5"/>
+        <rect x="295" y="316" width="214" height="3" rx="0.5"/>
+        <rect x="295" y="325" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="334" width="220" height="3" rx="0.5"/>
+        <rect x="295" y="343" width="228" height="3" rx="0.5"/>
+        <rect x="295" y="352" width="216" height="3" rx="0.5"/>
+        <rect x="295" y="361" width="224" height="3" rx="0.5"/>
+        <rect x="295" y="370" width="230" height="3" rx="0.5"/>
+        <rect x="295" y="379" width="218" height="3" rx="0.5"/>
+        <rect x="295" y="388" width="226" height="3" rx="0.5"/>
+      </g>
+      <!-- Variant reading markers in red -->
+      <g fill="#8B2500">
+        <rect x="35" y="199" width="14" height="3" rx="0.5"/>
+        <rect x="35" y="244" width="18" height="3" rx="0.5"/>
+        <rect x="35" y="289" width="12" height="3" rx="0.5"/>
+        <rect x="35" y="334" width="16" height="3" rx="0.5"/>
+        <rect x="295" y="208" width="14" height="3" rx="0.5"/>
+        <rect x="295" y="253" width="16" height="3" rx="0.5"/>
+        <rect x="295" y="298" width="12" height="3" rx="0.5"/>
+        <rect x="295" y="343" width="18" height="3" rx="0.5"/>
+      </g>
+      <!-- Siglum markers in blue -->
+      <g fill="#1B3A5C">
+        <rect x="35" y="217" width="10" height="3" rx="0.5"/>
+        <rect x="35" y="271" width="8" height="3" rx="0.5"/>
+        <rect x="35" y="316" width="10" height="3" rx="0.5"/>
+        <rect x="295" y="226" width="8" height="3" rx="0.5"/>
+        <rect x="295" y="271" width="10" height="3" rx="0.5"/>
+        <rect x="295" y="325" width="8" height="3" rx="0.5"/>
+      </g>
+      <!-- Margin annotations -->
+      <g fill="#8A7E6C" font-family="Crimson Pro, serif" font-size="7">
+        <text x="15" y="70" transform="rotate(-90 15 70)">l. 1</text>
+        <text x="15" y="100" transform="rotate(-90 15 100)">l. 5</text>
+        <text x="545" y="200" transform="rotate(90 545 200)">var.</text>
+        <text x="545" y="260" transform="rotate(90 545 260)">cod.</text>
+      </g>
+    </svg>
+  </div>
+  <p class="front-cap"><em>Apparatus Criticus.</em> A representative page layout: original text in the upper third, dense commentary filling the lower two-thirds in double columns, with variant readings marked in red and editorial sigla in blue.</p>
+</div>
+
+<p class="front-lede">This publication follows the centuries-old tradition of the apparatus criticus, in which the transmitted text of a classical or medieval work is displayed prominently at the head of the page, while beneath it the editor assembles a dense stratum of commentary: variant readings drawn from the manuscript witnesses, emendations proposed by earlier scholars, and explanatory notes upon matters of language, history, and interpretation. The apparatus is not a supplement to the text; it is its foundation.</p>
+
+<div class="two-col-wrap">
+  <div class="divider" aria-hidden="true">
+    <svg viewBox="0 0 44 400" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+      <line x1="22" y1="10" x2="22" y2="390" stroke="#C8C0AE" stroke-width="0.6"/>
+      <g transform="translate(22,60)">
+        <circle r="5" fill="none" stroke="#C8C0AE" stroke-width="0.7"/>
+        <circle r="2" fill="#C8C0AE"/>
+      </g>
+      <g transform="translate(22,160)">
+        <circle r="3" fill="none" stroke="#8B2500" stroke-width="0.8"/>
+        <circle r="1.2" fill="#8B2500"/>
+      </g>
+      <g transform="translate(22,260)">
+        <circle r="3" fill="none" stroke="#8B2500" stroke-width="0.8"/>
+        <circle r="1.2" fill="#8B2500"/>
+      </g>
+      <g transform="translate(22,340)">
+        <circle r="5" fill="none" stroke="#C8C0AE" stroke-width="0.7"/>
+        <circle r="2" fill="#C8C0AE"/>
+      </g>
+    </svg>
+  </div>
+
+<div class="two-col">
+
+<p class="illum-para">The tradition of textual commentary extends to the Alexandrian grammarians of the third century before the common era, who first undertook the systematic collation of variant readings in the Homeric poems. Aristarchus of Samothrace, Zenodotus, and their successors at the Library of Alexandria established the principles of textual criticism that remained in force through the Middle Ages and into the modern period: the identification of manuscript families, the construction of stemma codicum diagrams to show the relationships among witnesses, and the establishment of a preferred text through reasoned evaluation of the evidence.</p>
+
+<p>The present edition applies these methods to ten texts drawn from the classical and medieval canons. For each text, we present a stemma codicum showing the hypothetical relationships among the principal manuscript witnesses, an apparatus of variant readings keyed to the lemma text, and a commentary discussing the editorial decisions that have shaped the received text. The reader will find that no text has come down to us in a single, uncorrupted form; every work in this collection has been shaped by the hands of scribes, correctors, and editors across the centuries.</p>
+
+<p>The editorial method employed here follows the principles of Karl Lachmann, as refined by Paul Maas and further developed by the scholars of the twentieth century. We construct the stemma by identifying shared errors among the witnesses, group the manuscripts into families, and attempt to reconstruct the archetype - the earliest recoverable form of the text, which stands at the head of the surviving tradition. Where the evidence permits, we venture beyond the archetype toward the author's original, though we acknowledge that this goal remains, for most texts, an aspiration rather than an achievement.</p>
+
+<p>The apparatus is presented in the format standard to classical editions: the lemma (the reading adopted in the text) is followed by a right bracket, after which the variant readings are listed with their manuscript sigla. Conjectural emendations are attributed to the scholar who proposed them. The commentary that accompanies each text discusses matters of language, metre, historical context, and interpretive difficulty, with particular attention to passages where the textual evidence is uncertain or disputed.</p>
+
+</div>
+</div>
+
+## The Texts in Brief
+
+<ul class="featured-texts">
+  <li class="featured-text">
+    <a href="{{ base_url }}/texts/the-aeneid-book-i/">
+      <div class="featured-init">
+        <svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="68" height="68" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+          <rect x="6" y="6" width="60" height="60" fill="none" stroke="#C8C0AE" stroke-width="0.5"/>
+          <text x="36" y="52" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="42" font-weight="600" fill="#8B2500">A</text>
+        </svg>
+      </div>
+      <span class="featured-text-title">The Aeneid, Book I</span>
+      <span class="featured-text-dek">Virgilian Tradition</span>
+    </a>
+  </li>
+  <li class="featured-text">
+    <a href="{{ base_url }}/texts/beowulf-lines-1-50/">
+      <div class="featured-init">
+        <svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="68" height="68" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="1.2"/>
+          <rect x="6" y="6" width="60" height="60" fill="none" stroke="#C8C0AE" stroke-width="0.5"/>
+          <text x="36" y="52" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="42" font-weight="600" fill="#1B3A5C">B</text>
+        </svg>
+      </div>
+      <span class="featured-text-title">Beowulf, Lines 1-50</span>
+      <span class="featured-text-dek">Anglo-Saxon Tradition</span>
+    </a>
+  </li>
+  <li class="featured-text">
+    <a href="{{ base_url }}/texts/the-iliad-book-i/">
+      <div class="featured-init">
+        <svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="68" height="68" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+          <rect x="6" y="6" width="60" height="60" fill="none" stroke="#C8C0AE" stroke-width="0.5"/>
+          <text x="36" y="52" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="42" font-weight="600" fill="#8B2500">H</text>
+        </svg>
+      </div>
+      <span class="featured-text-title">The Iliad, Book I</span>
+      <span class="featured-text-dek">Homeric Tradition</span>
+    </a>
+  </li>
+  <li class="featured-text">
+    <a href="{{ base_url }}/texts/the-divine-comedy-inferno-i/">
+      <div class="featured-init">
+        <svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="2" width="68" height="68" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="1.2"/>
+          <rect x="6" y="6" width="60" height="60" fill="none" stroke="#C8C0AE" stroke-width="0.5"/>
+          <text x="36" y="52" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="42" font-weight="600" fill="#1B3A5C">D</text>
+        </svg>
+      </div>
+      <span class="featured-text-title">Inferno, Canto I</span>
+      <span class="featured-text-dek">Dantean Tradition</span>
+    </a>
+  </li>
+</ul>
+
+Turn to [the full table of texts](/texts/) for the complete programme, to [the apparatus](/apparatus/) for a discussion of our critical method, or to [the colophon](/colophon/) for particulars of this edition.

--- a/annotation-layer/content/texts/_index.md
+++ b/annotation-layer/content/texts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "The Texts"
+description = "Ten classical and medieval texts presented with apparatus criticus, stemma codicum diagrams, and editorial commentary."
+sort_by = "weight"
++++
+
+The texts collected here span nearly two millennia of literary production, from the Homeric epics of archaic Greece to the alliterative romances of fourteenth-century England. Each is presented with a stemma codicum showing the relationships among the principal manuscript witnesses, an apparatus of variant readings, and a commentary discussing the editorial tradition.

--- a/annotation-layer/content/texts/beowulf-lines-1-50.md
+++ b/annotation-layer/content/texts/beowulf-lines-1-50.md
@@ -1,0 +1,72 @@
++++
+title = "Beowulf, Lines 1-50"
+description = "The opening of the Old English epic - a unique witness surviving in a single manuscript, with editorial reconstruction of damaged passages."
+date = "2026-04-02"
+template = "text"
+weight = 2
+tags = ["epic", "old-english", "medieval"]
+[taxonomies]
+tradition = ["Anglo-Saxon"]
+[extra]
+text_no = "II"
+tradition = "Anglo-Saxon"
+author = "Anonymous (attributed to a single poet of uncertain date)"
+date_composed = "c. 700-1000 CE (date disputed)"
+witnesses = "Cotton Vitellius A.xv (British Library, c. 1000 CE) - sole surviving manuscript"
+source = "Collation based on Klaeber's Beowulf (4th ed., 2008) with reference to Zupitza facsimile (1882, repr. 1959)"
+apparatus_caption = "Stemma for Beowulf. The sole surviving manuscript (V) descends from a lost exemplar; damage from the 1731 Cotton fire has destroyed portions of the text now recoverable only from Thorkelin transcripts."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - BEOWULF</text>
+  <!-- Original composition -->
+  <rect x="260" y="40" width="80" height="24" fill="none" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="300" y="57" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#2C2416">Original</text>
+  <line x1="300" y1="64" x2="300" y2="90" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Lost intermediaries -->
+  <circle cx="300" cy="105" r="14" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="300" y="110" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">x</text>
+  <text x="340" y="108" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(lost intermediary)</text>
+  <line x1="300" y1="119" x2="300" y2="145" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Lost exemplar -->
+  <circle cx="300" cy="160" r="14" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="300" y="165" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">y</text>
+  <text x="340" y="163" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(lost exemplar)</text>
+  <line x1="300" y1="174" x2="300" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- The manuscript V -->
+  <rect x="270" y="200" width="60" height="32" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="300" y="222" text-anchor="middle" font-family="Cormorant, serif" font-size="18" font-weight="600" fill="#8B2500">V</text>
+  <text x="300" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Cotton Vitellius A.xv</text>
+  <text x="300" y="262" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">c. 1000 CE</text>
+  <!-- Thorkelin transcripts branching from V -->
+  <line x1="280" y1="232" x2="160" y2="270" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="320" y1="232" x2="440" y2="270" stroke="#2C2416" stroke-width="0.6"/>
+  <!-- Transcript A -->
+  <rect x="120" y="270" width="80" height="24" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="160" y="287" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">Thorkelin A</text>
+  <text x="160" y="308" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Copyist transcript, 1787</text>
+  <!-- Transcript B -->
+  <rect x="400" y="270" width="80" height="24" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="440" y="287" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">Thorkelin B</text>
+  <text x="440" y="308" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Thorkelin's own, 1787</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+Beowulf presents the textual critic with a unique problem: the poem survives in a single manuscript, Cotton Vitellius A.xv, housed in the British Library. There is no second witness against which to check the readings of the sole survivor, and the manuscript itself has suffered severe physical damage. The great fire of 1731 at Ashburnham House, which destroyed or damaged much of the Cotton collection, scorched the edges of the Beowulf manuscript, and subsequent crumbling of the burned margins has carried away letters and in some cases whole words that were still legible in the eighteenth century.
+
+## Variant Readings and Reconstruction
+
+In the absence of a second manuscript, the concept of "variant readings" takes on a different meaning for Beowulf than for texts with multiple witnesses. The variants here are not between manuscripts but between states of the single manuscript: the readings visible before the fire, as recorded in the two transcripts made by Grimmur Jonsson Thorkelin in 1787 (one by a hired copyist, designated A, and one in Thorkelin's own hand, designated B), versus the readings now visible in the damaged original. Where the Thorkelin transcripts agree on a reading that is no longer legible in the manuscript, editors adopt the transcript reading with reasonable confidence; where the transcripts disagree, the editor must choose between them on the basis of scribal habits and palaeographic probability.
+
+{{ alert(type="note", body="The two scribes of Cotton Vitellius A.xv - designated Scribe A and Scribe B - have distinct dialectal and orthographic habits. The division falls at line 1939 of the poem. The textual criticism of Beowulf must therefore account for the practices of two different copyists working from a common exemplar.") }}
+
+## The Stemma
+
+The stemma for Beowulf is necessarily conjectural and minimal. The sole manuscript V descends from a lost exemplar y, which itself derived from one or more earlier copies now lost. The dashed lines in the stemma indicate hypothetical links that cannot be verified by the usual method of shared errors across multiple witnesses. The Thorkelin transcripts, while not independent witnesses to the poem's composition, serve as secondary witnesses to the state of the manuscript before the worst of the post-fire deterioration, and are thus included in the diagram.
+
+## Editorial Method
+
+The editorial method for a text surviving in a single manuscript is necessarily conservative. Emendation is restricted to passages where the manuscript reading is manifestly corrupt - nonsensical, unmetrical, or inconsistent with the established grammar and vocabulary of Old English verse. Where the manuscript offers a reading that is merely unusual or unexpected, the editor is bound to retain it, since there is no means of determining whether the unusual reading is an error or a genuine feature of the poet's language. The present text follows Klaeber in the main, with departures noted in the apparatus where more recent scholarship has offered persuasive alternatives.

--- a/annotation-layer/content/texts/confessions-book-i.md
+++ b/annotation-layer/content/texts/confessions-book-i.md
@@ -1,0 +1,89 @@
++++
+title = "Confessions, Book I"
+description = "Augustine's spiritual autobiography - the most widely copied text of Latin patristic literature, with a complex tradition spanning over a thousand years of continuous transmission."
+date = "2026-04-08"
+template = "text"
+weight = 8
+tags = ["theological", "latin", "patristic"]
+[taxonomies]
+tradition = ["Augustinian"]
+[extra]
+text_no = "VIII"
+tradition = "Augustinian"
+author = "Aurelius Augustinus (354-430 CE)"
+date_composed = "c. 397-400 CE"
+witnesses = "S (Sessorianus 55, 6th c.), P (Parisinus lat. 1913, 9th c.), C (Corbeiensis, 9th c.), M (Monacensis, 10th c.), V (Vaticanus lat. 5756, 12th c.)"
+source = "Collation based on O'Donnell (1992) with reference to Verheijen (CCSL 27, 1981) and Skutella-Juergens-Schaub (Teubner, 1969)"
+apparatus_caption = "Stemma codicum for the Confessions. The sixth-century Sessorianus (S) is the oldest witness; the Carolingian manuscripts preserve an independent line of descent."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - CONFESSIONS</text>
+  <!-- Augustine's autograph -->
+  <rect x="230" y="38" width="140" height="22" fill="none" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="300" y="54" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#2C2416">Autograph (lost)</text>
+  <line x1="300" y1="60" x2="300" y2="80" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Archetype -->
+  <circle cx="300" cy="95" r="14" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="100" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#2C2416">O</text>
+  <!-- Two main branches -->
+  <line x1="286" y1="106" x2="170" y2="155" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="314" y1="106" x2="430" y2="155" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Early branch (S) -->
+  <circle cx="170" cy="170" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="170" y="175" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">a</text>
+  <line x1="170" y1="184" x2="170" y2="215" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="140" y="215" width="60" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="170" y="234" text-anchor="middle" font-family="Cormorant, serif" font-size="18" font-weight="600" fill="#8B2500">S</text>
+  <text x="170" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Sessorianus 55</text>
+  <text x="170" y="270" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">6th century</text>
+  <!-- Carolingian branch -->
+  <circle cx="430" cy="170" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="430" y="175" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">b</text>
+  <!-- From beta: P, C, M, V -->
+  <line x1="412" y1="182" x2="320" y2="225" stroke="#2C2416" stroke-width="0.7"/>
+  <line x1="424" y1="184" x2="395" y2="225" stroke="#2C2416" stroke-width="0.7"/>
+  <line x1="436" y1="184" x2="465" y2="225" stroke="#2C2416" stroke-width="0.7"/>
+  <line x1="448" y1="182" x2="535" y2="225" stroke="#2C2416" stroke-width="0.7"/>
+  <rect x="295" y="225" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="320" y="242" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">P</text>
+  <rect x="370" y="225" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="395" y="242" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">C</text>
+  <rect x="440" y="225" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="465" y="242" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">M</text>
+  <rect x="510" y="225" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="535" y="242" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">V</text>
+  <!-- Labels for Carolingian mss -->
+  <text x="320" y="264" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Par. lat. 1913</text>
+  <text x="320" y="274" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">9th c.</text>
+  <text x="395" y="264" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Corbeiensis</text>
+  <text x="395" y="274" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">9th c.</text>
+  <text x="465" y="264" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Monacensis</text>
+  <text x="465" y="274" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">10th c.</text>
+  <text x="535" y="264" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Vat. lat. 5756</text>
+  <text x="535" y="274" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">12th c.</text>
+  <!-- Note -->
+  <text x="300" y="300" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">Over 250 medieval manuscripts survive; only the principal witnesses are shown</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Confessions of Augustine is one of the most widely copied texts of the Latin Middle Ages, surviving in over two hundred and fifty manuscripts. The earliest and most important witness is the Sessorianus (S), a sixth-century manuscript that stands at the head of one of the two main branches of the tradition. The Carolingian manuscripts P and C represent the other branch, which is characterised by a distinct set of readings that can be traced to a lost exemplar of the eighth or ninth century. The sheer number of surviving manuscripts attests to the enormous influence of the Confessions upon medieval piety, but the majority of later copies are of limited value for establishing the text, as they derive from the same restricted family of exemplars.
+
+## Variant Readings
+
+The famous opening - *Magnus es, Domine, et laudabilis valde: magna virtus tua, et sapientiae tuae non est numerus* ("Great art thou, O Lord, and greatly to be praised: great is thy power, and of thy wisdom there is no number") - shows remarkable stability across the tradition, with only trivial orthographic variants. The text becomes more problematic in the narrative and philosophical sections, where Augustine's complex syntax sometimes led scribes to simplify or rearrange his sentences.
+
+At Conf. I.i.1, a significant variant occurs: S reads *et laudare te vult homo* ("and man wishes to praise thee") while the Carolingian manuscripts read *et laudare te delectat hominem* ("and it delights man to praise thee"). The Teubner editors have preferred the reading of S, but the alternative has its defenders, and the choice between the two remains disputed.
+
+{{ alert(type="note", body="Augustine himself revised the Confessions late in life, mentioning corrections in his Retractationes (II.6). The extent to which these revisions are reflected in the surviving manuscript tradition is a matter of debate; some scholars have argued that the two branches of the stemma may reflect different stages of authorial revision rather than scribal divergence.") }}
+
+## The Stemma
+
+The stemma codicum presented above simplifies a tradition that, in its full extent, involves over two hundred and fifty witnesses. The fundamental division is between the line of S (the Sessorianus, sixth century) and the Carolingian family represented by P, C, M, and V. Within the Carolingian branch, further subdivision is possible, but the details are less significant for the establishment of the text than the agreement or disagreement between S and the Carolingian witnesses as a group.
+
+## Editorial Method
+
+The present text follows the critical edition of James O'Donnell, who treats S as the primary authority and emends it only where it is clearly in error or where the Carolingian tradition offers a demonstrably superior reading. The apparatus records the readings of all five principal manuscripts and the most important conjectural emendations proposed by earlier editors. The biblical quotations embedded in Augustine's text present a special problem, as the version of the Latin Bible that Augustine used (the Old Latin, prior to Jerome's Vulgate) differs in many places from the texts familiar to medieval scribes, who sometimes "corrected" Augustine's quotations to match their own Bibles.

--- a/annotation-layer/content/texts/de-rerum-natura-book-i.md
+++ b/annotation-layer/content/texts/de-rerum-natura-book-i.md
@@ -1,0 +1,82 @@
++++
+title = "De Rerum Natura, Book I"
+description = "Lucretius on the nature of things - an Epicurean philosophical poem surviving through a single line of medieval transmission from a Carolingian ancestor."
+date = "2026-04-05"
+template = "text"
+weight = 5
+tags = ["philosophical", "latin", "classical"]
+[taxonomies]
+tradition = ["Lucretian"]
+[extra]
+text_no = "V"
+tradition = "Lucretian"
+author = "Titus Lucretius Carus (c. 99-c. 55 BCE)"
+date_composed = "c. 55 BCE"
+witnesses = "O (Oblongus, Vossianus lat. F. 30, 9th c.), Q (Quadratus, Vossianus lat. Q. 94, 9th c.), Itali (15th-century Italian manuscripts descended from a lost archetype)"
+source = "Collation based on Bailey (OCT, 1922) with reference to Martin (Teubner, 1963) and Deufert (2017)"
+apparatus_caption = "Stemma codicum for De Rerum Natura. The entire tradition descends from a single Carolingian archetype; the two surviving 9th-century manuscripts and the 15th-century Italian copies form distinct branches."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - DE RERUM NATURA</text>
+  <!-- Archetype -->
+  <circle cx="300" cy="55" r="16" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="60" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#2C2416">A</text>
+  <text x="340" y="58" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(Carolingian archetype)</text>
+  <!-- Three branches -->
+  <line x1="284" y1="68" x2="150" y2="130" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="300" y1="71" x2="300" y2="130" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="316" y1="68" x2="450" y2="130" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- O manuscript -->
+  <rect x="115" y="130" width="70" height="30" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="150" y="150" text-anchor="middle" font-family="Cormorant, serif" font-size="18" font-weight="600" fill="#8B2500">O</text>
+  <text x="150" y="178" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Oblongus</text>
+  <text x="150" y="188" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Voss. lat. F. 30, 9th c.</text>
+  <!-- Q manuscript -->
+  <rect x="265" y="130" width="70" height="30" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="300" y="150" text-anchor="middle" font-family="Cormorant, serif" font-size="18" font-weight="600" fill="#8B2500">Q</text>
+  <text x="300" y="178" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Quadratus</text>
+  <text x="300" y="188" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Voss. lat. Q. 94, 9th c.</text>
+  <!-- Lost Italian ancestor -->
+  <circle cx="450" cy="145" r="14" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="450" y="150" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">i</text>
+  <text x="490" y="148" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(lost)</text>
+  <!-- Italian manuscripts -->
+  <line x1="435" y1="158" x2="390" y2="210" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="450" y1="159" x2="450" y2="210" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="465" y1="158" x2="510" y2="210" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="365" y="210" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="390" y="227" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">L</text>
+  <rect x="425" y="210" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="450" y="227" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">N</text>
+  <rect x="485" y="210" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="510" y="227" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">V</text>
+  <text x="390" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Laur. 35.26</text>
+  <text x="450" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Niccoli copy</text>
+  <text x="510" y="248" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Vat. lat. 1569</text>
+  <!-- Note about Poggio -->
+  <text x="300" y="280" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">The Italian branch descends from the manuscript rediscovered</text>
+  <text x="300" y="292" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">by Poggio Bracciolini in a German monastery, 1417</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+De Rerum Natura, the great Epicurean poem of Lucretius, narrowly escaped oblivion. The poem was known to Roman readers of the first century BCE and quoted by later Latin authors, but the manuscript tradition narrows to a single Carolingian archetype from which all surviving copies descend. The poem was effectively lost to the Latin West during the early Middle Ages, surviving only in a few monasteries. Its rediscovery by the Italian humanist Poggio Bracciolini in 1417, in a German monastery that has never been definitively identified, is one of the celebrated events of Renaissance book-hunting. The manuscript Poggio found is itself now lost, but its readings survive in copies made for Poggio's humanist associates.
+
+## Variant Readings
+
+The text of De Rerum Natura presents numerous difficulties. Lucretius appears to have left the poem unfinished at his death, and the surviving manuscripts contain passages that are evidently disordered, incomplete, or corrupt. The opening invocation to Venus - *Aeneadum genetrix, hominum divomque voluptas* - is stable across all witnesses, but the text becomes increasingly troubled as Book I progresses. At line 44, the Oblongus reads *religio* where the Quadratus reads *religione*, a variation that affects the scansion; editors are divided.
+
+The apparatus records numerous places where the two ninth-century manuscripts disagree and where the Italian copies offer a third reading, sometimes one that appears to derive from the lost archetype by a different route of corruption.
+
+{{ alert(type="note", body="Lucretius employs an archaic Latin vocabulary that is often difficult to distinguish from scribal corruption. The word 'divom' for 'divorum', 'olli' for 'illi', and similar archaisms are genuine features of the poet's style, not errors, but scribes of later centuries sometimes 'corrected' them to standard forms.") }}
+
+## The Stemma
+
+The stemma for De Rerum Natura is relatively simple in outline: all manuscripts descend from a single Carolingian archetype A, which can be reconstructed from the agreement of the Oblongus (O) and the Quadratus (Q). The Italian manuscripts form a third branch through a lost intermediary that Poggio's copy represents. Where O and Q agree against the Italian tradition, the archetype reading is established with virtual certainty; where they disagree, the editor must choose between them on the basis of internal criteria.
+
+## Editorial Method
+
+The present text follows the Oxford Classical Text of Cyril Bailey, with modifications drawn from the more recent work of Marcus Deufert. The editorial approach is moderately conservative: the text of the archetype is restored where possible from the agreement of O and Q, and emendation is employed where the archetype reading is manifestly corrupt. The apparatus records the readings of both Leiden manuscripts, the principal Italian copies, and the most important conjectural emendations of Lachmann, Munro, and Lambinus.

--- a/annotation-layer/content/texts/piers-plowman-prologue.md
+++ b/annotation-layer/content/texts/piers-plowman-prologue.md
@@ -1,0 +1,100 @@
++++
+title = "Piers Plowman, Prologue"
+description = "Langland's allegorical vision of a fair field full of folk - surviving in three distinct authorial versions (A, B, and C) that complicate the textual tradition beyond ordinary measure."
+date = "2026-04-06"
+template = "text"
+weight = 6
+tags = ["allegory", "middle-english", "medieval"]
+[taxonomies]
+tradition = ["Langlandian"]
+[extra]
+text_no = "VI"
+tradition = "Langlandian"
+author = "William Langland (c. 1332-c. 1386)"
+date_composed = "c. 1370 (A-text), c. 1377-1379 (B-text), c. 1385-1386 (C-text)"
+witnesses = "Over fifty manuscripts in three versions: A (c. 17 MSS), B (c. 18 MSS), C (c. 18 MSS), plus Z-text and composite manuscripts"
+source = "Collation based on the Athlone editions: Kane (A-text, 1960), Kane-Donaldson (B-text, 1975), Russell-Kane (C-text, 1997)"
+apparatus_caption = "Stemma showing the three authorial versions and their manuscript families. The three versions share a common origin in Langland's working text but represent distinct stages of composition."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA VERSIONUM - PIERS PLOWMAN</text>
+  <!-- Langland's working text -->
+  <rect x="225" y="38" width="150" height="24" fill="none" stroke="#2C2416" stroke-width="0.8"/>
+  <text x="300" y="55" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#2C2416">Langland's Working Text</text>
+  <!-- Three versions branching -->
+  <line x1="260" y1="62" x2="120" y2="100" stroke="#2C2416" stroke-width="1"/>
+  <line x1="300" y1="62" x2="300" y2="100" stroke="#2C2416" stroke-width="1"/>
+  <line x1="340" y1="62" x2="480" y2="100" stroke="#2C2416" stroke-width="1"/>
+  <!-- A-text -->
+  <rect x="75" y="100" width="90" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="120" y="119" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">A-TEXT</text>
+  <text x="120" y="145" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">c. 1370</text>
+  <!-- B-text -->
+  <rect x="255" y="100" width="90" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="300" y="119" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">B-TEXT</text>
+  <text x="300" y="145" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">c. 1377-1379</text>
+  <!-- C-text -->
+  <rect x="435" y="100" width="90" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="480" y="119" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">C-TEXT</text>
+  <text x="480" y="145" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">c. 1385-1386</text>
+  <!-- A-text manuscripts -->
+  <line x1="100" y1="128" x2="60" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="120" y1="128" x2="120" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="140" y1="128" x2="180" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <rect x="40" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="60" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">T</text>
+  <rect x="100" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="120" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">V</text>
+  <rect x="160" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="180" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">H</text>
+  <!-- B-text manuscripts -->
+  <line x1="280" y1="128" x2="250" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="300" y1="128" x2="300" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="320" y1="128" x2="350" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <rect x="230" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="250" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">W</text>
+  <rect x="280" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="300" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">L</text>
+  <rect x="330" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="350" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">R</text>
+  <!-- C-text manuscripts -->
+  <line x1="460" y1="128" x2="430" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="480" y1="128" x2="480" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="500" y1="128" x2="530" y2="185" stroke="#2C2416" stroke-width="0.6"/>
+  <rect x="410" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="430" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">X</text>
+  <rect x="460" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="480" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">P</text>
+  <rect x="510" y="185" width="40" height="20" fill="#FFFFFF" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="530" y="199" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">U</text>
+  <!-- Composite manuscripts at bottom -->
+  <text x="300" y="240" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">Composite Manuscripts (mixing A/B/C)</text>
+  <line x1="120" y1="205" x2="220" y2="258" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="300" y1="205" x2="300" y2="258" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="480" y1="205" x2="380" y2="258" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <rect x="220" y="258" width="160" height="22" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8" stroke-dasharray="3,2"/>
+  <text x="300" y="274" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">AC, AB, BC composites</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+Piers Plowman presents a textual problem that is unique in English literary history. The poem exists in three distinct versions - the A-text, the B-text, and the C-text - each of which represents a stage of authorial revision. The A-text is the shortest, breaking off in the middle of Passus XII; the B-text is a thorough revision and continuation of A, extending the poem to twenty passus; the C-text is a further revision of B, with substantial rearrangement of material and the addition of an autobiographical passage. To this triad must be added the so-called Z-text, a problematic version that may represent an early draft preceding A, and numerous composite manuscripts in which scribes combined passages from two or more versions.
+
+## Variant Readings
+
+The Prologue - the vision of the "fair field full of folk" between the tower of Truth and the dungeon of Wrong - exists in all three versions and provides an excellent example of the difficulties that the editor of Piers Plowman faces. The B-text Prologue is approximately twice the length of the A-text Prologue, having been expanded with new material including the fable of belling the cat. The C-text revises the B-text Prologue with characteristic changes in vocabulary and word order but preserves its essential structure.
+
+Within each version, the individual manuscripts show considerable variation. The B-text manuscripts, for example, are divided into two main groups by the Kane-Donaldson edition, but the boundaries between these groups are blurred by contamination.
+
+{{ alert(type="note", body="The Kane-Donaldson edition of the B-text (1975) is among the most controversial critical editions in medieval English studies. The editors emended the text extensively on the basis of their perception of Langland's style and intentions, a method that many subsequent scholars have judged too subjective.") }}
+
+## The Stemma
+
+The stemma for Piers Plowman is unlike that of any other text in this collection, because it must represent not only the descent of manuscripts within each version but also the relationships between versions. The three versions share a common point of origin in Langland's working text, but they diverge at the point of release into wider circulation. Composite manuscripts introduce further complication by combining readings from different versions, sometimes within a single passus.
+
+## Editorial Method
+
+The editorial approach to Piers Plowman has been fiercely debated. The Athlone editions, which are the basis of the present text, employ an eclectic method that seeks to recover the archetype of each version through the genealogical method of Lachmann, supplemented by editorial judgement where the evidence is ambiguous. Critics of this approach argue that the extensive contamination among the manuscripts makes a truly genealogical stemma impossible, and that the editors' reliance on stylistic criteria introduces an unacceptable degree of subjectivity. The present apparatus records both the Athlone readings and the most significant alternatives proposed by other editors.

--- a/annotation-layer/content/texts/sir-gawain-and-the-green-knight.md
+++ b/annotation-layer/content/texts/sir-gawain-and-the-green-knight.md
@@ -1,0 +1,81 @@
++++
+title = "Sir Gawain and the Green Knight"
+description = "The finest of the Middle English alliterative romances - surviving, like Beowulf, in a single manuscript, yet presenting a text of remarkable integrity."
+date = "2026-04-10"
+template = "text"
+weight = 10
+tags = ["romance", "middle-english", "medieval"]
+[taxonomies]
+tradition = ["Gawain-Poet"]
+[extra]
+text_no = "X"
+tradition = "Gawain-Poet"
+author = "Anonymous (the 'Gawain-Poet' or 'Pearl-Poet', fl. late 14th century)"
+date_composed = "c. 1375-1400"
+witnesses = "Cotton Nero A.x (British Library, late 14th or early 15th c.) - sole surviving manuscript"
+source = "Collation based on Tolkien and Gordon (2nd ed., rev. Davis, 1967) with reference to Andrew and Waldron (2007)"
+apparatus_caption = "Stemma for Sir Gawain. The sole manuscript (N) contains four poems by the same anonymous author; the stemma shows the hypothetical descent from the poet's holograph through lost intermediaries."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - SIR GAWAIN</text>
+  <!-- Poet's holograph -->
+  <rect x="220" y="42" width="160" height="24" fill="none" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="300" y="59" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#2C2416">Poet's Holograph (lost)</text>
+  <line x1="300" y1="66" x2="300" y2="90" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Lost intermediary x -->
+  <circle cx="300" cy="105" r="14" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="300" y="110" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">x</text>
+  <text x="338" y="108" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(lost copy)</text>
+  <line x1="300" y1="119" x2="300" y2="148" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Lost intermediary y -->
+  <circle cx="300" cy="163" r="14" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="300" y="168" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">y</text>
+  <text x="338" y="166" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(exemplar of N)</text>
+  <line x1="300" y1="177" x2="300" y2="210" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- The manuscript N -->
+  <rect x="260" y="210" width="80" height="36" fill="#FFFFFF" stroke="#8B2500" stroke-width="1.2"/>
+  <text x="300" y="234" text-anchor="middle" font-family="Cormorant, serif" font-size="20" font-weight="600" fill="#8B2500">N</text>
+  <text x="300" y="268" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Cotton Nero A.x</text>
+  <text x="300" y="278" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">late 14th / early 15th c.</text>
+  <!-- The four poems in the manuscript -->
+  <text x="80" y="140" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">The manuscript contains</text>
+  <text x="80" y="154" font-family="Crimson Pro, serif" font-size="9" fill="#1B3A5C">four poems:</text>
+  <text x="80" y="174" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">1. Pearl</text>
+  <text x="80" y="186" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">2. Cleanness</text>
+  <text x="80" y="198" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">3. Patience</text>
+  <text x="80" y="210" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">4. Sir Gawain</text>
+  <!-- Illustrations note -->
+  <rect x="400" y="140" width="160" height="80" fill="none" stroke="#C8C0AE" stroke-width="0.5"/>
+  <text x="480" y="158" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">The manuscript includes</text>
+  <text x="480" y="170" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">twelve illustrations:</text>
+  <text x="480" y="186" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">4 for Pearl</text>
+  <text x="480" y="198" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">2 for Cleanness</text>
+  <text x="480" y="210" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">2 for Patience</text>
+  <!-- Note -->
+  <text x="300" y="302" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Dashed borders indicate lost or hypothetical stages; the stemma is necessarily conjectural</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+Sir Gawain and the Green Knight, like Beowulf, survives in a single manuscript: Cotton Nero A.x, now in the British Library. The manuscript contains four poems - Pearl, Cleanness, Patience, and Sir Gawain - all written in the same hand and all attributed to the same anonymous poet on the basis of shared dialect, vocabulary, and thematic concerns. The manuscript is a modest production, undecorated except for twelve crude illustrations, and appears to have been copied in the late fourteenth or early fifteenth century from an exemplar that is no longer extant.
+
+The textual situation of Sir Gawain is therefore analogous to that of Beowulf: there is no second manuscript against which to check the readings of the sole survivor. However, the Cotton Nero manuscript is in considerably better physical condition than the Beowulf manuscript, having escaped the Cotton fire of 1731 with only minor damage.
+
+## Variant Readings
+
+In the absence of a second manuscript, the "variant readings" for Sir Gawain consist not of differences between witnesses but of places where the sole manuscript appears to be in error and where editors have proposed emendations. The opening line - *Sithen the sege and the assaut was sesed at Troye* ("After the siege and the assault was ceased at Troy") - has been emended by some editors to read *cesed* for the manuscript's *sesed*, on the grounds that *sesed* is not attested elsewhere in the poet's dialect; others retain the manuscript reading as a legitimate dialectal form.
+
+The apparatus for Sir Gawain records approximately eighty substantive emendations proposed by editors from Madden (1839) to Andrew and Waldron (2007). Of these, roughly half have been adopted into the standard editions; the remainder are noted as proposed alternatives.
+
+{{ alert(type="note", body="The dialect of the Gawain-Poet has been localised to the area of south-east Cheshire or north-east Staffordshire, in the English North-West Midlands. This dialectal identification is of crucial importance for the textual criticism of the poem, since many apparent errors in the manuscript may be genuine dialectal forms unfamiliar to editors trained in the London-based standard of Chaucer's English.") }}
+
+## The Stemma
+
+The stemma for Sir Gawain is, by necessity, largely hypothetical. The sole manuscript N is separated from the poet's holograph by at least one and probably several lost intermediaries. The evidence for these lost stages consists of errors in N that are most plausibly explained as copying mistakes introduced during transmission rather than as features of the original composition. The number and character of these errors suggest that N is at least two stages removed from the holograph, though this conclusion must remain tentative in the absence of corroborating witnesses.
+
+## Editorial Method
+
+The editorial approach to Sir Gawain is conservative by necessity: the sole manuscript is emended only where its reading is clearly corrupt or where the metre demands a different form. The standard edition of Tolkien and Gordon, as revised by Norman Davis, remains the foundation of the present text, supplemented by the more recent work of Andrew and Waldron. The apparatus records all substantive emendations, indicating which have been adopted and which are presented as alternatives. The spelling of the manuscript is preserved, with the understanding that the scribe's orthography, while sometimes inconsistent, is a legitimate record of the poet's dialect.

--- a/annotation-layer/content/texts/the-aeneid-book-i.md
+++ b/annotation-layer/content/texts/the-aeneid-book-i.md
@@ -1,0 +1,92 @@
++++
+title = "The Aeneid, Book I"
+description = "Virgil's epic of Aeneas's journey from Troy to Italy - the foundational text of the Latin literary tradition, transmitted through an exceptionally rich manuscript stemma."
+date = "2026-04-01"
+template = "text"
+weight = 1
+tags = ["epic", "latin", "classical"]
+[taxonomies]
+tradition = ["Virgilian"]
+[extra]
+text_no = "I"
+tradition = "Virgilian"
+author = "Publius Vergilius Maro (70-19 BCE)"
+date_composed = "c. 29-19 BCE"
+witnesses = "R (Vaticanus lat. 3867, 5th c.), M (Mediceus, 5th c.), P (Palatinus, 4th-5th c.), G (Sangallensis, 4th-5th c.), F (Vaticanus lat. 3225, 4th c.)"
+source = "Collation based on Mynors (OCT, 1969) with reference to Ribbeck and Sabbadini"
+apparatus_caption = "Stemma codicum for the Aeneid. The archetype (O) descends through two principal branches: the 'ancient' manuscripts (FGMP) and the 'medieval' tradition represented by later copies."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - AENEID</text>
+  <!-- Archetype -->
+  <circle cx="300" cy="55" r="16" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="60" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#2C2416">O</text>
+  <!-- Branch lines from O -->
+  <line x1="288" y1="70" x2="160" y2="120" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="312" y1="70" x2="440" y2="120" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Hyparchetype alpha -->
+  <circle cx="160" cy="135" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="160" y="140" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">a</text>
+  <!-- Hyparchetype beta -->
+  <circle cx="440" cy="135" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="440" y="140" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">b</text>
+  <!-- From alpha: F, G -->
+  <line x1="148" y1="148" x2="100" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="172" y1="148" x2="220" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- From beta: M, P, R -->
+  <line x1="428" y1="148" x2="360" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="440" y1="149" x2="440" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="452" y1="148" x2="520" y2="200" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Manuscripts -->
+  <rect x="80" y="200" width="40" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="100" y="220" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">F</text>
+  <rect x="200" y="200" width="40" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="220" y="220" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">G</text>
+  <rect x="340" y="200" width="40" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="360" y="220" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">M</text>
+  <rect x="420" y="200" width="40" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="440" y="220" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">P</text>
+  <rect x="500" y="200" width="40" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="520" y="220" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">R</text>
+  <!-- Labels -->
+  <text x="100" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Vat. lat. 3225</text>
+  <text x="100" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">4th c.</text>
+  <text x="220" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Sangallensis</text>
+  <text x="220" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">4th-5th c.</text>
+  <text x="360" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Mediceus</text>
+  <text x="360" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">5th c.</text>
+  <text x="440" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Palatinus</text>
+  <text x="440" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">4th-5th c.</text>
+  <text x="520" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Vat. lat. 3867</text>
+  <text x="520" y="260" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">5th c.</text>
+  <!-- Legend -->
+  <line x1="40" y1="290" x2="60" y2="290" stroke="#2C2416" stroke-width="0.8"/>
+  <text x="65" y="293" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Descent</text>
+  <circle cx="130" cy="290" r="6" fill="none" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="142" y="293" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Hyparchetype</text>
+  <rect x="210" y="284" width="12" height="12" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="228" y="293" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Extant witness</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Aeneid of Virgil is among the most richly attested texts of classical antiquity. The poem survives in seven major manuscripts of the fourth and fifth centuries - an embarrassment of riches for the textual critic, though one which presents its own difficulties. The antiquity of the witnesses means that many of the errors they contain are themselves ancient, and the contamination between branches of the tradition began early. The stemma presented above represents a simplified view of the relationships; the actual transmission is complicated by horizontal contamination, by the influence of ancient commentaries (particularly that of Servius), and by the corrections introduced by later hands into several of the early manuscripts.
+
+## Variant Readings
+
+The opening line of the Aeneid - *Arma virumque cano, Troiae qui primus ab oris* - is attested uniformly across all major witnesses. The textual difficulties begin in earnest at line 2, where the reading *Italiam fato profugus* is given by most manuscripts but where the corrector of R offers *Lavinaque venit / litora* with a different word division from that found in M. Such variations, though individually minor, accumulate across the twelve books into a substantial body of evidence for the editorial tradition.
+
+The apparatus for Book I records over two hundred variant readings of philological significance. Of these, approximately thirty involve substantive differences in meaning rather than mere orthographic variation; the remainder concern spelling, word order, and the presence or absence of connecting particles - matters which are nonetheless of importance for establishing the habits of individual scribes and the relationships among the manuscripts.
+
+{{ alert(type="note", body="The so-called 'Virgilian appendix' - a group of minor poems attributed to the young Virgil - is transmitted separately from the Aeneid and does not appear in the major Aeneid manuscripts. Its textual tradition, though related, is distinct and is not treated in the present edition.") }}
+
+## The Stemma
+
+The stemma codicum presented above follows, in its essentials, the reconstruction of R. A. B. Mynors in his Oxford Classical Text of 1969. The archetype O is posited as the common ancestor of all surviving manuscripts, though it cannot be identified with any known codex. From O descend two principal branches: alpha (comprising the Schedae Vaticanae F and the Sangallensis G) and beta (comprising the Mediceus M, the Palatinus P, and the Romanus R). The division is supported by a body of shared errors within each branch, though individual manuscripts occasionally cross the divide - a phenomenon attributed to contamination from exemplars belonging to the other branch.
+
+## Editorial Method
+
+The present text follows Mynors in preferring the readings of the older manuscripts (F, G, M, P, R) over those of the medieval tradition, except where the older witnesses are clearly in error or where the medieval tradition preserves a reading demonstrably superior on internal grounds. Conjectural emendation is employed sparingly; the principal conjectures adopted are those of Heinsius, Bentley, and Ribbeck, all of which are noted in the apparatus. The orthography has been normalised to the standard of the first century BCE as established by modern scholarship, with the understanding that the original orthography of Virgil's own manuscripts is irrecoverable.

--- a/annotation-layer/content/texts/the-canterbury-tales-general-prologue.md
+++ b/annotation-layer/content/texts/the-canterbury-tales-general-prologue.md
@@ -1,0 +1,96 @@
++++
+title = "The Canterbury Tales, General Prologue"
+description = "Chaucer's great pilgrimage poem - transmitted in over eighty manuscripts with significant textual variation across the major witnesses."
+date = "2026-04-03"
+template = "text"
+weight = 3
+tags = ["poetry", "middle-english", "medieval"]
+[taxonomies]
+tradition = ["Chaucerian"]
+[extra]
+text_no = "III"
+tradition = "Chaucerian"
+author = "Geoffrey Chaucer (c. 1343-1400)"
+date_composed = "c. 1387-1400"
+witnesses = "El (Ellesmere, Huntington Library, c. 1400-1410), Hg (Hengwrt, National Library of Wales, c. 1400), Cp (Corpus Christi College Cambridge 198), La (Lansdowne 851), Ha4 (Harley 7334)"
+source = "Collation based on The Riverside Chaucer (3rd ed., 1987) with reference to Manly-Rickert (1940)"
+apparatus_caption = "Stemma codicum for the Canterbury Tales General Prologue. The complex tradition descends through multiple lost intermediaries, with extensive contamination between branches."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - CANTERBURY TALES</text>
+  <!-- Archetype O -->
+  <circle cx="300" cy="55" r="16" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="60" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#2C2416">O</text>
+  <!-- Three main branches -->
+  <line x1="284" y1="68" x2="120" y2="115" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="300" y1="71" x2="300" y2="115" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="316" y1="68" x2="480" y2="115" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Alpha branch -->
+  <circle cx="120" cy="130" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="120" y="135" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">a</text>
+  <!-- Beta branch -->
+  <circle cx="300" cy="130" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="300" y="135" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">b</text>
+  <!-- Gamma branch -->
+  <circle cx="480" cy="130" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="480" y="135" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">g</text>
+  <!-- Contamination line -->
+  <line x1="134" y1="130" x2="286" y2="130" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <line x1="314" y1="130" x2="466" y2="130" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <!-- Manuscripts from alpha -->
+  <line x1="108" y1="143" x2="70" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="132" y1="143" x2="170" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="45" y="195" width="50" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="70" y="213" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">Hg</text>
+  <rect x="145" y="195" width="50" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="170" y="213" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">Cp</text>
+  <!-- Manuscripts from beta -->
+  <line x1="300" y1="144" x2="300" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="275" y="195" width="50" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="300" y="213" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">El</text>
+  <!-- Manuscripts from gamma -->
+  <line x1="468" y1="143" x2="430" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="492" y1="143" x2="530" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="405" y="195" width="50" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="430" y="213" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">La</text>
+  <rect x="505" y="195" width="50" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="530" y="213" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">Ha4</text>
+  <!-- Labels -->
+  <text x="70" y="238" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Hengwrt, c. 1400</text>
+  <text x="170" y="238" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Corpus 198</text>
+  <text x="300" y="238" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Ellesmere, c. 1400</text>
+  <text x="430" y="238" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Lansdowne 851</text>
+  <text x="530" y="238" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Harley 7334</text>
+  <!-- Contamination note -->
+  <text x="300" y="275" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8B2500">Dashed red lines indicate contamination between branches</text>
+  <!-- Legend -->
+  <rect x="185" y="290" width="10" height="10" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="200" y="299" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Extant witness</text>
+  <circle cx="290" cy="295" r="5" fill="none" stroke="#1B3A5C" stroke-width="0.8"/>
+  <text x="300" y="299" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Hyparchetype</text>
+  <line x1="375" y1="295" x2="395" y2="295" stroke="#8B2500" stroke-width="0.5" stroke-dasharray="3,3"/>
+  <text x="400" y="299" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Contamination</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Canterbury Tales survive in over eighty manuscripts, making it one of the most copiously attested works of Middle English literature. Yet this abundance of witnesses has not simplified the task of the textual critic; rather, it has complicated it almost beyond measure. The manuscripts differ not only in individual readings but in the ordering of the tales, the presence or absence of certain linking passages, and the degree of completion of individual tales. Chaucer left the work unfinished at his death in 1400, and no manuscript preserves an arrangement that can be attributed with confidence to the author himself.
+
+## Variant Readings
+
+The opening line of the General Prologue - *Whan that Aprille with his shoures soote* - shows relatively little variation across the manuscripts, though the spelling of individual words differs considerably. The Hengwrt manuscript, generally regarded as the most authoritative witness, reads *Whan that Aueryll wt his shoures soote*, with the characteristic Hengwrt abbreviations. The Ellesmere, which is the most beautifully produced of the manuscripts, reads *Whan that Aueryll with his shoures soote*. Later manuscripts show progressively greater divergence, with some introducing readings that appear to be scribal improvements rather than authentic variants.
+
+The apparatus for the General Prologue records a substantial number of variants at points where the sense, the metre, or both are affected. At line 4, for example, the Hengwrt reads *of which vertu engendred is the flour* while several other manuscripts read *by which vertu*, a variation that affects the syntax though not the meaning.
+
+{{ alert(type="note", body="The relationship between the Hengwrt and Ellesmere manuscripts is a central problem of Chaucerian textual criticism. Both are believed to have been copied by the same scribe, Adam Pinkhurst, yet they differ in hundreds of readings and in the ordering of the tales. The prevailing view is that Hengwrt was copied first, from an incomplete and disordered set of exemplars, and Ellesmere later, from a more complete collection.") }}
+
+## The Stemma
+
+The stemma for the Canterbury Tales is among the most disputed in medieval textual criticism. The eight-volume edition of John M. Manly and Edith Rickert (1940), which attempted a comprehensive classification of all known manuscripts, ultimately concluded that no simple stemma could account for the relationships among the witnesses. The contamination between manuscript families is so extensive that the genealogical method breaks down; nearly every manuscript shows readings borrowed from multiple branches of the tradition.
+
+## Editorial Method
+
+Given the impossibility of constructing a reliable stemma, modern editors of the Canterbury Tales have adopted a base-text method: selecting a single manuscript as the primary authority and emending it only where it is clearly in error. The present text follows the Ellesmere manuscript as the base text, in keeping with the editorial tradition established by W. W. Skeat and continued in the Riverside Chaucer. Readings from Hengwrt and other witnesses are adopted where the Ellesmere appears to be in error, and all such departures from the base text are recorded in the apparatus.

--- a/annotation-layer/content/texts/the-divine-comedy-inferno-i.md
+++ b/annotation-layer/content/texts/the-divine-comedy-inferno-i.md
@@ -1,0 +1,94 @@
++++
+title = "The Divine Comedy, Inferno I"
+description = "Dante's journey through the dark wood - transmitted in over six hundred manuscripts, making it one of the most copiously attested texts of the European Middle Ages."
+date = "2026-04-09"
+template = "text"
+weight = 9
+tags = ["epic", "italian", "medieval"]
+[taxonomies]
+tradition = ["Dantean"]
+[extra]
+text_no = "IX"
+tradition = "Dantean"
+author = "Dante Alighieri (1265-1321)"
+date_composed = "c. 1308-1320"
+witnesses = "Ash (Ashburnhamiano 828, early 14th c.), Rb (Laurenziano 40.22, Boccaccio's copy), Triv (Trivulziano 1080, 1337), Mad (Madrileño 10186, mid-14th c.), Urb (Urbinate latino 366, 1352)"
+source = "Collation based on Petrocchi (1966-1967) with reference to Sanguineti (2001) and Trovato (2007)"
+apparatus_caption = "Stemma codicum for the Divine Comedy. The extraordinary number of witnesses (over 600) has not simplified but rather complicated the task of establishing the text; the stemma shown here represents the principal families."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - DIVINE COMEDY</text>
+  <!-- Dante's autograph -->
+  <rect x="230" y="38" width="140" height="22" fill="none" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="300" y="54" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#2C2416">Autograph (lost)</text>
+  <line x1="300" y1="60" x2="300" y2="78" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Archetype -->
+  <circle cx="300" cy="92" r="14" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="97" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#2C2416">O</text>
+  <!-- Three families -->
+  <line x1="282" y1="103" x2="120" y2="148" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="300" y1="106" x2="300" y2="148" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="318" y1="103" x2="480" y2="148" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Family alpha -->
+  <circle cx="120" cy="162" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="120" y="167" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">a</text>
+  <!-- Family beta -->
+  <circle cx="300" cy="162" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="300" y="167" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">b</text>
+  <!-- Family gamma -->
+  <circle cx="480" cy="162" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="480" y="167" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">g</text>
+  <!-- Contamination lines -->
+  <line x1="134" y1="162" x2="286" y2="162" stroke="#8B2500" stroke-width="0.4" stroke-dasharray="3,3"/>
+  <line x1="314" y1="162" x2="466" y2="162" stroke="#8B2500" stroke-width="0.4" stroke-dasharray="3,3"/>
+  <!-- Alpha manuscripts -->
+  <line x1="108" y1="175" x2="75" y2="215" stroke="#2C2416" stroke-width="0.7"/>
+  <line x1="132" y1="175" x2="165" y2="215" stroke="#2C2416" stroke-width="0.7"/>
+  <rect x="50" y="215" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="75" y="232" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-weight="600" fill="#8B2500">Ash</text>
+  <rect x="140" y="215" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="165" y="232" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-weight="600" fill="#8B2500">Triv</text>
+  <!-- Beta manuscripts -->
+  <line x1="288" y1="175" x2="260" y2="215" stroke="#2C2416" stroke-width="0.7"/>
+  <line x1="312" y1="175" x2="340" y2="215" stroke="#2C2416" stroke-width="0.7"/>
+  <rect x="235" y="215" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="260" y="232" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-weight="600" fill="#8B2500">Rb</text>
+  <rect x="315" y="215" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="340" y="232" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-weight="600" fill="#8B2500">Mad</text>
+  <!-- Gamma manuscripts -->
+  <line x1="480" y1="176" x2="480" y2="215" stroke="#2C2416" stroke-width="0.7"/>
+  <rect x="455" y="215" width="50" height="24" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="480" y="232" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-weight="600" fill="#8B2500">Urb</text>
+  <!-- Labels -->
+  <text x="75" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Ashb. 828</text>
+  <text x="165" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Triv. 1080, 1337</text>
+  <text x="260" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Boccaccio's copy</text>
+  <text x="340" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Madr. 10186</text>
+  <text x="480" y="252" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Urb. lat. 366, 1352</text>
+  <!-- Legend -->
+  <text x="300" y="285" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8B2500">Dashed red lines: contamination between families</text>
+  <text x="300" y="300" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Over 600 manuscripts survive; only the principal witnesses are shown</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Divine Comedy of Dante Alighieri survives in over six hundred manuscripts, an extraordinary number that reflects the poem's immediate and lasting popularity in Italy. No autograph survives; Dante's own manuscripts were lost after his death in Ravenna in 1321, and the earliest surviving copies date from within a decade or two of the poet's death. The sheer number of witnesses, far from simplifying the textual critic's task, has made it nearly intractable. The tradition is heavily contaminated: scribes freely compared their copies against other manuscripts and adopted readings from multiple exemplars, destroying the neat genealogical relationships that the stemmatic method requires.
+
+## Variant Readings
+
+The opening tercet of Inferno I - *Nel mezzo del cammin di nostra vita / mi ritrovai per una selva oscura / che la diritta via era smarrita* ("In the middle of the journey of our life / I found myself in a dark wood / where the straight way was lost") - is stable across almost all manuscripts. The textual problems begin at line 13, where the manuscripts divide between *la dove terminava quella valle* and *la ove terminava quella valle*, a seemingly trivial orthographic difference that nonetheless has consequences for the metre and for the establishment of manuscript families.
+
+The apparatus for Inferno I records over one hundred and fifty variant readings. Many of these are dialectal variants reflecting the diverse forms of Italian in the early fourteenth century, but a significant number involve differences that affect the meaning or the metre of the verse.
+
+{{ alert(type="note", body="Giovanni Boccaccio, Dante's first biographer and ardent champion, copied the Divine Comedy at least three times in his own hand. His copy designated Rb (Laurenziano 40.22) is a witness of particular interest because Boccaccio may have had access to manuscripts close to the archetype; however, his text also shows signs of editorial intervention, as Boccaccio was not merely a copyist but a literary critic who may have emended readings he judged corrupt.") }}
+
+## The Stemma
+
+The stemma for the Divine Comedy is a matter of ongoing scholarly controversy. The monumental edition of Giorgio Petrocchi (1966-1967), which has been the standard critical text for half a century, was based on a selection of twenty-seven manuscripts predating 1355, on the theory that later copies are too corrupt and too contaminated to be of value. Petrocchi divided these manuscripts into families but acknowledged the pervasive contamination that makes a clean stemma impossible. More recently, Federico Sanguineti has proposed a radically different text based on a single manuscript, the Urbinate (Urb), which he argues preserves the closest approximation to Dante's original.
+
+## Editorial Method
+
+The present text follows Petrocchi's edition, which represents a moderate eclecticism: the reading of the majority of early manuscripts is adopted where they agree, and where they divide, the choice is made on the basis of internal criteria (sense, metre, style, and the avoidance of lectio facilior). The apparatus records the readings of the five principal witnesses listed above, along with the most important conjectural emendations and the readings preferred by Sanguineti where they differ from Petrocchi. The reader will find that the textual problems of the Divine Comedy, while numerous, rarely affect the overall sense of the poem; they are matters of nuance and precision rather than of large-scale corruption.

--- a/annotation-layer/content/texts/the-iliad-book-i.md
+++ b/annotation-layer/content/texts/the-iliad-book-i.md
@@ -1,0 +1,88 @@
++++
+title = "The Iliad, Book I"
+description = "Homer's wrath of Achilles - the oldest and most extensively transmitted text of the Western tradition, with papyrus fragments predating all medieval manuscripts."
+date = "2026-04-04"
+template = "text"
+weight = 4
+tags = ["epic", "greek", "classical"]
+[taxonomies]
+tradition = ["Homeric"]
+[extra]
+text_no = "IV"
+tradition = "Homeric"
+author = "Homer (attributed, 8th-7th century BCE)"
+date_composed = "c. 750-700 BCE"
+witnesses = "Venetus A (Marcianus graecus 454, 10th c.), Venetus B (Marc. gr. 453, 11th c.), P.Oxy. (various papyri, 3rd c. BCE - 3rd c. CE), T (Townleianus, Burney 86, 11th c.)"
+source = "Collation based on M. L. West (Teubner, 1998-2000) with reference to Allen (OCT, 1920) and van Thiel (1996)"
+apparatus_caption = "Stemma codicum for the Iliad. The Alexandrian recension (Ar) produced a stabilised vulgate that is the ancestor of all medieval manuscripts; pre-Alexandrian papyri attest to a wilder, more varied text."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - ILIAD</text>
+  <!-- Oral tradition -->
+  <rect x="230" y="38" width="140" height="22" fill="none" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="300" y="54" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#2C2416">Oral Composition</text>
+  <line x1="300" y1="60" x2="300" y2="80" stroke="#2C2416" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <!-- Early written texts -->
+  <circle cx="300" cy="95" r="14" fill="none" stroke="#2C2416" stroke-width="1"/>
+  <text x="300" y="100" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#2C2416">W</text>
+  <text x="340" y="98" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(early written text)</text>
+  <!-- Two branches -->
+  <line x1="285" y1="108" x2="140" y2="150" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="315" y1="108" x2="440" y2="150" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Pre-Alexandrian wild texts -->
+  <rect x="80" y="150" width="120" height="24" fill="none" stroke="#1B3A5C" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="140" y="167" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" font-style="italic" fill="#1B3A5C">Pre-Alexandrian</text>
+  <!-- Papyri -->
+  <line x1="110" y1="174" x2="80" y2="210" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="140" y1="174" x2="140" y2="210" stroke="#2C2416" stroke-width="0.6"/>
+  <line x1="170" y1="174" x2="200" y2="210" stroke="#2C2416" stroke-width="0.6"/>
+  <rect x="55" y="210" width="50" height="22" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="80" y="226" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8B2500">P.Oxy. I</text>
+  <rect x="115" y="210" width="50" height="22" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="140" y="226" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8B2500">P.Oxy. II</text>
+  <rect x="175" y="210" width="50" height="22" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="200" y="226" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8B2500">P.Oxy. III</text>
+  <!-- Alexandrian recension -->
+  <circle cx="440" cy="165" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="440" y="170" text-anchor="middle" font-family="Cormorant, serif" font-size="12" font-style="italic" fill="#1B3A5C">Ar</text>
+  <text x="475" y="168" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(Aristarchus)</text>
+  <!-- Medieval manuscripts -->
+  <line x1="425" y1="178" x2="350" y2="225" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="440" y1="179" x2="440" y2="225" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="455" y1="178" x2="530" y2="225" stroke="#2C2416" stroke-width="0.8"/>
+  <rect x="320" y="225" width="60" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="350" y="243" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">Ven. A</text>
+  <rect x="410" y="225" width="60" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="440" y="243" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">Ven. B</text>
+  <rect x="500" y="225" width="60" height="26" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="530" y="243" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-weight="600" fill="#8B2500">T</text>
+  <!-- Labels -->
+  <text x="350" y="268" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Marc. gr. 454, 10th c.</text>
+  <text x="440" y="268" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Marc. gr. 453, 11th c.</text>
+  <text x="530" y="268" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Townleianus, 11th c.</text>
+  <!-- Legend -->
+  <text x="300" y="300" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">Dashed borders indicate lost or hypothetical stages of transmission</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Iliad is the most extensively transmitted text of classical Greek literature. The tradition divides into two broad strata: the pre-Alexandrian texts, known principally from papyrus fragments recovered from the sands of Egypt, and the medieval manuscript tradition, which descends from the standardised text established by the Alexandrian scholars - above all Aristarchus of Samothrace, who produced his critical edition of Homer in the second century BCE. The pre-Alexandrian papyri attest to a markedly different state of the text: they contain lines not found in the medieval tradition, omit lines that the medieval manuscripts include, and show numerous variant readings that suggest a fluid, perhaps still partially oral tradition.
+
+## Variant Readings
+
+The opening line of the Iliad - *menin aeide, thea, Peleiadeo Achileos* ("Sing, goddess, the wrath of Achilles, son of Peleus") - is stable across all witnesses. But the text becomes increasingly varied as one moves deeper into Book I. At line 5, the medieval tradition reads *heroeion* ("of heroes"), while a third-century BCE papyrus (P.Oxy. 445) reads *andreion* ("of men") - a reading that several modern editors have judged to be the older form, since the word *heros* in its Homeric sense may not originally have applied to the warriors at Troy.
+
+The apparatus for Book I records well over three hundred variant readings, drawn from the medieval manuscripts, the papyri, the quotations in ancient authors, and the marginal scholia of the Venetus A manuscript, which preserve many readings attributed to the Alexandrian critics.
+
+{{ alert(type="note", body="The Venetus A manuscript (Marcianus graecus 454) is of extraordinary importance not only for its text of the Iliad but for the scholia that fill its margins. These scholia, drawn from the commentaries of Aristarchus, Didymus, Aristonicus, and others, constitute our principal evidence for the textual criticism practised at the Library of Alexandria.") }}
+
+## The Stemma
+
+The stemma for the Iliad reflects the fundamental division between the pre-Alexandrian 'wild' texts and the post-Alexandrian vulgate. The Alexandrian recension, attributed primarily to Aristarchus, is the ancestor of all surviving medieval manuscripts; the pre-Alexandrian papyri represent a separate, earlier stage of the transmission which Aristarchus himself sought to regulate and standardise. The relationship between the papyri and the medieval tradition is not one of simple descent but of deliberate editorial intervention.
+
+## Editorial Method
+
+M. L. West's Teubner edition, which is the basis of the present text, represents a significant departure from the conservative editorial tradition of T. W. Allen. West was prepared to prefer papyrus readings over the medieval vulgate where he judged them superior on internal grounds, and to athetise (mark as spurious) lines that he believed to be post-Homeric interpolations. The present apparatus records West's decisions alongside the readings of the principal witnesses, allowing the reader to assess the evidence independently.

--- a/annotation-layer/content/texts/the-republic-book-vii.md
+++ b/annotation-layer/content/texts/the-republic-book-vii.md
@@ -1,0 +1,81 @@
++++
+title = "The Republic, Book VII"
+description = "Plato's Allegory of the Cave and the education of the philosopher-king - transmitted through the direct manuscript tradition and the extensive ancient commentary tradition."
+date = "2026-04-07"
+template = "text"
+weight = 7
+tags = ["philosophical", "greek", "classical"]
+[taxonomies]
+tradition = ["Platonic"]
+[extra]
+text_no = "VII"
+tradition = "Platonic"
+author = "Plato (c. 428-348 BCE)"
+date_composed = "c. 375 BCE"
+witnesses = "A (Parisinus graecus 1807, 9th c.), D (Bodleianus Clarkianus 39, 895 CE), F (Vindobonensis suppl. gr. 7, 11th-12th c.), P.Oxy. 3679 (2nd c. CE)"
+source = "Collation based on Slings (OCT, 2003) with reference to Burnet (OCT, 1902) and Adam (1902)"
+apparatus_caption = "Stemma codicum for the Republic. The tradition descends from a single ancient archetype; the ninth-century manuscripts A and D are the foundation of the text."
+apparatus_svg = '''
+<svg viewBox="0 0 600 320" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="600" height="320" fill="#FAFAF5" stroke="#C8C0AE" stroke-width="0.8"/>
+  <text x="300" y="24" text-anchor="middle" font-family="Crimson Pro, serif" font-size="10" fill="#8B2500" letter-spacing="0.15em">STEMMA CODICUM - REPUBLIC</text>
+  <!-- Ancient archetype -->
+  <circle cx="300" cy="55" r="16" fill="none" stroke="#2C2416" stroke-width="1.2"/>
+  <text x="300" y="60" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#2C2416">O</text>
+  <!-- Branch to papyri and medieval -->
+  <line x1="280" y1="68" x2="140" y2="115" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="320" y1="68" x2="420" y2="115" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Papyrus branch -->
+  <rect x="90" y="115" width="100" height="24" fill="none" stroke="#1B3A5C" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="140" y="132" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" font-style="italic" fill="#1B3A5C">Papyrus tradition</text>
+  <line x1="140" y1="139" x2="140" y2="170" stroke="#2C2416" stroke-width="0.6"/>
+  <rect x="105" y="170" width="70" height="22" fill="#FFFFFF" stroke="#8B2500" stroke-width="0.8"/>
+  <text x="140" y="186" text-anchor="middle" font-family="Crimson Pro, serif" font-size="9" fill="#8B2500">P.Oxy. 3679</text>
+  <text x="140" y="208" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">2nd c. CE</text>
+  <!-- Medieval branch -->
+  <circle cx="420" cy="130" r="14" fill="none" stroke="#1B3A5C" stroke-width="1"/>
+  <text x="420" y="135" text-anchor="middle" font-family="Cormorant, serif" font-size="14" font-style="italic" fill="#1B3A5C">m</text>
+  <text x="450" y="133" font-family="Crimson Pro, serif" font-size="8" fill="#8A7E6C">(medieval ancestor)</text>
+  <!-- Three medieval branches -->
+  <line x1="406" y1="142" x2="300" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="420" y1="144" x2="420" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <line x1="434" y1="142" x2="530" y2="195" stroke="#2C2416" stroke-width="0.8"/>
+  <!-- Manuscripts -->
+  <rect x="270" y="195" width="60" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="300" y="214" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">A</text>
+  <rect x="390" y="195" width="60" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="420" y="214" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">D</text>
+  <rect x="500" y="195" width="60" height="28" fill="#FFFFFF" stroke="#8B2500" stroke-width="1"/>
+  <text x="530" y="214" text-anchor="middle" font-family="Cormorant, serif" font-size="16" font-weight="600" fill="#8B2500">F</text>
+  <!-- Labels -->
+  <text x="300" y="240" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Par. gr. 1807, 9th c.</text>
+  <text x="420" y="240" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Bodl. Clark. 39, 895 CE</text>
+  <text x="530" y="240" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">Vindob. suppl. gr. 7</text>
+  <text x="530" y="250" text-anchor="middle" font-family="Crimson Pro, serif" font-size="7" fill="#8A7E6C">11th-12th c.</text>
+  <!-- Indirect tradition note -->
+  <line x1="80" y1="270" x2="520" y2="270" stroke="#C8C0AE" stroke-width="0.4"/>
+  <text x="300" y="288" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">Indirect tradition: quotations in Proclus, Stobaeus, and Eusebius</text>
+  <text x="300" y="300" text-anchor="middle" font-family="Crimson Pro, serif" font-size="8" fill="#1B3A5C">provide independent witnesses to many passages</text>
+</svg>
+'''
++++
+
+## The Textual Tradition
+
+The Republic of Plato is transmitted through a manuscript tradition that, while less extensive than that of Homer, is nevertheless of considerable antiquity and complexity. The oldest complete witness is the Bodleian Clarke manuscript (D), which is precisely dated by a colophon to the year 895 CE and was copied by the scribe Ioannes for Arethas of Caesarea. The Parisinus A, roughly contemporary with D, belongs to a different branch of the tradition and offers numerous independent readings. The fragmentary papyrus witness P.Oxy. 3679, dating to the second century of the common era, attests to an ancient state of the text that predates the medieval tradition by seven centuries.
+
+## Variant Readings
+
+Book VII opens with the celebrated Allegory of the Cave, and the textual tradition of this famous passage is remarkably stable. The opening words - *meta tauta de, eipon, apeikason toioutoi pathei ten hemeteran phusin paideias te peri kai apaideusias* - show only trivial variation across the manuscripts, with D and A in agreement against minor errors in F and the later witnesses. The difficulties increase in the more philosophical sections that follow the allegory, where the precise wording of Plato's dialectical arguments is crucial to interpretation.
+
+At 514a2, the manuscripts are divided between *desmotas* (A) and *desmiotas* (D), a variation that affects the meaning only slightly (both mean "prisoners") but that is nonetheless significant for establishing the relationships among the manuscripts. The papyrus fragment, where it overlaps with the medieval text, tends to confirm the readings of A.
+
+{{ alert(type="note", body="The indirect tradition of the Republic - that is, the quotations and paraphrases found in later ancient authors such as Proclus, Stobaeus, and Eusebius - is of particular importance for Book VII, since the Allegory of the Cave was one of the most frequently cited passages in later Platonism. These quotations sometimes preserve readings that differ from all surviving manuscripts.") }}
+
+## The Stemma
+
+The stemma for the Republic is relatively straightforward compared to those of Homer or Chaucer. The ancient archetype O, which cannot be identified with any surviving manuscript, is the ancestor of both the papyrus tradition and the medieval manuscripts. Within the medieval branch, the manuscripts A and D are the primary witnesses; F and later copies serve as secondary evidence. The text established by S. R. Slings in his 2003 Oxford Classical Text represents the most thorough modern recension of the manuscript evidence.
+
+## Editorial Method
+
+The present text follows Slings in taking A and D as the twin pillars of the text, preferring their agreement over the readings of later manuscripts except where both are manifestly in error. Where A and D disagree, the editor must choose between them on the basis of internal probability, with reference to the papyrus evidence where available and to the indirect tradition in ancient quotations. Conjectural emendation is employed very sparingly; the text of the Republic is generally well preserved, and the principal difficulties concern interpretation rather than the establishment of the wording.

--- a/annotation-layer/static/css/style.css
+++ b/annotation-layer/static/css/style.css
@@ -1,0 +1,806 @@
+/* =====================================================================
+   Annotation-Layer - A Study in Deep Commentary
+   Light scholarly ground with apparatus criticus layout.
+   No CSS gradients. All decorative visuals are inline SVG.
+   ===================================================================== */
+
+:root {
+  --cream: #FAFAF5;
+  --cream-deep: #F0EDE4;
+  --cream-card: #FFFFFF;
+  --ink: #2C2416;
+  --ink-mid: #4A3F30;
+  --ink-faint: #8A7E6C;
+  --apparatus: #8B2500;
+  --apparatus-deep: #6B1C00;
+  --editorial: #1B3A5C;
+  --editorial-light: #2A5580;
+  --rule: #C8C0AE;
+  --rule-faint: #DDD8CC;
+  --rule-dark: #9E9580;
+  --siglum: #5C4A2E;
+  --highlight: #FFF8E1;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--cream);
+}
+
+body {
+  font-family: "Crimson Pro", "Noto Serif", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--ink);
+  background: var(--cream);
+}
+
+/* ---------------- Main Wrapper ---------------- */
+
+.codex-frame {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 1rem 2.8rem 2rem;
+  background: var(--cream);
+  border-left: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+  position: relative;
+}
+
+/* ---------------- Header / Masthead ---------------- */
+
+.codex-header {
+  text-align: center;
+  padding: 0.5rem 0 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.scholarly-rule { max-width: 800px; margin: 0 auto; padding: 0.3rem 0; }
+.scholarly-rule svg { display: block; width: 100%; height: 18px; }
+
+.codex-brand {
+  display: block;
+  text-decoration: none;
+  margin: 0.8rem auto 0.5rem;
+  max-width: 520px;
+}
+.codex-brand .brand-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.codex-sub {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0.4rem 0 0.8rem;
+}
+
+.codex-nav {
+  display: flex;
+  justify-content: center;
+  gap: 2.2rem;
+  flex-wrap: wrap;
+  margin: 0.5rem 0 0;
+}
+
+.codex-nav a {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.82rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--ink-mid);
+  padding: 0.2rem 0;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+}
+.codex-nav a:hover,
+.codex-nav a:focus {
+  color: var(--apparatus);
+  border-bottom-color: var(--apparatus);
+}
+
+/* ---------------- Main Content Area ---------------- */
+
+.codex-main {
+  padding: 0 0 2rem;
+  min-height: 50vh;
+}
+
+/* ---------------- Frontispiece / Home ---------------- */
+
+.frontispiece {
+  text-align: center;
+  padding: 2.5rem 1rem 1.5rem;
+}
+
+.frontispiece .kicker {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--apparatus);
+  margin: 0 0 0.6rem;
+}
+
+.frontispiece h1 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 3rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
+}
+
+.frontispiece .sub {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1rem;
+  color: var(--ink-faint);
+  margin: 0;
+  font-style: italic;
+}
+
+.front-plate {
+  max-width: 600px;
+  margin: 2rem auto;
+  border: 1px solid var(--rule);
+  padding: 0.5rem;
+  background: var(--cream-card);
+}
+.front-plate-inner {
+  background: var(--cream);
+}
+.front-plate svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.front-cap {
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--ink-faint);
+  margin: 0.5rem 0 0;
+  padding: 0 1rem;
+}
+
+.front-lede {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 1.1rem;
+  line-height: 1.85;
+  max-width: 680px;
+  margin: 1.5rem auto 2rem;
+  text-align: center;
+  color: var(--ink-mid);
+}
+
+/* Two-column layout */
+.two-col-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  max-width: 800px;
+  margin: 2rem auto;
+}
+
+.two-col-wrap .divider {
+  flex: 0 0 44px;
+  min-height: 300px;
+}
+.two-col-wrap .divider svg {
+  display: block;
+  width: 44px;
+  height: 100%;
+  min-height: 300px;
+}
+
+.two-col {
+  column-count: 2;
+  column-gap: 2.2rem;
+  font-size: 0.92rem;
+  line-height: 1.75;
+}
+.two-col p {
+  margin: 0 0 1rem;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.illum-para::first-letter {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 3.2em;
+  float: left;
+  line-height: 0.8;
+  margin: 0.05em 0.12em 0 0;
+  color: var(--apparatus);
+  font-weight: 700;
+}
+
+/* Featured texts grid on homepage */
+.featured-texts {
+  list-style: none;
+  margin: 2rem auto;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  max-width: 800px;
+}
+.featured-text a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: var(--ink);
+  padding: 1rem 0.5rem;
+  border: 1px solid var(--rule-faint);
+  background: var(--cream-card);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.featured-text a:hover,
+.featured-text a:focus {
+  border-color: var(--apparatus);
+  box-shadow: 0 2px 8px rgba(44,36,22,0.08);
+}
+.featured-init svg {
+  display: block;
+  width: 72px;
+  height: 72px;
+  margin-bottom: 0.6rem;
+}
+.featured-text-title {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+}
+.featured-text-dek {
+  font-size: 0.75rem;
+  color: var(--ink-faint);
+  text-align: center;
+  margin-top: 0.15rem;
+}
+
+/* ---------------- Section Listing ---------------- */
+
+.section-head {
+  text-align: center;
+  padding: 2rem 0 1rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 2rem;
+}
+.section-head .kicker {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--apparatus);
+  margin: 0 0 0.4rem;
+}
+.section-head h1 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 2.2rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+  color: var(--ink);
+}
+.section-head p {
+  font-size: 0.95rem;
+  color: var(--ink-faint);
+  margin: 0;
+}
+
+.section-intro {
+  max-width: 680px;
+  margin: 0 auto 2rem;
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: var(--ink-mid);
+}
+
+.text-table {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.text-row {
+  border-bottom: 1px solid var(--rule-faint);
+}
+
+.text-link {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.9rem 0.5rem;
+  text-decoration: none;
+  color: var(--ink);
+  transition: background 0.15s;
+}
+.text-link:hover,
+.text-link:focus {
+  background: var(--highlight);
+}
+
+.text-no {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--apparatus);
+  flex: 0 0 2.5rem;
+  text-align: right;
+}
+
+.text-title-wrap {
+  flex: 1 1 0;
+}
+.text-title-bl {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  display: block;
+}
+.text-dek {
+  font-size: 0.82rem;
+  color: var(--ink-faint);
+  display: block;
+  margin-top: 0.1rem;
+}
+
+.text-tradition {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--editorial);
+  flex: 0 0 auto;
+}
+
+/* ---------------- Text Page (Article) ---------------- */
+
+.text-page {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.text-head {
+  text-align: center;
+  padding: 2rem 0 1.5rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.5rem;
+}
+.text-head .kicker {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--apparatus);
+  margin: 0 0 0.4rem;
+}
+.text-head h1 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 2.2rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: var(--ink);
+  line-height: 1.2;
+}
+.text-head .text-lede {
+  font-size: 0.95rem;
+  color: var(--ink-faint);
+  margin: 0;
+  font-style: italic;
+}
+
+/* Specs / metadata */
+.text-specs {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 1.2rem;
+  font-size: 0.85rem;
+  margin: 1.5rem 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid var(--rule-faint);
+  background: var(--cream-card);
+}
+.text-specs dt {
+  font-weight: 600;
+  color: var(--editorial);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  padding-top: 0.1rem;
+}
+.text-specs dd {
+  margin: 0;
+  color: var(--ink-mid);
+}
+
+/* Figure / apparatus SVG */
+.text-figure {
+  margin: 2rem 0;
+  border: 1px solid var(--rule);
+  padding: 0.5rem;
+  background: var(--cream-card);
+}
+.text-frame {
+  background: var(--cream);
+}
+.text-frame svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.text-figcap {
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--ink-faint);
+  margin: 0.5rem 0 0;
+  padding: 0 0.5rem;
+  font-style: italic;
+}
+
+/* Prose body */
+.text-prose {
+  font-size: 0.95rem;
+  line-height: 1.85;
+  color: var(--ink);
+}
+.text-prose h2 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 2.2rem 0 0.8rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--rule-faint);
+}
+.text-prose h3 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink-mid);
+  margin: 1.8rem 0 0.6rem;
+}
+.text-prose p {
+  margin: 0 0 1.1rem;
+  text-align: justify;
+  hyphens: auto;
+}
+.text-prose ul, .text-prose ol {
+  margin: 0 0 1.1rem;
+  padding-left: 1.4rem;
+}
+.text-prose blockquote {
+  border-left: 3px solid var(--apparatus);
+  margin: 1.2rem 0;
+  padding: 0.6rem 1.2rem;
+  background: var(--highlight);
+  color: var(--ink-mid);
+  font-style: italic;
+}
+.text-prose code {
+  font-size: 0.88em;
+  background: var(--cream-deep);
+  padding: 0.1em 0.35em;
+  border-radius: 2px;
+}
+.text-prose pre {
+  background: var(--cream-deep);
+  border: 1px solid var(--rule-faint);
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+/* Apparatus block: original text on top 1/3, dense commentary on bottom 2/3 */
+.apparatus-block {
+  border: 1px solid var(--rule);
+  margin: 2rem 0;
+  background: var(--cream-card);
+}
+.apparatus-original {
+  padding: 1.2rem 1.5rem;
+  border-bottom: 2px solid var(--apparatus);
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: var(--ink);
+  min-height: 33%;
+}
+.apparatus-original .source-line {
+  font-style: italic;
+  color: var(--ink-faint);
+  font-size: 0.82rem;
+  margin-top: 0.5rem;
+}
+.apparatus-commentary {
+  padding: 1rem 1.5rem;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  color: var(--ink-mid);
+  column-count: 2;
+  column-gap: 1.5rem;
+  min-height: 66%;
+}
+.apparatus-commentary p {
+  margin: 0 0 0.6rem;
+  text-align: justify;
+  hyphens: auto;
+}
+
+/* Stemma codicum diagrams */
+.stemma {
+  margin: 1.5rem auto;
+  text-align: center;
+  max-width: 500px;
+}
+.stemma svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.stemma-caption {
+  font-size: 0.78rem;
+  color: var(--ink-faint);
+  font-style: italic;
+  margin-top: 0.4rem;
+  text-align: center;
+}
+
+/* Variant readings */
+.variant-reading {
+  display: inline;
+  border-bottom: 1px dashed var(--apparatus);
+  color: var(--apparatus);
+  cursor: help;
+}
+.variant-reading:hover {
+  background: var(--highlight);
+}
+
+/* Back link */
+.text-foot {
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+.back-link {
+  font-size: 0.85rem;
+  color: var(--editorial);
+  text-decoration: none;
+}
+.back-link:hover,
+.back-link:focus {
+  color: var(--apparatus);
+  text-decoration: underline;
+}
+
+/* ---------------- Generic Page Content ---------------- */
+
+.codex-main > h1,
+.codex-main > h2 {
+  font-family: "Cormorant", "EB Garamond", serif;
+}
+
+.codex-main h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 1.5rem 0 0.8rem;
+}
+.codex-main h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 2rem 0 0.6rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--rule-faint);
+}
+.codex-main h3 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink-mid);
+  margin: 1.6rem 0 0.5rem;
+}
+.codex-main p {
+  margin: 0 0 1rem;
+}
+.codex-main a {
+  color: var(--editorial);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  transition: color 0.2s;
+}
+.codex-main a:hover {
+  color: var(--apparatus);
+  text-decoration-color: var(--apparatus);
+}
+
+/* ---------------- Alert Shortcode ---------------- */
+
+.alert {
+  border-left: 3px solid var(--editorial);
+  background: var(--highlight);
+  padding: 0.7rem 1rem;
+  margin: 1.2rem 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--ink-mid);
+}
+.alert strong {
+  color: var(--editorial);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+/* ---------------- 404 Error Page ---------------- */
+
+.error-page {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.error-page .kicker {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--apparatus);
+  margin: 0 0 0.6rem;
+}
+.error-page h1 {
+  font-family: "Cormorant", "EB Garamond", serif;
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 1rem;
+}
+.error-page p {
+  font-size: 0.95rem;
+  color: var(--ink-faint);
+  max-width: 560px;
+  margin: 0 auto 1rem;
+}
+
+/* ---------------- Footer ---------------- */
+
+.codex-foot {
+  border-top: 1px solid var(--rule);
+  margin-top: 3rem;
+  padding-top: 1rem;
+}
+
+.foot-ornament { max-width: 800px; margin: 0 auto; padding: 0 0 1rem; }
+.foot-ornament svg { display: block; width: 100%; height: 50px; }
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin: 0 0 1.5rem;
+}
+.foot-col {
+  font-size: 0.78rem;
+  line-height: 1.6;
+  color: var(--ink-faint);
+}
+.foot-head {
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--apparatus);
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+.foot-col p {
+  margin: 0;
+}
+
+.foot-stamp {
+  text-align: center;
+  font-family: "Crimson Pro", "Noto Serif", serif;
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--rule-dark);
+  margin: 1rem 0 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule-faint);
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 900px) {
+  .codex-frame {
+    padding: 0.8rem 1.5rem 1.5rem;
+  }
+  .frontispiece h1 {
+    font-size: 2.2rem;
+  }
+  .featured-texts {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .two-col {
+    column-count: 1;
+  }
+  .apparatus-commentary {
+    column-count: 1;
+  }
+  .foot-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .codex-frame {
+    padding: 0.5rem 0.8rem 1rem;
+    border-left: none;
+    border-right: none;
+  }
+  .codex-nav {
+    gap: 1rem;
+  }
+  .codex-nav a {
+    font-size: 0.72rem;
+  }
+  .frontispiece h1 {
+    font-size: 1.7rem;
+  }
+  .text-head h1 {
+    font-size: 1.6rem;
+  }
+  .section-head h1 {
+    font-size: 1.6rem;
+  }
+  .featured-texts {
+    grid-template-columns: 1fr 1fr;
+  }
+  .text-link {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .text-no {
+    flex: 0 0 auto;
+    text-align: left;
+  }
+  .text-tradition {
+    flex: 1 1 100%;
+    margin-left: 3.5rem;
+  }
+  .text-specs {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+  .text-specs dt {
+    margin-top: 0.4rem;
+  }
+  .two-col-wrap {
+    flex-direction: column;
+  }
+  .two-col-wrap .divider {
+    display: none;
+  }
+}
+
+@media (max-width: 420px) {
+  body {
+    font-size: 15px;
+  }
+  .frontispiece h1 {
+    font-size: 1.4rem;
+  }
+  .featured-texts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/annotation-layer/templates/404.html
+++ b/annotation-layer/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <div class="error-page">
+      <p class="kicker">A LACUNA IN THE TEXT</p>
+      <h1>404 - The Sought Passage is Wanting</h1>
+      <p>This leaf has not been found in the collation. Perhaps the folio reference is in error; perhaps the text was never transmitted in this recension of the edition.</p>
+      <p><a href="{{ base_url }}/" class="back-link">&larr; Return to the Prolegomena</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/annotation-layer/templates/footer.html
+++ b/annotation-layer/templates/footer.html
@@ -1,0 +1,37 @@
+    <footer class="codex-foot" role="contentinfo">
+      <div class="foot-ornament" aria-hidden="true">
+        <svg viewBox="0 0 800 50" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="40" y1="25" x2="355" y2="25" stroke="#C8C0AE" stroke-width="0.6"/>
+          <line x1="445" y1="25" x2="760" y2="25" stroke="#C8C0AE" stroke-width="0.6"/>
+          <g transform="translate(400,25)">
+            <circle r="6" fill="none" stroke="#C8C0AE" stroke-width="0.8"/>
+            <circle r="3" fill="none" stroke="#8B2500" stroke-width="0.6"/>
+            <circle r="1.2" fill="#8B2500"/>
+          </g>
+          <g fill="#C8C0AE">
+            <circle cx="30" cy="25" r="1.5"/>
+            <circle cx="770" cy="25" r="1.5"/>
+          </g>
+        </svg>
+      </div>
+      <div class="foot-grid">
+        <div class="foot-col">
+          <p class="foot-head">THE EDITORS</p>
+          <p>Compiled by the Office of Textual Criticism upon collations held in the Apparatus Archive.</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">CITATION</p>
+          <p>Cite this edition as "Annotation-Layer: A Study in Deep Commentary, Anno MMXXVI" with the text reference number.</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">LICENCE</p>
+          <p>Editorial commentary under Creative Commons. Source texts remain in the public domain as works of classical and medieval antiquity.</p>
+        </div>
+      </div>
+      <p class="foot-stamp">FINIS - APPARATUS CRITICUS - TYPESET WITH HWARO - Anno Domini MMXXVI</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/annotation-layer/templates/header.html
+++ b/annotation-layer/templates/header.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,400;0,500;0,600;0,700;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Noto+Serif:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="codex-frame" role="document">
+    <header class="codex-header" role="banner">
+      <div class="scholarly-rule top" aria-hidden="true">
+        <svg viewBox="0 0 800 18" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="40" y1="9" x2="355" y2="9" stroke="#C8C0AE" stroke-width="0.8"/>
+          <line x1="445" y1="9" x2="760" y2="9" stroke="#C8C0AE" stroke-width="0.8"/>
+          <g transform="translate(400,9)">
+            <circle r="2.5" fill="#8B2500"/>
+            <circle cx="-18" cy="0" r="1.2" fill="#C8C0AE"/>
+            <circle cx="18" cy="0" r="1.2" fill="#C8C0AE"/>
+            <circle cx="-32" cy="0" r="0.8" fill="#C8C0AE"/>
+            <circle cx="32" cy="0" r="0.8" fill="#C8C0AE"/>
+          </g>
+        </svg>
+      </div>
+      <a href="{{ base_url }}/" class="codex-brand" aria-label="Annotation-Layer home">
+        <svg viewBox="0 0 520 80" xmlns="http://www.w3.org/2000/svg" class="brand-svg" aria-hidden="true">
+          <text x="260" y="42" text-anchor="middle" font-family="Cormorant, EB Garamond, serif" font-size="34" font-weight="600" fill="#2C2416" letter-spacing="0.06em">ANNOTATION-LAYER</text>
+          <text x="260" y="68" text-anchor="middle" font-family="Crimson Pro, Noto Serif, serif" font-size="11" fill="#8A7E6C" letter-spacing="0.2em">A STUDY IN DEEP COMMENTARY</text>
+        </svg>
+      </a>
+      <p class="codex-sub">Original texts with dense apparatus criticus - variant readings - stemma codicum - editorial notes</p>
+      <nav class="codex-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Prolegomena</a>
+        <a href="{{ base_url }}/texts/">The Texts</a>
+        <a href="{{ base_url }}/apparatus/">Apparatus</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+      <div class="scholarly-rule bottom" aria-hidden="true">
+        <svg viewBox="0 0 800 18" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="40" y1="9" x2="355" y2="9" stroke="#C8C0AE" stroke-width="0.8"/>
+          <line x1="445" y1="9" x2="760" y2="9" stroke="#C8C0AE" stroke-width="0.8"/>
+          <g transform="translate(400,9)">
+            <circle r="2.5" fill="#8B2500"/>
+            <circle cx="-18" cy="0" r="1.2" fill="#C8C0AE"/>
+            <circle cx="18" cy="0" r="1.2" fill="#C8C0AE"/>
+            <circle cx="-32" cy="0" r="0.8" fill="#C8C0AE"/>
+            <circle cx="32" cy="0" r="0.8" fill="#C8C0AE"/>
+          </g>
+        </svg>
+      </div>
+    </header>

--- a/annotation-layer/templates/page.html
+++ b/annotation-layer/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/annotation-layer/templates/section.html
+++ b/annotation-layer/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">THE APPARATUS</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+      {% if page.description %}<p class="section-lede">{{ page.description | e }}</p>{% endif %}
+    </header>
+    <div class="section-intro">
+      {{ content }}
+    </div>
+    <ol class="text-table">
+      {% for tx in section.pages %}
+      <li class="text-row">
+        <a href="{{ tx.url }}" class="text-link">
+          <span class="text-no">{% if tx.extra.text_no %}{{ tx.extra.text_no | e }}{% else %}{{ loop.index }}{% endif %}</span>
+          <span class="text-title-wrap">
+            <span class="text-title-bl">{{ tx.title | e }}</span>
+            {% if tx.description %}<span class="text-dek">{{ tx.description | e }}</span>{% endif %}
+          </span>
+          {% if tx.extra.tradition %}<span class="text-tradition">{{ tx.extra.tradition | e }}</span>{% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/annotation-layer/templates/shortcodes/alert.html
+++ b/annotation-layer/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/annotation-layer/templates/taxonomy.html
+++ b/annotation-layer/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">INDEX LOCORUM</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/annotation-layer/templates/taxonomy_term.html
+++ b/annotation-layer/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">CLASSIFIED UNDER</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/annotation-layer/templates/text.html
+++ b/annotation-layer/templates/text.html
@@ -1,0 +1,38 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <article class="text-page">
+      <header class="text-head">
+        <p class="kicker">{% if page.extra.text_no %}TEXT {{ page.extra.text_no | e }}{% endif %}{% if page.extra.tradition %} - {{ page.extra.tradition | upper }}{% endif %}</p>
+        <h1 class="text-title">{{ page.title | e }}</h1>
+        {% if page.description %}<p class="text-lede">{{ page.description | e }}</p>{% endif %}
+      </header>
+
+      {% if page.extra.author or page.extra.date_composed or page.extra.tradition or page.extra.witnesses or page.extra.source %}
+      <dl class="text-specs">
+        {% if page.extra.author %}<dt>Author</dt><dd>{{ page.extra.author | e }}</dd>{% endif %}
+        {% if page.extra.date_composed %}<dt>Date Composed</dt><dd>{{ page.extra.date_composed | e }}</dd>{% endif %}
+        {% if page.extra.tradition %}<dt>Tradition</dt><dd>{{ page.extra.tradition | e }}</dd>{% endif %}
+        {% if page.extra.witnesses %}<dt>Witnesses</dt><dd>{{ page.extra.witnesses | e }}</dd>{% endif %}
+        {% if page.extra.source %}<dt>Source</dt><dd>{{ page.extra.source | e }}</dd>{% endif %}
+      </dl>
+      {% endif %}
+
+      {% if page.extra.apparatus_svg %}
+      <figure class="text-figure">
+        <div class="text-frame">
+          {{ page.extra.apparatus_svg | safe }}
+        </div>
+        {% if page.extra.apparatus_caption %}<figcaption class="text-figcap">{{ page.extra.apparatus_caption | e }}</figcaption>{% endif %}
+      </figure>
+      {% endif %}
+
+      <div class="text-prose">
+        {{ content }}
+      </div>
+
+      <footer class="text-foot">
+        <a href="{{ base_url }}/texts/" class="back-link">&larr; Return to the texts</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -117,6 +117,13 @@
     "medical",
     "vintage"
   ],
+  "annotation-layer": [
+    "book",
+    "light",
+    "scholarly",
+    "annotated",
+    "dense"
+  ],
   "anthology": [
     "light",
     "docs",


### PR DESCRIPTION
Closes #1553

## Summary
- Add annotation-layer example site: a deep commentary publication with light scholarly theme
- 10 annotated texts covering classical and medieval works (Aeneid, Beowulf, Canterbury Tales, Iliad, etc.)
- SVG apparatus criticus layout patterns and unique stemma codicum tree diagrams for each text
- Custom text template with apparatus display, variant readings, and editorial commentary
- Cormorant/EB Garamond display type with Crimson Pro/Noto Serif dense commentary body

## Test plan
- [ ] Verify `hwaro build` succeeds in annotation-layer directory
- [ ] Verify all 14 pages render correctly
- [ ] Check tags.json includes annotation-layer entry
- [ ] Confirm no CSS gradients or emojis present