### PR TITLE
feat: add fascicle example site (closes #1552)

### DIFF
--- a/fascicle/AGENTS.md
+++ b/fascicle/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/fascicle/config.toml
+++ b/fascicle/config.toml
@@ -1,0 +1,85 @@
+# =============================================================================
+# Fascicle - An Unbound Installment Publication
+# Issue #1552 | Tags: book, light, serial, unbound, installment
+# =============================================================================
+
+title = "FASCICLE - An Unbound Installment Publication"
+description = "A serial publication issued in unbound fascicles - loose gatherings within printed wrapper bands, delivered to subscribers in periodic installments. Period serial typography in Old Standard TT and Libre Baskerville."
+base_url = "http://localhost:3000"
+
+sections = ["issues"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "series"
+paginate_by = 10
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "monthly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A serial publication of unbound fascicles. Scholarly use; please cite if referenced."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["issues"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/fascicle/content/colophon.md
+++ b/fascicle/content/colophon.md
@@ -1,0 +1,39 @@
++++
+title = "Colophon"
+description = "Notes upon the typography, design, and production of the Fascicle publication."
+template = "page"
++++
+
+# Colophon
+
+## On the Design of This Publication
+
+The present publication has been designed to evoke the character and appearance of the Victorian serial fascicle -- a form of publication in which scholarly and scientific works were issued to subscribers in periodic installments of loose, unbound gatherings, each enclosed within a printed paper wrapper band.
+
+This mode of issuing was favoured by publishers of natural history, topography, and other illustrated works throughout the eighteenth and nineteenth centuries. It permitted the subscriber to receive the work in manageable portions, and to defer the expense of binding until the publication was complete.
+
+## Typography
+
+The display type throughout is set in **Old Standard TT**, a typeface designed by Alexey Kryukov that faithfully renders the modern serif style prevalent in European printing from the late eighteenth to the early twentieth century. Subsidiary display matter is set in **Libre Baskerville**, after the celebrated types of John Baskerville of Birmingham.
+
+The body text is set in **Crimson Pro**, a typeface designed by Jacques Le Bailly, with **Lora** employed as a companion face. Both are optimised for extended reading at text sizes and reflect the tradition of the readable book face that prevailed in the best printing of the period.
+
+## Colour and Material
+
+The colour palette has been chosen to suggest the materials of the unbound fascicle: warm cream paper, dark brown printing ink, and the muted tones of the paper wrapper bands that enclosed each gathering. No coloured inks or gradients are employed; the design relies upon solid colours, typographic hierarchy, and ruled lines in the manner of period printing.
+
+## The Wrapper Bands
+
+Each fascicle is accompanied by a decorative wrapper band rendered as an inline SVG illustration. These bands carry the series title, the fascicle number, and an ornamental device appropriate to the branch of natural history treated within. The ornaments -- fern fronds, shells, butterflies, ammonites, and the like -- follow the conventions of Victorian natural-history illustration, reduced to simple line-drawn forms.
+
+## Technical Production
+
+This publication is typeset with **Hwaro**, a static site generator. The source text is composed in Markdown with TOML front matter; the templates employ the Crinja templating language. All decorative elements are produced as inline SVG and require no external image files.
+
+## Acknowledgements
+
+The Publisher acknowledges with gratitude the creators of the open-source typefaces employed herein, and the makers of Hwaro for their instrument of typographic production.
+
+---
+
+*Published in parts by Fascicle Press, 14 Paternoster Row, London, E.C. Anno Domini MMXXVI.*

--- a/fascicle/content/index.md
+++ b/fascicle/content/index.md
@@ -1,0 +1,86 @@
++++
+title = "Fascicle"
+description = "An unbound installment publication - loose gatherings within printed wrapper bands, delivered to subscribers in periodic installments."
+template = "page"
++++
+
+<div class="frontispiece">
+
+<h1>Fascicle</h1>
+<p class="front-sub">An Unbound Installment Publication</p>
+
+<figure class="front-plate">
+<svg viewBox="0 0 560 400" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background: warm paper -->
+  <rect x="0" y="0" width="560" height="400" fill="#FAF8F0"/>
+  <rect x="2" y="2" width="556" height="396" fill="none" stroke="#A89880" stroke-width="1"/>
+  <rect x="6" y="6" width="548" height="388" fill="none" stroke="#D4C9B5" stroke-width="0.5"/>
+  <!-- Stack of loose unbound sheets -->
+  <g>
+    <!-- Bottom sheet, slightly askew -->
+    <rect x="120" y="240" width="340" height="140" fill="#F5F0E4" stroke="#A89880" stroke-width="0.8" transform="rotate(-1.5 290 310)"/>
+    <!-- Deckle edge pattern on bottom sheet -->
+    <path d="M 122 378 Q 130 376 138 379 Q 146 376 154 379 Q 162 376 170 379 Q 178 376 186 379 Q 194 376 202 379 Q 210 376 218 379 Q 226 376 234 379 Q 242 376 250 379 Q 258 376 266 379 Q 274 376 282 379 Q 290 376 298 379 Q 306 376 314 379 Q 322 376 330 379 Q 338 376 346 379 Q 354 376 362 379 Q 370 376 378 379 Q 386 376 394 379 Q 402 376 410 379 Q 418 376 426 379 Q 434 376 442 379 Q 450 376 458 379" fill="none" stroke="#A89880" stroke-width="0.6" transform="rotate(-1.5 290 310)"/>
+    <!-- Middle sheet -->
+    <rect x="115" y="225" width="340" height="140" fill="#FAF8F0" stroke="#A89880" stroke-width="0.8" transform="rotate(0.8 285 295)"/>
+    <!-- Deckle edge pattern on middle sheet -->
+    <path d="M 117 363 Q 125 361 133 364 Q 141 361 149 364 Q 157 361 165 364 Q 173 361 181 364 Q 189 361 197 364 Q 205 361 213 364 Q 221 361 229 364 Q 237 361 245 364 Q 253 361 261 364 Q 269 361 277 364 Q 285 361 293 364 Q 301 361 309 364 Q 317 361 325 364 Q 333 361 341 364 Q 349 361 357 364 Q 365 361 373 364 Q 381 361 389 364 Q 397 361 405 364 Q 413 361 421 364 Q 429 361 437 364 Q 445 361 453 364" fill="none" stroke="#A89880" stroke-width="0.6" transform="rotate(0.8 285 295)"/>
+    <!-- Top sheet -->
+    <rect x="110" y="210" width="340" height="140" fill="#FFFFFF" stroke="#A89880" stroke-width="0.8" transform="rotate(-0.3 280 280)"/>
+    <!-- Deckle edge on top sheet -->
+    <path d="M 112 348 Q 120 346 128 349 Q 136 346 144 349 Q 152 346 160 349 Q 168 346 176 349 Q 184 346 192 349 Q 200 346 208 349 Q 216 346 224 349 Q 232 346 240 349 Q 248 346 256 349 Q 264 346 272 349 Q 280 346 288 349 Q 296 346 304 349 Q 312 346 320 349 Q 328 346 336 349 Q 344 346 352 349 Q 360 346 368 349 Q 376 346 384 349 Q 392 346 400 349 Q 408 346 416 349 Q 424 346 432 349 Q 440 346 448 349" fill="none" stroke="#A89880" stroke-width="0.6" transform="rotate(-0.3 280 280)"/>
+    <!-- Text lines on top sheet -->
+    <line x1="140" y1="240" x2="420" y2="240" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+    <line x1="140" y1="256" x2="400" y2="256" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+    <line x1="140" y1="272" x2="410" y2="272" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+    <line x1="140" y1="288" x2="380" y2="288" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+    <line x1="140" y1="304" x2="415" y2="304" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+    <line x1="140" y1="320" x2="360" y2="320" stroke="#D4C9B5" stroke-width="0.4" transform="rotate(-0.3 280 280)"/>
+  </g>
+  <!-- Wrapper band encircling the stack -->
+  <rect x="80" y="120" width="400" height="100" fill="#EDE6D4" stroke="#7C5E3C" stroke-width="1.5"/>
+  <rect x="84" y="124" width="392" height="92" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Wrapper band text -->
+  <text x="280" y="152" text-anchor="middle" font-family="Old Standard TT, serif" font-size="10" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <text x="280" y="176" text-anchor="middle" font-family="Old Standard TT, serif" font-size="18" font-weight="700" fill="#3A2E1F" letter-spacing="2">FASCICLE</text>
+  <text x="280" y="198" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="3">ISSUED IN UNBOUND PARTS</text>
+  <!-- Decorative corner marks on wrapper -->
+  <g stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 92 132 L 92 136 M 92 132 L 96 132"/>
+    <path d="M 468 132 L 468 136 M 468 132 L 464 132"/>
+    <path d="M 92 208 L 92 204 M 92 208 L 96 208"/>
+    <path d="M 468 208 L 468 204 M 468 208 L 464 208"/>
+  </g>
+  <!-- Small leaf ornaments on wrapper -->
+  <g fill="none" stroke="#A89880" stroke-width="0.6">
+    <path d="M 130 170 Q 136 162 142 170 Q 136 178 130 170"/>
+    <path d="M 418 170 Q 424 162 430 170 Q 424 178 418 170"/>
+  </g>
+  <!-- Top: Title of the publication -->
+  <text x="280" y="56" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#7C5E3C" letter-spacing="5">A SERIAL PUBLICATION</text>
+  <line x1="120" y1="68" x2="440" y2="68" stroke="#D4C9B5" stroke-width="0.5"/>
+  <text x="280" y="90" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">Loose Gatherings Within Printed Wrapper Bands</text>
+</svg>
+<figcaption>A fascicle: loose unbound gatherings encircled by a printed wrapper band.</figcaption>
+</figure>
+
+</div>
+
+<div class="front-lede">
+
+The **fascicle** -- from the Latin *fasciculus*, a small bundle -- is one of the oldest forms of serial publication. Before the modern bound volume became the standard, scholarly and scientific works were issued to subscribers in periodic installments: loose, unfolded gatherings of printed sheets, held together only by a printed paper wrapper band.
+
+This manner of publication served the natural philosopher and the collector alike. Each fascicle could be studied individually, its plates examined at leisure, its descriptions compared with specimens in the cabinet. When the series reached its natural conclusion, the subscriber might have the accumulated parts bound into a single volume, or leave them in their original loose state -- a practice that preserved the uncut edges so prized by bibliophiles.
+
+The present publication, **The Naturalist's Cabinet**, continues this tradition. Each fascicle treats a distinct branch of natural history -- botany, zoology, entomology, geology -- and is issued with its own decorative wrapper band bearing the title and series ornament.
+
+## Featured Installments
+
+<ul class="featured-list">
+<li><span class="feat-no">I.</span> <a href="{{ base_url }}/issues/the-british-ferns/">The British Ferns</a> <span class="feat-series">Botanical</span></li>
+<li><span class="feat-no">III.</span> <a href="{{ base_url }}/issues/the-lepidoptera-of-surrey/">The Lepidoptera of Surrey</a> <span class="feat-series">Entomological</span></li>
+<li><span class="feat-no">V.</span> <a href="{{ base_url }}/issues/british-freshwater-fish/">British Freshwater Fish</a> <span class="feat-series">Ichthyological</span></li>
+<li><span class="feat-no">VII.</span> <a href="{{ base_url }}/issues/raptorial-birds-of-prey/">Raptorial Birds of Prey</a> <span class="feat-series">Ornithological</span></li>
+</ul>
+
+</div>

--- a/fascicle/content/issues/_index.md
+++ b/fascicle/content/issues/_index.md
@@ -1,0 +1,7 @@
++++
+title = "The Issues"
+description = "A complete catalogue of fascicles issued under the serial publication The Naturalist's Cabinet, arranged in order of publication."
+sort_by = "weight"
++++
+
+The following fascicles have been issued to date. Each part treats a separate branch of natural history and is delivered to subscribers in its own printed wrapper band. Parts may be bound together at the conclusion of each volume, or preserved in their original loose state.

--- a/fascicle/content/issues/british-freshwater-fish.md
+++ b/fascicle/content/issues/british-freshwater-fish.md
@@ -1,0 +1,76 @@
++++
+title = "British Freshwater Fish"
+description = "An account of the freshwater fishes of England, Scotland, and Wales, treating the Salmonidae, Cyprinidae, and lesser families, with observations upon their habits and the waters they frequent."
+date = "2026-04-05"
+template = "issue"
+weight = 5
+tags = ["ichthyology", "fish", "freshwater"]
+[taxonomies]
+series = ["Ichthyological"]
+[extra]
+issue_no = "V"
+series = "Ichthyological"
+author = "Mr. Henry Pennell, F.Z.S."
+date_published = "September 1856"
+pages_count = "60"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle V, bearing a fish ornament of the Ichthyological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Fish ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <ellipse rx="18" ry="8"/>
+    <path d="M 18 0 L 26 -8 L 26 8 Z"/>
+    <circle cx="-10" cy="-2" r="1.5" fill="#7C5E3C"/>
+    <line x1="-4" y1="0" x2="12" y2="0"/>
+    <path d="M 4 -6 Q 6 0 4 6"/>
+    <path d="M -2 -7 Q 0 0 -2 7"/>
+  </g>
+  <!-- Fish ornament right -->
+  <g transform="translate(495,100) scale(-1,1)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <ellipse rx="18" ry="8"/>
+    <path d="M 18 0 L 26 -8 L 26 8 Z"/>
+    <circle cx="-10" cy="-2" r="1.5" fill="#7C5E3C"/>
+    <line x1="-4" y1="0" x2="12" y2="0"/>
+    <path d="M 4 -6 Q 6 0 4 6"/>
+    <path d="M -2 -7 Q 0 0 -2 7"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE V</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">BRITISH FRESHWATER FISH</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">ICHTHYOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## The Fishes of British Waters
+
+The freshwater fishes of the British Isles, though modest in number when compared with the continental fauna, include several species of the highest interest to the naturalist and the angler alike. The rivers and lakes of England, Scotland, and Wales support approximately forty native species, distributed among a dozen families, of which the Salmonidae and the Cyprinidae are by far the most prominent.
+
+The present fascicle treats the principal freshwater fishes of Britain, with observations upon their habits, their distribution, and the character of the waters they frequent.
+
+## The Salmonidae
+
+The salmon family claims the noblest of British freshwater fishes. The Atlantic Salmon (*Salmo salar*) ascends the rivers of both eastern and western coasts in its annual spawning migration, a spectacle of nature that has inspired admiration since the earliest records of these islands. The Brown Trout (*Salmo trutta*), in its myriad local forms, inhabits nearly every stream and lake in the kingdom, from the peaty burns of the Scottish Highlands to the chalk streams of Hampshire.
+
+The Char (*Salvelinus alpinus*), a relic of the Ice Age, persists in the deeper lakes of the north and west -- Windermere, Llyn Padarn, and several of the Scottish lochs -- where it leads a retiring existence in the cooler waters below the thermocline.
+
+{{ alert(type="note", body="The systematics of the British Salmonidae remain in a state of some confusion. Many local populations have been described as distinct species, but the present work follows Gunther in regarding most of these as varieties of a smaller number of well-founded species.") }}
+
+## The Cyprinidae
+
+The carp family is well represented in the lowland rivers and lakes of England. The Common Carp (*Cyprinus carpio*), though not truly native, has been naturalised since at least the fifteenth century and is now firmly established in the warmer waters of the south and midlands. The native Cyprinidae include the Roach (*Rutilus rutilus*), the Dace (*Leuciscus leuciscus*), and the Chub (*Leuciscus cephalus*), all of which are familiar to the angler.
+
+## Lesser Families
+
+Among the lesser families, the Perch (*Perca fluviatilis*) deserves particular mention as one of the most handsome of British freshwater fishes, its bold vertical bars and scarlet fins presenting a striking appearance when the fish is taken from the water. The Pike (*Esox lucius*), solitary and predatory, frequents the weedy margins of lakes and slow rivers throughout the lowlands.
+
+## The Influence of Geology
+
+The distribution of freshwater fishes in Britain is intimately connected with the underlying geology. The chalk streams of southern England, fed by springs of crystalline purity, support thriving populations of trout and grayling. The sluggish, clay-bottomed rivers of the Midlands favour the coarser species of the carp family. The acid, peaty waters of the uplands, poor in dissolved minerals, support little beyond trout and the occasional eel.

--- a/fascicle/content/issues/fossils-of-the-chalk-downs.md
+++ b/fascicle/content/issues/fossils-of-the-chalk-downs.md
@@ -1,0 +1,76 @@
++++
+title = "Fossils of the Chalk Downs"
+description = "A description of the fossil fauna and flora preserved in the Upper Chalk of the North and South Downs, including echinoids, belemnites, and the celebrated flint-preserved specimens."
+date = "2026-04-04"
+template = "issue"
+weight = 4
+tags = ["geology", "fossils", "chalk"]
+[taxonomies]
+series = ["Geological"]
+[extra]
+issue_no = "IV"
+series = "Geological"
+author = "Dr. William Hargreaves, F.G.S."
+date_published = "July 1856"
+pages_count = "44"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle IV, bearing an ammonite ornament of the Geological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Ammonite ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <circle r="14"/>
+    <circle r="10"/>
+    <circle r="6"/>
+    <path d="M 0 -14 Q 5 -10 0 -6"/>
+    <path d="M 14 0 Q 10 5 6 0"/>
+    <path d="M 0 14 Q -5 10 0 6"/>
+    <path d="M -14 0 Q -10 -5 -6 0"/>
+  </g>
+  <!-- Ammonite ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <circle r="14"/>
+    <circle r="10"/>
+    <circle r="6"/>
+    <path d="M 0 -14 Q 5 -10 0 -6"/>
+    <path d="M 14 0 Q 10 5 6 0"/>
+    <path d="M 0 14 Q -5 10 0 6"/>
+    <path d="M -14 0 Q -10 -5 -6 0"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE IV</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">FOSSILS OF THE CHALK DOWNS</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">GEOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## The Chalk as a Repository of Fossils
+
+The Upper Chalk of the English Downs, that soft, white limestone composed almost entirely of the calcareous remains of minute marine organisms, is among the most prolific fossil-bearing formations in the geological record. Deposited during the Cretaceous period, when warm, shallow seas covered much of what is now southern England, the Chalk preserves a fauna of remarkable diversity and exquisite condition.
+
+The present fascicle surveys the principal fossil groups to be found within the Chalk, with attention to those localities most accessible to the collector and the amateur geologist.
+
+## The Echinoids
+
+No fossils are more characteristic of the Chalk than the echinoids, or sea urchins. The regular echinoid *Cidaris* is common throughout the formation, its separate interambulacral plates and detached spines occurring far more frequently than complete tests. The irregular echinoids, particularly the heart-urchin *Micraster*, furnish one of the most celebrated examples of evolutionary change within a single geological formation.
+
+{{ alert(type="note", body="The collector should be advised that Chalk echinoids, whilst often beautifully preserved in flint, are exceedingly brittle when found in the sofite chalk matrix. Specimens should be wrapped individually in cotton wool for transport.") }}
+
+## Belemnites and Ammonites
+
+The belemnites, those bullet-shaped internal shells of extinct cephalopods, are among the most instantly recognisable of Chalk fossils. The genus *Belemnitella* is characteristic of the Upper Chalk, and its guards may be found in abundance at any fresh exposure of the formation. The ammonites, by contrast, are far less common in the Chalk than in the underlying formations, but several distinctive species persist into the Cretaceous, among them the large and handsome *Schloenbachia*.
+
+## Flint Preservation
+
+A peculiarity of the Chalk is the occurrence of fossils preserved in flint -- that hard, dark, siliceous stone found in nodular bands throughout the formation. Fossils so preserved are often of extraordinary perfection, the original shell having been replaced molecule by molecule with chalcedonic silica. The flint echinoids of the Sussex Downs are justly celebrated among collectors, and fine specimens command respectable prices at the mineral dealers of Wardour Street.
+
+## Collecting Localities
+
+The best localities for Chalk fossils are those where the formation is actively quarried or where coastal erosion exposes fresh surfaces. The chalk pits of Gravesend and Northfleet in Kent, the sea cliffs at Beachy Head and the Seven Sisters in Sussex, and the quarries about Guildford in Surrey all furnish productive collecting grounds.

--- a/fascicle/content/issues/marine-shells-of-the-channel.md
+++ b/fascicle/content/issues/marine-shells-of-the-channel.md
@@ -1,0 +1,74 @@
++++
+title = "Marine Shells of the Channel"
+description = "An account of the marine Mollusca collected upon the shores of the English Channel, from the Scilly Isles to the Straits of Dover, with descriptions of the principal bivalves and gastropods."
+date = "2026-04-02"
+template = "issue"
+weight = 2
+tags = ["zoology", "mollusca", "marine"]
+[taxonomies]
+series = ["Zoological"]
+[extra]
+issue_no = "II"
+series = "Zoological"
+author = "Mr. James Corbett, F.Z.S."
+date_published = "March 1856"
+pages_count = "56"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle II, bearing a shell ornament of the Zoological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Shell ornament left: scallop -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M -16 8 Q 0 -20 16 8"/>
+    <line x1="-14" y1="6" x2="0" y2="-14"/>
+    <line x1="-8" y1="8" x2="0" y2="-14"/>
+    <line x1="0" y1="8" x2="0" y2="-14"/>
+    <line x1="8" y1="8" x2="0" y2="-14"/>
+    <line x1="14" y1="6" x2="0" y2="-14"/>
+    <path d="M -16 8 Q 0 16 16 8"/>
+  </g>
+  <!-- Shell ornament right: scallop -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M -16 8 Q 0 -20 16 8"/>
+    <line x1="-14" y1="6" x2="0" y2="-14"/>
+    <line x1="-8" y1="8" x2="0" y2="-14"/>
+    <line x1="0" y1="8" x2="0" y2="-14"/>
+    <line x1="8" y1="8" x2="0" y2="-14"/>
+    <line x1="14" y1="6" x2="0" y2="-14"/>
+    <path d="M -16 8 Q 0 16 16 8"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE II</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">MARINE SHELLS OF THE CHANNEL</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">ZOOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## The Channel Shore
+
+The English Channel, that narrow strait dividing Britain from the Continent, presents to the conchologist a collecting ground of exceptional richness. The western approaches, warmed by the remnant of the Atlantic drift, harbour species of a decidedly southern character; while the eastern narrows, scoured by stronger tides and colder currents, support a fauna more typical of the North Sea.
+
+The present fascicle describes the principal marine Mollusca to be found upon the Channel shores, from the granite headlands of Cornwall to the chalk cliffs of the Dover Strait. Both the bivalves (Lamellibranchiata) and the univalves (Gastropoda) are treated, with attention to those species most likely to reward the amateur collector.
+
+## The Bivalves
+
+Among the bivalves, the Common Cockle (*Cardium edule*) is perhaps the most familiar inhabitant of the Channel sands. Its ribbed valves, cast upon the strand in countless thousands after winter gales, are known to every child who has visited the seaside. Less conspicuous but no less interesting is the Razor Shell (*Ensis siliqua*), whose elongated valves betray the burrowing habit of the living animal.
+
+{{ alert(type="note", body="Specimens should be cleaned in fresh water and dried thoroughly before placement in the cabinet. The periostracum of many bivalves deteriorates rapidly if stored damp, and the hinge teeth may be obscured by encrusting growths if not attended to promptly.") }}
+
+## The Gastropods
+
+The rocky shores of the western Channel are home to a remarkable assemblage of gastropods. The several species of periwinkle (*Littorina*) occupy distinct zones upon the shore according to their tolerance of exposure to air, from the Small Periwinkle (*L. neritoides*) high upon the splash zone to the Common Periwinkle (*L. littorea*) amid the mid-tide seaweeds.
+
+The Top Shells (Trochidae) contribute their elegant, conical forms to the lower shore, their nacre gleaming with iridescence when the outer layers of the shell are worn away by the action of the surf.
+
+## Notes on Collecting
+
+The best collecting is to be had at the lowest spring tides, when the ebbing waters reveal ledges and rock pools ordinarily submerged. The collector should carry a canvas bag, a blunt knife for detaching limpets, and a hand lens for the examination of smaller species. A notebook is indispensable, for the precise station and habitat of each specimen should be recorded at the time of collection.

--- a/fascicle/content/issues/native-orchids.md
+++ b/fascicle/content/issues/native-orchids.md
@@ -1,0 +1,80 @@
++++
+title = "Native Orchids"
+description = "A descriptive catalogue of the wild orchids of England, with illustrations of the principal species of chalk downland, meadow, and woodland, and remarks upon their curious pollination mechanisms."
+date = "2026-04-08"
+template = "issue"
+weight = 8
+tags = ["botany", "orchids", "flora"]
+[taxonomies]
+series = ["Botanical"]
+[extra]
+issue_no = "VIII"
+series = "Botanical"
+author = "Prof. Edward Lathbury, F.L.S."
+date_published = "March 1857"
+pages_count = "52"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle VIII, bearing an orchid flower ornament of the Botanical series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Orchid ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 18 L 0 -4"/>
+    <ellipse cx="0" cy="-10" rx="3" ry="5"/>
+    <path d="M 0 -14 Q -8 -20 -4 -26"/>
+    <path d="M 0 -14 Q 8 -20 4 -26"/>
+    <path d="M -3 -10 Q -12 -6 -10 -2"/>
+    <path d="M 3 -10 Q 12 -6 10 -2"/>
+    <path d="M 0 -6 Q -4 2 -6 8 Q 0 6 6 8 Q 4 2 0 -6"/>
+    <path d="M -4 18 Q -2 14 0 18 Q 2 14 4 18"/>
+  </g>
+  <!-- Orchid ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 18 L 0 -4"/>
+    <ellipse cx="0" cy="-10" rx="3" ry="5"/>
+    <path d="M 0 -14 Q -8 -20 -4 -26"/>
+    <path d="M 0 -14 Q 8 -20 4 -26"/>
+    <path d="M -3 -10 Q -12 -6 -10 -2"/>
+    <path d="M 3 -10 Q 12 -6 10 -2"/>
+    <path d="M 0 -6 Q -4 2 -6 8 Q 0 6 6 8 Q 4 2 0 -6"/>
+    <path d="M -4 18 Q -2 14 0 18 Q 2 14 4 18"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE VIII</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="18" font-weight="700" fill="#3A2E1F" letter-spacing="1">NATIVE ORCHIDS</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">BOTANICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1857</text>
+</svg>
+'''
++++
+
+## The Orchids of England
+
+The orchid family, though popularly associated with the tropics, is well represented in the flora of the British Isles. Upwards of fifty species are native to these islands, ranging from the conspicuous spikes of the Early Purple Orchid (*Orchis mascula*), which adorns our hedgebanks and copses in April, to the elusive Ghost Orchid (*Epipogium aphyllum*), a plant so rare and so unpredictable in its appearances that many botanists pass an entire career without encountering it.
+
+The present fascicle describes the principal wild orchids of England, arranged by habitat, with particular attention to the species of the chalk downlands, the meadows, and the ancient woodlands.
+
+## Orchids of the Chalk Downland
+
+The short-turfed chalk downs of southern England are the richest habitat for orchids in the British Isles. Here, in the thin, alkaline soil, the Pyramidal Orchid (*Anacamptis pyramidalis*) raises its dense, conical spikes of vivid pink in June and July. The Fragrant Orchid (*Gymnadenia conopsea*) perfumes the air with its delicate, clove-like scent, attracting the attention of moths in the evening hours.
+
+The Bee Orchid (*Ophrys apifera*) is perhaps the most remarkable of the downland species. Its flowers bear an uncanny resemblance to a bumble-bee, an adaptation thought to attract male bees as pollinators, though in Britain the plant is almost invariably self-pollinated.
+
+{{ alert(type="note", body="The orchids of the chalk downland are declining throughout their range as a consequence of agricultural improvement and the cessation of traditional grazing. The botanist who discovers a thriving colony is urged to communicate the locality to the county recorder, but to refrain from publicising the precise station too widely.") }}
+
+## Woodland Orchids
+
+The shaded floor of the beechwood and oakwood harbours several distinctive orchids. The Bird's-nest Orchid (*Neottia nidus-avis*), entirely devoid of chlorophyll, obtains its nourishment through a symbiotic association with a soil fungus and appears as a curious, waxy, brown spike among the leaf litter. The Common Twayblade (*Listera ovata*), with its pair of broad basal leaves, is one of the most widely distributed of British orchids and may be found in almost any damp wood or hedge-bank.
+
+## Meadow Orchids
+
+The traditional hay meadow, mown late and left unimproved, supports the Green-winged Orchid (*Anacamptis morio*) and the Southern Marsh Orchid (*Dactylorhiza praetermissa*). These species, once common throughout the English lowlands, have suffered greatly from the conversion of permanent pasture to arable land and the application of artificial fertilisers.
+
+## Pollination Mechanisms
+
+The orchids display a bewildering variety of pollination mechanisms, many of them involving elaborate deceptions practised upon their insect visitors. The Fly Orchid (*Ophrys insectifera*) mimics the appearance and scent of a female wasp, luring male wasps into pseudocopulation with the flower and thereby effecting the transfer of pollen. Darwin himself devoted a celebrated monograph to these contrivances, regarding them as among the most persuasive evidence for the action of natural selection.

--- a/fascicle/content/issues/nocturnal-lepidoptera.md
+++ b/fascicle/content/issues/nocturnal-lepidoptera.md
@@ -1,0 +1,82 @@
++++
+title = "Nocturnal Lepidoptera"
+description = "A study of the moths of the British Isles, with especial reference to the hawk-moths, tiger moths, and geometers, and practical instructions for the employment of light-traps and sugar."
+date = "2026-04-10"
+template = "issue"
+weight = 10
+tags = ["entomology", "moths", "lepidoptera"]
+[taxonomies]
+series = ["Entomological"]
+[extra]
+issue_no = "X"
+series = "Entomological"
+author = "The Rev. Thomas Ashfield, M.A."
+date_published = "July 1857"
+pages_count = "56"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle X, bearing a moth and lamp ornament of the Entomological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Moth ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <ellipse cx="0" cy="4" rx="3" ry="8"/>
+    <path d="M 0 -2 Q -18 -18 -16 -8 Q -14 0 -3 2"/>
+    <path d="M 0 -2 Q 18 -18 16 -8 Q 14 0 3 2"/>
+    <path d="M -1 6 Q -12 4 -14 12 Q -8 10 -2 10"/>
+    <path d="M 1 6 Q 12 4 14 12 Q 8 10 2 10"/>
+    <line x1="-2" y1="-4" x2="-8" y2="-16"/>
+    <line x1="2" y1="-4" x2="8" y2="-16"/>
+    <circle cx="-8" cy="-16" r="1" fill="#7C5E3C"/>
+    <circle cx="8" cy="-16" r="1" fill="#7C5E3C"/>
+  </g>
+  <!-- Moth ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <ellipse cx="0" cy="4" rx="3" ry="8"/>
+    <path d="M 0 -2 Q -18 -18 -16 -8 Q -14 0 -3 2"/>
+    <path d="M 0 -2 Q 18 -18 16 -8 Q 14 0 3 2"/>
+    <path d="M -1 6 Q -12 4 -14 12 Q -8 10 -2 10"/>
+    <path d="M 1 6 Q 12 4 14 12 Q 8 10 2 10"/>
+    <line x1="-2" y1="-4" x2="-8" y2="-16"/>
+    <line x1="2" y1="-4" x2="8" y2="-16"/>
+    <circle cx="-8" cy="-16" r="1" fill="#7C5E3C"/>
+    <circle cx="8" cy="-16" r="1" fill="#7C5E3C"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE X</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="18" font-weight="700" fill="#3A2E1F" letter-spacing="1">NOCTURNAL LEPIDOPTERA</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">ENTOMOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1857</text>
+</svg>
+'''
++++
+
+## The Moths of Britain
+
+Whilst the butterflies command the greater share of popular attention, it is the moths -- the nocturnal Lepidoptera -- that constitute by far the larger and more diverse portion of the order. The British Isles support upwards of two thousand species of moth, ranging from the magnificent Privet Hawk-moth (*Sphinx ligustri*), with a wingspan of four inches, to the minute leaf-mining moths of the family Nepticulidae, whose caterpillars tunnel within the substance of a single leaf.
+
+The present fascicle introduces the principal families of British moths, with practical guidance for their observation and collection by means of light-traps and the technique of sugaring.
+
+## The Hawk-Moths
+
+The Sphingidae, or hawk-moths, are among the most impressive of British Lepidoptera. The Eyed Hawk-moth (*Smerinthus ocellatus*), with its striking blue-and-black eye-spots on the hindwings, is widespread in the southern counties. The Lime Hawk-moth (*Mimas tiliae*) frequents avenues and parks where its larval foodplant grows, and the Poplar Hawk-moth (*Laothoe populi*) is abundant wherever poplars and willows are found.
+
+Most spectacular of all is the Death's-head Hawk-moth (*Acherontia atropos*), an immigrant from the Continent that occasionally reaches our shores in autumn. Its thorax bears a pattern resembling a human skull, a feature that has inspired much superstitious dread among country folk.
+
+{{ alert(type="note", body="The employment of mercury-vapour lamps, though not available in the period of this publication, has since revolutionised the study of nocturnal moths. The original methods of sugaring and assembling, however, retain their value and their particular charm.") }}
+
+## The Tiger Moths and Ermines
+
+The Arctiidae, or tiger moths, include some of the most handsomely marked of all British insects. The Garden Tiger (*Arctia caja*), with its chocolate-and-cream forewings and scarlet-spotted hindwings, is a creature of such bold pattern that it seems almost tropical in its extravagance. The Scarlet Tiger (*Callimorpha dominula*), confined to a few localities in the southern counties, combines black, white, and crimson in a design of exceptional beauty.
+
+## The Geometers
+
+The Geometridae, or geometers, so named because their caterpillars progress by looping their bodies in a characteristic measuring motion, constitute the largest family of British moths. The Peppered Moth (*Biston betularia*) is of particular scientific interest, for it occurs in both a light and a dark form, the relative frequency of which varies according to the degree of industrial pollution in the locality.
+
+## Practical Methods
+
+The traditional method of attracting moths is by the application of a mixture of treacle, brown sugar, and rum to the trunks of trees at dusk -- a practice known as sugaring. The entomologist paints a series of trees along a woodland ride, then returns an hour after dark with a lantern to inspect each sugared patch. On a warm, humid, overcast night, the results may be spectacular, with dozens of moths jostling for a place at the feast.

--- a/fascicle/content/issues/raptorial-birds-of-prey.md
+++ b/fascicle/content/issues/raptorial-birds-of-prey.md
@@ -1,0 +1,80 @@
++++
+title = "Raptorial Birds of Prey"
+description = "An account of the diurnal and nocturnal birds of prey resident in or visiting the British Isles, with descriptions of the hawks, falcons, eagles, and owls, and notes upon their prey and nesting habits."
+date = "2026-04-07"
+template = "issue"
+weight = 7
+tags = ["ornithology", "raptors", "birds"]
+[taxonomies]
+series = ["Ornithological"]
+[extra]
+issue_no = "VII"
+series = "Ornithological"
+author = "Col. Richard Meade-Waldo"
+date_published = "January 1857"
+pages_count = "64"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle VII, bearing a raptor talon ornament of the Ornithological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Bird/feather ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 20 Q -2 0 4 -20"/>
+    <path d="M 4 -20 Q 8 -10 14 -16"/>
+    <path d="M 2 -10 Q 8 -2 14 -8"/>
+    <path d="M 1 0 Q 8 6 12 2"/>
+    <path d="M 0 10 Q 6 14 10 10"/>
+    <path d="M 4 -20 Q 0 -10 -8 -16"/>
+    <path d="M 2 -10 Q -4 -2 -10 -8"/>
+    <path d="M 1 0 Q -6 6 -10 2"/>
+    <path d="M 0 10 Q -4 14 -8 10"/>
+  </g>
+  <!-- Bird/feather ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 20 Q 2 0 -4 -20"/>
+    <path d="M -4 -20 Q -8 -10 -14 -16"/>
+    <path d="M -2 -10 Q -8 -2 -14 -8"/>
+    <path d="M -1 0 Q -8 6 -12 2"/>
+    <path d="M 0 10 Q -6 14 -10 10"/>
+    <path d="M -4 -20 Q 0 -10 8 -16"/>
+    <path d="M -2 -10 Q 4 -2 10 -8"/>
+    <path d="M -1 0 Q 6 6 10 2"/>
+    <path d="M 0 10 Q 4 14 8 10"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE VII</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">RAPTORIAL BIRDS OF PREY</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">ORNITHOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1857</text>
+</svg>
+'''
++++
+
+## The Raptors of Britain
+
+The birds of prey -- the hawks, falcons, eagles, harriers, and owls -- have exercised a powerful hold upon the human imagination since the dawn of recorded history. In the British Isles, these magnificent hunters occupy the summit of the avian food chain, from the Golden Eagle (*Aquila chrysaetos*) commanding the highest crags of the Scottish Highlands to the humble Kestrel (*Falco tinnunculus*) hovering above the roadside verge.
+
+The present fascicle describes the diurnal and nocturnal raptors of the British Isles, with attention to their identification, their habits, and the pressures that threaten their continued existence.
+
+## The Diurnal Raptors
+
+The Peregrine Falcon (*Falco peregrinus*), swiftest of all birds, breeds upon the sea cliffs of the western and northern coasts and upon certain inland crags. Its hunting stoop, in which the bird descends upon its prey at speeds that may exceed one hundred miles in the hour, is among the most thrilling spectacles afforded by British natural history.
+
+The Sparrowhawk (*Accipiter nisus*), a woodland hunter of consummate skill, takes its prey by surprise, dashing along hedgerows and through the understorey with a speed and agility that few birds can match. The Buzzard (*Buteo buteo*), more ponderous in its hunting, soars upon broad wings above the open country, descending to take rabbits and small mammals in the fields below.
+
+{{ alert(type="caution", body="Many British raptors have suffered grievously from persecution and the effects of pesticides. The collector of eggs is reminded that the taking of raptors' eggs is now prohibited by law, and that these birds are protected at all times of the year.") }}
+
+## The Eagles
+
+Britain possesses two resident eagles. The Golden Eagle is now confined almost exclusively to the Scottish Highlands and the Hebrides, where it nests upon remote cliff ledges and hunts over vast territories of moorland and mountain. The White-tailed Eagle (*Haliaeetus albicilla*), once widespread along the coasts of Britain and Ireland, was exterminated by persecution in the early years of the present century, and reintroduction efforts are now under way.
+
+## The Owls
+
+The nocturnal raptors are represented in Britain by five breeding species. The Barn Owl (*Tyto alba*), with its heart-shaped face and ghostly white plumage, is the most familiar, frequenting farm buildings and hunting over rough grassland at dusk. The Tawny Owl (*Strix aluco*), whose hooting call is the voice of the British night, is the commonest owl of the woodlands.
+
+The Long-eared Owl (*Asio otus*) and the Short-eared Owl (*A. flammeus*) complete the lowland assemblage, the former a bird of coniferous woodland, the latter a hunter of open moorland and marsh.

--- a/fascicle/content/issues/the-british-ferns.md
+++ b/fascicle/content/issues/the-british-ferns.md
@@ -1,0 +1,78 @@
++++
+title = "The British Ferns"
+description = "A survey of the ferns and fern-allies native to the British Isles, with particular attention to the genera Asplenium, Polypodium, and Dryopteris, and notes upon their habitats and distribution."
+date = "2026-04-01"
+template = "issue"
+weight = 1
+tags = ["botany", "ferns", "flora"]
+[taxonomies]
+series = ["Botanical"]
+[extra]
+issue_no = "I"
+series = "Botanical"
+author = "Prof. Edward Lathbury, F.L.S."
+date_published = "January 1856"
+pages_count = "48"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle I, bearing a fern-frond ornament of the Botanical series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Fern frond ornaments left -->
+  <g transform="translate(40,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 30 Q 0 0 5 -30"/>
+    <path d="M 2 20 Q 12 16 8 10"/>
+    <path d="M 2 10 Q 14 6 10 -2"/>
+    <path d="M 3 0 Q 15 -4 11 -12"/>
+    <path d="M 4 -10 Q 14 -16 10 -22"/>
+    <path d="M 0 20 Q -10 16 -6 10"/>
+    <path d="M 0 10 Q -12 6 -8 -2"/>
+    <path d="M 1 0 Q -13 -4 -9 -12"/>
+    <path d="M 2 -10 Q -12 -16 -8 -22"/>
+  </g>
+  <!-- Fern frond ornaments right -->
+  <g transform="translate(500,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 30 Q 0 0 -5 -30"/>
+    <path d="M -2 20 Q -12 16 -8 10"/>
+    <path d="M -2 10 Q -14 6 -10 -2"/>
+    <path d="M -3 0 Q -15 -4 -11 -12"/>
+    <path d="M -4 -10 Q -14 -16 -10 -22"/>
+    <path d="M 0 20 Q 10 16 6 10"/>
+    <path d="M 0 10 Q 12 6 8 -2"/>
+    <path d="M -1 0 Q 13 -4 9 -12"/>
+    <path d="M -2 -10 Q 12 -16 8 -22"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE I</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="18" font-weight="700" fill="#3A2E1F" letter-spacing="1">THE BRITISH FERNS</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">BOTANICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## The Ferns of Britain: An Introduction
+
+The ferns of the British Isles represent one of the most ancient lineages of vascular plants still thriving in our temperate climate. From the damp limestone walls of the West Country, where the Maidenhair Spleenwort (*Asplenium trichomanes*) clings in modest tufts, to the great Royal Fern (*Osmunda regalis*) presiding over the bogs of Ireland, these plants reward the attentive observer with a remarkable diversity of form and habit.
+
+The present fascicle surveys the principal genera found within the British Isles, with notes upon their preferred habitats, their distribution across the several counties, and the distinguishing characters by which the collector may identify them in the field.
+
+{{ alert(type="note", body="The nomenclature herein follows the system of Hooker and Bauer, as revised by Moore in his 'Nature-Printed British Ferns' (1855). Where synonymy exists, the accepted name is given first.") }}
+
+## Habitats and Distribution
+
+The ferns of Britain may be broadly divided according to their preferred habitats. The woodland species -- among them the Common Polypody (*Polypodium vulgare*) and the Male Fern (*Dryopteris filix-mas*) -- are found throughout the country wherever ancient woodland persists. The wall-ferns, principally of the genus *Asplenium*, colonise old masonry and natural rock faces, and are especially abundant in the limestone districts of Somerset, Derbyshire, and the Yorkshire Dales.
+
+The upland regions of Wales, the Lake District, and the Scottish Highlands harbour several species seldom encountered in the lowlands. The Alpine Woodsia (*Woodsia alpina*) is perhaps the rarest of all British ferns, known from fewer than a dozen stations among the higher crags.
+
+## Methods of Collection
+
+The collector of ferns is advised to carry a stout trowel, a supply of damp newspaper, and a vasculum of sufficient size. Specimens should be pressed promptly upon returning from the field, with care taken to display both the upper surface of the frond and the arrangement of the sori upon the lower. The roots and the base of the stipe should be preserved entire, as these often furnish diagnostic characters of the first importance.
+
+## Classification of Principal Genera
+
+The British fern flora comprises approximately forty-five species distributed among some twenty genera. The largest genus, *Dryopteris*, contributes eight species to the British list; *Asplenium* furnishes seven. The filmy ferns of the genus *Hymenophyllum*, with their translucent fronds of a single cell's thickness, represent the most delicate members of the assemblage and are confined to the wettest districts of the Atlantic seaboard.

--- a/fascicle/content/issues/the-geology-of-the-jurassic-coast.md
+++ b/fascicle/content/issues/the-geology-of-the-jurassic-coast.md
@@ -1,0 +1,81 @@
++++
+title = "The Geology of the Jurassic Coast"
+description = "A geological account of the remarkable coastal exposures of Dorset and East Devon, from the Triassic red beds of Exmouth to the Cretaceous Chalk of Studland, traversing one hundred and eighty million years of Earth history."
+date = "2026-04-09"
+template = "issue"
+weight = 9
+tags = ["geology", "jurassic", "coast"]
+[taxonomies]
+series = ["Geological"]
+[extra]
+issue_no = "IX"
+series = "Geological"
+author = "Dr. William Hargreaves, F.G.S."
+date_published = "May 1857"
+pages_count = "68"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle IX, bearing a stratified cliff ornament of the Geological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Stratified cliff ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <rect x="-16" y="-18" width="32" height="36"/>
+    <line x1="-16" y1="-10" x2="16" y2="-10"/>
+    <line x1="-16" y1="-2" x2="16" y2="-2"/>
+    <line x1="-16" y1="6" x2="16" y2="6"/>
+    <line x1="-16" y1="12" x2="16" y2="12"/>
+    <!-- Small fossil symbol -->
+    <circle cx="0" cy="-14" r="2.5"/>
+    <circle cx="-8" cy="2" r="1.5"/>
+    <circle cx="8" cy="9" r="2"/>
+  </g>
+  <!-- Stratified cliff ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <rect x="-16" y="-18" width="32" height="36"/>
+    <line x1="-16" y1="-10" x2="16" y2="-10"/>
+    <line x1="-16" y1="-2" x2="16" y2="-2"/>
+    <line x1="-16" y1="6" x2="16" y2="6"/>
+    <line x1="-16" y1="12" x2="16" y2="12"/>
+    <circle cx="0" cy="-14" r="2.5"/>
+    <circle cx="8" cy="2" r="1.5"/>
+    <circle cx="-8" cy="9" r="2"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE IX</text>
+  <text x="270" y="118" text-anchor="middle" font-family="Old Standard TT, serif" font-size="14" font-weight="700" fill="#3A2E1F" letter-spacing="1">THE GEOLOGY OF THE JURASSIC COAST</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">GEOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1857</text>
+</svg>
+'''
++++
+
+## A Walk Through Deep Time
+
+The coast of Dorset and East Devon presents to the geologist an unparalleled succession of rock formations, exposed in magnificent cliff sections that together span some one hundred and eighty million years of Earth history. From the Triassic red sandstones of Exmouth in the west to the Cretaceous Chalk of Studland Bay in the east, the attentive walker may trace the record of vanished seas, ancient deserts, and the slow accumulation of sediment upon the ocean floor.
+
+The present fascicle describes the principal geological formations to be observed along this remarkable coast, with notes upon the fossils they contain and the localities most worthy of the geologist's attention.
+
+## The Triassic
+
+The western end of the coast, about Exmouth and Sidmouth, is composed of vivid red sandstones and mudstones of Triassic age, deposited some two hundred and fifty million years ago in the arid conditions of a continental desert. These rocks yield few fossils, but their bold colouring and the dramatic landslips to which they are prone make them a striking introduction to the coastal sequence.
+
+{{ alert(type="note", body="The cliffs along the Jurassic Coast are subject to frequent and unpredictable landslips. The geologist is advised to keep a respectful distance from the cliff base and to observe the state of the tide before venturing upon the foreshore.") }}
+
+## The Jurassic: Lias and Oolite
+
+The transition from the Triassic to the Jurassic is marked by a dramatic change in the character of the rocks. The dark shales and limestones of the Lower Lias, magnificently exposed at Lyme Regis and Charmouth, are among the most celebrated fossil-bearing deposits in the world. It was here that Mary Anning, the daughter of a Lyme Regis cabinetmaker, discovered the first complete ichthyosaur skeleton in 1811, an event that did much to establish the science of palaeontology.
+
+The ammonites of the Lias are of extraordinary abundance and diversity. At certain horizons, the shore platforms are paved with their coiled shells, each one recording the form and ornament of a species that inhabited these seas some one hundred and ninety million years ago.
+
+## The Cretaceous
+
+The eastern portion of the coast, from Swanage to Studland, is composed of Cretaceous rocks, including the pure white Chalk that caps the Purbeck Hills. The Chalk cliffs of Old Harry Rocks, standing as isolated stacks against the sea, are among the most photographed geological features in England. The Chalk here contains flint bands rich in well-preserved echinoids and brachiopods.
+
+## The Collector's Guide
+
+The Jurassic Coast offers productive collecting at almost every point along its length. The foreshore at Charmouth, especially after winter storms, yields ammonites, belemnites, and occasional vertebrate remains. The limestone ledges at Kimmeridge furnish finely preserved bivalves. The collector should carry a geological hammer, a cold chisel, and a supply of newspaper for wrapping specimens, together with a notebook for recording the precise bed and locality of each find.

--- a/fascicle/content/issues/the-lepidoptera-of-surrey.md
+++ b/fascicle/content/issues/the-lepidoptera-of-surrey.md
@@ -1,0 +1,72 @@
++++
+title = "The Lepidoptera of Surrey"
+description = "An enumeration of the butterflies and diurnal moths observed in the county of Surrey, with particular notice of the chalk-downland species and the inhabitants of ancient heathlands."
+date = "2026-04-03"
+template = "issue"
+weight = 3
+tags = ["entomology", "lepidoptera", "butterflies"]
+[taxonomies]
+series = ["Entomological"]
+[extra]
+issue_no = "III"
+series = "Entomological"
+author = "The Rev. Thomas Ashfield, M.A."
+date_published = "May 1856"
+pages_count = "52"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle III, bearing a butterfly ornament of the Entomological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Butterfly ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 0 Q -18 -16 -10 -24 Q -2 -18 0 -6"/>
+    <path d="M 0 0 Q -16 8 -14 18 Q -4 14 0 4"/>
+    <path d="M 0 0 Q 18 -16 10 -24 Q 2 -18 0 -6"/>
+    <path d="M 0 0 Q 16 8 14 18 Q 4 14 0 4"/>
+    <line x1="0" y1="-6" x2="-4" y2="-18"/>
+    <line x1="0" y1="-6" x2="4" y2="-18"/>
+  </g>
+  <!-- Butterfly ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <path d="M 0 0 Q -18 -16 -10 -24 Q -2 -18 0 -6"/>
+    <path d="M 0 0 Q -16 8 -14 18 Q -4 14 0 4"/>
+    <path d="M 0 0 Q 18 -16 10 -24 Q 2 -18 0 -6"/>
+    <path d="M 0 0 Q 16 8 14 18 Q 4 14 0 4"/>
+    <line x1="0" y1="-6" x2="-4" y2="-18"/>
+    <line x1="0" y1="-6" x2="4" y2="-18"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE III</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">THE LEPIDOPTERA OF SURREY</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">ENTOMOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## The Butterflies of the Chalk Downs
+
+The chalk downlands of Surrey -- those rolling expanses of short, flower-rich turf stretching from Farnham to the borders of Kent -- support a butterfly fauna of considerable interest. Here, where the thin alkaline soil encourages the growth of horseshoe vetch and kidney vetch, the Adonis Blue (*Lysandra bellargus*) may still be found in its ancient strongholds, the males gleaming with an intensity of azure that no pigment can adequately represent.
+
+The Chalkhill Blue (*L. coridon*), somewhat paler than its congener, is more generally distributed and may be encountered upon any reasonably undisturbed stretch of downland turf during the month of August. Both species depend absolutely upon the ant *Myrmica sabuleti* for the completion of their larval development, a remarkable association that the present fascicle describes in some detail.
+
+## The Heathland Species
+
+The sandy heaths of western Surrey -- Chobham, Pirbright, Thursley, and the great commons about Hindhead -- harbour a distinct assemblage of Lepidoptera adapted to the acid soils and the heather that dominates them. The Silver-studded Blue (*Plebejus argus*), whose caterpillars feed upon ling and cross-leaved heath, is the characteristic butterfly of these open landscapes.
+
+{{ alert(type="caution", body="Several of the heathland species described herein are now exceedingly local. Collectors are earnestly requested to exercise the utmost restraint and to take no more specimens than are strictly necessary for their cabinets.") }}
+
+## Woodland Lepidoptera
+
+The ancient woodlands of the Weald, which abut the chalk escarpment to the south, contribute their own distinctive species to the Surrey list. The Purple Emperor (*Apatura iris*), that most coveted of British butterflies, frequents the oak canopy of certain woods in the county, descending to the rides on humid mornings to feed upon the juices of decaying matter.
+
+The White Admiral (*Limenitis camilla*), a more graceful creature, is found where honeysuckle trails through the understorey, for upon this plant the female deposits her eggs.
+
+## Methods of Observation
+
+The student of Lepidoptera is best served by patience and a keen eye. A close-focus field glass will often reveal details of wing pattern and behaviour that would otherwise require the capture and examination of the insect. When collecting is necessary, a net of fine muslin upon a light cane frame, together with a killing jar and a supply of setting boards, constitutes the essential equipment.

--- a/fascicle/content/issues/the-mosses-and-liverworts.md
+++ b/fascicle/content/issues/the-mosses-and-liverworts.md
@@ -1,0 +1,72 @@
++++
+title = "The Mosses and Liverworts"
+description = "A guide to the Bryophyta of the British Isles, describing the principal mosses and liverworts of woodland, moorland, and rock, with instructions for their collection and preservation."
+date = "2026-04-06"
+template = "issue"
+weight = 6
+tags = ["bryology", "mosses", "liverworts"]
+[taxonomies]
+series = ["Bryological"]
+[extra]
+issue_no = "VI"
+series = "Bryological"
+author = "Miss Catherine Spruce"
+date_published = "November 1856"
+pages_count = "40"
+printer = "Bradbury & Evans, Whitefriars"
+wrapper_caption = "Wrapper band for Fascicle VI, bearing a moss capsule ornament of the Bryological series."
+wrapper_svg = '''
+<svg viewBox="0 0 540 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="540" height="200" fill="#EDE6D4"/>
+  <rect x="3" y="3" width="534" height="194" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+  <rect x="8" y="8" width="524" height="184" fill="none" stroke="#A89880" stroke-width="0.5"/>
+  <!-- Moss capsule ornament left -->
+  <g transform="translate(45,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <line x1="0" y1="20" x2="0" y2="-8"/>
+    <ellipse cx="0" cy="-14" rx="4" ry="7"/>
+    <path d="M -4 -20 Q 0 -26 4 -20"/>
+    <line x1="-6" y1="20" x2="6" y2="20"/>
+    <path d="M -8 22 Q -4 18 0 22 Q 4 18 8 22"/>
+  </g>
+  <!-- Moss capsule ornament right -->
+  <g transform="translate(495,100)" stroke="#7C5E3C" stroke-width="0.8" fill="none">
+    <line x1="0" y1="20" x2="0" y2="-8"/>
+    <ellipse cx="0" cy="-14" rx="4" ry="7"/>
+    <path d="M -4 -20 Q 0 -26 4 -20"/>
+    <line x1="-6" y1="20" x2="6" y2="20"/>
+    <path d="M -8 22 Q -4 18 0 22 Q 4 18 8 22"/>
+  </g>
+  <text x="270" y="52" text-anchor="middle" font-family="Old Standard TT, serif" font-size="9" fill="#8A7D6E" letter-spacing="4">THE NATURALIST'S CABINET</text>
+  <line x1="80" y1="62" x2="460" y2="62" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="90" text-anchor="middle" font-family="Old Standard TT, serif" font-size="11" fill="#4A5568" letter-spacing="3">FASCICLE VI</text>
+  <text x="270" y="120" text-anchor="middle" font-family="Old Standard TT, serif" font-size="16" font-weight="700" fill="#3A2E1F" letter-spacing="1">THE MOSSES AND LIVERWORTS</text>
+  <line x1="80" y1="134" x2="460" y2="134" stroke="#A89880" stroke-width="0.4"/>
+  <text x="270" y="155" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="9" fill="#8A7D6E" letter-spacing="2">BRYOLOGICAL SERIES</text>
+  <text x="270" y="178" text-anchor="middle" font-family="Libre Baskerville, serif" font-size="8" fill="#A89880" letter-spacing="1">London: Fascicle Press, Paternoster Row, 1856</text>
+</svg>
+'''
++++
+
+## An Introduction to the Bryophytes
+
+The mosses and liverworts, collectively the Bryophyta, are among the most overlooked members of the British flora. Yet no group of plants is more intimately woven into the fabric of our landscape. The emerald cushions of Sphagnum upon the moorland bog, the feathery plumes of *Hylocomium splendens* carpeting the woodland floor, the dark rosettes of *Marchantia* upon damp walls -- all these are bryophytes, and all reward the attentive observer with a delicacy of structure that rivals the finest lacework.
+
+The present fascicle introduces the principal British mosses and liverworts, arranged by habitat, with guidance for the beginner in their identification, collection, and preservation.
+
+## Woodland Mosses
+
+The floor of the deciduous woodland is the richest habitat for mosses in the British Isles. Here, in the dappled shade beneath oak and beech, one may find dozens of species within a few paces. The Common Hair Cap (*Polytrichum commune*) forms dense, dark-green swards upon acid soils; the Feather Moss (*Thuidium tamariscinum*) spreads its finely divided fronds like miniature fern plants over logs and banks.
+
+{{ alert(type="note", body="A hand lens of at least ten times magnification is indispensable for the study of mosses. Many species cannot be reliably identified without microscopic examination of the leaf cells, but a good lens will reveal sufficient characters for a working determination in the field.") }}
+
+## Moorland and Bog Mosses
+
+The Sphagnum mosses of the upland bogs are of particular ecological importance, for they are the principal architects of peat. These remarkable plants absorb and retain water in quantities far exceeding their own weight, creating the waterlogged, acid conditions upon which the bog community depends. The British Isles support some thirty species of Sphagnum, distinguished chiefly by the colour and arrangement of their branches.
+
+## Liverworts
+
+The liverworts, though less conspicuous than the mosses, constitute a distinct division of the Bryophyta and include some of the most beautiful plants to be found in these islands. The leafy liverworts of the Atlantic woodlands -- species of *Plagiochila*, *Frullania*, and *Scapania* -- festoon the trunks and branches of trees in the western districts with a verdure that persists through the darkest months of winter.
+
+## Collection and Preservation
+
+Bryophyte specimens are best collected in small paper packets, with a note of the locality, habitat, and date. Upon returning home, they should be dried slowly in a warm room and then mounted upon stiff card for the herbarium. Unlike flowering plants, mosses and liverworts may be moistened and restored to their natural form at any time, even after decades in the herbarium -- a property that greatly facilitates their study.

--- a/fascicle/content/subscription.md
+++ b/fascicle/content/subscription.md
@@ -1,0 +1,40 @@
++++
+title = "Subscription"
+description = "Terms of subscription to The Naturalist's Cabinet, a serial publication issued in unbound fascicles."
+template = "page"
++++
+
+# Terms of Subscription
+
+**The Naturalist's Cabinet** is published in periodic fascicles, each treating a distinct branch of natural history. The publication is issued to subscribers upon the following terms.
+
+## Annual Subscription
+
+The annual subscription, payable in advance, entitles the subscriber to receive all fascicles issued during the year of subscription, delivered carriage-free to any address within the United Kingdom. The current annual rate is **One Guinea** (twenty-one shillings).
+
+Subscribers residing abroad may receive their fascicles by international post at an additional charge of Five Shillings per annum to cover the excess postage.
+
+## Single Parts
+
+Individual fascicles may be purchased singly at the rate of **Two Shillings and Sixpence** per part, exclusive of postage. Single parts are available from the Publisher's office at 14 Paternoster Row, London, E.C., and from all respectable booksellers.
+
+## Back Numbers
+
+Back numbers of all fascicles previously issued remain available whilst stocks permit. Subscribers who wish to complete their sets are invited to apply to the Publisher, who will furnish a list of parts still in print.
+
+## Binding
+
+At the conclusion of each volume (comprising ten fascicles), subscribers may return their accumulated parts to the Publisher for binding in cloth boards at a charge of **Three Shillings and Sixpence**. The bound volume will include a title page, contents leaf, and index prepared expressly for the purpose.
+
+Subscribers who prefer to have their parts bound by their own binder may obtain the title page and index separately, gratis, upon application to the Publisher.
+
+## Correspondence
+
+All communications regarding subscription, payment, and delivery should be addressed to:
+
+**The Publisher**<br>
+Fascicle Press<br>
+14 Paternoster Row<br>
+London, E.C.
+
+Contributions, corrections, and communications of a scientific nature should be directed to the Editor at the same address, and will receive the most respectful attention.

--- a/fascicle/static/css/style.css
+++ b/fascicle/static/css/style.css
@@ -1,0 +1,812 @@
+/* ==========================================================================
+   FASCICLE - An Unbound Installment Publication
+   Light theme evoking loose gatherings, wrapper bands, and serial parts
+   NO gradients. Solid colours and borders only.
+   ========================================================================== */
+
+/* ---------- Foundations ---------- */
+
+:root {
+  --paper:        #FAF8F0;
+  --paper-warm:   #F5F0E4;
+  --paper-edge:   #EDE6D4;
+  --ink:          #3A2E1F;
+  --ink-light:    #5C4D3C;
+  --ink-faint:    #8A7D6E;
+  --accent-blue:  #4A5568;
+  --accent-brown: #7C5E3C;
+  --accent-rust:  #9B6B3F;
+  --rule-light:   #D4C9B5;
+  --rule-dark:    #A89880;
+  --wrapper-bg:   #EDE6D4;
+  --wrapper-border:#A89880;
+  --font-display: 'Old Standard TT', 'Libre Baskerville', 'Georgia', serif;
+  --font-body:    'Crimson Pro', 'Lora', 'Georgia', serif;
+  --font-small:   'Libre Baskerville', 'Georgia', serif;
+  --measure:      740px;
+  --gutter:       1.5rem;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  line-height: 1.72;
+  color: var(--ink);
+  background-color: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- Typography ---------- */
+
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+h1 {
+  font-size: 2.2rem;
+  letter-spacing: 0.01em;
+  margin-bottom: 0.6em;
+}
+
+h2 {
+  font-size: 1.6rem;
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+}
+
+h3 {
+  font-size: 1.25rem;
+  margin-top: 1.6em;
+  margin-bottom: 0.4em;
+}
+
+h4 {
+  font-size: 1.05rem;
+  font-style: italic;
+  margin-top: 1.4em;
+  margin-bottom: 0.3em;
+}
+
+p {
+  margin: 0 0 1.15em;
+}
+
+a {
+  color: var(--accent-brown);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+a:hover,
+a:focus {
+  border-bottom-color: var(--accent-brown);
+}
+
+strong {
+  font-weight: 600;
+}
+
+em {
+  font-style: italic;
+}
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--rule-dark);
+  background-color: var(--paper-warm);
+  font-style: italic;
+  color: var(--ink-light);
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.88em;
+  background-color: var(--paper-warm);
+  padding: 0.15em 0.35em;
+  border: 1px solid var(--paper-edge);
+}
+
+pre {
+  background-color: var(--paper-warm);
+  border: 1px solid var(--rule-light);
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  margin: 1.5em 0;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--rule-light);
+  margin: 2em 0;
+}
+
+ul, ol {
+  margin: 0 0 1.15em 1.4em;
+}
+
+li {
+  margin-bottom: 0.3em;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ---------- Layout: Fascicle Frame ---------- */
+
+.fascicle-frame {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+/* ---------- Header ---------- */
+
+.fascicle-header {
+  padding: 2rem 0 1.5rem;
+  text-align: center;
+  border-bottom: 2px solid var(--rule-dark);
+}
+
+.fascicle-brand-svg {
+  display: block;
+  max-width: 520px;
+  margin: 0.8rem auto;
+  height: auto;
+}
+
+.fascicle-sub {
+  font-family: var(--font-small);
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0.8rem 0 1.2rem;
+}
+
+.fascicle-nav {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin-top: 0.6rem;
+}
+
+.fascicle-nav a {
+  font-family: var(--font-small);
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-light);
+  padding: 0.3em 0;
+  border-bottom: 1px solid transparent;
+}
+
+.fascicle-nav a:hover,
+.fascicle-nav a:focus {
+  color: var(--accent-brown);
+  border-bottom-color: var(--accent-brown);
+}
+
+/* ---------- Wrapper Band ---------- */
+
+.wrapper-band {
+  display: block;
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.wrapper-band svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 80px;
+}
+
+.wrapper-band-header svg {
+  max-height: 56px;
+}
+
+/* ---------- Loose Edge ---------- */
+
+.loose-edge {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+}
+
+.loose-edge svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* ---------- Main ---------- */
+
+.fascicle-main {
+  padding: 2.5rem 0 3rem;
+  min-height: calc(100vh - 320px);
+}
+
+/* ---------- Frontispiece (Home) ---------- */
+
+.frontispiece {
+  text-align: center;
+  padding: 2rem 0 1rem;
+}
+
+.frontispiece h1 {
+  font-family: var(--font-display);
+  font-size: 2.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.2em;
+}
+
+.frontispiece .front-sub {
+  font-family: var(--font-small);
+  font-size: 1rem;
+  font-style: italic;
+  color: var(--ink-light);
+  margin-bottom: 1.5rem;
+}
+
+.front-plate {
+  margin: 2rem auto;
+  max-width: 560px;
+}
+
+.front-plate svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.front-plate figcaption {
+  font-family: var(--font-small);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--ink-faint);
+  text-align: center;
+  margin-top: 0.6em;
+}
+
+.front-lede {
+  max-width: 580px;
+  margin: 2rem auto;
+  text-align: left;
+}
+
+.front-lede p {
+  font-size: 1.05rem;
+}
+
+.front-lede h2 {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: center;
+  margin-top: 2.5em;
+  margin-bottom: 0.8em;
+}
+
+.featured-list {
+  list-style: none;
+  margin: 1em 0;
+  padding: 0;
+}
+
+.featured-list li {
+  margin-bottom: 0.6em;
+  padding: 0.5em 0;
+  border-bottom: 1px solid var(--rule-light);
+}
+
+.featured-list a {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: var(--accent-brown);
+}
+
+.featured-list .feat-no {
+  font-variant-numeric: oldstyle-nums;
+  color: var(--accent-blue);
+  margin-right: 0.5em;
+  font-weight: 600;
+}
+
+.featured-list .feat-series {
+  font-family: var(--font-small);
+  font-size: 0.78rem;
+  color: var(--ink-faint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-left: 0.6em;
+}
+
+/* ---------- Section Head ---------- */
+
+.section-head {
+  text-align: center;
+  padding: 1rem 0 1.5rem;
+  border-bottom: 1px solid var(--rule-light);
+  margin-bottom: 2rem;
+}
+
+.section-head .kicker {
+  font-family: var(--font-small);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  margin-bottom: 0.4em;
+}
+
+.section-head h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  margin-bottom: 0.3em;
+}
+
+.section-head .section-lede {
+  font-style: italic;
+  color: var(--ink-light);
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.section-intro {
+  max-width: 580px;
+  margin: 0 auto 2rem;
+}
+
+/* ---------- Issue Table (section list) ---------- */
+
+.issue-table {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2rem;
+}
+
+.issue-row {
+  border-bottom: 1px solid var(--rule-light);
+}
+
+.issue-row:first-child {
+  border-top: 1px solid var(--rule-light);
+}
+
+.issue-link {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 0.4rem;
+  text-decoration: none;
+  border-bottom: none;
+  color: var(--ink);
+}
+
+.issue-link:hover,
+.issue-link:focus {
+  background-color: var(--paper-warm);
+  border-bottom: none;
+}
+
+.issue-no {
+  flex-shrink: 0;
+  width: 2.6rem;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--accent-blue);
+  text-align: right;
+}
+
+.issue-title-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
+.issue-title-bl {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.issue-dek {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--ink-light);
+  font-style: italic;
+  margin-top: 0.15em;
+}
+
+.issue-series {
+  flex-shrink: 0;
+  font-family: var(--font-small);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ---------- Issue Page ---------- */
+
+.issue-page {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.issue-head {
+  text-align: center;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule-light);
+  margin-bottom: 2rem;
+}
+
+.issue-head .kicker {
+  font-family: var(--font-small);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  margin-bottom: 0.4em;
+}
+
+.issue-head h1 {
+  font-size: 2rem;
+  margin-bottom: 0.3em;
+}
+
+.issue-head .issue-lede {
+  font-style: italic;
+  color: var(--ink-light);
+  font-size: 1rem;
+}
+
+/* Issue Specs */
+
+.issue-specs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2em 1.2em;
+  margin: 1.5rem 0 2rem;
+  padding: 1rem 1.2rem;
+  background-color: var(--paper-warm);
+  border: 1px solid var(--rule-light);
+}
+
+.issue-specs dt {
+  font-family: var(--font-small);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  font-weight: 400;
+}
+
+.issue-specs dd {
+  font-size: 0.92rem;
+  color: var(--ink);
+}
+
+/* Issue Figure (Wrapper SVG) */
+
+.issue-figure {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.issue-figure svg {
+  display: block;
+  width: 100%;
+  max-width: 540px;
+  height: auto;
+  margin: 0 auto;
+  border: 1px solid var(--rule-light);
+}
+
+.issue-figcap {
+  font-family: var(--font-small);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--ink-faint);
+  margin-top: 0.6em;
+}
+
+/* Issue Prose */
+
+.issue-prose {
+  margin: 2rem 0;
+}
+
+.issue-prose h2 {
+  font-size: 1.35rem;
+  border-bottom: 1px solid var(--rule-light);
+  padding-bottom: 0.3em;
+}
+
+.issue-prose h3 {
+  font-size: 1.1rem;
+}
+
+/* Issue Footer */
+
+.issue-foot {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule-light);
+}
+
+.back-link {
+  font-family: var(--font-small);
+  font-size: 0.85rem;
+  color: var(--accent-brown);
+}
+
+/* ---------- Page Prose (subscription, colophon) ---------- */
+
+.page-prose {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.page-prose h1 {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.page-prose h2 {
+  font-size: 1.35rem;
+  border-bottom: 1px solid var(--rule-light);
+  padding-bottom: 0.3em;
+}
+
+/* ---------- Footer ---------- */
+
+.fascicle-foot {
+  border-top: 2px solid var(--rule-dark);
+  padding: 2rem 0 1.5rem;
+  margin-top: 3rem;
+}
+
+.foot-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.foot-col h4 {
+  font-family: var(--font-small);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  margin-bottom: 0.8em;
+  font-style: normal;
+}
+
+.foot-col p,
+.foot-col address {
+  font-size: 0.82rem;
+  color: var(--ink-light);
+  font-style: normal;
+  line-height: 1.6;
+}
+
+.foot-col a {
+  color: var(--accent-brown);
+}
+
+.foot-rule {
+  display: block;
+  width: 100%;
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.foot-rule svg {
+  display: inline-block;
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+}
+
+.foot-stamp {
+  text-align: center;
+  font-family: var(--font-small);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-top: 0.6rem;
+}
+
+/* ---------- Taxonomy ---------- */
+
+.taxonomy-page {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.taxonomy-page h1 {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 0.3em;
+}
+
+.taxonomy-desc {
+  text-align: center;
+  font-style: italic;
+  color: var(--ink-light);
+  margin-bottom: 2rem;
+}
+
+/* ---------- Error Page ---------- */
+
+.error-page {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.error-page h1 {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  color: var(--accent-blue);
+  margin-bottom: 0.3em;
+}
+
+.error-page p {
+  font-style: italic;
+  color: var(--ink-light);
+  margin-bottom: 1.5rem;
+}
+
+.error-page a {
+  font-family: var(--font-small);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-brown);
+  border-bottom: 1px solid var(--accent-brown);
+  padding-bottom: 0.15em;
+}
+
+/* ---------- Alert Shortcode ---------- */
+
+.alert {
+  margin: 1.5em 0;
+  padding: 0.9em 1.1em;
+  border: 1px solid var(--rule-light);
+  border-left: 4px solid var(--accent-brown);
+  background-color: var(--paper-warm);
+}
+
+.alert strong {
+  font-family: var(--font-small);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 720px) {
+  :root {
+    --gutter: 1rem;
+  }
+
+  .frontispiece h1 {
+    font-size: 2rem;
+  }
+
+  h1 {
+    font-size: 1.7rem;
+  }
+
+  h2 {
+    font-size: 1.3rem;
+  }
+
+  .fascicle-nav {
+    gap: 1.2rem;
+  }
+
+  .foot-cols {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+
+  .issue-link {
+    flex-wrap: wrap;
+  }
+
+  .issue-series {
+    width: 100%;
+    margin-top: 0.2em;
+    padding-left: 3.6rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .frontispiece h1 {
+    font-size: 1.6rem;
+  }
+
+  .fascicle-brand-svg {
+    max-width: 300px;
+  }
+
+  .fascicle-nav {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .issue-specs {
+    grid-template-columns: 1fr;
+    gap: 0.3em 0;
+  }
+
+  .issue-specs dt {
+    margin-top: 0.5em;
+  }
+}
+
+/* ---------- Print ---------- */
+
+@media print {
+  body {
+    background: #fff;
+    color: #000;
+    font-size: 11pt;
+  }
+
+  .fascicle-header,
+  .fascicle-foot,
+  .fascicle-nav {
+    display: none;
+  }
+
+  .fascicle-main {
+    padding: 0;
+  }
+
+  a {
+    color: #000;
+    border-bottom: none;
+  }
+
+  .issue-figure svg {
+    border: 1px solid #999;
+  }
+}

--- a/fascicle/templates/404.html
+++ b/fascicle/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <div class="error-page">
+      <h1>404</h1>
+      <p>The requested fascicle cannot be located. It may have been lost in the post, or the gatherings may have been mislaid by the binder.</p>
+      <a href="{{ base_url }}/">Return to the title page</a>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/fascicle/templates/footer.html
+++ b/fascicle/templates/footer.html
@@ -1,0 +1,42 @@
+    <footer class="fascicle-foot" role="contentinfo">
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h4>The Publisher</h4>
+          <address>
+            Fascicle Press<br>
+            14 Paternoster Row<br>
+            London, E.C.
+          </address>
+        </div>
+        <div class="foot-col">
+          <h4>Subscription</h4>
+          <p>Annual subscription: One Guinea.<br>
+          Single parts: Two Shillings Sixpence.<br>
+          <a href="{{ base_url }}/subscription/">Terms of subscription</a></p>
+        </div>
+        <div class="foot-col">
+          <h4>Terms</h4>
+          <p>Published in unbound fascicles for the convenience of the subscriber. Parts may be bound at the conclusion of each volume. The Publisher assumes no responsibility for loose sheets lost in the post.</p>
+        </div>
+      </div>
+      <!-- Ornamental rule -->
+      <div class="foot-rule" aria-hidden="true">
+        <svg viewBox="0 0 400 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+          <line x1="10" y1="10" x2="170" y2="10" stroke="#A89880" stroke-width="0.8"/>
+          <line x1="230" y1="10" x2="390" y2="10" stroke="#A89880" stroke-width="0.8"/>
+          <g transform="translate(200,10)">
+            <path d="M 0 -6 L 6 0 L 0 6 L -6 0 Z" fill="none" stroke="#7C5E3C" stroke-width="0.8"/>
+            <circle r="2" fill="#7C5E3C"/>
+          </g>
+          <!-- Small leaf ornaments -->
+          <path d="M 60 10 Q 65 4 70 10 Q 65 16 60 10" fill="none" stroke="#A89880" stroke-width="0.5"/>
+          <path d="M 330 10 Q 335 4 340 10 Q 335 16 330 10" fill="none" stroke="#A89880" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <p class="foot-stamp">FINIS &middot; PUBLISHED IN PARTS &middot; TYPESET WITH HWARO &middot; Anno Domini MMXXVI</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/fascicle/templates/header.html
+++ b/fascicle/templates/header.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <!-- SVG Wrapper Band: top decorative band evoking a printed paper wrapper -->
+  <div class="wrapper-band wrapper-band-header" aria-hidden="true">
+    <svg viewBox="0 0 960 56" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+      <rect x="0" y="0" width="960" height="56" fill="#EDE6D4"/>
+      <line x1="0" y1="3" x2="960" y2="3" stroke="#A89880" stroke-width="1.5"/>
+      <line x1="0" y1="7" x2="960" y2="7" stroke="#D4C9B5" stroke-width="0.5"/>
+      <!-- Repeating wrapper band pattern -->
+      <g stroke="#A89880" stroke-width="0.6" fill="none">
+        <line x1="40" y1="14" x2="40" y2="42"/>
+        <line x1="120" y1="14" x2="120" y2="42"/>
+        <line x1="200" y1="14" x2="200" y2="42"/>
+        <line x1="280" y1="14" x2="280" y2="42"/>
+        <line x1="360" y1="14" x2="360" y2="42"/>
+        <line x1="600" y1="14" x2="600" y2="42"/>
+        <line x1="680" y1="14" x2="680" y2="42"/>
+        <line x1="760" y1="14" x2="760" y2="42"/>
+        <line x1="840" y1="14" x2="840" y2="42"/>
+        <line x1="920" y1="14" x2="920" y2="42"/>
+      </g>
+      <text x="480" y="34" text-anchor="middle" font-family="Old Standard TT, serif" font-size="13" fill="#7C5E3C" letter-spacing="6">AN UNBOUND INSTALLMENT PUBLICATION</text>
+      <line x1="0" y1="49" x2="960" y2="49" stroke="#D4C9B5" stroke-width="0.5"/>
+      <line x1="0" y1="53" x2="960" y2="53" stroke="#A89880" stroke-width="1.5"/>
+    </svg>
+  </div>
+
+  <div class="fascicle-frame" role="document">
+    <header class="fascicle-header" role="banner">
+      <a href="{{ base_url }}/" class="fascicle-brand" aria-label="Fascicle home">
+        <svg viewBox="0 0 520 80" xmlns="http://www.w3.org/2000/svg" class="fascicle-brand-svg" aria-hidden="true">
+          <!-- Fascicle monogram -->
+          <g transform="translate(36,40)">
+            <rect x="-22" y="-22" width="44" height="44" fill="none" stroke="#7C5E3C" stroke-width="1.2"/>
+            <rect x="-16" y="-16" width="32" height="32" fill="none" stroke="#A89880" stroke-width="0.6"/>
+            <text x="0" y="9" text-anchor="middle" font-family="Old Standard TT, serif" font-size="26" font-weight="700" fill="#7C5E3C">F</text>
+          </g>
+          <text x="76" y="34" font-family="Old Standard TT, serif" font-size="34" font-weight="700" fill="#3A2E1F" letter-spacing="4">FASCICLE</text>
+          <text x="76" y="60" font-family="Libre Baskerville, serif" font-size="11" fill="#8A7D6E" letter-spacing="3">ISSUED IN UNBOUND PARTS</text>
+        </svg>
+      </a>
+      <p class="fascicle-sub">Loose gatherings within printed wrapper bands, delivered to subscribers in periodic installments</p>
+      <nav class="fascicle-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Title Page</a>
+        <a href="{{ base_url }}/issues/">The Issues</a>
+        <a href="{{ base_url }}/subscription/">Subscription</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>

--- a/fascicle/templates/issue.html
+++ b/fascicle/templates/issue.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <article class="issue-page">
+      <header class="issue-head">
+        <p class="kicker">{% if page.extra.issue_no %}FASCICLE {{ page.extra.issue_no | e }}{% endif %}{% if page.extra.series %} &middot; {{ page.extra.series | upper }}{% endif %}</p>
+        <h1>{{ page.title | e }}</h1>
+        {% if page.description %}<p class="issue-lede">{{ page.description | e }}</p>{% endif %}
+      </header>
+
+      {% if page.extra.author or page.extra.date_published or page.extra.series or page.extra.pages_count %}
+      <dl class="issue-specs">
+        {% if page.extra.author %}<dt>Author</dt><dd>{{ page.extra.author | e }}</dd>{% endif %}
+        {% if page.extra.date_published %}<dt>Date Published</dt><dd>{{ page.extra.date_published | e }}</dd>{% endif %}
+        {% if page.extra.series %}<dt>Series</dt><dd>{{ page.extra.series | e }}</dd>{% endif %}
+        {% if page.extra.pages_count %}<dt>Pages</dt><dd>{{ page.extra.pages_count | e }}</dd>{% endif %}
+        {% if page.extra.printer %}<dt>Printer</dt><dd>{{ page.extra.printer | e }}</dd>{% endif %}
+      </dl>
+      {% endif %}
+
+      {% if page.extra.wrapper_svg %}
+      <figure class="issue-figure">
+        {{ page.extra.wrapper_svg | safe }}
+        {% if page.extra.wrapper_caption %}<figcaption class="issue-figcap">{{ page.extra.wrapper_caption | e }}</figcaption>{% endif %}
+      </figure>
+      {% endif %}
+
+      <div class="issue-prose">
+        {{ content }}
+      </div>
+
+      <footer class="issue-foot">
+        <a href="{{ base_url }}/issues/" class="back-link">&larr; Return to the catalogue of parts</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/fascicle/templates/page.html
+++ b/fascicle/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <div class="page-prose">
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/fascicle/templates/section.html
+++ b/fascicle/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <header class="section-head">
+      <p class="kicker">THE CATALOGUE OF PARTS</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+      {% if page.description %}<p class="section-lede">{{ page.description | e }}</p>{% endif %}
+    </header>
+    <div class="section-intro">
+      {{ content }}
+    </div>
+    <ol class="issue-table">
+      {% for iss in section.pages %}
+      <li class="issue-row">
+        <a href="{{ iss.url }}" class="issue-link">
+          <span class="issue-no">{% if iss.extra.issue_no %}{{ iss.extra.issue_no | e }}{% else %}{{ loop.index }}{% endif %}</span>
+          <span class="issue-title-wrap">
+            <span class="issue-title-bl">{{ iss.title | e }}</span>
+            {% if iss.description %}<span class="issue-dek">{{ iss.description | e }}</span>{% endif %}
+          </span>
+          {% if iss.extra.series %}<span class="issue-series">{{ iss.extra.series | e }}</span>{% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/fascicle/templates/shortcodes/alert.html
+++ b/fascicle/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/fascicle/templates/taxonomy.html
+++ b/fascicle/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <div class="taxonomy-page">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this classification:</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/fascicle/templates/taxonomy_term.html
+++ b/fascicle/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="fascicle-main" role="main">
+    <div class="taxonomy-page">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Fascicles classified under this term:</p>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1417,6 +1417,13 @@
     "docs",
     "faq"
   ],
+  "fascicle": [
+    "book",
+    "light",
+    "serial",
+    "unbound",
+    "installment"
+  ],
   "fault-siren": [
     "event",
     "dark",


### PR DESCRIPTION
Closes #1552

## Summary
- Add fascicle example site: an unbound installment publication with light period-serial theme
- 10 fascicle issues of "The Naturalist's Cabinet" covering Victorian natural history topics
- SVG wrapper band illustrations unique to each issue with botanical/zoological motifs
- SVG loose-sheet edge patterns suggesting unbound gatherings
- Old Standard TT / Libre Baskerville display type with Crimson Pro / Lora body text

## Test plan
- [ ] Verify `hwaro build` succeeds in fascicle directory
- [ ] Verify all 14 pages render correctly
- [ ] Check tags.json includes fascicle entry
- [ ] Confirm no CSS gradients or emojis present