### PR TITLE
feat: add main-act example site (closes #1551)

### DIFF
--- a/main-act/AGENTS.md
+++ b/main-act/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/main-act/config.toml
+++ b/main-act/config.toml
@@ -1,0 +1,85 @@
+# =============================================================================
+# Main Act - Headline Performer
+# Issue #1551 | Tags: event, concert, headline, performer, dramatic
+# =============================================================================
+
+title = "MAIN ACT - Headline Performer"
+description = "The headline performer takes the stage - a dramatic concert event site with bold Oswald typography, stage truss framing, and moving-head light fixtures rendered in SVG. Dark and intense."
+base_url = "http://localhost:3000"
+
+sections = ["lineup"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "stage"
+paginate_by = 10
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.6
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A single-night electronic music festival. Three stages, ten performers, one headline act. Dark, dramatic, intense."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 20
+sections = ["lineup"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/main-act/content/index.md
+++ b/main-act/content/index.md
@@ -1,0 +1,187 @@
++++
+title = "The Event"
+description = "The headline performer takes the stage. Three stages, ten performers, one night. Ironworks Arena, Saturday 10 October 2026."
+template = "page"
++++
+
+<section class="hero-section">
+  <p class="kicker">SATURDAY 10 OCTOBER 2026</p>
+  <h1 class="hero-headline">MAIN ACT</h1>
+  <p class="hero-sub">The Headline Performer Takes the Stage</p>
+  <div class="hero-date-strip">
+    <div class="date-block">
+      <span class="date-label">Date</span>
+      <span class="date-value">10 OCT 2026</span>
+    </div>
+    <div class="date-block">
+      <span class="date-label">Doors</span>
+      <span class="date-value">16:00</span>
+    </div>
+    <div class="date-block">
+      <span class="date-label">Main Act</span>
+      <span class="date-value">23:00</span>
+    </div>
+    <div class="date-block">
+      <span class="date-label">Close</span>
+      <span class="date-value">03:00</span>
+    </div>
+  </div>
+  <p class="hero-lede">Ten performers across three stages at the Ironworks Arena. Eleven hours of electronic music from downtempo openings to industrial headline sets. One night, no repeats, no recordings. The headline act goes on at twenty-three hundred hours and does not stop until the power is cut.</p>
+</section>
+
+<!-- Stage Scene SVG -->
+<div class="stage-scene" aria-hidden="true">
+  <svg viewBox="0 0 900 300" xmlns="http://www.w3.org/2000/svg">
+    <!-- Truss structure across the top -->
+    <line x1="0" y1="20" x2="900" y2="20" stroke="#333333" stroke-width="2"/>
+    <line x1="0" y1="50" x2="900" y2="50" stroke="#333333" stroke-width="2"/>
+    <!-- Truss vertical posts -->
+    <line x1="50" y1="20" x2="50" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="100" y1="20" x2="100" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="150" y1="20" x2="150" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="200" y1="20" x2="200" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="250" y1="20" x2="250" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="300" y1="20" x2="300" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="350" y1="20" x2="350" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="400" y1="20" x2="400" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="450" y1="20" x2="450" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="500" y1="20" x2="500" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="550" y1="20" x2="550" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="600" y1="20" x2="600" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="650" y1="20" x2="650" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="700" y1="20" x2="700" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="750" y1="20" x2="750" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="800" y1="20" x2="800" y2="50" stroke="#333333" stroke-width="1"/>
+    <line x1="850" y1="20" x2="850" y2="50" stroke="#333333" stroke-width="1"/>
+    <!-- Cross-bracing on truss -->
+    <line x1="50" y1="20" x2="100" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="100" y1="20" x2="50" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="150" y1="20" x2="200" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="200" y1="20" x2="150" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="250" y1="20" x2="300" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="300" y1="20" x2="250" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="350" y1="20" x2="400" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="400" y1="20" x2="350" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="450" y1="20" x2="500" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="500" y1="20" x2="450" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="550" y1="20" x2="600" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="600" y1="20" x2="550" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="650" y1="20" x2="700" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="700" y1="20" x2="650" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="750" y1="20" x2="800" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <line x1="800" y1="20" x2="750" y2="50" stroke="#222222" stroke-width="0.6"/>
+    <!-- Vertical truss legs (sides) -->
+    <line x1="50" y1="50" x2="50" y2="230" stroke="#333333" stroke-width="2"/>
+    <line x1="850" y1="50" x2="850" y2="230" stroke="#333333" stroke-width="2"/>
+    <!-- Moving-head light fixture 1 -->
+    <g transform="translate(200, 50)">
+      <rect x="-6" y="0" width="12" height="5" fill="#444444" rx="1"/>
+      <rect x="-4" y="5" width="8" height="7" fill="#333333" rx="1"/>
+      <circle cx="0" cy="15" r="5" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/>
+      <circle cx="0" cy="15" r="2.5" fill="#FFB300" opacity="0.9"/>
+      <polygon points="-3,18 -70,230 70,230 3,18" fill="#FFB300" opacity="0.04"/>
+    </g>
+    <!-- Moving-head light fixture 2 -->
+    <g transform="translate(370, 50)">
+      <rect x="-6" y="0" width="12" height="5" fill="#444444" rx="1"/>
+      <rect x="-4" y="5" width="8" height="7" fill="#333333" rx="1"/>
+      <circle cx="0" cy="15" r="5" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/>
+      <circle cx="0" cy="15" r="2.5" fill="#FF1744" opacity="0.9"/>
+      <polygon points="-3,18 -55,230 55,230 3,18" fill="#FF1744" opacity="0.04"/>
+    </g>
+    <!-- Moving-head light fixture 3 (center) -->
+    <g transform="translate(450, 50)">
+      <rect x="-6" y="0" width="12" height="5" fill="#444444" rx="1"/>
+      <rect x="-4" y="5" width="8" height="7" fill="#333333" rx="1"/>
+      <circle cx="0" cy="15" r="5" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/>
+      <circle cx="0" cy="15" r="2.5" fill="#FFFFFF" opacity="0.9"/>
+      <polygon points="-3,18 -50,230 50,230 3,18" fill="#FFFFFF" opacity="0.04"/>
+    </g>
+    <!-- Moving-head light fixture 4 -->
+    <g transform="translate(530, 50)">
+      <rect x="-6" y="0" width="12" height="5" fill="#444444" rx="1"/>
+      <rect x="-4" y="5" width="8" height="7" fill="#333333" rx="1"/>
+      <circle cx="0" cy="15" r="5" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/>
+      <circle cx="0" cy="15" r="2.5" fill="#FF1744" opacity="0.9"/>
+      <polygon points="-3,18 -55,230 55,230 3,18" fill="#FF1744" opacity="0.04"/>
+    </g>
+    <!-- Moving-head light fixture 5 -->
+    <g transform="translate(700, 50)">
+      <rect x="-6" y="0" width="12" height="5" fill="#444444" rx="1"/>
+      <rect x="-4" y="5" width="8" height="7" fill="#333333" rx="1"/>
+      <circle cx="0" cy="15" r="5" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/>
+      <circle cx="0" cy="15" r="2.5" fill="#FFB300" opacity="0.9"/>
+      <polygon points="-3,18 -70,230 70,230 3,18" fill="#FFB300" opacity="0.04"/>
+    </g>
+    <!-- Stage platform silhouette -->
+    <rect x="80" y="230" width="740" height="8" fill="#1A1A1A"/>
+    <rect x="100" y="238" width="700" height="40" fill="#0A0A0A" stroke="#222222" stroke-width="1"/>
+    <!-- Stage floor markers -->
+    <line x1="250" y1="230" x2="250" y2="238" stroke="#FF1744" stroke-width="1.5"/>
+    <line x1="450" y1="230" x2="450" y2="238" stroke="#FF1744" stroke-width="1.5"/>
+    <line x1="650" y1="230" x2="650" y2="238" stroke="#FF1744" stroke-width="1.5"/>
+  </svg>
+</div>
+
+<ul class="stats-strip">
+  <li>
+    <span class="stat-num">3</span>
+    <span class="stat-label">Stages</span>
+  </li>
+  <li>
+    <span class="stat-num">10</span>
+    <span class="stat-label">Performers</span>
+  </li>
+  <li>
+    <span class="stat-num">11</span>
+    <span class="stat-label">Hours</span>
+  </li>
+  <li>
+    <span class="stat-num">1</span>
+    <span class="stat-label">Headline</span>
+  </li>
+</ul>
+
+## The Stages
+
+The Ironworks Arena is divided into three distinct performance spaces. Each stage runs its own programme from doors to close. Move between them freely; the venue is connected by covered walkways and a central bar area that serves all three stages.
+
+### Main Stage
+
+The primary performance space inside Hangar 9 proper. Full concert production with a twelve-metre truss rig, forty-eight moving-head fixtures, and a d&b audiotechnik J-Series line array. Capacity 2,400 standing. The headline set from VORTEX runs 23:00 to 01:00.
+
+### Warehouse
+
+A converted loading bay on the east side of the arena. Stripped-back production with a focused Funktion-One Evo 7 system, minimal lighting, and raw concrete walls. Capacity 600. The Warehouse programme runs darker and harder than the Main Stage.
+
+### The Basement
+
+Below the main hangar, accessed via the loading ramp. A low-ceiling room designed for close-quarters sound. Martin Audio MLA Compact system tuned for bass weight at low volume. Capacity 300. The Basement runs from 21:00 through to 03:00 and hosts the most extreme sets of the night.
+
+## Running Order Highlights
+
+<div class="support-acts">
+  <h2>Main Stage</h2>
+  <ul>
+    <li><span class="act-name">VORTEX</span> <span class="act-time">23:00 - 01:00</span></li>
+    <li><span class="act-name">PULSE THEORY</span> <span class="act-time">21:00 - 23:00</span></li>
+    <li><span class="act-name">NEON ARCHIVE</span> <span class="act-time">19:00 - 21:00</span></li>
+    <li><span class="act-name">ZERO POINT</span> <span class="act-time">17:00 - 19:00</span></li>
+  </ul>
+  <h2>Warehouse</h2>
+  <ul>
+    <li><span class="act-name">BLACK SIGNAL</span> <span class="act-time">00:00 - 02:00</span></li>
+    <li><span class="act-name">CHROMATIC</span> <span class="act-time">22:00 - 00:00</span></li>
+    <li><span class="act-name">DRIFT PROTOCOL</span> <span class="act-time">20:00 - 22:00</span></li>
+  </ul>
+  <h2>The Basement</h2>
+  <ul>
+    <li><span class="act-name">STATIC FIELD</span> <span class="act-time">01:00 - 03:00</span></li>
+    <li><span class="act-name">ECHO CHAMBER</span> <span class="act-time">23:00 - 01:00</span></li>
+    <li><span class="act-name">PHASE SHIFT</span> <span class="act-time">21:00 - 23:00</span></li>
+  </ul>
+</div>
+
+The full [lineup](/lineup/) is available with individual performer profiles, set descriptions, and technical details. The running order is final and will not change.
+
+[Get your tickets now](/tickets/) - advance sales close at midnight on Friday 9 October.

--- a/main-act/content/info.md
+++ b/main-act/content/info.md
@@ -1,0 +1,57 @@
++++
+title = "Venue Information"
+description = "Everything you need to know about the Ironworks Arena, Hangar 9. Location, access, facilities, and house rules."
+template = "page"
++++
+
+<div class="page-content">
+
+## The Venue
+
+MAIN ACT takes place at the **Ironworks Arena**, a converted industrial complex on the eastern edge of the city. The main performance space is **Hangar 9**, a steel-framed warehouse with a floor area of 2,800 square metres and a ceiling height of fourteen metres in the main span. The venue was decommissioned as a freight depot in 2019 and has operated as a licensed event space since 2022.
+
+## Getting There
+
+The Ironworks Arena is located at **Unit 9, Ironworks Road, Industrial Quarter, E14 7TL**.
+
+- **By rail**: Ironworks Road station is a four-minute walk from the venue entrance. Services run every fifteen minutes from Central until 01:30, with a night service at 02:00 and 03:00.
+- **By bus**: Routes 47 and 122 stop at Ironworks Junction, a two-minute walk from the venue gate.
+- **By car**: Limited parking is available in the industrial estate car park. The venue strongly recommends public transport. There is no on-site parking.
+- **By bicycle**: Covered cycle parking is available at the venue entrance. Bring your own lock.
+
+## The Stages
+
+### Main Stage (Hangar 9)
+
+The primary performance space. Capacity 2,400 standing. Full concert production with a twelve-metre overhead truss rig, forty-eight moving-head light fixtures, laser system, and a d&b audiotechnik J-Series line array driven by d&b D80 amplifiers. The sound system is tuned for even coverage across the full floor area, with a delay system for the rear third of the room.
+
+### Warehouse (East Loading Bay)
+
+A converted loading bay attached to the east side of Hangar 9. Capacity 600 standing. Stripped-back production with a Funktion-One Evo 7 system, minimal lighting (four moving-head fixtures only), and raw concrete surfaces. Accessed via the covered walkway from the main hangar.
+
+### The Basement (Below Hangar 9)
+
+Below the main hangar, accessed via the loading ramp at the south end. Capacity 300 standing. Low ceiling (2.4 metres) with a Martin Audio MLA Compact system tuned for maximum bass weight at controlled volume. The Basement is the most intense acoustic environment at the venue.
+
+## Facilities
+
+- **Bar**: Full bar service across all three stages and the central courtyard. Cashless payments only. A selection of beers, wines, spirits, soft drinks, and water. Water refill stations are free.
+- **Cloakroom**: Located at the main entrance. Fee applies. Open from doors until thirty minutes after the event closes.
+- **Toilets**: Located at the main entrance, the central courtyard, and adjacent to The Basement entrance.
+- **First aid**: A staffed first aid station is located in the central courtyard for the duration of the event.
+- **Accessibility**: The Main Stage and Warehouse are step-free. The Basement is accessed via a ramp with a moderate incline. An accessible viewing platform is available at the Main Stage. Contact the venue in advance for specific requirements.
+
+## House Rules
+
+- This is an **18+ event**. Valid photo ID is required at the door. No exceptions.
+- **Hearing protection** is strongly recommended and available free at the entrance.
+- **No photography or recording** on the performance floors without prior authorisation.
+- **No re-entry** after midnight. If you leave, you cannot return.
+- Be considerate of other attendees. The venue operates a zero-tolerance policy for antisocial behaviour.
+- Follow the instructions of venue staff at all times.
+
+## Contact
+
+For accessibility enquiries, lost property, or other questions, contact **info@mainact-event.com** or call the venue office on **020 7946 0123** (weekdays 10:00 to 18:00).
+
+</div>

--- a/main-act/content/lineup/_index.md
+++ b/main-act/content/lineup/_index.md
@@ -1,0 +1,11 @@
++++
+title = "The Lineup"
+description = "Ten performers across three stages. Downtempo to industrial, 17:00 to 03:00."
+template = "section"
+sort_by = "weight"
+transparent = false
++++
+
+Below is the full running order for Saturday 10 October 2026 at the Ironworks Arena. Times are fixed and final. Click through to any performer for a biography, genre breakdown, technical specifications, and a description of what to expect from their set.
+
+The Main Stage programme runs from 17:00 to 01:00. The Warehouse opens at 20:00 and runs through to 02:00. The Basement starts at 21:00 and closes the night at 03:00.

--- a/main-act/content/lineup/black-signal.md
+++ b/main-act/content/lineup/black-signal.md
@@ -1,0 +1,39 @@
++++
+title = "BLACK SIGNAL"
+description = "Dark techno from the deep end. Warehouse-grade sound design, sub-bass pressure, and an atmosphere of controlled menace."
+date = "2026-04-10"
+template = "performer"
+weight = 4
+tags = ["dark-techno", "warehouse", "industrial"]
+[taxonomies]
+stage = ["Warehouse"]
+[extra]
+slot = "00:00 - 02:00"
+stage = "Warehouse"
+tagline = "The Signal"
+origin = "Rotterdam"
+genre = "Dark Techno"
+bpm = "136 - 145"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(200,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -30,200 30,200 2,12" fill="#FF1744" opacity="0.07"/></g><g transform="translate(400,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -30,200 30,200 2,12" fill="#FF1744" opacity="0.07"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Warehouse Set
+
+BLACK SIGNAL takes the Warehouse stage at midnight for two hours of uncompromising dark techno. The Warehouse space is specifically suited to this kind of sound: low ceiling, raw concrete surfaces, and a Funktion-One system that delivers sub-bass as a physical force rather than merely an audible frequency. The lighting for this set is deliberately minimal, with only two moving-head fixtures operating in slow, sweeping patterns through dense haze.
+
+The set starts hard and stays hard. Opening tempo is 136 bpm, climbing steadily to 145 by the halfway mark and holding that intensity through the close at 02:00. There are no melodic breaks, no ambient interludes, and no concessions to comfort.
+
+{{ alert(type="warning", body="The Warehouse operates at reduced lighting for this set. Watch your footing on the concrete floor and be aware of the pillars in the centre of the space.") }}
+
+## The Producer
+
+BLACK SIGNAL is Yael de Vries, a Rotterdam-based producer whose work sits at the intersection of techno and industrial noise. Her productions are characterised by heavily processed kick drums that border on distortion, sub-bass patterns that oscillate between frequencies designed to be felt in the chest, and an atmosphere that one reviewer described as what it sounds like inside a collapsing factory.
+
+She has released on Perc Trax, Mord Records, and her own Black Signal Recordings, and has been a fixture of the Rotterdam and Berlin industrial scenes since 2019. Her live sets are played from an Elektron setup augmented by a chain of analogue distortion pedals.
+
+## Sound Architecture
+
+The set is constructed in eight-bar blocks that stack and interlock like machinery. Each block introduces one new element while removing another, creating a sense of constant motion within a framework that never actually changes tempo for more than a few beats at a time. The result is hypnotic in the way that watching heavy equipment operate is hypnotic: repetitive, powerful, and faintly dangerous.
+
+If you prefer melody to machinery, the Warehouse during this slot is not for you. If you want to know what it feels like to stand inside a kick drum, this is exactly where you should be.

--- a/main-act/content/lineup/chromatic.md
+++ b/main-act/content/lineup/chromatic.md
@@ -1,0 +1,39 @@
++++
+title = "CHROMATIC"
+description = "Minimal techno with surgical precision. Every element placed with intent, every silence loaded with anticipation."
+date = "2026-04-10"
+template = "performer"
+weight = 5
+tags = ["minimal", "techno", "precise"]
+[taxonomies]
+stage = ["Warehouse"]
+[extra]
+slot = "22:00 - 00:00"
+stage = "Warehouse"
+tagline = "The Minimalist"
+origin = "Bucharest"
+genre = "Minimal Techno"
+bpm = "128 - 134"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(200,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -25,200 25,200 2,12" fill="#FFB300" opacity="0.05"/></g><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -25,200 25,200 2,12" fill="#FFB300" opacity="0.05"/></g><g transform="translate(400,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -25,200 25,200 2,12" fill="#FFB300" opacity="0.05"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Approach
+
+CHROMATIC opens the Warehouse at 22:00 with a set built on the principles of minimal techno as practiced in Bucharest and Berlin: tight percussion, carefully sculpted low-end, and a restrained use of melodic elements that makes each appearance of a tonal sound feel like a significant event. The tempo begins at 128 bpm and climbs to 134 over two hours, preparing the room for BLACK SIGNAL's harder programme at midnight.
+
+The mixing style is long and precise. Transitions run over four to eight minutes, with elements from two or three tracks layered simultaneously. The effect is of a single, evolving piece of music rather than a sequence of discrete tracks.
+
+{{ alert(type="info", body="CHROMATIC uses a four-channel mixing approach. A Pioneer DJM-V10 mixer provides the routing flexibility required for the layered transitions that characterise this set.") }}
+
+## Background
+
+CHROMATIC is Andrei Vasile, one of the architects of the contemporary Romanian minimal sound. His productions on [a:rpia:r], Arpiar Recordings, and his own Chroma imprint have defined a sub-genre characterised by micro-rhythmic complexity and an almost architectural sense of structure.
+
+Vasile began his career in the clubs of Bucharest in 2014 and has since become one of the most in-demand DJs in the European minimal circuit. His residency at Club Control in Bucharest, running since 2017, has produced some of the most celebrated sets in the genre's recent history.
+
+## What to Listen For
+
+Pay attention to the percussion. CHROMATIC's sets are percussion-forward, with complex hi-hat patterns, metallic textures, and rhythmic elements that shift and evolve on cycles of sixteen, thirty-two, and sixty-four bars. The bass is present but never dominant, sitting beneath the percussion as a foundation rather than a feature.
+
+The set rewards close listening. Every element you hear has been placed there with deliberate intent, and the spaces between elements are as important as the sounds themselves. This is not background music. It is a masterclass in economy of means.

--- a/main-act/content/lineup/drift-protocol.md
+++ b/main-act/content/lineup/drift-protocol.md
@@ -1,0 +1,39 @@
++++
+title = "DRIFT PROTOCOL"
+description = "Ambient techno that dissolves the boundary between listening and dancing. Textural, immersive, and designed to alter your perception of time."
+date = "2026-04-10"
+template = "performer"
+weight = 6
+tags = ["ambient", "techno", "atmospheric"]
+[taxonomies]
+stage = ["Warehouse"]
+[extra]
+slot = "20:00 - 22:00"
+stage = "Warehouse"
+tagline = "The Drifter"
+origin = "Reykjavik"
+genre = "Ambient Techno"
+bpm = "118 - 126"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(200,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300" opacity="0.6"/><polygon points="-2,12 -80,200 80,200 2,12" fill="#FFB300" opacity="0.03"/></g><g transform="translate(400,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300" opacity="0.6"/><polygon points="-2,12 -80,200 80,200 2,12" fill="#FFB300" opacity="0.03"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Opening
+
+DRIFT PROTOCOL opens the Warehouse at 20:00 with a set designed to establish the atmosphere for the rest of the night in that space. The Warehouse is a stripped-back, concrete room, and DRIFT PROTOCOL's ambient techno is the ideal sound for introducing its character. The set begins without a kick drum, floating on pads and textural elements for the first fifteen minutes before a rhythm emerges slowly from beneath the surface.
+
+By the one-hour mark, the set has developed into full ambient techno at around 122 bpm, but the beat never dominates the texture. The drums sit within the sound rather than on top of it, creating a listening experience that is simultaneously danceable and meditative.
+
+{{ alert(type="info", body="The Warehouse lighting during DRIFT PROTOCOL is set to a single warm amber wash. No strobes, no movement. The intention is total immersion.") }}
+
+## The Artist
+
+DRIFT PROTOCOL is the live project of Sigrun Helgadottir, a Reykjavik-based composer and producer whose work spans ambient music, modern classical composition, and the more atmospheric end of electronic dance music. She has released four albums on Erased Tapes Records, each exploring the relationship between natural field recordings and synthesised sound.
+
+Her approach to live performance is architectural. She constructs environments rather than sets, building layered soundscapes from pre-recorded stems, live processing, and hardware synthesisers. The audience is not so much watching a performance as inhabiting a space that DRIFT PROTOCOL has created.
+
+## Sound and Texture
+
+The palette is sparse and deliberate. Long reverb tails blur the distinction between individual sounds. Field recordings from Icelandic landscapes, captured by Sigrun over more than a decade, appear throughout the set as textural anchors. A low-frequency drone underpins everything, providing a foundation that you feel more than hear.
+
+If you arrive early and enter the Warehouse at 20:00, give it twenty minutes. The set does not announce itself. It arrives slowly, and by the time you realise you are inside it, you have already been there for some time.

--- a/main-act/content/lineup/echo-chamber.md
+++ b/main-act/content/lineup/echo-chamber.md
@@ -1,0 +1,39 @@
++++
+title = "ECHO CHAMBER"
+description = "Dub techno in its purest form. Infinite delay lines, submerged chords, and the sensation of listening to sound arrive from a great distance."
+date = "2026-04-10"
+template = "performer"
+weight = 8
+tags = ["dub-techno", "deep", "atmospheric"]
+[taxonomies]
+stage = ["The Basement"]
+[extra]
+slot = "23:00 - 01:00"
+stage = "The Basement"
+tagline = "The Echo"
+origin = "Tokyo"
+genre = "Dub Techno"
+bpm = "120 - 128"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(200,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300" opacity="0.5"/><polygon points="-2,12 -70,200 70,200 2,12" fill="#FFB300" opacity="0.03"/></g><g transform="translate(400,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300" opacity="0.5"/><polygon points="-2,12 -70,200 70,200 2,12" fill="#FFB300" opacity="0.03"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Set
+
+ECHO CHAMBER occupies the middle slot in The Basement, running from 23:00 to 01:00. The set is positioned between PHASE SHIFT's breakbeat energy and STATIC FIELD's hardcore onslaught, and serves as a deep, hypnotic counterpoint to both. Dub techno at 120 to 128 bpm, built on cascading delay lines, submerged chord progressions, and a sense of space that seems impossible in a room with a two-metre ceiling.
+
+The mixing is seamless. Transitions between tracks are so gradual that it becomes impossible to tell where one piece ends and another begins. The set functions as a continuous stream of sound, evolving slowly over two hours.
+
+{{ alert(type="info", body="ECHO CHAMBER performs with an external hardware delay chain. Three Strymon Timeline units process the mixer output in series, creating the cascading echo textures that define the sound.") }}
+
+## The Producer
+
+ECHO CHAMBER is the alias of Haruki Tanaka, a Tokyo-based producer who has been releasing dub techno under various names since 2012. His work on Chain Reaction's successor labels, as well as his own Echo Series imprint, has established him as one of the leading practitioners of a genre that demands both patience and precision.
+
+Tanaka's productions are built around delay. Every element passes through multiple stages of echo and reverb before reaching the final mix, creating a sound that is perpetually receding into the distance. The kick drum arrives and immediately begins to dissolve. The chords appear and smear into fog. The result is music that occupies a space between presence and absence.
+
+## Listening Notes
+
+The Basement during ECHO CHAMBER is a particular experience. The low ceiling and concrete walls create natural reflections that interact with the delay processing in unpredictable ways. Tanaka has visited the venue in advance and adjusted his delay times to complement rather than fight the room acoustics.
+
+Stand near the back wall for the most pronounced echo effect. Stand near the front if you prefer the direct sound. Either position is valid; they are simply different ways of experiencing the same set. This is music that changes depending on where you are standing, and that is entirely by design.

--- a/main-act/content/lineup/neon-archive.md
+++ b/main-act/content/lineup/neon-archive.md
@@ -1,0 +1,39 @@
++++
+title = "NEON ARCHIVE"
+description = "Synthwave and electro pulled from the deep catalogue. Analogue machines, tape echo, and the sound of a future that never quite arrived."
+date = "2026-04-10"
+template = "performer"
+weight = 3
+tags = ["synthwave", "electro", "retro"]
+[taxonomies]
+stage = ["Main Stage"]
+[extra]
+slot = "19:00 - 21:00"
+stage = "Main Stage"
+tagline = "The Archivist"
+origin = "Detroit"
+genre = "Synthwave / Electro"
+bpm = "110 - 124"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(150,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="0,12 -70,200 -10,200" fill="#FFB300" opacity="0.04"/></g><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -45,200 45,200 2,12" fill="#FF1744" opacity="0.05"/></g><g transform="translate(450,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="0,12 10,200 70,200" fill="#FFB300" opacity="0.04"/></g><rect x="60" y="180" width="480" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Programme
+
+NEON ARCHIVE takes the Main Stage at 19:00 for a two-hour set that bridges the opening downtempo programme and the progressive house of PULSE THEORY. The set draws heavily from the synthwave and electro catalogues of the early 1980s through the present day, recontextualised for a live audience through hardware performance and careful selection.
+
+The first hour tends toward the slower end of the spectrum, around 110 bpm, with arpeggiated sequences and cinematic pad textures that evoke a sense of arrival. The second hour shifts into harder electro territory, pushing toward 124 bpm by the handoff to PULSE THEORY at 21:00.
+
+{{ alert(type="info", body="NEON ARCHIVE performs entirely on vintage hardware. The stage setup includes a Roland Jupiter-8, a Sequential Circuits Prophet-5, and a pair of Roland TR-808 drum machines synchronised via MIDI.") }}
+
+## The Collector
+
+NEON ARCHIVE is the live project of Damon Cross, a Detroit-based collector and producer who has spent the better part of two decades amassing one of the largest private collections of analogue synthesizer recordings in North America. His performances draw from this archive, pulling unreleased tracks, rare studio recordings, and forgotten demos alongside his own productions.
+
+Cross is a self-described preservationist. His label, Archive Tapes, releases limited-edition cassette compilations of material sourced from estate sales, studio closures, and private collections. The label has documented over three hundred previously unreleased recordings since 2017.
+
+## What You Will Hear
+
+The sound is unmistakably analogue. Warm oscillators, tape-saturated drums, and the particular character of circuits that were designed before digital precision became the standard. If you have ever wondered what it would sound like if John Carpenter scored a rave, NEON ARCHIVE is your answer.
+
+The set will include at least three tracks that have never been played in public before. Cross does not announce which ones. Part of the appeal is not knowing what is archive and what is new.

--- a/main-act/content/lineup/phase-shift.md
+++ b/main-act/content/lineup/phase-shift.md
@@ -1,0 +1,39 @@
++++
+title = "PHASE SHIFT"
+description = "Breakbeat and jungle pulled forward into the present. Chopped breaks, rolling bass, and the kinetic energy of a genre built for movement."
+date = "2026-04-10"
+template = "performer"
+weight = 9
+tags = ["breakbeat", "jungle", "bass"]
+[taxonomies]
+stage = ["The Basement"]
+[extra]
+slot = "21:00 - 23:00"
+stage = "The Basement"
+tagline = "The Break"
+origin = "Bristol"
+genre = "Breakbeat / Jungle"
+bpm = "140 - 170"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(150,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -35,200 35,200 2,12" fill="#FF1744" opacity="0.06"/></g><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -30,200 30,200 2,12" fill="#FFB300" opacity="0.06"/></g><g transform="translate(450,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -35,200 35,200 2,12" fill="#FF1744" opacity="0.06"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Basement Opens
+
+PHASE SHIFT opens The Basement at 21:00 with a set that spans the full range of breakbeat and jungle, from classic Amen Break chops to contemporary bass music that uses breakbeat structures at modern production standards. The tempo range is wide, 140 to 170 bpm, reflecting a genre that has always been more interested in energy than metronome precision.
+
+The first hour focuses on the lower end of the tempo range, with half-time breaks, rolling sub-bass, and the kind of syncopated rhythms that make breakbeat fundamentally different from four-to-the-floor techno. The second hour accelerates into full jungle territory, with chopped and timestretched breaks layered over deep, rumbling bass lines.
+
+{{ alert(type="info", body="PHASE SHIFT uses a hybrid DJ/production setup. Two turntables for vinyl playback are augmented by an MPC Live for live sampling and break manipulation during the set.") }}
+
+## The Selector
+
+PHASE SHIFT is Kezia Drummond, a Bristol-based DJ, producer, and sound system operator who has been active in the UK breakbeat and jungle scenes since 2015. Her connection to the Bristol sound tradition is direct: she grew up attending events run by the city's legendary sound systems and began playing vinyl at fourteen.
+
+Her productions bridge the gap between the raw energy of early nineties jungle and the production sophistication of contemporary bass music. She has released on Metalheadz, Rupture, and her own Shift Recordings imprint, and her radio show on Noods Radio has been a weekly fixture of the Bristol electronic music calendar since 2019.
+
+## What to Expect
+
+The Basement during PHASE SHIFT is the most kinetic room in the venue. Breakbeats demand movement in a way that four-to-the-floor rhythms do not; the syncopation pulls your body in multiple directions simultaneously, and the bass weight in The Basement's compact space adds a physical dimension that you cannot replicate through headphones.
+
+Expect classic breaks alongside modern productions. Expect the Amen to appear in at least six different configurations over the course of two hours. Expect bass that you feel in your teeth. And expect the energy level to be at its peak by the time ECHO CHAMBER takes over at 23:00 and changes the mood entirely.

--- a/main-act/content/lineup/pulse-theory.md
+++ b/main-act/content/lineup/pulse-theory.md
@@ -1,0 +1,39 @@
++++
+title = "PULSE THEORY"
+description = "Progressive house built on long melodic arcs, patient builds, and an emotional payoff that justifies every minute of the journey."
+date = "2026-04-10"
+template = "performer"
+weight = 2
+tags = ["progressive-house", "melodic", "main-stage"]
+[taxonomies]
+stage = ["Main Stage"]
+[extra]
+slot = "21:00 - 23:00"
+stage = "Main Stage"
+tagline = "The Builder"
+origin = "Buenos Aires"
+genre = "Progressive House"
+bpm = "122 - 128"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(180,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -60,200 60,200 2,12" fill="#FFB300" opacity="0.05"/></g><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -55,200 55,200 2,12" fill="#FFB300" opacity="0.06"/></g><g transform="translate(420,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300"/><polygon points="-2,12 -60,200 60,200 2,12" fill="#FFB300" opacity="0.05"/></g><rect x="60" y="180" width="480" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Set
+
+PULSE THEORY occupies the two-hour slot immediately before the headline act, a position that demands careful construction. The set begins at a moderate 122 bpm with deep, rolling basslines and sparse melodic elements. Over the course of two hours, the tempo increases gradually to 128 bpm while the harmonic complexity builds layer by layer.
+
+The final thirty minutes of the PULSE THEORY set are designed to bring the room to a state of heightened anticipation. The melodies become more urgent, the builds longer and more dramatic, and the drops more expansive. By the time the set ends at 23:00, the room should be ready for VORTEX to take it apart.
+
+{{ alert(type="info", body="PULSE THEORY performs with a live keyboard rig on stage. A Moog One and a Dave Smith Prophet Rev2 provide the melodic layers over pre-programmed rhythmic foundations.") }}
+
+## Background
+
+PULSE THEORY is Matias Correa, a Buenos Aires producer who emerged from the Argentine progressive scene in 2019. His productions draw on the long tradition of South American progressive house: patient, hypnotic, and unafraid of silence. His debut album, released on Hernan Cattaneo's Sudbeat label in 2022, established him as one of the most promising melodic producers in the genre.
+
+He has since released on Balance Music, microCastle, and his own Theory Recordings imprint. His DJ sets run long by design, typically four to six hours, though at MAIN ACT the two-hour format demands a more compressed narrative arc.
+
+## Sound Profile
+
+Expect long melodic phrases that develop over eight to sixteen bars before resolving. The low end is warm and round rather than aggressive, designed to move bodies rather than punish them. Pad textures are drawn from analogue synthesizers and processed through tape saturation for a sound that feels organic despite its electronic origins.
+
+The set will not be aggressive. It will not be fast. It will, however, be relentlessly beautiful, and by the ninety-minute mark you will understand exactly why Matias was chosen for this slot.

--- a/main-act/content/lineup/static-field.md
+++ b/main-act/content/lineup/static-field.md
@@ -1,0 +1,39 @@
++++
+title = "STATIC FIELD"
+description = "Hardcore and gabber at terminal velocity. The final set of the night in The Basement, and the most physically demanding two hours on the programme."
+date = "2026-04-10"
+template = "performer"
+weight = 7
+tags = ["hardcore", "gabber", "extreme"]
+[taxonomies]
+stage = ["The Basement"]
+[extra]
+slot = "01:00 - 03:00"
+stage = "The Basement"
+tagline = "The Closer"
+origin = "Amsterdam"
+genre = "Hardcore / Gabber"
+bpm = "160 - 180"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(150,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -20,200 20,200 2,12" fill="#FF1744" opacity="0.08"/></g><g transform="translate(250,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -20,200 20,200 2,12" fill="#FF1744" opacity="0.08"/></g><g transform="translate(350,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -20,200 20,200 2,12" fill="#FF1744" opacity="0.08"/></g><g transform="translate(450,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -20,200 20,200 2,12" fill="#FF1744" opacity="0.08"/></g><rect x="80" y="180" width="440" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Final Set
+
+STATIC FIELD closes The Basement and the entire MAIN ACT event with two hours of hardcore and gabber that begins at 160 bpm and ends at 180. This is the last sound you will hear at the festival, and it is designed to be memorable. The set runs from 01:00 to 03:00, at which point the power is cut and the event is over.
+
+The Basement is the smallest venue on the site, capacity three hundred, with a low ceiling that amplifies the physical impact of the sound system. At the tempos STATIC FIELD operates at, the kick drum becomes less a rhythmic element and more a continuous pressure wave. The room shakes. The walls sweat. The floor vibrates.
+
+{{ alert(type="warning", body="Hearing protection is mandatory for The Basement during this set. Staff will distribute free earplugs at the loading ramp entrance. SPL levels will exceed 105 dBA.") }}
+
+## The Performer
+
+STATIC FIELD is Joost van der Berg, an Amsterdam native who has been a fixture of the Dutch hardcore scene since he was seventeen years old. Now twenty-nine, he runs the FIELD label, a cassette-only imprint dedicated to experimental hardcore and gabber that has released thirty-six tapes since 2020.
+
+His DJ sets are played from vinyl exclusively, using a pair of Technics 1210 turntables and a simple two-channel mixer. The record bag for a STATIC FIELD set contains between eighty and one hundred records, all pressed on 12-inch vinyl, many of them white-label test pressings or one-off cuts from his own studio.
+
+## What to Expect
+
+Expect speed, weight, and relentlessness. STATIC FIELD's sets do not have light moments. There are no breakdowns that last longer than four bars. The tempo does not drop once it has been established. If you are in The Basement at 01:00, you have made a choice, and that choice is to be punished by sound for two hours.
+
+The set will include several unreleased productions from the forthcoming FIELD compilation, alongside classic gabber tracks from the Rotterdam and Amsterdam archives. Van der Berg's mixing is fast and tight, with cuts every sixty to ninety seconds and no smooth transitions. This is not subtle. It is not meant to be.

--- a/main-act/content/lineup/vortex.md
+++ b/main-act/content/lineup/vortex.md
@@ -1,0 +1,39 @@
++++
+title = "VORTEX"
+description = "The headline act. Industrial techno at its most punishing. Two hours of relentless pressure from the architect of the MAIN ACT series."
+date = "2026-04-10"
+template = "performer"
+weight = 1
+tags = ["techno", "industrial", "headline"]
+[taxonomies]
+stage = ["Main Stage"]
+[extra]
+slot = "23:00 - 01:00"
+stage = "Main Stage"
+tagline = "The Headline Act"
+origin = "Berlin"
+genre = "Techno / Industrial"
+bpm = "140 - 152"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="60" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="60" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="540" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="540" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(150,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -50,200 50,200 2,12" fill="#FF1744" opacity="0.06"/></g><g transform="translate(250,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -40,200 40,200 2,12" fill="#FF1744" opacity="0.08"/></g><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFFFFF"/><polygon points="-2,12 -35,200 35,200 2,12" fill="#FFFFFF" opacity="0.06"/></g><g transform="translate(350,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -40,200 40,200 2,12" fill="#FF1744" opacity="0.08"/></g><g transform="translate(450,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FF1744"/><polygon points="-2,12 -50,200 50,200 2,12" fill="#FF1744" opacity="0.06"/></g><rect x="60" y="180" width="480" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Headline
+
+VORTEX closes the Main Stage with the most anticipated set of the night. The two-hour headline slot begins at 23:00 and runs without pause or interruption until 01:00. The set is designed as a single continuous arc: the opening twenty minutes establish a foundation at 140 bpm before the tempo and intensity begin their steady climb toward a sustained peak that occupies the final forty-five minutes of the performance.
+
+The production brief for the headline set calls for the full lighting rig to be active, all forty-eight moving-head fixtures tracking in synchronised patterns, and the stage haze pushed to maximum density. The sound system operates at full capacity for the duration. There is no support, no warm-up; VORTEX takes a cold stage at precisely 23:00.
+
+{{ alert(type="warning", body="The headline set operates at sustained SPL levels above 100 dBA. Hearing protection is strongly recommended and available free at the venue entrance.") }}
+
+## The Artist
+
+VORTEX is the production alias of Kara Drexler, a Berlin-based producer and sound designer who has been a defining figure in European industrial techno since 2016. Her productions are characterised by distorted kick drums, granular synthesis textures, and a relentless forward momentum that rarely drops below 140 bpm.
+
+She runs the VRTX label, which has released over forty records since its founding in 2018, and operates a mastering studio in Kreuzberg that services labels across the industrial and hard techno spectrum. Her live performances are played from a hardware rig consisting of two Elektron Analog Rytm units, a Moog Subharmonicon, and a custom-built modular effects chain.
+
+## What to Expect
+
+The headline set at MAIN ACT is an exclusively live performance. There are no pre-recorded stems, no backing tracks, and no safety net. Every sound that comes through the system is generated and manipulated in real time on stage. The set list does not exist before the performance begins; VORTEX builds the set in response to the room.
+
+Expect industrial-weight kick drums, screaming analogue leads, and a wall of sound that makes conversation impossible from the third row onward. The tempo will peak at approximately 152 bpm around 00:30 and hold that level through to the final breakdown at 00:50. The last ten minutes are a controlled demolition.

--- a/main-act/content/lineup/zero-point.md
+++ b/main-act/content/lineup/zero-point.md
@@ -1,0 +1,39 @@
++++
+title = "ZERO POINT"
+description = "The opening set. Downtempo and ambient textures that ease the audience into the evening and establish the sonic character of the Main Stage."
+date = "2026-04-10"
+template = "performer"
+weight = 10
+tags = ["downtempo", "ambient", "opening"]
+[taxonomies]
+stage = ["Main Stage"]
+[extra]
+slot = "17:00 - 19:00"
+stage = "Main Stage"
+tagline = "The Opening"
+origin = "Copenhagen"
+genre = "Downtempo / Opening"
+bpm = "90 - 110"
+set_length = "120 min"
+light_svg = """<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="10" x2="600" y2="10" stroke="#333333" stroke-width="2"/><line x1="0" y1="30" x2="600" y2="30" stroke="#333333" stroke-width="2"/><line x1="0" y1="10" x2="30" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="30" y1="10" x2="0" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="570" y1="10" x2="600" y2="30" stroke="#222222" stroke-width="0.6"/><line x1="600" y1="10" x2="570" y2="30" stroke="#222222" stroke-width="0.6"/><g transform="translate(300,30)"><rect x="-5" y="0" width="10" height="5" fill="#444444"/><circle cx="0" cy="9" r="4" fill="#1A1A1A" stroke="#555555" stroke-width="0.8"/><circle cx="0" cy="9" r="2" fill="#FFB300" opacity="0.4"/><polygon points="-2,12 -90,200 90,200 2,12" fill="#FFB300" opacity="0.02"/></g><rect x="60" y="180" width="480" height="6" fill="#1A1A1A"/></svg>"""
++++
+
+## The Beginning
+
+ZERO POINT opens the Main Stage at 17:00, the first sound the audience hears when doors open. The set runs for two hours at tempos between 90 and 110 bpm, establishing the sonic territory of the evening without imposing upon it. The audience is arriving, finding their bearings, meeting friends, and exploring the venue; the music must accommodate all of this while still being worth listening to on its own terms.
+
+The opening thirty minutes are essentially ambient, with soft pad textures and processed field recordings creating an atmosphere of quiet anticipation. A beat enters around the forty-minute mark, gentle and unhurried, and from there the set builds patiently toward the 110 bpm handoff to NEON ARCHIVE at 19:00.
+
+{{ alert(type="info", body="The Main Stage lighting during ZERO POINT is limited to a single warm wash across the stage. The full moving-head rig activates from 19:00 onward.") }}
+
+## The Artist
+
+ZERO POINT is Astrid Lindholm, a Copenhagen-based ambient producer and sound designer whose work has appeared on Kompakt's Pop Ambient series, Mille Plateaux, and her own Zero Series imprint. She has scored two feature films and a television series, and her installation work has been exhibited at the Louisiana Museum of Modern Art and the Barbican Centre.
+
+Her approach to opening sets is informed by her installation practice. She thinks of the opening as a spatial composition rather than a performance, designing the sound to complement the architecture and atmosphere of the venue rather than to command attention.
+
+## Sound Design
+
+The palette for the ZERO POINT set is drawn from a custom library of processed recordings. Piano notes run through granular synthesis until they become clouds of harmonic partials. String recordings from the Copenhagen Philharmonic, licensed for this project, are slowed and stretched to create evolving drone textures. Percussion, when it appears, is soft and organic: brushed cymbals, muted kicks, and hand drums processed through long reverb chains.
+
+This is the gentlest set of the evening. It is also, for those who arrive early and listen carefully, one of the most rewarding. The craft required to hold a room's attention at 90 bpm with no drop and no hook is considerable, and Astrid Lindholm is one of the finest practitioners in the field.

--- a/main-act/content/tickets.md
+++ b/main-act/content/tickets.md
@@ -1,0 +1,74 @@
++++
+title = "Tickets"
+description = "Advance tickets for MAIN ACT at the Ironworks Arena, Saturday 10 October 2026. Three tiers, three stages, one night."
+template = "page"
++++
+
+<div class="page-content">
+
+## Get Your Tickets
+
+MAIN ACT takes place on **Saturday 10 October 2026** at the **Ironworks Arena, Hangar 9**. Doors open at 16:00. The event runs until 03:00.
+
+Advance ticket sales close at **midnight on Friday 9 October**. A limited number of door tickets may be available on the night at an increased price, subject to capacity. Advance purchase is strongly recommended.
+
+<div class="ticket-grid">
+  <div class="ticket-tier">
+    <div class="tier-name">Early Bird</div>
+    <div class="tier-price">35</div>
+    <div class="tier-desc">Limited allocation at the lowest price. Available until sold out.</div>
+    <ul>
+      <li>Access to all three stages</li>
+      <li>Doors at 16:00</li>
+      <li>Free hearing protection</li>
+      <li>Subject to availability</li>
+    </ul>
+  </div>
+  <div class="ticket-tier">
+    <div class="tier-name">Standard</div>
+    <div class="tier-price">50</div>
+    <div class="tier-desc">General admission to the full event. The standard ticket for the night.</div>
+    <ul>
+      <li>Access to all three stages</li>
+      <li>Doors at 16:00</li>
+      <li>Free hearing protection</li>
+      <li>Cloakroom included</li>
+    </ul>
+  </div>
+  <div class="ticket-tier">
+    <div class="tier-name">Premium</div>
+    <div class="tier-price">85</div>
+    <div class="tier-desc">Priority entry, dedicated bar access, and a viewing platform at the Main Stage.</div>
+    <ul>
+      <li>Access to all three stages</li>
+      <li>Priority entry (no queue)</li>
+      <li>Premium bar access</li>
+      <li>Main Stage viewing platform</li>
+      <li>Cloakroom included</li>
+    </ul>
+  </div>
+</div>
+
+## Important Information
+
+- All tickets are **non-refundable** after purchase. Transfers are permitted up to 48 hours before the event.
+- This is an **18+ event**. You must bring valid photo ID. No ID, no entry, no exceptions.
+- **No re-entry** after midnight. Once you leave the venue after midnight, your ticket is void.
+- Tickets are delivered electronically. Present the QR code on your phone or a printed copy at the door.
+- Group bookings of ten or more should contact **tickets@mainact-event.com** for allocation.
+
+## On the Door
+
+A limited number of **door tickets** may be available at **65** on the night, subject to venue capacity. Door sales open at 16:00 and close when capacity is reached. Cash is not accepted; contactless payment only.
+
+## The Programme
+
+Your ticket grants access to all three stages for the full duration of the event:
+
+- **Main Stage** (Hangar 9): ZERO POINT, NEON ARCHIVE, PULSE THEORY, VORTEX
+- **Warehouse** (East Loading Bay): DRIFT PROTOCOL, CHROMATIC, BLACK SIGNAL
+- **The Basement** (Below Hangar 9): PHASE SHIFT, ECHO CHAMBER, STATIC FIELD
+
+View the full [lineup](/lineup/) for set times, performer profiles, and technical details.
+
+</div>

--- a/main-act/static/css/style.css
+++ b/main-act/static/css/style.css
@@ -1,0 +1,958 @@
+/* =============================================================================
+   MAIN ACT - Headline Performer
+   A dramatic dark concert theme with stage truss framing and moving-head lights.
+   Oswald Heavy at massive vw-based sizes. Karla Bold for support text.
+   No emojis. No gradients. Pure stage black.
+   ============================================================================= */
+
+/* --- Reset & Base --- */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: 'Karla', sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #E0E0E0;
+  background: #000000;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+img, svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: #FF1744;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: #FFB300;
+}
+
+/* --- Typography --- */
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  line-height: 1.05;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin-top: 1.8em;
+  margin-bottom: 0.4em;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 6vw, 5rem);
+}
+
+h2 {
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  font-weight: 700;
+}
+
+h3 {
+  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-weight: 700;
+}
+
+h4 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+p {
+  margin: 1em 0;
+}
+
+strong {
+  font-weight: 700;
+  color: #FFFFFF;
+}
+
+em {
+  font-style: italic;
+}
+
+blockquote {
+  border-left: 4px solid #FF1744;
+  padding: 0.8rem 1.2rem;
+  margin: 1.5rem 0;
+  color: #B0B0B0;
+  font-style: italic;
+}
+
+blockquote p {
+  margin: 0.4em 0;
+}
+
+code {
+  font-family: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.88em;
+  background: #1A1A1A;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  color: #FFB300;
+}
+
+pre {
+  background: #0A0A0A;
+  border: 1px solid #222222;
+  border-radius: 4px;
+  padding: 1.2rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  color: #E0E0E0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid #222222;
+  margin: 2.5rem 0;
+}
+
+ul, ol {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+li {
+  margin-bottom: 0.3rem;
+}
+
+dl {
+  margin: 1rem 0;
+}
+
+dt {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #888888;
+  margin-top: 1rem;
+}
+
+dd {
+  font-family: 'Karla', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #FFFFFF;
+  margin-left: 0;
+  margin-top: 0.15rem;
+}
+
+/* --- Layout: Stage Frame --- */
+
+.stage-frame {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* --- Header --- */
+
+.stage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  border-bottom: 2px solid #222222;
+  position: relative;
+}
+
+.stage-brand {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.brand-text {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: 1.5rem;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.brand-text:hover {
+  color: #FF1744;
+}
+
+.stage-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.stage-nav a {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #888888;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.stage-nav a:hover {
+  color: #FFFFFF;
+}
+
+.stage-nav .nav-cta {
+  color: #000000;
+  background: #FF1744;
+  padding: 0.35rem 1rem;
+  border-radius: 2px;
+  font-weight: 900;
+}
+
+.stage-nav .nav-cta:hover {
+  background: #FFB300;
+  color: #000000;
+}
+
+/* --- Truss Frame (SVG decorative border) --- */
+
+.truss-frame {
+  width: 100%;
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+.truss-frame svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* --- Light Rig --- */
+
+.light-rig {
+  width: 100%;
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+.light-rig svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* --- Main Content --- */
+
+.stage-main {
+  flex: 1;
+  padding: 2rem 0;
+}
+
+.stage-main > h1:first-child,
+.stage-main > h2:first-child {
+  margin-top: 0;
+}
+
+/* --- Hero Headline --- */
+
+.hero-headline {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: clamp(60px, 15vw, 250px);
+  line-height: 0.9;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  margin: 0;
+  padding: 0.2em 0;
+  text-align: center;
+}
+
+.hero-sub {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1rem, 2.5vw, 2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: #FF1744;
+  text-align: center;
+  margin: 0 0 1rem 0;
+}
+
+.hero-section {
+  text-align: center;
+  padding: 2rem 0 3rem 0;
+}
+
+.hero-section .kicker {
+  margin-bottom: 0.5rem;
+}
+
+.hero-date-strip {
+  display: flex;
+  justify-content: center;
+  gap: 3rem;
+  margin: 2rem 0;
+  flex-wrap: wrap;
+}
+
+.hero-date-strip .date-block {
+  text-align: center;
+}
+
+.date-label {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #888888;
+  display: block;
+}
+
+.date-value {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: clamp(1.4rem, 3vw, 2.2rem);
+  color: #FFFFFF;
+  display: block;
+  margin-top: 0.15rem;
+}
+
+.hero-lede {
+  max-width: 700px;
+  margin: 2rem auto;
+  font-size: 1.1rem;
+  color: #B0B0B0;
+  text-align: center;
+  line-height: 1.8;
+}
+
+/* --- Kicker --- */
+
+.kicker {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: #FF1744;
+  margin-bottom: 0.5rem;
+}
+
+/* --- Support Acts --- */
+
+.support-acts {
+  font-family: 'Karla', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  color: #E0E0E0;
+  margin: 2rem 0;
+}
+
+.support-acts h2 {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.2rem, 2vw, 1.6rem);
+  color: #FFB300;
+  margin-bottom: 1rem;
+}
+
+.support-acts ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.support-acts li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #1A1A1A;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.support-acts li:last-child {
+  border-bottom: none;
+}
+
+.support-acts .act-name {
+  color: #FFFFFF;
+  font-weight: 700;
+}
+
+.support-acts .act-time {
+  font-size: 0.85rem;
+  color: #888888;
+}
+
+/* --- Stats Strip --- */
+
+.stats-strip {
+  list-style: none;
+  padding: 0;
+  margin: 2.5rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 3rem;
+  flex-wrap: wrap;
+  border-top: 1px solid #222222;
+  border-bottom: 1px solid #222222;
+  padding: 1.5rem 0;
+}
+
+.stats-strip li {
+  text-align: center;
+}
+
+.stat-num {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  color: #FFFFFF;
+  display: block;
+  line-height: 1;
+}
+
+.stat-label {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #888888;
+  display: block;
+  margin-top: 0.3rem;
+}
+
+/* --- Section Head --- */
+
+.section-head {
+  margin-bottom: 2rem;
+}
+
+.section-head .kicker {
+  margin-bottom: 0.3rem;
+}
+
+.section-head h1 {
+  margin-top: 0;
+  margin-bottom: 0.3rem;
+}
+
+.section-head p {
+  color: #B0B0B0;
+  max-width: 600px;
+}
+
+.section-intro {
+  margin-bottom: 2rem;
+  color: #B0B0B0;
+}
+
+/* --- Lineup Grid --- */
+
+.lineup-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1px;
+  background: #222222;
+  border: 1px solid #222222;
+  margin: 2rem 0;
+}
+
+/* --- Performer Card --- */
+
+.performer-card {
+  background: #0A0A0A;
+  padding: 1.5rem;
+  transition: background 0.2s ease;
+}
+
+.performer-card:hover {
+  background: #111111;
+}
+
+.performer-card a {
+  text-decoration: none;
+  display: block;
+}
+
+.performer-card .card-slot {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #888888;
+  margin-bottom: 0.3rem;
+}
+
+.performer-card .card-stage {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #FFB300;
+}
+
+.performer-card .card-name {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  color: #FFFFFF;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+  margin: 0.4rem 0 0.3rem 0;
+}
+
+.performer-card .card-tagline {
+  font-family: 'Karla', sans-serif;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: #888888;
+  margin-top: 0.2rem;
+}
+
+.performer-card .card-arrow {
+  display: inline-block;
+  margin-top: 0.8rem;
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #FF1744;
+}
+
+/* --- Performer Page --- */
+
+.performer-page {
+  max-width: 800px;
+}
+
+.performer-head {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px solid #222222;
+}
+
+.performer-head .kicker {
+  margin-bottom: 0.4rem;
+}
+
+.performer-head h1 {
+  font-size: clamp(3rem, 10vw, 8rem);
+  margin: 0;
+  line-height: 0.95;
+}
+
+.performer-head .performer-tagline {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #FF1744;
+  margin-top: 0.5rem;
+}
+
+/* --- Performer Specs --- */
+
+.performer-specs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.8rem 2rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid #222222;
+  margin-bottom: 2rem;
+}
+
+.performer-specs dt {
+  margin-top: 0;
+}
+
+.performer-specs dd {
+  margin-bottom: 0;
+}
+
+/* --- Performer Figure --- */
+
+.performer-figure {
+  margin: 2rem 0;
+  padding: 1rem 0;
+  border-top: 1px solid #1A1A1A;
+  border-bottom: 1px solid #1A1A1A;
+}
+
+.performer-figure svg {
+  display: block;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  height: auto;
+}
+
+/* --- Performer Prose --- */
+
+.performer-prose {
+  margin-top: 2rem;
+}
+
+.performer-prose h2 {
+  margin-top: 2rem;
+}
+
+.performer-prose p {
+  color: #E0E0E0;
+}
+
+/* --- Back Link --- */
+
+.back-link {
+  display: inline-block;
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #FF1744;
+  text-decoration: none;
+  margin-top: 2rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid #222222;
+}
+
+.back-link:hover {
+  color: #FFB300;
+}
+
+/* --- Alert Shortcode --- */
+
+.alert {
+  border: 1px solid #222222;
+  border-left: 4px solid #FF1744;
+  background: #0A0A0A;
+  padding: 1rem 1.2rem;
+  margin: 1.5rem 0;
+}
+
+.alert-head {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #FF1744;
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.alert-body {
+  font-family: 'Karla', sans-serif;
+  font-size: 0.95rem;
+  color: #B0B0B0;
+}
+
+.alert[data-kind="warning"] {
+  border-left-color: #FFB300;
+}
+
+.alert[data-kind="warning"] .alert-head {
+  color: #FFB300;
+}
+
+.alert[data-kind="info"] {
+  border-left-color: #448AFF;
+}
+
+.alert[data-kind="info"] .alert-head {
+  color: #448AFF;
+}
+
+.alert[data-kind="success"] {
+  border-left-color: #00E676;
+}
+
+.alert[data-kind="success"] .alert-head {
+  color: #00E676;
+}
+
+/* --- Error Page --- */
+
+.error-page {
+  text-align: center;
+  padding: 6rem 1rem;
+}
+
+.error-page h1 {
+  font-size: clamp(2rem, 6vw, 5rem);
+  margin-top: 0.5rem;
+}
+
+.error-page p {
+  color: #888888;
+  max-width: 500px;
+  margin: 1rem auto;
+}
+
+/* --- Footer --- */
+
+.stage-foot {
+  margin-top: 3rem;
+  border-top: 2px solid #222222;
+  padding: 2rem 0 1.5rem 0;
+}
+
+.foot-truss {
+  margin-bottom: 1.5rem;
+}
+
+.foot-truss svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.foot-col p {
+  font-size: 0.85rem;
+  margin: 0.2rem 0;
+  color: #666666;
+}
+
+.foot-head {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #888888;
+  margin-bottom: 0.5rem;
+}
+
+.foot-stamp {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #333333;
+  text-align: center;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #1A1A1A;
+}
+
+/* --- Stage Scene SVG --- */
+
+.stage-scene {
+  margin: 2rem 0;
+}
+
+.stage-scene svg {
+  display: block;
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  height: auto;
+}
+
+/* --- Page Content --- */
+
+.page-content {
+  max-width: 700px;
+}
+
+.page-content h1:first-child {
+  margin-top: 0;
+}
+
+/* --- CTA Button --- */
+
+.cta-btn {
+  display: inline-block;
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #000000;
+  background: #FF1744;
+  padding: 0.7rem 2rem;
+  border: none;
+  border-radius: 2px;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.cta-btn:hover {
+  background: #FFB300;
+  color: #000000;
+}
+
+/* --- Ticket Tiers --- */
+
+.ticket-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1px;
+  background: #222222;
+  border: 1px solid #222222;
+  margin: 2rem 0;
+}
+
+.ticket-tier {
+  background: #0A0A0A;
+  padding: 1.5rem;
+}
+
+.ticket-tier .tier-name {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 900;
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  color: #FFFFFF;
+  margin-bottom: 0.3rem;
+}
+
+.ticket-tier .tier-price {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 2rem;
+  color: #FF1744;
+  margin-bottom: 0.5rem;
+}
+
+.ticket-tier .tier-desc {
+  font-size: 0.9rem;
+  color: #888888;
+}
+
+.ticket-tier ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.8rem 0 0 0;
+}
+
+.ticket-tier li {
+  font-size: 0.85rem;
+  color: #B0B0B0;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #1A1A1A;
+}
+
+.ticket-tier li:last-child {
+  border-bottom: none;
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 900px) {
+  .lineup-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  .foot-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .hero-date-strip {
+    gap: 2rem;
+  }
+
+  .performer-specs {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .stage-header {
+    flex-direction: column;
+    gap: 0.8rem;
+    align-items: flex-start;
+  }
+
+  .stage-nav {
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .stage-frame {
+    padding: 0 1rem;
+  }
+
+  .hero-headline {
+    letter-spacing: -0.03em;
+  }
+
+  .lineup-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-date-strip {
+    gap: 1.5rem;
+  }
+
+  .performer-head h1 {
+    font-size: clamp(2.5rem, 12vw, 5rem);
+  }
+
+  .stats-strip {
+    gap: 1.5rem;
+  }
+
+  .ticket-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 400px) {
+  .hero-headline {
+    font-size: clamp(40px, 18vw, 200px);
+  }
+
+  .brand-text {
+    font-size: 1.2rem;
+  }
+}

--- a/main-act/templates/404.html
+++ b/main-act/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    <div class="error-page">
+      <p class="kicker">SIGNAL LOST</p>
+      <h1>404 - NO PERFORMER HERE</h1>
+      <p>The stage you are looking for is dark. The act has moved, or the set never existed. Head back to the main stage.</p>
+      <p><a href="{{ base_url }}/" class="back-link">&larr; BACK TO THE EVENT</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/main-act/templates/footer.html
+++ b/main-act/templates/footer.html
@@ -1,0 +1,56 @@
+    <footer class="stage-foot" role="contentinfo">
+      <div class="foot-truss" aria-hidden="true">
+        <svg viewBox="0 0 1200 24" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+          <line x1="0" y1="2" x2="1200" y2="2" stroke="#222222" stroke-width="1.5"/>
+          <line x1="0" y1="22" x2="1200" y2="22" stroke="#222222" stroke-width="1.5"/>
+          <line x1="0" y1="2" x2="40" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="40" y1="2" x2="0" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="40" y1="2" x2="80" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="80" y1="2" x2="40" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="80" y1="2" x2="120" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="120" y1="2" x2="80" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="120" y1="2" x2="160" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="160" y1="2" x2="120" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="160" y1="2" x2="200" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="200" y1="2" x2="160" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="200" y1="2" x2="240" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="240" y1="2" x2="200" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1000" y1="2" x2="1040" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1040" y1="2" x2="1000" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1040" y1="2" x2="1080" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1080" y1="2" x2="1040" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1080" y1="2" x2="1120" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1120" y1="2" x2="1080" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1120" y1="2" x2="1160" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1160" y1="2" x2="1120" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1160" y1="2" x2="1200" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+          <line x1="1200" y1="2" x2="1160" y2="22" stroke="#1A1A1A" stroke-width="0.6"/>
+        </svg>
+      </div>
+      <div class="foot-grid">
+        <div class="foot-col">
+          <p class="foot-head">The Event</p>
+          <p>Saturday 10 October 2026</p>
+          <p>Doors 16:00, Main Act 23:00</p>
+          <p>Sound off at 03:00</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">The Venue</p>
+          <p>Ironworks Arena, Hangar 9</p>
+          <p>Three stages, full production</p>
+          <p>Licensed bar, 18+ only</p>
+        </div>
+        <div class="foot-col">
+          <p class="foot-head">Promoted By</p>
+          <p>MAIN ACT Productions Ltd.</p>
+          <p>All rights reserved 2026</p>
+          <p>Built with Hwaro</p>
+        </div>
+      </div>
+      <p class="foot-stamp">MAIN ACT - THE HEADLINE PERFORMER TAKES THE STAGE - BUILT WITH HWARO</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/main-act/templates/header.html
+++ b/main-act/templates/header.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700;900&family=Karla:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="stage-frame">
+    <!-- Truss Top Bar -->
+    <div class="truss-frame" aria-hidden="true">
+      <svg viewBox="0 0 1200 40" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+        <!-- Top rail -->
+        <line x1="0" y1="4" x2="1200" y2="4" stroke="#333333" stroke-width="2"/>
+        <!-- Bottom rail -->
+        <line x1="0" y1="36" x2="1200" y2="36" stroke="#333333" stroke-width="2"/>
+        <!-- Vertical posts -->
+        <line x1="0" y1="4" x2="0" y2="36" stroke="#333333" stroke-width="2"/>
+        <line x1="60" y1="4" x2="60" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="120" y1="4" x2="120" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="180" y1="4" x2="180" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="240" y1="4" x2="240" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="300" y1="4" x2="300" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="360" y1="4" x2="360" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="420" y1="4" x2="420" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="480" y1="4" x2="480" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="540" y1="4" x2="540" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="600" y1="4" x2="600" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="660" y1="4" x2="660" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="720" y1="4" x2="720" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="780" y1="4" x2="780" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="840" y1="4" x2="840" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="900" y1="4" x2="900" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="960" y1="4" x2="960" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="1020" y1="4" x2="1020" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="1080" y1="4" x2="1080" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="1140" y1="4" x2="1140" y2="36" stroke="#333333" stroke-width="1"/>
+        <line x1="1200" y1="4" x2="1200" y2="36" stroke="#333333" stroke-width="2"/>
+        <!-- Cross-bracing (X patterns) -->
+        <line x1="0" y1="4" x2="60" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="60" y1="4" x2="0" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="60" y1="4" x2="120" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="120" y1="4" x2="60" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="120" y1="4" x2="180" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="180" y1="4" x2="120" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="180" y1="4" x2="240" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="240" y1="4" x2="180" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="240" y1="4" x2="300" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="300" y1="4" x2="240" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="300" y1="4" x2="360" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="360" y1="4" x2="300" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="360" y1="4" x2="420" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="420" y1="4" x2="360" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="420" y1="4" x2="480" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="480" y1="4" x2="420" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="480" y1="4" x2="540" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="540" y1="4" x2="480" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="540" y1="4" x2="600" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="600" y1="4" x2="540" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="600" y1="4" x2="660" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="660" y1="4" x2="600" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="660" y1="4" x2="720" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="720" y1="4" x2="660" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="720" y1="4" x2="780" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="780" y1="4" x2="720" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="780" y1="4" x2="840" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="840" y1="4" x2="780" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="840" y1="4" x2="900" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="900" y1="4" x2="840" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="900" y1="4" x2="960" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="960" y1="4" x2="900" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="960" y1="4" x2="1020" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1020" y1="4" x2="960" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1020" y1="4" x2="1080" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1080" y1="4" x2="1020" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1080" y1="4" x2="1140" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1140" y1="4" x2="1080" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1140" y1="4" x2="1200" y2="36" stroke="#222222" stroke-width="0.8"/>
+        <line x1="1200" y1="4" x2="1140" y2="36" stroke="#222222" stroke-width="0.8"/>
+      </svg>
+    </div>
+
+    <!-- Moving-Head Light Rig -->
+    <div class="light-rig" aria-hidden="true">
+      <svg viewBox="0 0 1200 80" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+        <!-- Light fixture 1 (left) -->
+        <g transform="translate(200, 0)">
+          <rect x="-8" y="0" width="16" height="6" fill="#333333" rx="1"/>
+          <rect x="-5" y="6" width="10" height="8" fill="#444444" rx="1"/>
+          <circle cx="0" cy="18" r="6" fill="#1A1A1A" stroke="#555555" stroke-width="1"/>
+          <circle cx="0" cy="18" r="3" fill="#FFB300" opacity="0.9"/>
+          <!-- Beam -->
+          <polygon points="-3,21 -40,80 40,80 3,21" fill="#FFB300" opacity="0.06"/>
+        </g>
+        <!-- Light fixture 2 (center-left) -->
+        <g transform="translate(450, 0)">
+          <rect x="-8" y="0" width="16" height="6" fill="#333333" rx="1"/>
+          <rect x="-5" y="6" width="10" height="8" fill="#444444" rx="1"/>
+          <circle cx="0" cy="18" r="6" fill="#1A1A1A" stroke="#555555" stroke-width="1"/>
+          <circle cx="0" cy="18" r="3" fill="#FF1744" opacity="0.9"/>
+          <!-- Beam -->
+          <polygon points="-3,21 -35,80 35,80 3,21" fill="#FF1744" opacity="0.06"/>
+        </g>
+        <!-- Light fixture 3 (center-right) -->
+        <g transform="translate(750, 0)">
+          <rect x="-8" y="0" width="16" height="6" fill="#333333" rx="1"/>
+          <rect x="-5" y="6" width="10" height="8" fill="#444444" rx="1"/>
+          <circle cx="0" cy="18" r="6" fill="#1A1A1A" stroke="#555555" stroke-width="1"/>
+          <circle cx="0" cy="18" r="3" fill="#FF1744" opacity="0.9"/>
+          <!-- Beam -->
+          <polygon points="-3,21 -35,80 35,80 3,21" fill="#FF1744" opacity="0.06"/>
+        </g>
+        <!-- Light fixture 4 (right) -->
+        <g transform="translate(1000, 0)">
+          <rect x="-8" y="0" width="16" height="6" fill="#333333" rx="1"/>
+          <rect x="-5" y="6" width="10" height="8" fill="#444444" rx="1"/>
+          <circle cx="0" cy="18" r="6" fill="#1A1A1A" stroke="#555555" stroke-width="1"/>
+          <circle cx="0" cy="18" r="3" fill="#FFB300" opacity="0.9"/>
+          <!-- Beam -->
+          <polygon points="-3,21 -40,80 40,80 3,21" fill="#FFB300" opacity="0.06"/>
+        </g>
+      </svg>
+    </div>
+
+    <header class="stage-header" role="banner">
+      <a href="{{ base_url }}/" class="stage-brand" aria-label="Main Act home">
+        <svg viewBox="0 0 180 30" xmlns="http://www.w3.org/2000/svg" class="brand-svg" width="180" height="30" aria-hidden="true">
+          <!-- Mini truss icon -->
+          <rect x="0" y="2" width="24" height="26" fill="none" stroke="#FF1744" stroke-width="1.5" rx="1"/>
+          <line x1="0" y1="2" x2="24" y2="28" stroke="#FF1744" stroke-width="0.8"/>
+          <line x1="24" y1="2" x2="0" y2="28" stroke="#FF1744" stroke-width="0.8"/>
+          <line x1="0" y1="15" x2="24" y2="15" stroke="#FF1744" stroke-width="0.8"/>
+          <!-- Brand name -->
+          <text x="32" y="13" font-family="Oswald, sans-serif" font-weight="900" font-size="12" fill="#FFFFFF" letter-spacing="3">MAIN</text>
+          <text x="32" y="26" font-family="Oswald, sans-serif" font-weight="900" font-size="12" fill="#FF1744" letter-spacing="3">ACT</text>
+        </svg>
+      </a>
+      <nav class="stage-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">The Event</a>
+        <a href="{{ base_url }}/lineup/">Lineup</a>
+        <a href="{{ base_url }}/info/">Info</a>
+        <a href="{{ base_url }}/tickets/" class="nav-cta">Tickets</a>
+      </nav>
+    </header>

--- a/main-act/templates/page.html
+++ b/main-act/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/main-act/templates/performer.html
+++ b/main-act/templates/performer.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    <article class="performer-page">
+      <header class="performer-head">
+        {% if page.extra.slot %}<p class="kicker">{{ page.extra.slot | upper }}{% if page.extra.stage %} - {{ page.extra.stage | upper }}{% endif %}</p>{% endif %}
+        <h1>{{ page.title | e }}</h1>
+        {% if page.extra.tagline %}<p class="performer-tagline">{{ page.extra.tagline | e }}</p>{% endif %}
+        {% if page.description %}<p style="color:#B0B0B0; margin-top:0.8rem;">{{ page.description | e }}</p>{% endif %}
+      </header>
+
+      <dl class="performer-specs">
+        {% if page.extra.genre %}<div><dt>Genre</dt><dd>{{ page.extra.genre | e }}</dd></div>{% endif %}
+        {% if page.extra.origin %}<div><dt>Origin</dt><dd>{{ page.extra.origin | e }}</dd></div>{% endif %}
+        {% if page.extra.set_length %}<div><dt>Set Length</dt><dd>{{ page.extra.set_length | e }}</dd></div>{% endif %}
+        {% if page.extra.bpm %}<div><dt>BPM</dt><dd>{{ page.extra.bpm | e }}</dd></div>{% endif %}
+        {% if page.extra.stage %}<div><dt>Stage</dt><dd>{{ page.extra.stage | e }}</dd></div>{% endif %}
+      </dl>
+
+      {% if page.extra.light_svg %}
+      <figure class="performer-figure" aria-hidden="true">
+        {{ page.extra.light_svg }}
+      </figure>
+      {% endif %}
+
+      <div class="performer-prose">
+        {{ content }}
+      </div>
+
+      <footer>
+        <a href="{{ base_url }}/lineup/" class="back-link">&larr; FULL LINEUP</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/main-act/templates/section.html
+++ b/main-act/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    <header class="section-head">
+      <p class="kicker">ON THE BILL</p>
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}<p>{{ page.description | e }}</p>{% endif %}
+    </header>
+    <div class="section-intro">{{ content }}</div>
+    <div class="lineup-grid">
+      {% for performer in section.pages %}
+      <div class="performer-card">
+        <a href="{{ performer.url }}">
+          <div class="card-slot">
+            {% if performer.extra.slot %}<span>{{ performer.extra.slot | e }}</span>{% endif %}
+          </div>
+          {% if performer.extra.stage %}<span class="card-stage">{{ performer.extra.stage | e }}</span>{% endif %}
+          <div class="card-name">{{ performer.title | e }}</div>
+          {% if performer.extra.tagline %}<div class="card-tagline">{{ performer.extra.tagline | e }}</div>{% endif %}
+          <span class="card-arrow">&rarr;</span>
+        </a>
+      </div>
+      {% endfor %}
+    </div>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/main-act/templates/shortcodes/alert.html
+++ b/main-act/templates/shortcodes/alert.html
@@ -1,0 +1,4 @@
+<aside class="alert" data-kind="{{ type | lower }}">
+  <span class="alert-head">{{ type | upper }}</span>
+  <span class="alert-body">{{ body }}</span>
+</aside>

--- a/main-act/templates/taxonomy.html
+++ b/main-act/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    <header class="section-head">
+      <p class="kicker">INDEX</p>
+      <h1>{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/main-act/templates/taxonomy_term.html
+++ b/main-act/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="stage-main" role="main">
+    <header class="section-head">
+      <p class="kicker">STAGE</p>
+      <h1>{{ page.title | e }}</h1>
+    </header>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2378,6 +2378,13 @@
     "magnetar",
     "cosmic"
   ],
+  "main-act": [
+    "event",
+    "concert",
+    "headline",
+    "performer",
+    "dramatic"
+  ],
   "mainstage": [
     "event",
     "dark",


### PR DESCRIPTION
Closes #1551

## Summary
- Add main-act example site: a dramatic headline performer concert event with dark theme
- 10 performers across Main Stage, Warehouse, and Basement stages for a fictional electronic music festival
- SVG stage truss structure as geometric frame with cross-bracing; SVG moving-head light fixtures with beam cones
- Oswald Heavy at 250px with vw units (clamp) for responsive hero headline; Karla Bold at 20px for support acts
- Custom performer template with specs display, unique light rig SVGs, and stage taxonomy

## Test plan
- [ ] Verify `hwaro build` succeeds in main-act directory
- [ ] Verify all 14 pages render correctly
- [ ] Check tags.json includes main-act entry
- [ ] Confirm no CSS gradients or emojis present
- [ ] Verify Oswald Heavy with vw units for headline scaling