### PR TITLE
feat: add duodecimo example site (closes #1549)

### DIFF
--- a/duodecimo/AGENTS.md
+++ b/duodecimo/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/duodecimo/config.toml
+++ b/duodecimo/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Duodecimo - Pocket Format Publication
+# Issue #1549 | Tags: book, light, compact, portable, efficient
+# =============================================================================
+
+title = "Duodecimo"
+description = "A compact, light publication modeled on the pocket-sized duodecimo format. SVG narrow decorative borders and miniature section ornaments scaled for tight margins. Barlow Condensed and Roboto Condensed Bold for display, IBM Plex Serif and Crimson Pro for body text at small but readable sizes."
+base_url = "http://localhost:3000"
+
+sections = ["chapters"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/duodecimo/content/about.md
+++ b/duodecimo/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "About this pocket-format publication and the duodecimo tradition."
++++
+
+<p class="pocket-label">Reference</p>
+
+# About This Edition
+
+<p class="lede">This publication is a study of the duodecimo format: the pocket-sized book that transformed reading from a sedentary activity into a portable one.</p>
+
+## The duodecimo tradition
+
+<p>The duodecimo format dates to the early days of printing, but it reached its peak in the seventeenth and eighteenth centuries, when pocket editions of devotional texts, poetry, almanacs, and classical authors were produced in enormous quantities. A gentleman's pocket library might include a duodecimo Bible, a duodecimo Horace, and a duodecimo almanac, all carried together in a coat.</p>
+
+## Design principles
+
+<p>This site is designed to reflect the constraints and virtues of the pocket format. The layout is narrow and compact. The type is set at readable but economical sizes. The margins are tight. The ornaments are miniature -- scaled to match the intimate proportions of a small page rather than the generous spaces of a folio.</p>
+
+<p>Every design decision here serves the same goal that drove the original duodecimo printers: to fit the most readable text into the smallest possible space, without sacrificing clarity or elegance.</p>
+
+<blockquote>A pocket book is not a small large book. It is its own format, with its own rules, its own proportions, and its own typographic voice.</blockquote>

--- a/duodecimo/content/chapters/1-the-fold.md
+++ b/duodecimo/content/chapters/1-the-fold.md
@@ -1,0 +1,32 @@
++++
+title = "The Fold"
+description = "How paper folding determines book format and size."
+tags = ["format", "production"]
++++
+
+<p class="pocket-label">Chapter I</p>
+
+# The Fold
+
+<p class="lede">Every book format begins with a sheet of paper and a sequence of folds. The number of folds determines the number of leaves, the size of each leaf, and the proportions of the finished page. The duodecimo is defined by its fold: twelve leaves from a single sheet.</p>
+
+## The geometry of folding
+
+<p>A sheet of hand-press paper, roughly 19 by 24 inches, can be folded in several ways. Fold it once and you have a folio: two leaves, four pages, each page nearly as large as the original sheet. Fold it twice for a quarto: four leaves, eight pages. Three folds produce an octavo: eight leaves, sixteen pages. The duodecimo requires a more complex imposition: the sheet is divided into twelve leaves through a combination of folds and cuts.</p>
+
+## Imposition
+
+<p>The compositor must arrange the type pages on the press form so that when the sheet is printed on both sides, folded, and cut, the pages appear in the correct order. Duodecimo imposition is more complex than octavo because the twelve-leaf format does not fold symmetrically. The printer must calculate the positions carefully, and any error produces pages out of sequence -- a defect visible only after binding.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>Sheet size</h3>
+<p>The starting point. A standard hand-press sheet yields different page sizes depending on the number of folds. The duodecimo page is roughly 7.5 by 5 inches.</p>
+</div>
+<div class="pocket-card">
+<h3>Grain direction</h3>
+<p>Paper folds more cleanly along the grain. The duodecimo's multiple folds make grain direction critical: a cross-grain fold produces a rough, uneven edge.</p>
+</div>
+</div>
+
+<blockquote>The fold is the first design decision. Everything that follows -- the page size, the type area, the margins, the binding -- is a consequence of how the sheet was folded.</blockquote>

--- a/duodecimo/content/chapters/2-the-pocket.md
+++ b/duodecimo/content/chapters/2-the-pocket.md
@@ -1,0 +1,32 @@
++++
+title = "The Pocket"
+description = "The cultural significance of the pocket-sized book."
+tags = ["culture", "portability"]
++++
+
+<p class="pocket-label">Chapter II</p>
+
+# The Pocket
+
+<p class="lede">The duodecimo is the book that fits in a pocket. This simple physical fact changed the relationship between readers and their books, transforming reading from a stationary activity performed at a desk into something done anywhere: on a coach, in a garden, at a cafe, on a battlefield.</p>
+
+## Aldus and the portable library
+
+<p>In 1501, the Venetian printer Aldus Manutius began publishing pocket editions of classical texts in his revolutionary italic type. These small octavos and duodecimos were designed for scholars who wanted to carry their Virgil or Cicero rather than leaving them chained to a library desk. The Aldine editions created a new category of object: the book as personal possession, as traveling companion, as part of the reader's daily life.</p>
+
+## The pocket library
+
+<p>By the eighteenth century, the pocket book was a standard commercial format. Publishers issued entire libraries in duodecimo: pocket Bibles, pocket dictionaries, pocket atlases, pocket editions of Shakespeare and Milton. Travelers carried pocket guidebooks. Soldiers carried pocket prayer books. Lawyers carried pocket statute books. The format was democratic: cheaper to produce than larger formats, more accessible to readers of modest means.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>Devotional texts</h3>
+<p>The Book of Common Prayer, breviaries, and catechisms were among the most common duodecimos. Small enough for daily carry, sturdy enough for years of handling.</p>
+</div>
+<div class="pocket-card">
+<h3>Almanacs</h3>
+<p>Annual pocket almanacs combined calendars, weather predictions, tide tables, and miscellaneous information in a single small volume carried year-round.</p>
+</div>
+</div>
+
+<blockquote>The pocket book changed reading from an event into a habit. When you can carry a book, you can read in the gaps between other activities -- and those gaps, over a lifetime, add up to a library.</blockquote>

--- a/duodecimo/content/chapters/3-the-type.md
+++ b/duodecimo/content/chapters/3-the-type.md
@@ -1,0 +1,32 @@
++++
+title = "The Type"
+description = "Typography for compact formats and small pages."
+tags = ["typography", "design"]
++++
+
+<p class="pocket-label">Chapter III</p>
+
+# The Type
+
+<p class="lede">Setting type for a duodecimo is an exercise in economy. The page is small, the margins are narrow, and every pica of space must earn its place. The compositor chooses a compact face, sets it at a small but readable size, and calibrates the leading and word spacing to fill the page without crowding it.</p>
+
+## Choosing the face
+
+<p>A good duodecimo typeface has a large x-height relative to its body size, moderate ascenders and descenders, and open counters. These features ensure that the type remains legible at 9 or 10 points even on a crowded page. Faces with long extenders waste vertical space. Faces with tight counters become illegible when printed small on rough paper. The ideal pocket-format face is sturdy, economical, and unambiguous at a glance.</p>
+
+## The mathematics of the type area
+
+<p>In a duodecimo, the type area typically occupies 65 to 75 percent of the page -- far more than in a folio or quarto, where generous margins frame the text. The narrow margins of the pocket page mean that the type itself must create a sense of order and proportion. The line length is short -- usually 20 to 24 ems -- which affects hyphenation, word spacing, and the overall rhythm of the text.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>X-height</h3>
+<p>The height of lowercase letters without ascenders. A generous x-height improves readability at small sizes by making the letterforms more distinct.</p>
+</div>
+<div class="pocket-card">
+<h3>Set width</h3>
+<p>The horizontal space each character occupies. A narrower set width fits more characters per line, reducing hyphenation and improving the texture of justified text.</p>
+</div>
+</div>
+
+<blockquote>Small type is not merely large type reduced. It must be designed for its size: sturdier, more open, with thicker strokes and wider counters than the same face at display sizes.</blockquote>

--- a/duodecimo/content/chapters/4-the-margin.md
+++ b/duodecimo/content/chapters/4-the-margin.md
@@ -1,0 +1,32 @@
++++
+title = "The Margin"
+description = "The role of margins in compact book formats."
+tags = ["design", "production"]
++++
+
+<p class="pocket-label">Chapter IV</p>
+
+# The Margin
+
+<p class="lede">The margin is not empty space. It is the frame that gives the type area its shape, the gutter that protects the text from the binding, and the edge where the reader's thumb rests. In a duodecimo, where every fraction of an inch matters, the margin becomes a critical design element.</p>
+
+## The four margins
+
+<p>Every page has four margins: head (top), foot (bottom), fore-edge (outer), and gutter (inner, toward the binding). In traditional book design, these margins follow a fixed ratio: the gutter is the smallest, the head slightly larger, the fore-edge larger still, and the foot the largest. This progression creates an optical centering that places the type area slightly above and to the inside of the geometric center of the page.</p>
+
+## Margins in the pocket format
+
+<p>In a duodecimo, the traditional margin ratios are compressed. There is simply not enough page to accommodate generous white space on all four sides. The compositor must decide which margin to sacrifice. The gutter margin must remain wide enough for the binding. The head margin must leave room for the running head. The foot margin is often the first to shrink. The fore-edge -- the margin where the reader holds the book -- must remain wide enough for a thumb.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>Binding margin</h3>
+<p>The gutter must be wide enough that the text is not lost in the fold. In a tightly bound duodecimo, the inner margin needs at least three-eighths of an inch.</p>
+</div>
+<div class="pocket-card">
+<h3>Thumb margin</h3>
+<p>The reader holds a pocket book with the thumb on the fore-edge. If the margin is too narrow, the thumb covers the text. A quarter-inch minimum is practical.</p>
+</div>
+</div>
+
+<blockquote>In a folio, the margins are a luxury. In a duodecimo, they are a negotiation between the needs of the text, the constraints of the binding, and the anatomy of the reader's hand.</blockquote>

--- a/duodecimo/content/chapters/5-the-companion.md
+++ b/duodecimo/content/chapters/5-the-companion.md
@@ -1,0 +1,32 @@
++++
+title = "The Companion"
+description = "The duodecimo as a reader's daily companion."
+tags = ["culture", "portability"]
++++
+
+<p class="pocket-label">Chapter V</p>
+
+# The Companion
+
+<p class="lede">A duodecimo is not just a small book. It is a companion: an object designed to be carried, handled, consulted, and returned to the pocket. The best pocket books are worn smooth by use, their spines cracked, their corners rounded, their pages marked by a hundred readings. They are books that have lived.</p>
+
+## The book in the pocket
+
+<p>The pocket book occupies a different place in the reader's life than a shelf book. A folio sits on a table and demands a session. A quarto sits on a shelf and waits to be consulted. A duodecimo goes into the pocket and comes out whenever there is a moment: on a train, in a waiting room, during a pause in conversation. The pocket book is the book of interstitial reading, of stolen minutes, of reading as a habit rather than an event.</p>
+
+## The vade mecum
+
+<p>The Latin term vade mecum -- "go with me" -- was used for centuries to describe pocket reference books: compact volumes of essential knowledge designed to be carried at all times. A physician's vade mecum contained drug dosages and diagnostic tables. A clergyman's vade mecum contained the order of service and essential prayers. A gentleman's vade mecum contained etiquette rules and useful addresses. The duodecimo was the natural format for the vade mecum: small enough to carry, comprehensive enough to consult.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>The soldier's book</h3>
+<p>Pocket Bibles and prayer books were issued to soldiers from the English Civil War through the World Wars. The duodecimo format survived mud, rain, and the confines of a uniform pocket.</p>
+</div>
+<div class="pocket-card">
+<h3>The traveler's guide</h3>
+<p>Murray's and Baedeker's pocket guidebooks shaped nineteenth-century tourism. A duodecimo guide to Florence fit in the same pocket as a train ticket and a handful of lire.</p>
+</div>
+</div>
+
+<blockquote>The duodecimo is the format of intimacy. It is the book you hold in one hand while the other hand holds a coffee cup, a railing, a child's hand. It is the book that shares your day.</blockquote>

--- a/duodecimo/content/chapters/_index.md
+++ b/duodecimo/content/chapters/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Chapters"
+description = "The chapters of this pocket-format publication."
++++
+
+<p class="lede">Five chapters, each examining a different aspect of the pocket book. From the economics of paper folding to the typography of tight margins, the duodecimo format has shaped how readers carry knowledge.</p>
+
+<p>The chapters are arranged to guide the reader from the physical format through to the cultural impact of the portable book.</p>

--- a/duodecimo/content/colophon.md
+++ b/duodecimo/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "Production details of this pocket-format publication."
++++
+
+<div class="colophon-page">
+<p class="pocket-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="miniature-ornament" aria-hidden="true">
+<svg viewBox="0 0 120 10" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="5" x2="100" y2="5" stroke="#c4b898" stroke-width="0.4"/>
+<circle cx="60" cy="5" r="1.5" fill="none" stroke="#a8977e" stroke-width="0.5"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of the duodecimo format: the pocket-sized book that brought reading out of the library and into the world.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Barlow Condensed and Roboto Condensed Bold, space-efficient condensed faces that maximize legibility within the narrow column width of the pocket format.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in IBM Plex Serif and Crimson Pro, compact text faces chosen for their clarity at small sizes and their generous x-heights.</p>
+
+<p class="colophon-detail"><strong>Decorative borders</strong> are drawn as inline SVG at miniature scale, fitting the tight margins of the pocket page. The ornaments are reduced versions of traditional typographic devices: dots, circles, and thin rules.</p>
+
+<p class="colophon-detail"><strong>The page proportions</strong> reflect the duodecimo format: narrow, tall, and compact, with margins calibrated for close reading rather than generous display.</p>
+
+<div class="miniature-ornament" aria-hidden="true">
+<svg viewBox="0 0 120 10" xmlns="http://www.w3.org/2000/svg">
+<circle cx="54" cy="5" r="1" fill="#a8977e"/>
+<circle cx="60" cy="5" r="1" fill="#a8977e"/>
+<circle cx="66" cy="5" r="1" fill="#a8977e"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First pocket edition, 2026.</p>
+</div>

--- a/duodecimo/content/index.md
+++ b/duodecimo/content/index.md
@@ -1,0 +1,55 @@
++++
+title = "Duodecimo"
+description = "A pocket-format publication in the tradition of the duodecimo."
++++
+
+<div class="pocket-cover">
+<p class="pocket-label">Pocket Edition</p>
+<h1 class="pocket-display">Duodecimo</h1>
+<p class="pocket-subtitle">A Study of the Portable Book</p>
+</div>
+
+<div class="miniature-ornament" aria-hidden="true">
+<svg viewBox="0 0 120 12" xmlns="http://www.w3.org/2000/svg">
+<line x1="10" y1="6" x2="45" y2="6" stroke="#c4b898" stroke-width="0.4"/>
+<circle cx="52" cy="6" r="1.2" fill="#a8977e"/>
+<circle cx="60" cy="6" r="1.8" fill="none" stroke="#a8977e" stroke-width="0.5"/>
+<circle cx="68" cy="6" r="1.2" fill="#a8977e"/>
+<line x1="75" y1="6" x2="110" y2="6" stroke="#c4b898" stroke-width="0.4"/>
+</svg>
+</div>
+
+## On the duodecimo format
+
+<p class="lede">The duodecimo -- abbreviated 12mo -- is a book format in which each printed sheet is folded into twelve leaves, producing twenty-four pages. The result is a volume roughly 7.5 inches tall and 5 inches wide: a book that fits in the hand, in the coat pocket, in the saddlebag. It is the format of portability.</p>
+
+## Why small books matter
+
+<p>The duodecimo was the paperback of its era. When Aldus Manutius began printing pocket-sized editions of the classics in Venice in 1501, he changed reading from a desk-bound activity to a portable one. His octavo Virgil could be carried on a journey, read in a garden, consulted at a lecture. The duodecimo pushed this further: smaller still, cheaper to produce, and designed for readers who moved through the world with books in their pockets.</p>
+
+## The economics of compression
+
+<p>A duodecimo uses paper efficiently. Twelve leaves from a single sheet means fewer sheets per copy, lower paper costs, and faster presswork. The trade-off is tight margins and small type. The compositor must set the text in a compact face at a size that rewards close reading. Every element of the page -- margins, leading, word spacing, paragraph indentation -- must be calibrated to work within the narrow confines of the pocket format.</p>
+
+<div class="pocket-grid">
+<div class="pocket-card">
+<h3>Folio</h3>
+<p>One fold, two leaves, four pages. The largest common format. Used for atlases, legal texts, and display volumes too large for the shelf.</p>
+</div>
+<div class="pocket-card">
+<h3>Quarto</h3>
+<p>Two folds, four leaves, eight pages. The standard academic format. Large enough for generous margins, small enough for a reading desk.</p>
+</div>
+<div class="pocket-card">
+<h3>Octavo</h3>
+<p>Three folds, eight leaves, sixteen pages. The most common book format since the sixteenth century. A good balance of size and economy.</p>
+</div>
+<div class="pocket-card">
+<h3>Duodecimo</h3>
+<p>Four folds, twelve leaves, twenty-four pages. The pocket format. Compact, portable, and economical. The book you carry with you.</p>
+</div>
+</div>
+
+## The typography of tight margins
+
+<p>Setting type for a duodecimo demands discipline. The margins are narrow -- often less than half an inch -- and the type area fills most of the page. The compositor chooses a compact text face with a generous x-height and moderate ascenders: a face that reads clearly at 9 or 10 points without losing its character. The leading is tight but never cramped. The result is a page that feels full but not crowded, dense but not illegible.</p>

--- a/duodecimo/static/css/style.css
+++ b/duodecimo/static/css/style.css
@@ -1,0 +1,442 @@
+/* =============================================================================
+   Duodecimo - Pocket Format Publication
+   Issue #1549 | book, light, compact, portable, efficient
+   Palette: warm parchment, muted tan accents, dark ink
+   No gradients. Narrow borders + miniature ornaments as inline SVG.
+   ============================================================================= */
+
+:root {
+  --parchment: #f8f5ed;
+  --parchment-soft: #f0ebdf;
+  --parchment-deep: #e2dacb;
+  --parchment-edge: #c4b898;
+  --ink: #3a3630;
+  --ink-soft: #5c564d;
+  --ink-dim: #8a8070;
+  --tan: #a8977e;
+  --tan-light: #c4b898;
+  --brown: #6b5a42;
+  --bg: #fcfaf4;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "IBM Plex Serif", "Crimson Pro", Georgia, serif;
+  font-size: 15px;
+  line-height: 1.68;
+  min-height: 100vh;
+}
+
+.pocket-shell {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 1.25rem 0 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--parchment-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 32px; height: 42px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.logo-sub {
+  font-family: "Crimson Pro", serif;
+  font-weight: 400;
+  font-size: 0.72rem;
+  color: var(--tan);
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+}
+.site-nav a:hover { color: var(--brown); border-bottom-color: var(--brown); }
+
+/* --- Pocket page --------------------------------------------------------- */
+.site-main {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 2rem;
+}
+
+.pocket-page {
+  position: relative;
+  background-color: var(--parchment);
+  border: 1px solid var(--parchment-edge);
+  min-height: 480px;
+  box-shadow:
+    0 1px 0 var(--parchment-deep),
+    0 8px 20px rgba(140, 128, 112, 0.07);
+}
+
+.pocket-page-narrow {
+  max-width: 440px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.pocket-border { text-align: center; padding: 0.8rem 1rem 0; }
+.pocket-border svg { max-width: 100%; height: 8px; display: block; margin: 0 auto; }
+.pocket-border-bottom { padding: 0 1rem 0.8rem; }
+
+.pocket-body {
+  padding: clamp(1rem, 3vw, 2rem) clamp(1rem, 3vw, 2rem);
+  text-align: center;
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.pocket-body h1,
+.pocket-body h2,
+.pocket-body h3 {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  color: var(--ink);
+  line-height: 1.2;
+  font-weight: 600;
+}
+.pocket-body h1 {
+  font-size: clamp(1.4rem, 3.5vw, 1.9rem);
+  margin: 0 0 0.3em;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.pocket-body h2 {
+  font-size: 1.1rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--parchment-edge);
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.pocket-body h3 {
+  font-size: 0.92rem;
+  margin: 1.2em 0 0.15em;
+  color: var(--brown);
+  text-align: left;
+}
+
+.pocket-body p {
+  margin: 0.8em 0;
+  color: var(--ink);
+  font-family: "IBM Plex Serif", "Crimson Pro", serif;
+  font-size: 0.92rem;
+  text-align: left;
+  line-height: 1.62;
+}
+.pocket-body p.lede {
+  font-family: "Crimson Pro", serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 30em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.pocket-label {
+  display: inline-block;
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--tan);
+  margin: 0 0 0.4em;
+}
+
+.pocket-head { margin-bottom: 1.25rem; text-align: center; }
+.pocket-title {
+  font-family: "Barlow Condensed", "Roboto Condensed", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.4rem, 3.5vw, 1.9rem);
+  margin: 0;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+.pocket-body a {
+  color: var(--brown);
+  text-decoration: none;
+  border-bottom: 1px solid var(--tan-light);
+}
+.pocket-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+blockquote {
+  margin: 1.5rem auto;
+  padding: 0.4rem 1rem;
+  border-left: 2px solid var(--tan);
+  background-color: var(--parchment-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.95rem;
+  text-align: left;
+  max-width: 28em;
+}
+
+.pocket-body ul,
+.pocket-body ol {
+  margin: 0.8em 0 0.8em 1.2em;
+  padding: 0;
+  text-align: left;
+  font-size: 0.92rem;
+}
+.pocket-body ul { list-style: disc; }
+.pocket-body ol { list-style: decimal; }
+.pocket-body li { padding: 0.15em 0; }
+
+/* --- Pocket cover display ------------------------------------------------ */
+.pocket-cover {
+  padding: clamp(2.5rem, 8vw, 5rem) 0;
+  text-align: center;
+}
+.pocket-display {
+  font-family: "Roboto Condensed", "Barlow Condensed", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  color: var(--ink);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0 0 0.15em;
+}
+.pocket-subtitle {
+  font-family: "Crimson Pro", serif;
+  font-size: 0.95rem;
+  font-style: italic;
+  color: var(--tan);
+  letter-spacing: 0.06em;
+  margin: 0;
+}
+
+/* --- Miniature ornament -------------------------------------------------- */
+.miniature-ornament {
+  text-align: center;
+  margin: 1.25rem 0;
+}
+.miniature-ornament svg {
+  max-width: 120px;
+  height: 12px;
+  display: inline-block;
+}
+
+/* --- Pocket card grid ---------------------------------------------------- */
+.pocket-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.6rem;
+  margin: 1rem 0;
+  text-align: left;
+}
+.pocket-card {
+  background-color: var(--parchment-soft);
+  border: 1px solid var(--parchment-edge);
+  padding: 0.6rem 0.75rem;
+  position: relative;
+}
+.pocket-card h3 {
+  margin: 0 0 0.2em;
+  color: var(--brown);
+  font-size: 0.85rem;
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.pocket-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 1.25rem 0;
+}
+.colophon-page h1 {
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.88rem;
+  color: var(--ink-soft);
+}
+.colophon-detail strong {
+  color: var(--ink);
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+}
+.colophon-imprint {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  color: var(--tan);
+  font-size: 0.88rem;
+  margin-top: 1.25rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  border-top: 1px solid var(--parchment-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.5rem 0.2rem;
+  border-bottom: 1px solid var(--parchment-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: "IBM Plex Serif", serif;
+  font-size: 0.88rem;
+}
+.section-list li::before {
+  content: "\00B7";
+  color: var(--tan);
+  font-size: 1.1em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 0.9rem;
+}
+.section-list li a:hover { color: var(--brown); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1rem;
+  text-align: left;
+  font-size: 0.88rem;
+}
+
+nav.pagination { margin-top: 1.25rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.2em 0.5em;
+  border: 1px solid var(--parchment-edge);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 0.78rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--parchment-soft);
+}
+nav.pagination a:hover { color: var(--brown); border-color: var(--brown); }
+.pagination-current span { color: var(--brown); border-color: var(--brown); }
+
+/* --- Footer device ------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 0.6rem;
+}
+.footer-device svg {
+  width: 32px;
+  height: 32px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+  border-top: 1px solid var(--parchment-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1rem; }
+.footer-line {
+  font-family: "Barlow Condensed", sans-serif;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0.15em 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+}
+.footer-line-small {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.78rem;
+  margin: 0.15em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 560px) {
+  .pocket-body { padding: 0.8rem 0.8rem 1.25rem; }
+  .site-header { padding: 1rem 0 0.75rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 0.8rem; }
+  .pocket-title, .pocket-body h1, .pocket-display { font-size: 1.5rem; }
+  .pocket-body h2 { font-size: 1rem; }
+  .pocket-cover { padding: 2rem 0; }
+}

--- a/duodecimo/templates/404.html
+++ b/duodecimo/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="pocket-page pocket-page-narrow">
+      <div class="pocket-body">
+        <header class="pocket-head">
+          <p class="pocket-label">404</p>
+          <h1 class="pocket-title">Page not found</h1>
+        </header>
+        <p>This leaf was never bound into the pocket edition. It may have been trimmed during production. Please return to the cover.</p>
+        <p><a href="{{ base_url }}/">Back to the cover</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/duodecimo/templates/footer.html
+++ b/duodecimo/templates/footer.html
@@ -1,0 +1,19 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+          <rect x="10" y="8" width="20" height="24" fill="none" stroke="#a8977e" stroke-width="0.6"/>
+          <line x1="14" y1="14" x2="26" y2="14" stroke="#c4b898" stroke-width="0.3"/>
+          <line x1="14" y1="17" x2="26" y2="17" stroke="#c4b898" stroke-width="0.3"/>
+          <line x1="14" y1="20" x2="22" y2="20" stroke="#c4b898" stroke-width="0.3"/>
+          <line x1="14" y1="26" x2="26" y2="26" stroke="#c4b898" stroke-width="0.3"/>
+        </svg>
+      </div>
+      <p class="footer-line">Duodecimo</p>
+      <p class="footer-line-small">A pocket-format publication, compact by design.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; set in condensed type for close reading</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/duodecimo/templates/header.html
+++ b/duodecimo/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700&family=Roboto+Condensed:wght@400;500;700&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="pocket-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Duodecimo home">
+        <svg viewBox="0 0 36 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="32" height="44" fill="none" stroke="#4a4540" stroke-width="0.8"/>
+          <rect x="5" y="5" width="26" height="38" fill="none" stroke="#a8977e" stroke-width="0.4"/>
+          <line x1="8" y1="18" x2="28" y2="18" stroke="#a8977e" stroke-width="0.3"/>
+          <line x1="8" y1="30" x2="28" y2="30" stroke="#a8977e" stroke-width="0.3"/>
+          <text x="18" y="26" font-family="serif" font-size="8" fill="#4a4540" text-anchor="middle" font-weight="600">12mo</text>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Duodecimo</span>
+          <span class="logo-sub">Pocket Format</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/chapters/">Chapters</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/duodecimo/templates/page.html
+++ b/duodecimo/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="pocket-page">
+      <div class="pocket-border" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="4" x2="170" y2="4" stroke="#c4b898" stroke-width="0.4"/>
+          <circle cx="180" cy="4" r="1.2" fill="#a8977e"/>
+          <circle cx="190" cy="4" r="0.8" fill="#c4b898"/>
+          <circle cx="200" cy="4" r="1.5" fill="#a8977e"/>
+          <circle cx="210" cy="4" r="0.8" fill="#c4b898"/>
+          <circle cx="220" cy="4" r="1.2" fill="#a8977e"/>
+          <line x1="230" y1="4" x2="400" y2="4" stroke="#c4b898" stroke-width="0.4"/>
+        </svg>
+      </div>
+      <div class="pocket-body">
+        {{ content }}
+      </div>
+      <div class="pocket-border pocket-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="80" y1="4" x2="320" y2="4" stroke="#c4b898" stroke-width="0.4"/>
+          <circle cx="80" cy="4" r="1" fill="#a8977e"/>
+          <circle cx="200" cy="4" r="1" fill="#a8977e"/>
+          <circle cx="320" cy="4" r="1" fill="#a8977e"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/duodecimo/templates/section.html
+++ b/duodecimo/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="pocket-page">
+      <div class="pocket-border" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="4" x2="170" y2="4" stroke="#c4b898" stroke-width="0.4"/>
+          <circle cx="190" cy="4" r="1.2" fill="#a8977e"/>
+          <circle cx="200" cy="4" r="1.5" fill="#a8977e"/>
+          <circle cx="210" cy="4" r="1.2" fill="#a8977e"/>
+          <line x1="230" y1="4" x2="400" y2="4" stroke="#c4b898" stroke-width="0.4"/>
+        </svg>
+      </div>
+      <div class="pocket-body">
+        <header class="pocket-head">
+          <p class="pocket-label">Contents</p>
+          <h1 class="pocket-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/duodecimo/templates/shortcodes/alert.html
+++ b/duodecimo/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 0.6rem 0.8rem; border: 1px solid #c4b898; background-color: #faf8f2; border-left: 3px solid #a8977e; margin: 0.8rem 0; font-size: 0.88rem;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/duodecimo/templates/taxonomy.html
+++ b/duodecimo/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="pocket-page pocket-page-narrow">
+      <div class="pocket-body">
+        <header class="pocket-head">
+          <p class="pocket-label">Index</p>
+          <h1 class="pocket-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this pocket volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/duodecimo/templates/taxonomy_term.html
+++ b/duodecimo/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="pocket-page pocket-page-narrow">
+      <div class="pocket-body">
+        <header class="pocket-head">
+          <p class="pocket-label">Subject</p>
+          <h1 class="pocket-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Chapters filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1234,6 +1234,13 @@
     "desert",
     "travel"
   ],
+  "duodecimo": [
+    "book",
+    "light",
+    "compact",
+    "portable",
+    "efficient"
+  ],
   "dusk": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1549

## Summary
- Add duodecimo (pocket format publication) example site
- Light theme with compact layout reflecting the 12mo book format
- SVG narrow decorative borders and miniature section ornaments scaled for tight margins
- Typography: Barlow Condensed / Roboto Condensed Bold for display, IBM Plex Serif / Crimson Pro for body at small but readable sizes
- 5 chapters covering the fold, the pocket, the type, the margin, and the companion
- Tags: book, light, compact, portable, efficient

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of pocket-format layout and compact typography
- [ ] Verify SVG ornaments render at miniature scale
- [ ] Check responsive behavior on narrow viewports