### PR TITLE
feat: add rubric example site (closes #1550)

### DIFF
--- a/rubric/AGENTS.md
+++ b/rubric/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/rubric/config.toml
+++ b/rubric/config.toml
@@ -1,0 +1,85 @@
+# =============================================================================
+# Rubric - A Red-Marked Publication
+# Issue #1550 | Tags: book, light, rubricated, two-color, traditional
+# =============================================================================
+
+title = "RUBRIC - A Red-Marked Publication"
+description = "A study of the rubrication tradition - red initial letters, paragraph marks, and section symbols applied to manuscripts and early printed books. Two-color printing in the medieval and Renaissance manner."
+base_url = "http://localhost:3000"
+
+sections = ["chapters"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+[series]
+enabled = false
+
+[related]
+enabled = true
+limit = 4
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "script"
+paginate_by = 10
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "monthly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A study of the medieval rubrication tradition. Scholarly use; please cite if referenced."
+full_enabled = false
+full_filename = "llms-full.txt"
+
+[feeds]
+enabled = true
+filename = ""
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = ["chapters"]
+
+[markdown]
+safe = false
+lazy_loading = false
+emoji = false

--- a/rubric/content/chapters/_index.md
+++ b/rubric/content/chapters/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Chapters"
+description = "Ten chapters upon the tradition of rubrication - the application of red ink to initial letters, paragraph marks, and section symbols in manuscripts and early printed books."
+template = "section"
+sort_by = "weight"
+transparent = false
++++
+
+The chapters are arranged in a progression from the earliest origins of the paragraph mark through the materials and techniques of the rubricator, the forms of decorated capitals, the transition to print, and the survival of the two-colour tradition into the modern era. Each chapter gives a survey of its subject with attention to the script, the materials, and the visual conventions of the period.

--- a/rubric/content/chapters/lombardic-capitals.md
+++ b/rubric/content/chapters/lombardic-capitals.md
@@ -1,0 +1,69 @@
++++
+title = "Lombardic Capitals"
+description = "The round, heavy capital letters of the Lombardic tradition - the most recognisable form of the rubricated initial in the medieval book."
+date = "2026-04-10"
+template = "chapter"
+weight = 4
+tags = ["lombardic", "capitals", "initials", "decorated"]
+[taxonomies]
+script = ["Lombardic"]
+[extra]
+chapter_no = "IV"
+script = "Lombardic Capital"
+scribe = "Anonymous, northern Italian scriptorium"
+date_written = "c. 1100-1200 AD"
+material = "Vellum, vermilion, lapis lazuli"
+source = "Biblioteca Apostolica Vaticana, MS Vat. lat. 39"
+initial_caption = "A Lombardic capital L with the characteristic rounded forms, heavy strokes, and split-stem terminals of the tradition."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Rounded arch frame (Lombardic/Romanesque) -->
+  <path d="M24,200 L24,50 Q24,20 100,20 Q176,20 176,50 L176,200" fill="none" stroke="#8B0000" stroke-width="2"/>
+  <line x1="24" y1="200" x2="176" y2="200" stroke="#8B0000" stroke-width="2"/>
+  <!-- Inner arch -->
+  <path d="M34,194 L34,54 Q34,30 100,30 Q166,30 166,54 L166,194" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <line x1="34" y1="194" x2="166" y2="194" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <!-- Large initial L -->
+  <text x="100" y="160" text-anchor="middle" font-family="'Cinzel', serif" font-size="120" font-weight="900" fill="#8B0000">L</text>
+  <!-- Rounded split-stem decorations -->
+  <path d="M58,50 C48,50 42,58 48,66 C54,74 48,82 40,80" fill="none" stroke="#8B0000" stroke-width="1" opacity="0.6"/>
+  <circle cx="40" cy="80" r="3" fill="#8B0000" opacity="0.5"/>
+  <path d="M58,50 C68,44 72,50 68,58" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <circle cx="68" cy="58" r="2" fill="#8B0000" opacity="0.4"/>
+  <!-- Rounded leaf forms at base of L -->
+  <path d="M140,170 C150,168 158,174 154,182 C150,190 140,188 142,180" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M148,165 C158,160 168,168 162,178" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.4"/>
+  <circle cx="162" cy="178" r="2" fill="#8B0000" opacity="0.4"/>
+  <!-- Circular ornaments in Lombardic style -->
+  <circle cx="100" cy="20" r="4" fill="none" stroke="#8B0000" stroke-width="1"/>
+  <circle cx="100" cy="20" r="1.5" fill="#8B0000"/>
+  <circle cx="38" cy="110" r="3" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="38" cy="110" r="1" fill="#8B0000" opacity="0.4"/>
+  <circle cx="162" cy="110" r="3" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="162" cy="110" r="1" fill="#8B0000" opacity="0.4"/>
+</svg>
+'''
++++
+
+## Origins of the Form
+
+The Lombardic capital is the most widely recognised form of the rubricated initial in the medieval Western book. Characterised by its rounded, heavy strokes, its split or bifurcated terminals, and its generous, open counters, the Lombardic capital evolved from late Roman and early medieval uncial and half-uncial letterforms, filtered through the scriptoria of northern Italy in the eleventh and twelfth centuries. The name is somewhat misleading: while the style has associations with Lombardy, it was never confined to that region and was used throughout Western Europe from the twelfth century onward.
+
+The essential feature of the Lombardic capital is its roundness. Where the Gothic textura hand reduced letterforms to angular, compressed modules, the Lombardic capital retained and exaggerated the curved strokes inherited from the uncial tradition. The letters are broad, with thick main strokes and characteristically flat or slightly cupped serifs that often terminate in a distinctive split or fish-tail form.
+
+## Rubrication and the Lombardic Initial
+
+The Lombardic capital was ideally suited to the rubricator's work. Its bold, simple forms were easy to execute with a broad pen, and its visual weight was sufficient to mark the beginning of a chapter or section clearly, even at a modest size. A skilled rubricator could produce a Lombardic initial at two or three lines in height in a matter of seconds, whereas a comparable Gothic penwork initial, with its elaborate flourishing, might require several minutes.
+
+{{ alert(type="nota", body="Lombardic capitals were frequently alternated in red and blue, a convention known as 'rubrication in two colours.' The pattern typically followed the sequence of textual divisions: the first chapter initial in red, the second in blue, the third in red, and so on. This alternation served both a decorative and a practical function, helping the reader to distinguish successive divisions at a glance.") }}
+
+## The Spread of the Form
+
+From its origins in Italian scriptoria, the Lombardic capital spread rapidly throughout Western Europe in the twelfth and thirteenth centuries, carried by the international networks of the monastic orders and the emerging university system. By 1200, Lombardic initials were standard equipment in every scriptorium from Seville to Uppsala. They appeared in Bibles, psalters, missals, breviaries, legal texts, philosophical treatises, and medical compendia -- in short, in every category of book that required internal division and navigation aids.
+
+The form proved remarkably stable. The Lombardic capital of the fifteenth century is recognisably the same letterform as the Lombardic capital of the twelfth, with only minor variations in the degree of roundness, the treatment of terminals, and the density of stroke weight. This stability made the form an ideal candidate for transfer to the printed book, where it survived in the form of woodcut and cast initial letters well into the sixteenth century.
+
+## Variants and Developments
+
+The basic Lombardic form admitted several levels of elaboration. At its simplest, the Lombardic initial was a plain red letter, unadorned save for the characteristic split terminals. More elaborate versions added simple penwork flourishes -- hairline extensions in red or a contrasting colour that radiated from the body of the letter into the surrounding margin. The most decorated Lombardic initials were filled with coloured grounds (typically blue or gold) and surrounded by frames of interlacing vine or foliate ornament, approaching the status of full illuminated initials.

--- a/rubric/content/chapters/red-lead-and-vermilion.md
+++ b/rubric/content/chapters/red-lead-and-vermilion.md
@@ -1,0 +1,75 @@
++++
+title = "Red Lead and Vermilion"
+description = "The pigments of the rubricator - red lead (minium) and vermilion (cinnabar) as the materials of the two-colour book."
+date = "2026-04-10"
+template = "chapter"
+weight = 2
+tags = ["pigments", "minium", "vermilion", "materials"]
+[taxonomies]
+script = ["Insular"]
+[extra]
+chapter_no = "II"
+script = "Insular Majuscule"
+scribe = "Anonymous, Insular tradition"
+date_written = "c. 700-800 AD"
+material = "Vellum, red lead (minium), vermilion (cinnabar)"
+source = "Trinity College Dublin, MS 58 (Book of Kells)"
+initial_caption = "A rubricated initial R rendered in the Insular style, with interlace knotwork filling the counter and extending from the terminals."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Interlace border pattern -->
+  <path d="M14,14 L186,14" stroke="#8B0000" stroke-width="1.2" fill="none"/>
+  <path d="M14,206 L186,206" stroke="#8B0000" stroke-width="1.2" fill="none"/>
+  <path d="M14,14 L14,206" stroke="#8B0000" stroke-width="1.2" fill="none"/>
+  <path d="M186,14 L186,206" stroke="#8B0000" stroke-width="1.2" fill="none"/>
+  <!-- Interlace knot corner ornaments -->
+  <circle cx="14" cy="14" r="4" fill="#8B0000"/>
+  <circle cx="186" cy="14" r="4" fill="#8B0000"/>
+  <circle cx="14" cy="206" r="4" fill="#8B0000"/>
+  <circle cx="186" cy="206" r="4" fill="#8B0000"/>
+  <!-- Mid-border dots -->
+  <circle cx="100" cy="14" r="2.5" fill="#8B0000"/>
+  <circle cx="100" cy="206" r="2.5" fill="#8B0000"/>
+  <circle cx="14" cy="110" r="2.5" fill="#8B0000"/>
+  <circle cx="186" cy="110" r="2.5" fill="#8B0000"/>
+  <!-- Large initial R -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="120" font-weight="900" fill="#8B0000">R</text>
+  <!-- Interlace knotwork inside bowl of R -->
+  <path d="M105,62 C120,55 140,60 140,75 C140,90 125,95 110,88" fill="none" stroke="#8B0000" stroke-width="1" opacity="0.5"/>
+  <path d="M110,88 C100,82 95,70 105,62" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.4"/>
+  <!-- Spiral terminals -->
+  <path d="M130,140 C140,135 148,142 145,150 C142,158 132,155 135,148" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M155,155 C162,150 168,158 164,164 C160,170 152,166 156,160" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.4"/>
+  <!-- Dot pattern around letter -->
+  <circle cx="45" cy="60" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="45" cy="80" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="45" cy="100" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="45" cy="120" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="45" cy="140" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="160" cy="60" r="1.5" fill="#8B0000" opacity="0.3"/>
+  <circle cx="160" cy="80" r="1.5" fill="#8B0000" opacity="0.3"/>
+  <circle cx="160" cy="100" r="1.5" fill="#8B0000" opacity="0.3"/>
+</svg>
+'''
++++
+
+## The Chemistry of Red
+
+The rubricator's art depended upon the chemistry of two principal red pigments: red lead (*minium*) and vermilion (*cinnabar*). These substances, derived respectively from lead oxide and mercury sulphide, provided the intense, opaque red that distinguished the rubricator's work from the black iron-gall ink of the main text. The choice between them, and the techniques for preparing and applying them, formed a specialised body of craft knowledge transmitted from master to apprentice in the scriptoria of the early and high Middle Ages.
+
+Red lead, known to the Romans as *minium* (from which the word *miniature* ultimately derives, referring originally to the red-decorated letters, not to small size), was produced by heating white lead in an open furnace until it oxidised to a bright orange-red. The resulting powder was ground with a binding medium -- typically gum arabic or egg white -- to produce a smooth, workable ink. Red lead was cheap and readily available, but it had disadvantages: it was toxic, it darkened over time when exposed to air and moisture, and it could react with the sulphur compounds present in some vellum preparations, turning black.
+
+## Vermilion and Its Preparation
+
+Vermilion, the pigment derived from cinnabar (mercury sulphide), was the superior alternative. Natural cinnabar was mined in Spain, at the famous Almaden deposits, and in parts of central Europe and China. The raw ore was ground to a fine powder and purified by repeated washing and levigation. By the eighth century, European artisans had also learned to produce synthetic vermilion by combining mercury and sulphur and sublimating the resulting compound -- a process described in several medieval recipe collections, including the *Mappae Clavicula* and the *De Diversis Artibus* of Theophilus.
+
+{{ alert(type="nota", body="Theophilus Presbyter, writing in the early twelfth century, gives detailed instructions for the preparation of vermilion: 'Take some sulphur and grind it on a dry stone; add to it two parts of mercury, weighed on a balance; mix them carefully; place the mixture in a glass jar and cover it with clay; set it upon the coals and as soon as it begins to smoke, close the top of the jar quickly, for the smoke is the vermilion itself rising to the upper part of the vessel.'") }}
+
+## Application and Technique
+
+The rubricator applied red ink with a quill pen cut to a different width than the text pen, or occasionally with a reed pen for broader strokes. The technique required care: red lead and vermilion were thicker and more opaque than iron-gall ink, and they behaved differently on the vellum surface. The rubricator typically worked after the main text had been written, following guide marks left by the scribe -- small letters written in the margin or in the spaces left blank for rubrication. In some manuscripts, the guide letters are still visible where the rubricator failed to cover them completely.
+
+## The Insular Tradition
+
+The Insular manuscripts of the seventh and eighth centuries, produced in the monasteries of Ireland and Anglo-Saxon England, display some of the most inventive uses of red pigment in the Western tradition. In manuscripts such as the Book of Kells and the Lindisfarne Gospels, red lead and vermilion are used not only for structural marks and initials but also as elements in elaborate decorative programmes that combine interlace, animal ornament, and geometric patterns. The Insular rubricator was not merely a marker of paragraphs but a partner in the creation of visual splendour.

--- a/rubric/content/chapters/red-printing-in-the-modern-age.md
+++ b/rubric/content/chapters/red-printing-in-the-modern-age.md
@@ -1,0 +1,71 @@
++++
+title = "Red Printing in the Modern Age"
+description = "The survival and revival of two-colour printing from the private press movement to contemporary typography and design."
+date = "2026-04-10"
+template = "chapter"
+weight = 10
+tags = ["modern", "private-press", "revival", "two-colour"]
+[taxonomies]
+script = ["Modern"]
+[extra]
+chapter_no = "X"
+script = "Modern Revival"
+scribe = "William Morris, Kelmscott Press"
+date_written = "c. 1891-present"
+material = "Handmade paper, letterpress in red and black"
+source = "Various private press editions"
+initial_caption = "A rubricated initial R in the modern revival style, combining the weight and presence of the medieval tradition with a contemporary sensitivity to form."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Clean modern frame with red accents -->
+  <rect x="16" y="16" width="168" height="188" fill="none" stroke="#8B0000" stroke-width="2"/>
+  <!-- Corner squares (Kelmscott/Arts & Crafts style) -->
+  <rect x="16" y="16" width="10" height="10" fill="#8B0000"/>
+  <rect x="174" y="16" width="10" height="10" fill="#8B0000"/>
+  <rect x="16" y="194" width="10" height="10" fill="#8B0000"/>
+  <rect x="174" y="194" width="10" height="10" fill="#8B0000"/>
+  <!-- Inner line creating double frame -->
+  <rect x="22" y="22" width="156" height="176" fill="none" stroke="#8B0000" stroke-width="0.5"/>
+  <!-- Large initial R -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="110" font-weight="900" fill="#8B0000">R</text>
+  <!-- Arts & Crafts vine ornament -->
+  <path d="M30,40 C38,36 46,42 50,38 C54,34 62,38 66,34" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M134,34 C138,38 146,34 150,38 C154,42 162,36 170,40" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <!-- Small leaf forms -->
+  <path d="M42,38 C40,32 36,30 34,34" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M58,35 C56,29 52,27 50,31" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M142,35 C144,29 148,27 150,31" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M158,38 C160,32 164,30 166,34" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <!-- Bottom vine -->
+  <path d="M30,180 C38,184 46,178 50,182 C54,186 62,182 66,186" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.4"/>
+  <path d="M134,186 C138,182 146,186 150,182 C154,178 162,184 170,180" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.4"/>
+  <!-- Central dot ornament above letter -->
+  <circle cx="100" cy="38" r="2" fill="#8B0000" opacity="0.5"/>
+  <circle cx="90" cy="38" r="1" fill="#8B0000" opacity="0.3"/>
+  <circle cx="110" cy="38" r="1" fill="#8B0000" opacity="0.3"/>
+</svg>
+'''
++++
+
+## The Private Press Revival
+
+The revival of two-colour printing in the modern era begins with the private press movement of the late nineteenth century. William Morris, the Pre-Raphaelite artist and designer who founded the Kelmscott Press in 1891, was the pivotal figure. Morris, inspired by the incunables he studied in the British Museum and the Bodleian Library, sought to revive the visual richness of the medieval book, including the use of red ink for headings, rubrics, and initial letters. The Kelmscott Press editions, printed on handmade paper in specially designed typefaces with red-and-black printing and elaborate woodcut borders, became the model for the entire private press movement that followed.
+
+Morris's followers and successors -- C. R. Ashbee at the Essex House Press, Emery Walker and T. J. Cobden-Sanderson at the Doves Press, and later Eric Gill at the Golden Cockerel Press -- each interpreted the two-colour tradition in their own way. Some, like Morris, embraced the full decorative programme of the medieval book; others, like Cobden-Sanderson, stripped away the ornament to concentrate on the beauty of red and black type alone.
+
+{{ alert(type="nota", body="The Doves Bible, printed by the Doves Press between 1903 and 1905, is perhaps the supreme achievement of the two-colour private press book. Set entirely in the Doves Roman type with red initials by Edward Johnston (the calligrapher who later designed the London Underground typeface), it demonstrates that the red-and-black scheme can achieve the utmost simplicity and refinement.") }}
+
+## The Twentieth Century
+
+Two-colour printing continued as a living tradition throughout the twentieth century, though it was increasingly confined to the fine press and limited edition market. Printers such as Giovanni Mardersteig at the Officina Bodoni in Verona, Victor Hammer at his various hand-press operations, and Jan Tschichold in his typographic work all made significant use of red-and-black printing. Tschichold, in particular, demonstrated that the two-colour scheme was compatible with modernist design principles, using red sparingly and precisely for titles, running heads, and structural accents.
+
+## The Digital Inheritance
+
+The digital revolution of the late twentieth and early twenty-first centuries has paradoxically both threatened and revived the two-colour tradition. On one hand, the ease and cheapness of full-colour printing has made the deliberate restriction to two colours seem arbitrary or quaint. On the other hand, the same digital tools have made it easier than ever for designers and typographers to experiment with red-and-black schemes, and the growing interest in historical typography and book design has brought renewed attention to the rubrication tradition.
+
+Contemporary web design, in particular, has found in the two-colour scheme a natural model for the design of text-heavy pages. The use of a single accent colour (often red or a related warm hue) against a predominantly black-and-white text layout is a direct, if usually unconscious, descendant of the medieval rubrication tradition. The structural function of colour -- to mark headings, links, and points of emphasis -- remains exactly what it was in the manuscript of the ninth century.
+
+## The Persistence of Red
+
+Red retains its primacy among accent colours for reasons that are partly cultural and partly physiological. The human visual system is highly sensitive to red, which stands out against the grey and brown tones of paper and parchment more effectively than any other colour. The association of red with authority, importance, and warning (the "red flag," the "red line") reinforces its use as a structural marker. And the tradition itself, stretching back more than a millennium, gives red a weight of cultural association that no other colour can match in the context of the book and the written word.

--- a/rubric/content/chapters/rubrication-in-the-book-of-hours.md
+++ b/rubric/content/chapters/rubrication-in-the-book-of-hours.md
@@ -1,0 +1,69 @@
++++
+title = "Rubrication in the Book of Hours"
+description = "The most personal of medieval books - how rubrication served devotion, navigation, and beauty in the lay prayer book."
+date = "2026-04-10"
+template = "chapter"
+weight = 8
+tags = ["book-of-hours", "devotion", "liturgy", "batarde"]
+[taxonomies]
+script = ["Batarde"]
+[extra]
+chapter_no = "VIII"
+script = "Batarde"
+scribe = "Anonymous, Flemish workshop"
+date_written = "c. 1420-1460 AD"
+material = "Vellum, gold leaf, vermilion, ultramarine"
+source = "The Cloisters, Metropolitan Museum of Art, MS 54.1.1"
+initial_caption = "A rubricated initial R in the Batarde style, with flowing cursive penwork and delicate leaf-spray extensions characteristic of Flemish workshops."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Delicate vine border (Flemish style) -->
+  <path d="M20,20 C40,15 60,25 80,18 C100,11 120,22 140,16 C160,10 175,20 180,20" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <path d="M20,200 C40,205 60,195 80,202 C100,209 120,198 140,204 C160,210 175,200 180,200" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <!-- Leaf sprays from border -->
+  <path d="M50,18 C48,10 42,8 38,12" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M110,14 C108,6 102,4 98,8" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M160,14 C158,6 152,4 148,8" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <!-- Large initial R -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="115" font-weight="900" fill="#8B0000">R</text>
+  <!-- Flowing cursive penwork from R -->
+  <path d="M135,140 C150,135 165,140 170,155 C175,170 165,180 155,175 C145,170 150,158 160,158" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.5"/>
+  <path d="M155,175 C148,185 140,192 132,188" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <!-- Leaf spray from upper terminal -->
+  <path d="M130,55 C142,45 150,35 148,25" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <path d="M148,25 C146,20 140,18 136,22 C132,26 136,30 140,28" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <path d="M130,55 C138,50 145,52 142,58" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <!-- Stem decoration -->
+  <path d="M62,168 C50,175 38,172 35,162 C32,152 42,145 48,152" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <circle cx="48" cy="152" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <!-- Small flower buds -->
+  <circle cx="38" cy="12" r="2" fill="#8B0000" opacity="0.4"/>
+  <circle cx="98" cy="8" r="2" fill="#8B0000" opacity="0.4"/>
+  <circle cx="148" cy="8" r="2" fill="#8B0000" opacity="0.4"/>
+  <circle cx="132" cy="188" r="2" fill="#8B0000" opacity="0.4"/>
+</svg>
+'''
++++
+
+## The Book of Hours
+
+The Book of Hours was the most widely produced and most personally owned book of the later Middle Ages. A compilation of devotional texts arranged around the eight canonical hours of the day, it served as the layperson's guide to daily prayer and meditation. From the mid-thirteenth century through the sixteenth, Books of Hours were produced in enormous numbers, ranging from modestly rubricated workshop products to extravagantly illuminated commissions for princes and magnates. In all cases, rubrication played a central role in making the book usable and beautiful.
+
+The devotional texts of the Book of Hours required precise navigation. The reader needed to find, quickly and without confusion, the correct prayers for each hour of the day, the appropriate texts for saints' feast days, and the seasonal variations of the liturgical calendar. Red ink provided the solution: rubrics (in the original sense of the word -- directions printed or written in red) told the reader what to say, when to say it, and how to adapt the text to the day's occasion.
+
+## The Flemish Workshops
+
+The finest Books of Hours of the fifteenth century were produced in the workshops of Flanders and Burgundy, particularly in the cities of Bruges, Ghent, and Tournai. These workshops perfected a system of production that combined the work of multiple specialists: scribes writing in the Batarde hand (a graceful cursive script developed in the Franco-Burgundian court), rubricators applying red and blue marks and initials, and illuminators painting miniatures, borders, and decorated initials.
+
+{{ alert(type="nota", body="The Batarde hand, also known as lettre batarde, was a cursive script that combined elements of the formal Gothic book hands with the fluency of contemporary business and chancery scripts. It was particularly associated with the Burgundian court and was widely used in Books of Hours, chronicles, and literary manuscripts of the fifteenth century.") }}
+
+## The Rubric as Instruction
+
+In the Book of Hours, the word *rubric* carries its fullest meaning. The red text was not merely decorative but functionally essential: it provided the instructions that guided the reader through the complex liturgical programme. A typical rubric might read, in red, *Incipit officium beatae Mariae virginis ad matutinas* ("Here begins the office of the Blessed Virgin Mary at matins"), followed by the prayer text in black. Without the rubric, the reader would be unable to distinguish one office from another or to know when one section ended and the next began.
+
+## Calendar and Feast Days
+
+The calendar at the beginning of the Book of Hours was particularly heavily rubricated. The names of major feast days were written in red (hence the phrase "red-letter day," which survives in English to this day), while ordinary days were written in black. The alternation of red and black in the calendar was thus a functional system of classification, distinguishing the most important days of the liturgical year at a glance.
+
+The rubrication of the calendar required the rubricator to have a working knowledge of the liturgical calendar, including the local saints' feasts appropriate to the diocese or region for which the book was intended. A Book of Hours made for use in Paris would have different red-letter days from one made for use in Bruges or Rome, reflecting the local veneration of particular saints.

--- a/rubric/content/chapters/section-and-paragraph-marks.md
+++ b/rubric/content/chapters/section-and-paragraph-marks.md
@@ -1,0 +1,72 @@
++++
+title = "Section and Paragraph Marks"
+description = "The pilcrow, the section sign, and the other red marks that structured the medieval page - a grammar of visual navigation."
+date = "2026-04-10"
+template = "chapter"
+weight = 5
+tags = ["pilcrow", "section-sign", "marks", "navigation"]
+[taxonomies]
+script = ["Carolingian"]
+[extra]
+chapter_no = "V"
+script = "Carolingian to Gothic transitional"
+scribe = "Anonymous, Parisian workshop"
+date_written = "c. 1180-1220 AD"
+material = "Vellum, red lead, blue woad ink"
+source = "British Library, MS Royal 1 D.I"
+initial_caption = "A rubricated initial S incorporating pilcrow and section marks as decorative elements within the letter form."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Rectangular frame with pilcrow marks at corners -->
+  <rect x="18" y="18" width="164" height="184" fill="none" stroke="#8B0000" stroke-width="1"/>
+  <text x="12" y="24" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#182;</text>
+  <text x="180" y="24" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#167;</text>
+  <text x="12" y="208" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#167;</text>
+  <text x="180" y="208" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#182;</text>
+  <!-- Large initial S -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="110" font-weight="900" fill="#8B0000">S</text>
+  <!-- Scattered pilcrow and section marks as decoration -->
+  <text x="36" y="55" font-family="'EB Garamond', serif" font-size="16" fill="#8B0000" opacity="0.5">&#182;</text>
+  <text x="155" y="55" font-family="'EB Garamond', serif" font-size="16" fill="#8B0000" opacity="0.5">&#167;</text>
+  <text x="32" y="110" font-family="'EB Garamond', serif" font-size="14" fill="#8B0000" opacity="0.4">&#167;</text>
+  <text x="160" y="110" font-family="'EB Garamond', serif" font-size="14" fill="#8B0000" opacity="0.4">&#182;</text>
+  <text x="36" y="165" font-family="'EB Garamond', serif" font-size="16" fill="#8B0000" opacity="0.5">&#182;</text>
+  <text x="155" y="165" font-family="'EB Garamond', serif" font-size="16" fill="#8B0000" opacity="0.5">&#167;</text>
+  <!-- Decorative dots along frame edges -->
+  <circle cx="60" cy="18" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="100" cy="18" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="140" cy="18" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="60" cy="202" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="100" cy="202" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <circle cx="140" cy="202" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <!-- Hairline divider under frame top -->
+  <line x1="30" y1="35" x2="170" y2="35" stroke="#8B0000" stroke-width="0.4" opacity="0.4"/>
+  <line x1="30" y1="185" x2="170" y2="185" stroke="#8B0000" stroke-width="0.4" opacity="0.4"/>
+</svg>
+'''
++++
+
+## A System of Signs
+
+The rubricated manuscript page was organised by a system of red signs, each with a specific structural function. The modern reader, accustomed to the white space, indentation, and typographic variation of the printed page, may not immediately appreciate the importance of these marks; but in a manuscript written in a continuous block of text, with minimal spacing between words and no paragraph indentation, the red marks were the primary means by which the reader navigated the page and understood the structure of the argument.
+
+The two most important marks were the pilcrow and the section sign, both of which survive in modern typography, though now as relics rather than as functional elements. Together with a range of subsidiary marks -- pointing hands, nota signs, and various marginal indicators -- they constituted a visual grammar that was understood throughout literate Western Europe.
+
+## The Pilcrow
+
+The pilcrow, as discussed in the first chapter of this work, marked the beginning of a new paragraph within a chapter or section. In its mature form, as standardised in the twelfth and thirteenth centuries, the pilcrow resembled a reversed and sometimes elaborated letter P, drawn in red. The rubricator placed it at the beginning of the line or slightly in the left margin, and the surrounding text wrapped around it in the natural reading flow.
+
+{{ alert(type="nota", body="The modern convention of indenting the first line of a new paragraph is a direct descendant of the pilcrow mark. As printing gradually eliminated the rubricator's role, the space formerly occupied by the pilcrow was left blank, creating the indented paragraph opening. The pilcrow thus survives, invisibly, in every indented paragraph in every printed book.") }}
+
+## The Section Sign
+
+The section sign, written as a pair of interlinked S-forms, marked a larger division of the text than the pilcrow. It typically indicated the beginning of a new numbered section within a chapter, or a major thematic break within a continuous argument. In legal texts, which were among the most heavily rubricated of all medieval manuscript genres, the section sign was indispensable: the division of a legal code into numbered sections, each introduced by a red section sign, made it possible for lawyers, judges, and students to locate and cite specific passages with precision.
+
+## Other Marks
+
+Beyond the pilcrow and the section sign, the rubricator's repertoire included several other marks. The pointing hand (*manicule*), drawn in the margin beside a passage of particular importance, directed the reader's attention. The *nota bene* mark, typically an abbreviation of the Latin *nota* written in red, served a similar function. Marginal cross-references, chapter numbers, and running titles (the short identifying text at the top of the page) were all typically executed in red, completing the system of visual navigation that made the medieval manuscript a usable reference tool.
+
+## The Transition to Print
+
+When the printed book replaced the manuscript in the fifteenth century, the system of red marks was one of the last elements of the manuscript tradition to be abandoned. Early printers left spaces in their text for the rubricator to fill in by hand, maintaining the two-colour system even as the black text was produced mechanically. The gradual elimination of these hand-applied marks, and their replacement by typographic equivalents (indentation, printed headings, and eventually printed section numbers), is the subject of a later chapter in this work.

--- a/rubric/content/chapters/the-decline-of-hand-rubrication.md
+++ b/rubric/content/chapters/the-decline-of-hand-rubrication.md
@@ -1,0 +1,72 @@
++++
+title = "The Decline of Hand-Rubrication"
+description = "The gradual obsolescence of the rubricator's craft as the printed book developed its own conventions for structure and navigation."
+date = "2026-04-10"
+template = "chapter"
+weight = 9
+tags = ["decline", "printing", "typography", "roman-type"]
+[taxonomies]
+script = ["Roman"]
+[extra]
+chapter_no = "IX"
+script = "Roman (Humanistic)"
+scribe = "Nicolas Jenson, Venice"
+date_written = "c. 1470-1520 AD"
+material = "Paper, printed in black with occasional red"
+source = "Biblioteca Marciana, Venice"
+initial_caption = "A rubricated initial D in the humanistic Roman style, with classical proportions and restrained penwork reflecting the transition from medieval to Renaissance taste."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Classical frame with triangular pediment -->
+  <line x1="24" y1="30" x2="24" y2="200" stroke="#8B0000" stroke-width="1.2"/>
+  <line x1="176" y1="30" x2="176" y2="200" stroke="#8B0000" stroke-width="1.2"/>
+  <line x1="24" y1="200" x2="176" y2="200" stroke="#8B0000" stroke-width="1.2"/>
+  <line x1="24" y1="30" x2="100" y2="14" stroke="#8B0000" stroke-width="1.2"/>
+  <line x1="100" y1="14" x2="176" y2="30" stroke="#8B0000" stroke-width="1.2"/>
+  <line x1="24" y1="30" x2="176" y2="30" stroke="#8B0000" stroke-width="0.6"/>
+  <!-- Small circle at pediment apex -->
+  <circle cx="100" cy="14" r="3" fill="none" stroke="#8B0000" stroke-width="0.8"/>
+  <circle cx="100" cy="14" r="1" fill="#8B0000"/>
+  <!-- Large initial D -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="115" font-weight="900" fill="#8B0000">D</text>
+  <!-- Classical penwork: restrained, symmetrical -->
+  <line x1="40" y1="38" x2="40" y2="50" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <line x1="160" y1="38" x2="160" y2="50" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <!-- Small ornamental leaf at pediment -->
+  <path d="M96,20 C94,24 96,26 100,26 C104,26 106,24 104,20" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.5"/>
+  <!-- Base ornaments -->
+  <line x1="40" y1="190" x2="40" y2="194" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <line x1="160" y1="190" x2="160" y2="194" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <circle cx="40" cy="196" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <circle cx="160" cy="196" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <!-- Horizontal accents inside frame -->
+  <line x1="30" y1="170" x2="50" y2="170" stroke="#8B0000" stroke-width="0.4" opacity="0.3"/>
+  <line x1="150" y1="170" x2="170" y2="170" stroke="#8B0000" stroke-width="0.4" opacity="0.3"/>
+</svg>
+'''
++++
+
+## The Typographic Revolution
+
+The decline of hand-rubrication was not a sudden event but a gradual transition spanning approximately half a century, from the 1470s to the 1520s. During this period, the printed book developed its own visual conventions for indicating textual structure, and these conventions progressively eliminated the need for the rubricator's hand. The story of this transition is the story of the printed book learning to stand on its own, freeing itself from the last vestiges of the manuscript tradition.
+
+The key innovations were four: the printed initial letter, the indented paragraph, the printed heading, and the title page. Each of these typographic devices replaced a function that had previously been performed by the rubricator, and together they created a new visual grammar for the book that depended on typography alone, without recourse to colour.
+
+## The Printed Initial
+
+The first function of the rubricator to be replaced was the provision of initial letters. Early printers, as noted in the preceding chapter, left spaces for the rubricator to fill. But from the 1460s onward, printers began to include initial letters in their printed output, first as woodcut blocks and later as cast type. These printed initials were necessarily black (two-colour printing being too expensive for routine use), but they were designed to be visually prominent enough to serve the same structural function as the red initials they replaced.
+
+{{ alert(type="nota", body="The transition from hand-rubricated to printed initials can be traced in the career of a single printer. In his earliest books, from the 1460s, Peter Schoeffer of Mainz left spaces for hand-rubrication. By the 1470s, he was printing some initials from woodblocks while still leaving spaces for others. By the 1480s, most of his books included printed initials throughout, and the rubricator's role was effectively eliminated.") }}
+
+## The Indented Paragraph
+
+The replacement of the pilcrow by the indented paragraph was perhaps the most consequential of all the changes in the visual grammar of the book. In the manuscript tradition, the pilcrow mark, applied by the rubricator in red, was the sole indicator of a new paragraph. The text was written continuously, without the blank line or indented first line that modern readers expect. When printers eliminated the rubricator, they initially left a small space where the pilcrow would have been placed, creating an accidental indentation. This convention was quickly recognised as useful in its own right and was adopted as the standard method of indicating paragraph divisions in the printed book.
+
+## The Printed Heading
+
+The third function of the rubricator to be replaced was the provision of headings and running titles. In manuscripts, chapter headings and section titles were typically written in red, distinguishing them from the body text. Printers achieved the same effect by using larger or bolder type for headings, or by employing a contrasting typeface (roman versus italic, or roman versus blackletter). The visual hierarchy that had been created by the contrast between red and black was thus recreated by the contrast between different sizes and styles of black type.
+
+## The Humanistic Context
+
+The decline of hand-rubrication coincided with the broader cultural transition from the medieval to the Renaissance world. The humanistic scholars of fifteenth-century Italy, who championed the revival of classical literature and the reform of script and book production, had little interest in the Gothic visual conventions of the medieval book. They favoured a clean, uncluttered page design inspired by the manuscripts of classical antiquity, and they actively promoted the adoption of the roman typeface over the Gothic blackletter. In this cultural context, the red marks of the rubricator came to seem old-fashioned, associated with the scholastic and monastic traditions that the humanists sought to transcend.

--- a/rubric/content/chapters/the-incunable-rubric.md
+++ b/rubric/content/chapters/the-incunable-rubric.md
@@ -1,0 +1,66 @@
++++
+title = "The Incunable Rubric"
+description = "Rubrication in the earliest printed books - the transition from manuscript to print and the hybrid books of the fifteenth century."
+date = "2026-04-10"
+template = "chapter"
+weight = 7
+tags = ["incunable", "printing", "transition", "hybrid"]
+[taxonomies]
+script = ["Rotunda"]
+[extra]
+chapter_no = "VII"
+script = "Rotunda"
+scribe = "Various, hand-rubrication of printed sheets"
+date_written = "c. 1460-1500 AD"
+material = "Paper, printed in black, rubricated by hand in red"
+source = "Bayerische Staatsbibliothek, Munich, 2 Inc.c.a. 340"
+initial_caption = "A rubricated initial I in the Rotunda style, with the vertical stroke broadened into a decorative pillar flanked by penwork flourishes."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Pillar-like frame for I -->
+  <rect x="80" y="24" width="40" height="172" fill="none" stroke="#8B0000" stroke-width="1.5" rx="2"/>
+  <!-- Decorative capital and base for pillar -->
+  <rect x="70" y="18" width="60" height="12" fill="#8B0000" rx="1"/>
+  <rect x="70" y="190" width="60" height="12" fill="#8B0000" rx="1"/>
+  <!-- Large initial I -->
+  <text x="100" y="158" text-anchor="middle" font-family="'Cinzel', serif" font-size="120" font-weight="900" fill="#8B0000">I</text>
+  <!-- Penwork flourishes extending left -->
+  <path d="M80,60 C60,55 40,65 35,80" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M35,80 C30,95 38,105 50,100" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="50" cy="100" r="2" fill="#8B0000" opacity="0.4"/>
+  <path d="M80,100 C55,98 35,110 30,130" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.5"/>
+  <circle cx="30" cy="130" r="2.5" fill="#8B0000" opacity="0.5"/>
+  <path d="M80,140 C65,138 45,145 40,160" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="40" cy="160" r="2" fill="#8B0000" opacity="0.4"/>
+  <!-- Penwork flourishes extending right -->
+  <path d="M120,70 C140,65 158,75 162,90" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <path d="M162,90 C166,105 158,115 148,110" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="148" cy="110" r="2" fill="#8B0000" opacity="0.4"/>
+  <path d="M120,120 C145,118 162,128 166,145" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.5"/>
+  <circle cx="166" cy="145" r="2.5" fill="#8B0000" opacity="0.5"/>
+  <path d="M120,160 C140,158 155,165 158,178" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.4"/>
+  <circle cx="158" cy="178" r="2" fill="#8B0000" opacity="0.4"/>
+</svg>
+'''
++++
+
+## The Hybrid Book
+
+The earliest printed books, known as incunables (from the Latin *incunabula*, cradle), occupied an ambiguous position between the manuscript and the fully printed book. Gutenberg and his immediate successors printed the body text in black but relied on hand-applied rubrication for all the elements that had traditionally been in red: initial letters, paragraph marks, running titles, and headings. The result was a hybrid artefact, partly mechanical and partly handmade, that preserved the two-colour visual grammar of the manuscript while exploiting the new technology for the bulk of the text.
+
+This hybrid method was not a temporary expedient; it was the standard practice of the incunable period. Printers routinely left spaces in their text blocks for the rubricator to fill, often printing small guide letters (barely visible to the modern eye) to indicate which initial was required. The rubricator, working in the traditional manner with quill and red ink, then added the initials and marks to the printed sheets before they were bound.
+
+## The Rubricator's Instructions
+
+Some incunables preserve printed instructions to the rubricator, typically found at the end of the volume in a section called the *tabula rubricarum* or register of rubrics. These instructions specified which initials were to be rubricated, at which positions in the text, and sometimes indicated the size and style of the letters required. The existence of such printed instructions is itself evidence of the industrialisation of the rubrication process: the rubricator was no longer an integral member of the producing scriptorium but an outside contractor working from standardised specifications.
+
+{{ alert(type="nota", body="Not all copies of a given incunable were rubricated. Some were sold unrubricated, either because the purchaser could not afford the additional cost or because they preferred to commission their own rubrication in a style and quality of their choosing. The variation between copies of the same edition is one of the distinctive features of incunable bibliography.") }}
+
+## The Rotunda Hand
+
+The rubrication of Italian incunables frequently employed the Rotunda hand, a rounded version of the Gothic textura that had developed in the scriptoria of Italy. The Rotunda hand produced initials that were softer and rounder than their northern Gothic equivalents, with curved strokes that complemented the humanistic roman types being developed by Italian printers such as Sweynheym and Pannartz, Jenson, and Aldus Manutius. The tension between the handwritten Rotunda initial and the printed Roman text is one of the visual hallmarks of the Italian incunable.
+
+## The Decline of Hand-Rubrication in Print
+
+The practice of hand-rubrication in printed books declined gradually through the last decades of the fifteenth century. As printing techniques improved and readers became accustomed to the conventions of the printed page, the need for red marks diminished. Printers began to include printed initial letters (woodcut or cast) in their fonts, eliminating the need for hand-drawn initials. Paragraph marks were replaced by indentation. Running titles and headings were printed in the same black ink as the body text, distinguished by size or style rather than colour. By 1500, the rubricator's role in book production was largely extinct, surviving only in the specialised domain of liturgical printing.

--- a/rubric/content/chapters/the-pilcrow-and-its-origins.md
+++ b/rubric/content/chapters/the-pilcrow-and-its-origins.md
@@ -1,0 +1,70 @@
++++
+title = "The Pilcrow and Its Origins"
+description = "The paragraph mark from its Roman antecedents through the Carolingian scriptoria - the birth of the red pilcrow as a structural device in the Western manuscript."
+date = "2026-04-10"
+template = "chapter"
+weight = 1
+tags = ["pilcrow", "paragraph-mark", "carolingian"]
+[taxonomies]
+script = ["Carolingian"]
+[extra]
+chapter_no = "I"
+script = "Carolingian Minuscule"
+scribe = "Anonymous, scriptorium of Tours"
+date_written = "c. 820-850 AD"
+material = "Vellum, iron-gall ink, red lead"
+source = "Bibliotheque Nationale de France, MS lat. 1"
+initial_caption = "A rubricated initial P in the Carolingian manner, with penwork flourishes extending from the vertical stroke."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <rect x="14" y="14" width="172" height="192" fill="none" stroke="#8B0000" stroke-width="0.6"/>
+  <!-- Decorative corner flourishes -->
+  <path d="M14,14 Q14,34 34,34" fill="none" stroke="#8B0000" stroke-width="0.8"/>
+  <path d="M186,14 Q186,34 166,34" fill="none" stroke="#8B0000" stroke-width="0.8"/>
+  <path d="M14,206 Q14,186 34,186" fill="none" stroke="#8B0000" stroke-width="0.8"/>
+  <path d="M186,206 Q186,186 166,186" fill="none" stroke="#8B0000" stroke-width="0.8"/>
+  <!-- Large initial P -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="120" font-weight="900" fill="#8B0000">P</text>
+  <!-- Penwork decoration around the letter -->
+  <path d="M52,50 C42,70 38,100 42,130" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.6"/>
+  <path d="M48,45 C35,75 32,115 38,145" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <circle cx="42" cy="130" r="2" fill="#8B0000" opacity="0.6"/>
+  <circle cx="38" cy="145" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <!-- Filigree extending from bowl of P -->
+  <path d="M135,65 C150,60 160,70 155,85" fill="none" stroke="#8B0000" stroke-width="0.7" opacity="0.6"/>
+  <path d="M155,85 C150,95 158,105 165,100" fill="none" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <circle cx="165" cy="100" r="1.5" fill="#8B0000" opacity="0.5"/>
+  <!-- Vertical penwork along stem -->
+  <path d="M70,160 C65,170 60,180 65,190" fill="none" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <circle cx="65" cy="190" r="2" fill="#8B0000" opacity="0.5"/>
+  <!-- Small red dots as decoration -->
+  <circle cx="30" cy="50" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <circle cx="170" cy="50" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <circle cx="30" cy="170" r="1.5" fill="#8B0000" opacity="0.4"/>
+  <circle cx="170" cy="170" r="1.5" fill="#8B0000" opacity="0.4"/>
+</svg>
+'''
++++
+
+## The Roman Ancestry
+
+The paragraph mark which we call the pilcrow has its distant origins in the classical Roman practice of marking new sections of text. Roman scribes used the letter C (for *caput*, head) written in the margin to signal the beginning of a new chapter or section. In some manuscripts this C was drawn larger than the surrounding text and placed in the left margin, creating a visual cue that the reader could locate at a glance when scanning a long roll of text. The practice was not uniform; other marks, including simple horizontal lines and the occasional Greek-derived paragraphos (a short horizontal stroke drawn beneath the first word of a new section), served similar functions in different scriptoria.
+
+As the codex form replaced the scroll in the fourth and fifth centuries, the need for structural marks became more acute. The codex page, unlike the scroll, presented text in a fixed, framed space; the reader could no longer rely on the physical rhythm of unrolling to sense the passage from one section to the next. Visual markers within the text became essential.
+
+## The Carolingian Reform
+
+The decisive transformation of the paragraph mark occurred in the Carolingian period, during the great reform of script and book production undertaken at the court of Charlemagne in the late eighth and early ninth centuries. The scholars and scribes gathered at Aachen and at the great monasteries of Tours, Corbie, and Reichenau established the Carolingian minuscule as the standard book hand of Western Europe, and with it they regularised the system of punctuation and structural marks.
+
+The Carolingian scribes adopted the letter C as the basis for their paragraph mark, but they transformed it. The mark was drawn in red ink, not black, setting it apart from the body text and creating the two-colour system that would define the Western book for the next seven centuries. The C was often elaborated with a vertical stroke, creating the form that eventually became the pilcrow as we know it today.
+
+{{ alert(type="nota", body="The word pilcrow is itself of uncertain etymology. Some scholars derive it from the Old French pelagraphe, a corruption of paragraphe; others connect it to the medieval Latin pylcrafte. The Oxford English Dictionary records its earliest English use in the fifteenth century.") }}
+
+## The Function of the Mark
+
+The pilcrow served a precise structural function in the Carolingian manuscript. It marked the beginning of a new paragraph or section within a chapter, allowing the reader to navigate the text without the aid of indentation (which was not yet standard practice). The rubricator applied the pilcrow after the main scribe had completed the black text, working from annotations or guide letters left in the margins. In well-organised scriptoria, the division of labour was strict: the scribe wrote, the rubricator marked, and the illuminator painted.
+
+## The Legacy
+
+The Carolingian pilcrow survived the dissolution of the Carolingian empire and the diversification of scripts in the eleventh and twelfth centuries. It was adopted into the Gothic book hands, adapted for use in legal and liturgical texts, and eventually transferred to the printed book. Even today, the pilcrow symbol persists in typographic practice as the standard sign for paragraph in legal citation, editorial markup, and word-processing software, a direct descendant of the red marks applied by Carolingian rubricators more than a thousand years ago.

--- a/rubric/content/chapters/the-rubricators-art.md
+++ b/rubric/content/chapters/the-rubricators-art.md
@@ -1,0 +1,72 @@
++++
+title = "The Rubricator's Art"
+description = "The craft and status of the rubricator in the medieval scriptorium - a specialist scribe operating between the writer and the illuminator."
+date = "2026-04-10"
+template = "chapter"
+weight = 3
+tags = ["rubricator", "scriptorium", "craft", "gothic"]
+[taxonomies]
+script = ["Gothic"]
+[extra]
+chapter_no = "III"
+script = "Gothic Textura"
+scribe = "Master rubricator, Dominican scriptorium"
+date_written = "c. 1250-1300 AD"
+material = "Vellum, red lead, oak-gall ink"
+source = "Bodleian Library, Oxford, MS Laud Misc. 165"
+initial_caption = "A rubricated initial T in the Gothic style, with angular penwork extensions and diamond-shaped terminals characteristic of the textura tradition."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Gothic pointed arch frame -->
+  <path d="M20,206 L20,40 Q100,10 180,40 L180,206" fill="none" stroke="#8B0000" stroke-width="1.5"/>
+  <path d="M20,206 L180,206" stroke="#8B0000" stroke-width="1.5"/>
+  <!-- Gothic tracery at top -->
+  <path d="M20,40 Q60,20 100,30 Q140,20 180,40" fill="none" stroke="#8B0000" stroke-width="0.8" opacity="0.6"/>
+  <circle cx="100" cy="22" r="3" fill="#8B0000"/>
+  <!-- Large initial T -->
+  <text x="100" y="155" text-anchor="middle" font-family="'Cinzel', serif" font-size="110" font-weight="900" fill="#8B0000">T</text>
+  <!-- Angular penwork extensions from serifs -->
+  <line x1="45" y1="60" x2="32" y2="48" stroke="#8B0000" stroke-width="0.8" opacity="0.6"/>
+  <line x1="32" y1="48" x2="32" y2="38" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <line x1="155" y1="60" x2="168" y2="48" stroke="#8B0000" stroke-width="0.8" opacity="0.6"/>
+  <line x1="168" y1="48" x2="168" y2="38" stroke="#8B0000" stroke-width="0.6" opacity="0.5"/>
+  <!-- Diamond terminals (Gothic style) -->
+  <polygon points="32,35 35,38 32,41 29,38" fill="#8B0000" opacity="0.6"/>
+  <polygon points="168,35 171,38 168,41 165,38" fill="#8B0000" opacity="0.6"/>
+  <!-- Penwork descending from stem base -->
+  <line x1="100" y1="165" x2="100" y2="185" stroke="#8B0000" stroke-width="0.8" opacity="0.5"/>
+  <polygon points="100,185 103,190 100,195 97,190" fill="#8B0000" opacity="0.5"/>
+  <!-- Angular hairline decorations -->
+  <line x1="60" y1="100" x2="45" y2="108" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <line x1="45" y1="108" x2="45" y2="120" stroke="#8B0000" stroke-width="0.5" opacity="0.3"/>
+  <line x1="140" y1="100" x2="155" y2="108" stroke="#8B0000" stroke-width="0.5" opacity="0.4"/>
+  <line x1="155" y1="108" x2="155" y2="120" stroke="#8B0000" stroke-width="0.5" opacity="0.3"/>
+  <!-- Small diamond accents -->
+  <polygon points="45,120 47,123 45,126 43,123" fill="#8B0000" opacity="0.4"/>
+  <polygon points="155,120 157,123 155,126 153,123" fill="#8B0000" opacity="0.4"/>
+</svg>
+'''
++++
+
+## A Specialist Craft
+
+The rubricator occupied a distinct position in the medieval scriptorium, standing between the scribe who wrote the body text and the illuminator who painted the major decorated initials and miniatures. The rubricator's task was specific: to apply red ink to those elements of the page that required it -- headings, initial letters at the minor divisions of the text, paragraph marks, running titles, and various marginal indicators. This was skilled work, requiring a steady hand, a knowledge of the text's structure, and an eye for the visual rhythm of the page.
+
+In the great monastic scriptoria of the twelfth and thirteenth centuries, rubrication was often assigned to a single specialist who worked on multiple books simultaneously. The main scribe would complete a gathering (a quire of folded sheets) and pass it to the rubricator, who would add all the red elements before the gathering was passed on to the binder. This assembly-line method of production allowed the scriptorium to produce books efficiently while maintaining a consistent standard of visual quality.
+
+## The Tools and Materials
+
+The rubricator's kit was modest: a quill pen (often cut from goose or swan feathers), a pot of red ink, and a small knife for corrections. The red ink was prepared from red lead or vermilion ground with gum arabic, as described in the preceding chapter. Some rubricators also kept a supply of blue ink (typically made from woad or, later, from imported ultramarine) for alternating blue-and-red initial letters, a decorative convention common in liturgical manuscripts from the twelfth century onward.
+
+{{ alert(type="nota", body="The rubricator's guide letters -- small letters written in the margin to indicate which initial should be drawn -- are sometimes still visible in finished manuscripts. These guides were normally trimmed away during binding or painted over during rubrication, but where the rubricator missed one or the binder left a wide margin, they survive as evidence of the production process.") }}
+
+## The Gothic Period
+
+The Gothic period, from the mid-twelfth century through the fifteenth, represents the high point of the rubricator's art. The transition from Romanesque round hands to the angular, compressed Gothic textura created new demands and opportunities for the rubricator. The red initials of Gothic manuscripts are characteristically angular, with sharp, pointed serifs and diamond-shaped terminals that echo the forms of the textura hand. Penwork flourishing -- delicate hairline extensions in red or blue that radiate from the body of the initial -- became increasingly elaborate, filling the margins with patterns of spirals, interlace, and leaf forms.
+
+The mendicant orders, particularly the Dominicans and Franciscans, became major producers and consumers of rubricated books in the thirteenth century. Their preaching and teaching missions required large numbers of portable Bibles, service books, and theological compilations, all of which demanded rubrication as a practical aid to navigation as well as a mark of devotional quality.
+
+## The Division of Labour
+
+The relationship between the rubricator and the illuminator was not always clear-cut. In some scriptoria, the rubricator was responsible for all red and blue elements, including the smaller decorated initials, while the illuminator handled only the large historiated or figurative initials. In others, the rubricator's domain was limited to the simplest marks -- pilcrows, running titles, and plain two-line initials -- while a more skilled artist executed the penwork flourished initials. The boundary between the two roles shifted according to the standards and resources of each workshop.

--- a/rubric/content/chapters/two-colour-printing.md
+++ b/rubric/content/chapters/two-colour-printing.md
@@ -1,0 +1,66 @@
++++
+title = "Two-Colour Printing"
+description = "The technical challenge of printing in red and black - from Fust and Schoeffer's Psalter of 1457 to the title pages of the sixteenth century."
+date = "2026-04-10"
+template = "chapter"
+weight = 6
+tags = ["printing", "two-colour", "psalter", "fust-schoeffer"]
+[taxonomies]
+script = ["Textura"]
+[extra]
+chapter_no = "VI"
+script = "Textura (printed)"
+scribe = "Peter Schoeffer, Mainz"
+date_written = "1457 AD"
+material = "Paper and vellum, printed in red and black"
+source = "British Library, IC.122; Bibliotheque Nationale, Velins 221"
+initial_caption = "A rubricated initial T as it might appear in two-colour printing, with the letter printed in red against surrounding black text."
+initial_svg = '''
+<svg viewBox="0 0 200 220" xmlns="http://www.w3.org/2000/svg" width="200" height="220">
+  <rect x="4" y="4" width="192" height="212" fill="#FAF6EE" stroke="#8B7332" stroke-width="1"/>
+  <!-- Double-rule frame evoking printed border -->
+  <rect x="12" y="12" width="176" height="196" fill="none" stroke="#1A1A18" stroke-width="1.5"/>
+  <rect x="16" y="16" width="168" height="188" fill="none" stroke="#1A1A18" stroke-width="0.5"/>
+  <!-- Red printed initial T -->
+  <text x="100" y="150" text-anchor="middle" font-family="'Cinzel', serif" font-size="110" font-weight="900" fill="#8B0000">T</text>
+  <!-- Simulated surrounding black printed text -->
+  <text x="24" y="28" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">Beatus uir qui non abiit in consilio impiorum</text>
+  <text x="24" y="36" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">et in uia peccatorum non stetit et in cathedra</text>
+  <text x="24" y="44" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">pestilentiae non sedit. Sed in lege Domini</text>
+  <!-- Red printing marks - registration guides -->
+  <line x1="8" y1="110" x2="12" y2="110" stroke="#8B0000" stroke-width="0.5"/>
+  <line x1="188" y1="110" x2="192" y2="110" stroke="#8B0000" stroke-width="0.5"/>
+  <line x1="100" y1="8" x2="100" y2="12" stroke="#8B0000" stroke-width="0.5"/>
+  <line x1="100" y1="208" x2="100" y2="212" stroke="#8B0000" stroke-width="0.5"/>
+  <!-- Bottom printed text -->
+  <text x="24" y="180" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">uoluntas eius et in lege eius meditabitur die</text>
+  <text x="24" y="188" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">ac nocte. Et erit tamquam lignum quod plan-</text>
+  <text x="24" y="196" font-family="'EB Garamond', serif" font-size="6" fill="#1A1A18" opacity="0.4">tatum est secus decursus aquarum quod</text>
+  <!-- Printer's device: two dots and cross -->
+  <circle cx="94" cy="198" r="1.5" fill="#8B0000"/>
+  <line x1="100" y1="194" x2="100" y2="202" stroke="#8B0000" stroke-width="0.6"/>
+  <line x1="96" y1="198" x2="104" y2="198" stroke="#8B0000" stroke-width="0.6"/>
+  <circle cx="106" cy="198" r="1.5" fill="#8B0000"/>
+</svg>
+'''
++++
+
+## The Psalter of 1457
+
+The first printed book to achieve true two-colour printing was the Mainz Psalter of 1457, produced by Johann Fust and Peter Schoeffer, who had acquired Gutenberg's press and types after the famous lawsuit of 1455. The Psalter was a tour de force of early typography: large folio pages printed in black and red, with magnificent two-colour initial letters -- the B of *Beatus vir* and the D of *Dixit Dominus* -- that were themselves printed, not added by hand. The achievement was technically extraordinary and would not be equalled for decades.
+
+The challenge of two-colour printing lay in the registration: the sheet had to pass through the press twice, once for the black impression and once for the red, and the two impressions had to align precisely. A misregistration of even a millimetre would produce a blurred, overlapping effect that ruined the visual effect. Fust and Schoeffer solved this problem with a system of guide marks (small pin-holes or inked registration points) that allowed the pressman to position the sheet accurately for the second impression.
+
+{{ alert(type="nota", body="The 1457 Psalter is one of the rarest and most valuable of all printed books. Only ten copies are known to survive, seven on vellum and three on paper. The copy in the British Library was purchased at auction in 1884 for the then-remarkable sum of 4,950 pounds sterling.") }}
+
+## The Economics of Two-Colour
+
+Despite the success of the 1457 Psalter, two-colour printing did not immediately become standard practice. The double impression required twice the press time, doubled the risk of error, and demanded more precise craftsmanship from the pressman. Most printers found it more economical to print the text in black alone and hire a rubricator to add the red elements by hand -- exactly as manuscript producers had done for centuries. This hybrid method, combining mechanical black printing with manual red rubrication, was the standard practice for incunable production throughout the 1460s, 1470s, and into the 1480s.
+
+## Title Pages and Display
+
+Two-colour printing found its most lasting application not in the body of the text but in the title page. From the early sixteenth century onward, printers routinely printed title pages in red and black, using the red for the author's name, the title, or a decorative device, and the black for the remainder. This practice gave the title page a visual dignity and prominence that a single-colour page could not match, and it persisted well into the eighteenth century. Some of the finest title pages of the Renaissance and Baroque periods are exercises in two-colour design, balancing red and black type in elaborate typographic compositions.
+
+## The Legacy in Liturgical Printing
+
+Liturgical books -- missals, breviaries, and psalters -- retained two-colour printing longer than any other category of printed book. The rubrics of the Mass (the instructions to the celebrant, printed in red to distinguish them from the spoken text) gave the word *rubric* its extended meaning of "a rule or instruction," and they demanded genuine red-and-black printing throughout the life of the hand-press period. Specialised liturgical printers, such as the Plantin press in Antwerp, maintained the expertise and equipment for two-colour work long after secular printers had abandoned it.

--- a/rubric/content/colophon.md
+++ b/rubric/content/colophon.md
@@ -1,0 +1,39 @@
++++
+title = "Colophon"
+description = "Particulars of this edition - typography, design, construction, and acknowledgements."
+date = "2026-04-10"
+template = "page"
+tags = ["colophon", "typography", "design"]
++++
+
+## About This Edition
+
+*Rubric: A Red-Marked Publication* is a study of the rubrication tradition, composed and designed as a demonstration of the two-colour principle that it describes. The work is set in a palette of two colours -- dark red (#8B0000, approximating the hue of red lead or minium) and near-black (#1A1A18) -- against a warm parchment ground (#FAF6EE), in conscious imitation of the medieval manuscript page.
+
+## Typography
+
+The display type is set in **Cinzel**, a typeface designed by Natanael Gama, inspired by the classical Roman inscriptional capitals of the first century. It is used for all headings, navigation, and structural elements, rendered in the rubric red to echo the rubricated headings of the medieval book. Secondary display elements use **Cormorant SC**, a small-capitals variant of the Cormorant family designed by Christian Thalmann.
+
+The body text is set in **EB Garamond**, Georg Maurer's digital revival of the Garamond types cut by Claude Garamond in the sixteenth century. The fallback body face is **Crimson Pro**, designed by Jacques Le Bailly. Both are serif typefaces in the humanistic tradition, chosen for their readability and their historical connection to the period in which the transition from manuscript rubrication to printed typography took place.
+
+## Design Principles
+
+The design follows three principles drawn from the rubrication tradition:
+
+**Two-colour discipline.** The entire site is designed using only two colours plus the background, in strict emulation of the two-colour manuscript and early printed book. No gradients, no photographic images, and no colours outside the red-black-parchment palette are used.
+
+**Structural colour.** Red is used exclusively for structural and navigational elements -- headings, initial letters, links, paragraph marks, and section symbols. It is never used for purely decorative purposes. This follows the medieval rubricator's practice of using red as a functional marker, not an ornament.
+
+**Inline SVG.** All decorative elements are rendered as inline SVG, in the spirit of the rubricator who drew directly upon the page rather than inserting pre-made ornaments. Each chapter's initial letter is a unique SVG composition in the style of the script tradition discussed in that chapter.
+
+## Construction
+
+This site is built with [Hwaro](https://github.com/hahwul/hwaro), a static site generator. The content is written in Markdown with TOML front matter. Templates use the Tera templating engine. No JavaScript is required for the core reading experience.
+
+## Sources and Acknowledgements
+
+The historical information presented in the chapters draws upon the standard scholarly literature on Western manuscript production, including the works of M. B. Parkes (*Pause and Effect*), Raymond Clemens and Timothy Graham (*Introduction to Manuscript Studies*), Christopher de Hamel (*A History of Illuminated Manuscripts*), and Michelle Brown (*Understanding Illuminated Manuscripts*). The descriptions of pigments and materials draw upon Daniel V. Thompson's *The Materials and Techniques of Medieval Painting* and the recipe collections of Theophilus Presbyter and Cennino Cennini.
+
+## Date
+
+Composed and set in the year of grace MMXXVI.

--- a/rubric/content/index.md
+++ b/rubric/content/index.md
@@ -1,0 +1,121 @@
++++
+title = "Rubric"
+description = "A study of the rubrication tradition - red initial letters, paragraph marks, and section symbols in the manuscript and early printed book."
+template = "page"
++++
+
+<div class="frontispiece">
+
+<h1>RUBRIC</h1>
+
+<p class="front-lede">A study of the red-marking tradition from the scriptoria of the early Middle Ages through the printing houses of the Renaissance. The rubricator's art: initial letters, paragraph marks, and section symbols rendered in red upon the written page.</p>
+
+<div class="front-plate">
+<svg viewBox="0 0 480 560" xmlns="http://www.w3.org/2000/svg" width="480" height="560" aria-label="A manuscript page showing rubricated elements: a large red initial letter, red pilcrow marks, red section symbols, and black body text on parchment">
+  <!-- Parchment page -->
+  <rect x="10" y="10" width="460" height="540" fill="#FAF6EE" stroke="#8B7332" stroke-width="1.5" rx="2"/>
+  <!-- Inner margin rule -->
+  <rect x="30" y="30" width="420" height="500" fill="none" stroke="#C8BFA0" stroke-width="0.5"/>
+  <!-- Red ruled lines for text -->
+  <line x1="50" y1="70" x2="430" y2="70" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="120" x2="430" y2="120" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="170" x2="430" y2="170" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="220" x2="430" y2="220" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="270" x2="430" y2="270" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="320" x2="430" y2="320" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="370" x2="430" y2="370" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="420" x2="430" y2="420" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <line x1="50" y1="470" x2="430" y2="470" stroke="#8B0000" stroke-width="0.3" opacity="0.4"/>
+  <!-- Large rubricated initial I -->
+  <rect x="50" y="50" width="60" height="72" fill="#8B0000" rx="2"/>
+  <rect x="53" y="53" width="54" height="66" fill="none" stroke="#FAF6EE" stroke-width="0.8" rx="1"/>
+  <text x="80" y="108" text-anchor="middle" font-family="'Cinzel', serif" font-size="56" font-weight="900" fill="#FAF6EE">I</text>
+  <!-- Decorative flourish on initial -->
+  <line x1="56" y1="56" x2="66" y2="56" stroke="#FAF6EE" stroke-width="0.5"/>
+  <line x1="56" y1="56" x2="56" y2="66" stroke="#FAF6EE" stroke-width="0.5"/>
+  <line x1="96" y1="112" x2="104" y2="112" stroke="#FAF6EE" stroke-width="0.5"/>
+  <line x1="104" y1="103" x2="104" y2="112" stroke="#FAF6EE" stroke-width="0.5"/>
+  <!-- Body text lines in black (simulated) -->
+  <text x="120" y="68" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">n principio erat uerbum et uerbum erat</text>
+  <text x="120" y="88" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">apud deum et deus erat uerbum. Hoc erat</text>
+  <text x="120" y="108" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">in principio apud deum. Omnia per ipsum</text>
+  <text x="50" y="140" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">facta sunt et sine ipso factum est nihil quod factum est.</text>
+  <!-- Red pilcrow mark -->
+  <text x="50" y="168" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#182;</text>
+  <text x="68" y="168" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">In ipso uita erat et uita erat lux hominum et lux in</text>
+  <text x="50" y="190" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">tenebris lucet et tenebrae eam non comprehenderunt.</text>
+  <!-- Red section symbol -->
+  <text x="50" y="218" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#167;</text>
+  <text x="68" y="218" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">Fuit homo missus a deo cui nomen erat Iohannes. Hic</text>
+  <text x="50" y="240" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">uenit in testimonium ut testimonium perhiberet de lumine</text>
+  <!-- Another red pilcrow mark -->
+  <text x="50" y="268" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#182;</text>
+  <text x="68" y="268" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">ut omnes crederent per illum. Non erat ille lux sed ut</text>
+  <text x="50" y="290" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">testimonium perhiberet de lumine. Erat lux uera quae</text>
+  <!-- Red pilcrow and section marks interleaved -->
+  <text x="50" y="318" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#182;</text>
+  <text x="68" y="318" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">inluminat omnem hominem uenientem in mundum. In</text>
+  <text x="50" y="340" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">mundo erat et mundus per ipsum factus est et mundus</text>
+  <text x="50" y="368" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#167;</text>
+  <text x="68" y="368" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">eum non cognouit. In propria uenit et sui eum non</text>
+  <text x="50" y="390" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">receperunt. Quotquot autem receperunt eum dedit eis</text>
+  <!-- Red chapter heading in lower portion -->
+  <text x="50" y="418" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#182;</text>
+  <text x="68" y="418" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">potestatem filios dei fieri his qui credunt in nomine eius.</text>
+  <text x="50" y="440" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">Qui non ex sanguinibus neque ex uoluntate carnis neque</text>
+  <text x="50" y="468" font-family="'EB Garamond', serif" font-size="16" font-weight="700" fill="#8B0000">&#167;</text>
+  <text x="68" y="468" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">ex uoluntate uiri sed ex deo nati sunt. Et uerbum caro</text>
+  <text x="50" y="490" font-family="'EB Garamond', serif" font-size="14" fill="#1A1A18">factum est et habitauit in nobis et uidimus gloriam eius.</text>
+  <!-- Bottom ornamental rule in red -->
+  <line x1="140" y1="510" x2="200" y2="510" stroke="#8B0000" stroke-width="0.8"/>
+  <text x="212" y="514" font-family="'EB Garamond', serif" font-size="11" fill="#8B0000">&#182;</text>
+  <circle cx="230" cy="510" r="2" fill="#8B0000"/>
+  <text x="240" y="514" font-family="'EB Garamond', serif" font-size="11" fill="#8B0000">&#182;</text>
+  <line x1="255" y1="510" x2="340" y2="510" stroke="#8B0000" stroke-width="0.8"/>
+</svg>
+</div>
+
+<p class="front-lede">The word <em>rubric</em> descends from the Latin <em>rubrica</em>, meaning red earth or red ochre. In the manuscript tradition, the rubricator was the specialist scribe who applied red ink to initial letters, paragraph marks, headings, and marginal notations after the main text had been written in black. This two-colour system -- red upon black -- became the fundamental visual grammar of the Western book for nearly a thousand years.</p>
+
+</div>
+
+<div class="featured-chapters">
+
+## Featured Chapters
+
+<div class="featured-grid">
+<a href="{{ base_url }}/chapters/the-pilcrow-and-its-origins/" class="featured-card">
+<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" width="80" height="80" aria-hidden="true">
+  <rect x="2" y="2" width="76" height="76" fill="#FAF6EE" stroke="#8B0000" stroke-width="1.5" rx="2"/>
+  <text x="40" y="58" text-anchor="middle" font-family="'Cinzel', serif" font-size="48" font-weight="900" fill="#8B0000">P</text>
+</svg>
+<span class="card-title">The Pilcrow and Its Origins</span>
+<span class="card-script">Carolingian</span>
+</a>
+<a href="{{ base_url }}/chapters/red-lead-and-vermilion/" class="featured-card">
+<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" width="80" height="80" aria-hidden="true">
+  <rect x="2" y="2" width="76" height="76" fill="#FAF6EE" stroke="#8B0000" stroke-width="1.5" rx="2"/>
+  <text x="40" y="58" text-anchor="middle" font-family="'Cinzel', serif" font-size="48" font-weight="900" fill="#8B0000">R</text>
+</svg>
+<span class="card-title">Red Lead and Vermilion</span>
+<span class="card-script">Insular</span>
+</a>
+<a href="{{ base_url }}/chapters/lombardic-capitals/" class="featured-card">
+<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" width="80" height="80" aria-hidden="true">
+  <rect x="2" y="2" width="76" height="76" fill="#FAF6EE" stroke="#8B0000" stroke-width="1.5" rx="2"/>
+  <text x="40" y="58" text-anchor="middle" font-family="'Cinzel', serif" font-size="48" font-weight="900" fill="#8B0000">L</text>
+</svg>
+<span class="card-title">Lombardic Capitals</span>
+<span class="card-script">Lombardic</span>
+</a>
+<a href="{{ base_url }}/chapters/the-incunable-rubric/" class="featured-card">
+<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" width="80" height="80" aria-hidden="true">
+  <rect x="2" y="2" width="76" height="76" fill="#FAF6EE" stroke="#8B0000" stroke-width="1.5" rx="2"/>
+  <text x="40" y="58" text-anchor="middle" font-family="'Cinzel', serif" font-size="48" font-weight="900" fill="#8B0000">I</text>
+</svg>
+<span class="card-title">The Incunable Rubric</span>
+<span class="card-script">Rotunda</span>
+</a>
+</div>
+
+</div>

--- a/rubric/content/practice.md
+++ b/rubric/content/practice.md
@@ -1,0 +1,41 @@
++++
+title = "The Practice of Rubrication"
+description = "A practical account of the rubricator's materials, tools, and techniques from the early medieval period to the age of print."
+date = "2026-04-10"
+template = "page"
+tags = ["practice", "technique", "materials"]
++++
+
+## Definition and Scope
+
+Rubrication, from the Latin *rubricare* (to colour red), is the practice of applying red ink or pigment to specific elements of a manuscript or printed page. The term encompasses the full range of the rubricator's work: the drawing of initial letters in red, the placement of paragraph marks (pilcrows) and section signs, the writing of headings and running titles, the marking of feast days in calendars, and the provision of marginal notations and finding aids. In its broadest sense, rubrication refers to any use of colour as a structural or navigational device in the written or printed book.
+
+The practice is attested from the earliest surviving Western manuscripts and persisted in some form until the end of the hand-press period in the early nineteenth century. At its height, in the twelfth through fifteenth centuries, rubrication was an organised craft with its own specialists, materials, and conventions, practised in every scriptorium and later in every printing house in Western Europe.
+
+## Materials
+
+The rubricator's primary material was red ink, prepared from one of two principal pigments: red lead (*minium*) or vermilion (*cinnabar*). Red lead, an oxide of lead, was the cheaper and more widely available option, suitable for routine work. Vermilion, derived from mercury sulphide, was more expensive but produced a more brilliant and stable red. Both pigments were ground to a fine powder and mixed with a binding agent -- typically gum arabic, egg white, or fish glue -- to produce a smooth, workable ink.
+
+The choice of binding agent affected the appearance and handling of the ink. Gum arabic produced a matte, slightly rough surface; egg white (*glair*) gave a smoother, slightly glossy finish; fish glue was particularly favoured for its flexibility and adhesion on vellum. The rubricator prepared his ink in small quantities, grinding the pigment on a stone slab and mixing it with the binder in a shell or small pot.
+
+## Tools
+
+The rubricator's tools were essentially those of the scribe: quill pens, a penknife for cutting and sharpening, a ruler for straight lines, and a pot for the prepared ink. The pen was typically cut from a goose or swan feather, with the nib shaped to produce a stroke of the desired width. For large initials, the rubricator might use a broader pen or a reed pen; for fine hairline flourishes, a very narrow, flexible nib was required.
+
+In addition to the pen, some rubricators used a small brush for filling in large areas of colour, particularly when drawing the bodies of Lombardic or other decorated initials. A pair of compasses was used for drawing circular elements, and a template or stencil might be employed for frequently repeated forms such as the pilcrow mark.
+
+## Technique
+
+The rubricator typically worked after the main scribe had completed the body text of a manuscript. The scribe would leave spaces for the red elements, often marking the positions with small guide letters or marginal annotations to indicate what was required. The rubricator then filled in these spaces, working through the manuscript gathering by gathering (a gathering being a quire of folded sheets that formed a unit of the book).
+
+The order of work was generally from larger to smaller elements: first the major initials, then the minor initials, then the pilcrows and section marks, and finally the headings and running titles. This sequence minimised the risk of smudging, as the rubricator's hand moved across the page from the completed to the uncompleted portions.
+
+## The Two-Colour System
+
+The fundamental principle of rubrication was contrast: the opposition of red against black created a visual hierarchy that guided the reader through the text. This two-colour system was not merely decorative but functionally essential, providing the primary means of navigating the page in an era before indentation, printed headings, and typographic variation.
+
+The red elements formed a secondary text, running alongside and within the primary black text. Headings in red announced the subject of the following passage. Pilcrows in red marked the logical divisions of the argument. Section signs in red indicated the numbered sections of legal or theological texts. Running titles in red at the top of the page identified the book and chapter. Together, these red elements created a system of visual signposting that made the medieval manuscript a navigable and usable document.
+
+## The Rubricator's Place
+
+The rubricator occupied a specific position in the hierarchy of the medieval scriptorium. Below the illuminator, who was responsible for the major decorative programme (miniatures, historiated initials, and elaborate border designs), and above the binder and the ink-maker, the rubricator was a skilled artisan whose work was essential to the finished book but whose status was that of a craftsman rather than an artist. In some scriptoria, the rubricator was a specialist; in others, the work was performed by the main scribe or by a junior member of the workshop.

--- a/rubric/static/css/style.css
+++ b/rubric/static/css/style.css
@@ -1,0 +1,799 @@
+/* ==========================================================================
+   RUBRIC - A Red-Marked Publication
+   Two-colour design: red (#8B0000) and black (#1A1A18) on parchment
+   ========================================================================== */
+
+/* -- Foundations ----------------------------------------------------------- */
+:root {
+  --parchment:    #FAF6EE;
+  --parchment-dk: #F0EBD8;
+  --ink:          #1A1A18;
+  --ink-light:    #3D3D38;
+  --rubric:       #8B0000;
+  --rubric-light: #A52A2A;
+  --gold:         #8B7332;
+  --gold-light:   #B8993E;
+  --rule:         #C8BFA0;
+  --body-font:    'EB Garamond', 'Crimson Pro', 'Georgia', serif;
+  --display-font: 'Cinzel', 'Cormorant SC', serif;
+  --mono-font:    'Iowan Old Style', 'Palatino', 'Georgia', serif;
+  --measure:      740px;
+  --gutter:       1.5rem;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 18px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--body-font);
+  line-height: 1.72;
+  color: var(--ink);
+  background: var(--parchment);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* -- Links ---------------------------------------------------------------- */
+a {
+  color: var(--rubric);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s;
+}
+a:hover,
+a:focus {
+  border-bottom-color: var(--rubric);
+}
+
+::selection {
+  background: var(--rubric);
+  color: var(--parchment);
+}
+
+/* -- Typography ----------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--display-font);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--rubric);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+h1 { font-size: 2.2rem; margin-bottom: 0.6em; }
+h2 { font-size: 1.6rem; margin-top: 2em; margin-bottom: 0.5em; }
+h3 { font-size: 1.25rem; margin-top: 1.6em; margin-bottom: 0.4em; }
+h4 { font-size: 1.05rem; margin-top: 1.4em; margin-bottom: 0.4em; }
+
+p {
+  margin: 1em 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--rubric);
+  background: var(--parchment-dk);
+  font-style: italic;
+  color: var(--ink-light);
+}
+
+ul, ol {
+  margin: 1em 0;
+  padding-left: 1.6em;
+}
+li { margin-bottom: 0.35em; }
+
+hr {
+  border: none;
+  height: 1px;
+  background: var(--rule);
+  margin: 2em 0;
+}
+
+code {
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.85em;
+  background: var(--parchment-dk);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+pre {
+  background: var(--parchment-dk);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1.5em 0;
+}
+pre code {
+  background: none;
+  padding: 0;
+}
+
+strong { font-weight: 700; }
+em { font-style: italic; }
+
+/* -- Codex Frame (main wrapper) ------------------------------------------- */
+.codex-frame {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* -- Codex Header --------------------------------------------------------- */
+.codex-header {
+  padding: 1.5rem 0 1rem;
+  border-bottom: 2px solid var(--rubric);
+}
+
+.codex-header .header-rule {
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.codex-header .header-rule svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.codex-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  border-bottom: none;
+  margin-bottom: 0.75rem;
+}
+
+.codex-brand svg {
+  flex-shrink: 0;
+}
+
+.codex-brand:hover {
+  border-bottom: none;
+}
+
+.codex-nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.codex-nav a {
+  font-family: var(--display-font);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border-bottom: 2px solid transparent;
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.codex-nav a:hover,
+.codex-nav a:focus {
+  color: var(--rubric);
+  border-bottom-color: var(--rubric);
+}
+
+/* -- Codex Main ----------------------------------------------------------- */
+.codex-main {
+  flex: 1;
+  padding: 2rem 0;
+}
+
+/* -- Codex Footer --------------------------------------------------------- */
+.codex-foot {
+  margin-top: auto;
+  padding: 2rem 0 1.5rem;
+  border-top: 2px solid var(--rubric);
+  font-size: 0.82rem;
+  color: var(--ink-light);
+}
+
+.foot-rule {
+  display: block;
+  margin-bottom: 1.5rem;
+}
+
+.foot-rule svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.foot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.foot-col h4 {
+  font-family: var(--display-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rubric);
+  margin-bottom: 0.5em;
+  margin-top: 0;
+}
+
+.foot-col p {
+  text-align: left;
+  margin: 0.3em 0;
+  line-height: 1.5;
+}
+
+.foot-col a {
+  color: var(--ink-light);
+  border-bottom: 1px solid var(--rule);
+}
+
+.foot-col a:hover {
+  color: var(--rubric);
+  border-bottom-color: var(--rubric);
+}
+
+.foot-stamp {
+  text-align: center;
+  font-family: var(--display-font);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gold);
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+/* -- Frontispiece --------------------------------------------------------- */
+.frontispiece {
+  text-align: center;
+  padding: 1rem 0 2rem;
+}
+
+.front-plate {
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+}
+
+.front-plate svg {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.front-lede {
+  max-width: 560px;
+  margin: 0 auto;
+  font-size: 1.05rem;
+  color: var(--ink-light);
+  text-align: center;
+  line-height: 1.7;
+}
+
+.front-lede p {
+  text-align: center;
+}
+
+/* -- Rubric Initial (large red decorative letter) ------------------------- */
+.rubric-initial {
+  display: inline-block;
+  margin-right: 0.2em;
+  vertical-align: top;
+}
+
+.rubric-initial svg {
+  width: 4em;
+  height: 4em;
+  display: block;
+}
+
+/* -- Pilcrow Mark --------------------------------------------------------- */
+.pilcrow-mark {
+  color: var(--rubric);
+  font-size: 1.1em;
+  font-weight: 700;
+  margin-right: 0.15em;
+}
+
+/* -- Section Symbol ------------------------------------------------------- */
+.section-symbol {
+  color: var(--rubric);
+  font-size: 1.05em;
+  font-weight: 700;
+  margin-right: 0.15em;
+}
+
+/* -- Section Head --------------------------------------------------------- */
+.section-head {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.section-head .kicker {
+  font-family: var(--display-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 0.4em;
+}
+
+.section-head h1 {
+  margin-bottom: 0.3em;
+}
+
+.section-intro {
+  max-width: 580px;
+  margin: 0 auto 2rem;
+  text-align: center;
+  color: var(--ink-light);
+}
+
+.section-intro p {
+  text-align: center;
+}
+
+/* -- Chapter Table (section listing) -------------------------------------- */
+.chapter-table {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: chapter;
+}
+
+.chapter-row {
+  border-bottom: 1px solid var(--rule);
+}
+
+.chapter-row:first-child {
+  border-top: 1px solid var(--rule);
+}
+
+.chapter-link {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 0.5rem;
+  border-bottom: none;
+  transition: background 0.15s;
+}
+
+.chapter-link:hover {
+  background: var(--parchment-dk);
+  border-bottom: none;
+}
+
+.chapter-no {
+  font-family: var(--display-font);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--rubric);
+  min-width: 2.5rem;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.chapter-title-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15em;
+}
+
+.chapter-title-rl {
+  font-family: var(--display-font);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+
+.chapter-link:hover .chapter-title-rl {
+  color: var(--rubric);
+}
+
+.chapter-dek {
+  font-size: 0.82rem;
+  color: var(--ink-light);
+  line-height: 1.4;
+}
+
+.chapter-script {
+  font-family: var(--display-font);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gold);
+  flex-shrink: 0;
+  text-align: right;
+}
+
+/* -- Chapter Page --------------------------------------------------------- */
+.chapter-page {
+  max-width: var(--measure);
+}
+
+.chapter-head {
+  text-align: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.chapter-head .kicker {
+  font-family: var(--display-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 0.4em;
+}
+
+.chapter-head h1 {
+  color: var(--rubric);
+  margin-bottom: 0.3em;
+}
+
+.chapter-head .chapter-lede {
+  font-size: 1.05rem;
+  color: var(--ink-light);
+  font-style: italic;
+  max-width: 540px;
+  margin: 0 auto;
+}
+
+/* -- Chapter Specs -------------------------------------------------------- */
+.chapter-specs {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1rem;
+  margin: 0 0 2rem;
+  padding: 1rem 1.2rem;
+  background: var(--parchment-dk);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  font-size: 0.88rem;
+}
+
+.chapter-specs dt {
+  font-family: var(--display-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--rubric);
+  font-weight: 700;
+  padding-top: 0.15em;
+}
+
+.chapter-specs dd {
+  color: var(--ink-light);
+}
+
+/* -- Chapter Figure ------------------------------------------------------- */
+.chapter-figure {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.chapter-frame {
+  display: inline-block;
+  border: 2px solid var(--rubric);
+  padding: 0.5rem;
+  background: var(--parchment);
+}
+
+.chapter-frame svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.chapter-figcap {
+  margin-top: 0.6rem;
+  font-size: 0.82rem;
+  color: var(--ink-light);
+  font-style: italic;
+}
+
+/* -- Chapter Prose -------------------------------------------------------- */
+.chapter-prose {
+  margin: 2rem 0;
+}
+
+.chapter-prose h2 {
+  margin-top: 2.5em;
+}
+
+.chapter-prose h2::before {
+  content: "\00B6 ";
+  color: var(--rubric);
+  font-weight: 400;
+}
+
+/* -- Chapter Footer ------------------------------------------------------- */
+.chapter-foot {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.back-link {
+  font-family: var(--display-font);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+
+.back-link:hover {
+  color: var(--rubric);
+  border-bottom-color: var(--rubric);
+}
+
+/* -- Error Page ----------------------------------------------------------- */
+.error-page {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-page h1 {
+  font-size: 3rem;
+  color: var(--rubric);
+  margin-bottom: 0.3em;
+}
+
+.error-page p {
+  text-align: center;
+  font-size: 1.05rem;
+  color: var(--ink-light);
+}
+
+/* -- Alert Shortcode ------------------------------------------------------ */
+.alert {
+  margin: 1.5em 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--rubric);
+  background: var(--parchment-dk);
+  border-radius: 2px;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.alert strong {
+  font-family: var(--display-font);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--rubric);
+}
+
+/* -- Featured Chapters (on frontispiece) ---------------------------------- */
+.featured-chapters {
+  margin: 2.5rem 0;
+}
+
+.featured-chapters h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.featured-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.featured-card {
+  display: block;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border: 1px solid var(--rule);
+  background: var(--parchment);
+  border-bottom: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.featured-card:hover {
+  border-color: var(--rubric);
+  box-shadow: 0 2px 8px rgba(139, 0, 0, 0.08);
+  border-bottom: none;
+}
+
+.featured-card svg {
+  display: block;
+  margin: 0 auto 0.8rem;
+}
+
+.featured-card .card-title {
+  font-family: var(--display-font);
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+  display: block;
+}
+
+.featured-card:hover .card-title {
+  color: var(--rubric);
+}
+
+.featured-card .card-script {
+  font-size: 0.72rem;
+  color: var(--gold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: block;
+  margin-top: 0.25em;
+}
+
+/* -- Taxonomy Pages ------------------------------------------------------- */
+.taxonomy-desc {
+  color: var(--ink-light);
+  margin-bottom: 1.5rem;
+  font-style: italic;
+}
+
+.section-list {
+  list-style: none;
+  padding: 0;
+}
+
+.section-list li {
+  margin-bottom: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--parchment-dk);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+}
+
+.section-list li a {
+  font-weight: 600;
+}
+
+/* -- Pagination ----------------------------------------------------------- */
+nav.pagination {
+  margin: 1.5rem 0;
+}
+
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+nav.pagination a {
+  display: inline-block;
+  padding: 0.25rem 0.55rem;
+  border-radius: 3px;
+  border: 1px solid var(--rule);
+  color: var(--ink-light);
+}
+
+nav.pagination a:hover {
+  color: var(--rubric);
+  border-color: var(--rubric);
+}
+
+/* -- Page Content (practice, colophon) ------------------------------------ */
+.page-content {
+  max-width: var(--measure);
+}
+
+.page-content h1 {
+  text-align: center;
+  margin-bottom: 0.5em;
+}
+
+.page-content h2::before {
+  content: "\00A7 ";
+  color: var(--rubric);
+  font-weight: 400;
+}
+
+/* -- Responsive ----------------------------------------------------------- */
+@media (max-width: 768px) {
+  html { font-size: 16px; }
+
+  .codex-frame { padding: 0 1rem; }
+
+  .foot-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .featured-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .chapter-link {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .chapter-no {
+    min-width: auto;
+    text-align: left;
+  }
+
+  .chapter-script {
+    width: 100%;
+    text-align: left;
+    padding-left: 3.5rem;
+  }
+
+  .chapter-specs {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .chapter-specs dt {
+    margin-top: 0.5em;
+  }
+
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.3rem; }
+}
+
+@media (max-width: 480px) {
+  html { font-size: 15px; }
+
+  .codex-nav {
+    gap: 0.8rem;
+  }
+
+  .codex-nav a {
+    font-size: 0.72rem;
+  }
+
+  .codex-header {
+    padding: 1rem 0 0.75rem;
+  }
+
+  .front-plate svg {
+    max-width: 280px;
+  }
+
+  .chapter-frame svg {
+    max-width: 240px;
+  }
+
+  .foot-stamp {
+    font-size: 0.6rem;
+  }
+}
+
+/* -- Print ---------------------------------------------------------------- */
+@media print {
+  body { background: white; }
+  .codex-header, .codex-foot { display: none; }
+  .codex-main { padding: 0; }
+  a { color: var(--ink); border-bottom: none; }
+  h1, h2, h3, h4 { color: var(--ink); }
+}

--- a/rubric/templates/404.html
+++ b/rubric/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <div class="error-page">
+      <h1>CDIV</h1>
+      <p>The folio you seek is not present in this codex.</p>
+      <p>The rubricator has found no such page.</p>
+      <p><a href="{{ base_url }}/">&larr; Return to the Frontispiece</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/rubric/templates/chapter.html
+++ b/rubric/templates/chapter.html
@@ -1,0 +1,38 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <article class="chapter-page">
+      <header class="chapter-head">
+        <p class="kicker">{% if page.extra.chapter_no %}CAP. {{ page.extra.chapter_no | e }}{% endif %}{% if page.extra.script %} &middot; {{ page.extra.script | upper }}{% endif %}</p>
+        <h1 class="chapter-title">{{ page.title | e }}</h1>
+        {% if page.description %}<p class="chapter-lede">{{ page.description | e }}</p>{% endif %}
+      </header>
+
+      {% if page.extra.scribe or page.extra.date_written or page.extra.script or page.extra.material or page.extra.source %}
+      <dl class="chapter-specs">
+        {% if page.extra.scribe %}<dt>Scribe</dt><dd>{{ page.extra.scribe | e }}</dd>{% endif %}
+        {% if page.extra.date_written %}<dt>Date</dt><dd>{{ page.extra.date_written | e }}</dd>{% endif %}
+        {% if page.extra.script %}<dt>Script</dt><dd>{{ page.extra.script | e }}</dd>{% endif %}
+        {% if page.extra.material %}<dt>Material</dt><dd>{{ page.extra.material | e }}</dd>{% endif %}
+        {% if page.extra.source %}<dt>Source</dt><dd>{{ page.extra.source | e }}</dd>{% endif %}
+      </dl>
+      {% endif %}
+
+      {% if page.extra.initial_svg %}
+      <figure class="chapter-figure">
+        <div class="chapter-frame">
+          {{ page.extra.initial_svg | safe }}
+        </div>
+        {% if page.extra.initial_caption %}<figcaption class="chapter-figcap">{{ page.extra.initial_caption | e }}</figcaption>{% endif %}
+      </figure>
+      {% endif %}
+
+      <div class="chapter-prose">
+        {{ content }}
+      </div>
+
+      <footer class="chapter-foot">
+        <a href="{{ base_url }}/chapters/" class="back-link">&larr; Return to the Table of Chapters</a>
+      </footer>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/rubric/templates/footer.html
+++ b/rubric/templates/footer.html
@@ -1,0 +1,36 @@
+    <footer class="codex-foot">
+      <div class="foot-rule">
+        <svg viewBox="0 0 740 14" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <line x1="0" y1="7" x2="200" y2="7" stroke="#8B0000" stroke-width="0.6"/>
+          <circle cx="210" cy="7" r="2" fill="#8B0000"/>
+          <text x="222" y="11" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#182;</text>
+          <circle cx="240" cy="7" r="2" fill="#8B0000"/>
+          <line x1="250" y1="7" x2="490" y2="7" stroke="#8B0000" stroke-width="0.6"/>
+          <circle cx="500" cy="7" r="2" fill="#8B0000"/>
+          <text x="512" y="11" font-family="'EB Garamond', serif" font-size="12" fill="#8B0000">&#182;</text>
+          <circle cx="530" cy="7" r="2" fill="#8B0000"/>
+          <line x1="540" y1="7" x2="740" y2="7" stroke="#8B0000" stroke-width="0.6"/>
+        </svg>
+      </div>
+      <div class="foot-grid">
+        <div class="foot-col">
+          <h4>The Rubricator</h4>
+          <p>A study of the red-marking tradition from its manuscript origins through early printing and into the modern age.</p>
+          <p><a href="{{ base_url }}/chapters/">Read the Chapters</a></p>
+        </div>
+        <div class="foot-col">
+          <h4>Citation</h4>
+          <p><em>Rubric: A Red-Marked Publication.</em> Composed and set in the year MMXXVI. Typeset in EB Garamond and Cinzel.</p>
+        </div>
+        <div class="foot-col">
+          <h4>Licence</h4>
+          <p>This work is offered for scholarly study. Content may be cited with attribution. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+        </div>
+      </div>
+      <p class="foot-stamp">FINIS &middot; RUBRICATUM EST &middot; TYPESET WITH HWARO &middot; Anno Domini MMXXVI</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/rubric/templates/header.html
+++ b/rubric/templates/header.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Cormorant+SC:wght@400;700&family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=EB+Garamond:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="codex-frame">
+    <header class="codex-header">
+      <div class="header-rule">
+        <svg viewBox="0 0 740 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <line x1="0" y1="8" x2="310" y2="8" stroke="#8B0000" stroke-width="1"/>
+          <text x="325" y="12" font-family="'EB Garamond', serif" font-size="14" fill="#8B0000">&#182;</text>
+          <text x="345" y="12" font-family="'EB Garamond', serif" font-size="14" fill="#8B0000">&#167;</text>
+          <text x="365" y="12" font-family="'EB Garamond', serif" font-size="14" fill="#8B0000">&#182;</text>
+          <line x1="385" y1="8" x2="740" y2="8" stroke="#8B0000" stroke-width="1"/>
+        </svg>
+      </div>
+      <a href="{{ base_url }}/" class="codex-brand" aria-label="Rubric - Home">
+        <svg viewBox="0 0 260 36" xmlns="http://www.w3.org/2000/svg" width="260" height="36" aria-hidden="true">
+          <rect x="0" y="0" width="34" height="34" fill="#8B0000" rx="2"/>
+          <text x="17" y="27" text-anchor="middle" font-family="'Cinzel', serif" font-size="26" font-weight="900" fill="#FAF6EE">R</text>
+          <text x="46" y="27" font-family="'Cinzel', serif" font-size="22" font-weight="700" fill="#1A1A18" letter-spacing="0.12em">UBRIC</text>
+        </svg>
+      </a>
+      <nav class="codex-nav" aria-label="Main navigation">
+        <a href="{{ base_url }}/">Frontispiece</a>
+        <a href="{{ base_url }}/chapters/">The Chapters</a>
+        <a href="{{ base_url }}/practice/">Practice</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>

--- a/rubric/templates/page.html
+++ b/rubric/templates/page.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <div class="page-content">
+      <h1>{{ page.title | e }}</h1>
+      {{ content }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/rubric/templates/section.html
+++ b/rubric/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">THE TABLE OF CHAPTERS</p>
+      <h1 class="section-title">{{ page.title | e }}</h1>
+      {% if page.description %}<p class="section-lede">{{ page.description | e }}</p>{% endif %}
+    </header>
+    <div class="section-intro">
+      {{ content }}
+    </div>
+    <ol class="chapter-table">
+      {% for ch in section.pages %}
+      <li class="chapter-row">
+        <a href="{{ ch.url }}" class="chapter-link">
+          <span class="chapter-no">{% if ch.extra.chapter_no %}{{ ch.extra.chapter_no | e }}{% else %}{{ loop.index }}{% endif %}</span>
+          <span class="chapter-title-wrap">
+            <span class="chapter-title-rl">{{ ch.title | e }}</span>
+            {% if ch.description %}<span class="chapter-dek">{{ ch.description | e }}</span>{% endif %}
+          </span>
+          {% if ch.extra.script %}<span class="chapter-script">{{ ch.extra.script | e }}</span>{% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ol>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/rubric/templates/shortcodes/alert.html
+++ b/rubric/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/rubric/templates/taxonomy.html
+++ b/rubric/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">TAXONOMY</p>
+      <h1>{{ page.title | e }}</h1>
+    </header>
+    <p class="taxonomy-desc">Browse all terms within this classification:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/rubric/templates/taxonomy_term.html
+++ b/rubric/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="codex-main" role="main">
+    <header class="section-head">
+      <p class="kicker">CLASSIFIED UNDER</p>
+      <h1>{{ page.title | e }}</h1>
+    </header>
+    <p class="taxonomy-desc">Chapters and pages bearing this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3647,6 +3647,13 @@
     "blog",
     "bold"
   ],
+  "rubric": [
+    "book",
+    "light",
+    "rubricated",
+    "two-color",
+    "traditional"
+  ],
   "runbook": [
     "light",
     "docs",


### PR DESCRIPTION
Closes #1550

## Summary
- Add rubric example site: a red-marked publication in the rubrication tradition with light two-color theme
- 10 chapters covering the history of rubrication from Carolingian pilcrows to modern red printing
- SVG red initial letters unique to each chapter with ornamental penwork decoration
- SVG red paragraph marks (pilcrows) and section symbols throughout
- Cinzel / Cormorant SC display in red (#8B0000); EB Garamond / Crimson Pro body in black
- Custom chapter template with specs, initial SVG figures, and script taxonomy

## Test plan
- [ ] Verify `hwaro build` succeeds in rubric directory
- [ ] Verify all 14 pages render correctly
- [ ] Check tags.json includes rubric entry
- [ ] Confirm no CSS gradients or emojis present
- [ ] Verify two-color (red + black) design throughout