### PR TITLE
feat: add palimpsest-noir example site (closes #1548)

### DIFF
--- a/palimpsest-noir/AGENTS.md
+++ b/palimpsest-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/palimpsest-noir/config.toml
+++ b/palimpsest-noir/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Palimpsest Noir - Dark Overwrite Publication
+# Issue #1548 | Tags: book, dark, layered, erased, ghostly
+# =============================================================================
+
+title = "Palimpsest Noir"
+description = "A dark publication modeled on the palimpsest: a manuscript scraped and overwritten, where ghost text from earlier layers shows through beneath the current writing. SVG erasure textures and ghost letter fragments. Inter Bold for current text on near-black, EB Garamond Italic for faint ghost text beneath."
+base_url = "http://localhost:3000"
+
+sections = ["layers"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/palimpsest-noir/content/about.md
+++ b/palimpsest-noir/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About this dark overwrite publication and the palimpsest tradition."
++++
+
+<p class="manuscript-label">Reference</p>
+
+# About This Publication
+
+<p class="lede">This publication is a study of the palimpsest: the manuscript that has been scraped and overwritten, where the ghost of the original text persists beneath the surface.</p>
+
+## The dark overwrite
+
+<p>The design of this site uses a near-black background to evoke the darkness of aged parchment, with current text in clean white and ghost text in faint gray beneath. The visual language reflects the palimpsest itself: what is written now is clear and sharp, but underneath, the traces of earlier writing remain visible to those who look closely.</p>
+
+## Design principles
+
+<p>Every page carries SVG textures that suggest scraping and erasure: faint horizontal lines where text was removed, ghost letter fragments that hint at previous content. The typography uses two contrasting voices: Inter Bold for the current, legible text, and EB Garamond Italic for the ghostly under-text that shows through beneath.</p>
+
+<blockquote>A palimpsest is not a document that has been erased. It is a document that refuses to be erased. The under-text persists because the act of writing leaves traces deeper than the surface.</blockquote>

--- a/palimpsest-noir/content/colophon.md
+++ b/palimpsest-noir/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "Production details of this dark overwrite publication."
++++
+
+<div class="colophon-page">
+<p class="manuscript-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="ghost-fragment ghost-fragment-small" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="8" x2="180" y2="8" stroke="#3a3a3a" stroke-width="0.5"/>
+<text x="100" y="7" font-family="'EB Garamond', serif" font-size="7" fill="#333" font-style="italic" opacity="0.2" text-anchor="middle">finis</text>
+</svg>
+</div>
+
+<p>This publication was designed as a study of the palimpsest: the overwritten manuscript where erased text ghosts beneath the current writing.</p>
+
+<p class="colophon-detail"><strong>Current text</strong> is set in Inter Bold, a clean sans-serif chosen for its clarity and authority against the dark background. The current layer is always the most legible.</p>
+
+<p class="colophon-detail"><strong>Ghost text</strong> is set in EB Garamond Italic, a classical serif that evokes the manuscript tradition. Ghost text appears in faint gray, partially visible beneath the current writing, as the under-text of a palimpsest appears beneath the scraping.</p>
+
+<p class="colophon-detail"><strong>Erasure textures</strong> are drawn as inline SVG, representing the scrape marks and ghost letter fragments that remain after the original text has been removed. These textures are subtle and atmospheric, suggesting the presence of earlier writing without competing with the current text.</p>
+
+<p class="colophon-detail"><strong>The dark ground</strong> represents the aged parchment of a palimpsest that has been scraped many times. Each scraping darkens the surface, and after centuries, the parchment takes on a deep, near-black tone that makes the surviving text even more ghostly.</p>
+
+<div class="ghost-fragment ghost-fragment-small" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<circle cx="90" cy="8" r="1.5" fill="#4a4a4a"/>
+<circle cx="100" cy="8" r="1.5" fill="#4a4a4a"/>
+<circle cx="110" cy="8" r="1.5" fill="#4a4a4a"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First overwritten edition, 2026.</p>
+</div>

--- a/palimpsest-noir/content/index.md
+++ b/palimpsest-noir/content/index.md
@@ -1,0 +1,58 @@
++++
+title = "Palimpsest Noir"
+description = "A dark overwrite publication where erased text ghosts beneath the surface."
++++
+
+<div class="surface-page">
+<p class="manuscript-label">Surface Layer</p>
+<h1 class="surface-display">Palimpsest Noir</h1>
+<p class="surface-subtitle">What Was Written Before</p>
+</div>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 40" xmlns="http://www.w3.org/2000/svg">
+<text x="30" y="15" font-family="'EB Garamond', serif" font-size="11" fill="#333" font-style="italic" opacity="0.3">in the beginning was the word and the word was</text>
+<text x="60" y="30" font-family="'EB Garamond', serif" font-size="10" fill="#333" font-style="italic" opacity="0.2">overwritten erased forgotten scraped away</text>
+<line x1="25" y1="14" x2="370" y2="14" stroke="#2a2a2a" stroke-width="0.3" opacity="0.15"/>
+<line x1="55" y1="29" x2="340" y2="29" stroke="#2a2a2a" stroke-width="0.3" opacity="0.1"/>
+</svg>
+</div>
+
+## On the palimpsest
+
+<p class="lede">A palimpsest is a manuscript page that has been scraped clean and written over. The original text is erased -- but not destroyed. Beneath the new writing, traces of the old remain: faint letters, ghostly words, the shadow of a text that was supposed to disappear. The palimpsest is a document that remembers what it was told to forget.</p>
+
+## The act of erasure
+
+<p>In the medieval scriptorium, parchment was expensive and labor-intensive to produce. When a text was no longer needed -- an outdated legal document, a superseded liturgical text, a work that had fallen out of favor -- the scribe scraped the surface with a knife or pumice stone, washing away the ink and preparing the skin for new writing. The process was thorough but imperfect. The iron gall ink used in medieval manuscripts bonded with the collagen fibers of the parchment, leaving chemical traces that no amount of scraping could fully remove.</p>
+
+## Layers of meaning
+
+<p>Every palimpsest contains at least two texts: the upper text, written most recently and fully legible, and the under-text, the erased original that ghosts beneath the surface. Some palimpsests contain three, four, or even five layers of writing, each one scraped away to make room for the next. The result is a document of extraordinary density: a single page that carries centuries of writing, each layer partially visible through the one above.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>The upper text</h3>
+<p class="ghost-text" aria-hidden="true">previous writing faintly visible</p>
+<p>The current, legible writing. In a palimpsest, this is the text the scribe intended to preserve. It is written in fresh ink over the scraped surface.</p>
+</div>
+<div class="layer-card">
+<h3>The under-text</h3>
+<p class="ghost-text" aria-hidden="true">original words almost gone now</p>
+<p>The erased original. Visible only as faint traces beneath the upper text, the under-text can sometimes be recovered through ultraviolet imaging or chemical reagents.</p>
+</div>
+<div class="layer-card">
+<h3>The scrape marks</h3>
+<p class="ghost-text" aria-hidden="true">the knife left traces too</p>
+<p>The physical evidence of erasure. Scraping roughens the parchment surface, creating a visible texture that differs from the smooth areas where no text was removed.</p>
+</div>
+<div class="layer-card">
+<h3>The chemical ghost</h3>
+<p class="ghost-text" aria-hidden="true">iron gall ink bonds with skin</p>
+<p>Even after scraping, the iron in the original ink reacts with the parchment over centuries, producing a faint brownish shadow that reveals the shapes of the erased letters.</p>
+</div>
+</div>
+
+## Reading the erased
+
+<p>Modern technology has made it possible to recover under-texts that were invisible for centuries. Multispectral imaging captures the parchment at wavelengths where the chemical traces of the original ink fluoresce, revealing text that the naked eye cannot see. The most famous example is the Archimedes Palimpsest, a tenth-century copy of works by Archimedes that was scraped and overwritten with a prayer book in the thirteenth century. The mathematical text was recovered in the early 2000s using X-ray fluorescence imaging.</p>

--- a/palimpsest-noir/content/layers/1-the-scraping.md
+++ b/palimpsest-noir/content/layers/1-the-scraping.md
@@ -1,0 +1,41 @@
++++
+title = "The Scraping"
+description = "The physical act of erasing a manuscript to prepare it for reuse."
+tags = ["erasure", "craft"]
++++
+
+<p class="manuscript-label">Layer I</p>
+
+# The Scraping
+
+<p class="lede">The palimpsest begins with destruction. A scribe takes a knife -- a lunellum, a curved scraping blade -- and draws it across the surface of the parchment, shaving away the top layer of skin along with the ink it carries. The text disappears. The surface is roughened, ready for new writing.</p>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="20" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#333" font-style="italic" opacity="0.25">the original text lived here before the knife</text>
+<line x1="15" y1="11" x2="350" y2="11" stroke="#2a2a2a" stroke-width="0.2" opacity="0.2"/>
+</svg>
+</div>
+
+## The tools of erasure
+
+<p>The medieval scribe had several tools for text removal. The lunellum was the primary scraping tool: a crescent-shaped blade held flat against the parchment surface. For stubborn inks, pumice stone was used to abrade the surface more aggressively. Finally, the scribe might wash the scraped area with a mixture of milk and oat bran to smooth and whiten the surface for new writing. Despite these efforts, the erasure was never complete.</p>
+
+## Why texts were erased
+
+<p>Parchment was expensive. A single large Bible might require the skins of 250 sheep. When a text became obsolete -- a legal document whose terms had expired, a liturgical text superseded by a new rite, a classical work no longer read in the monastery -- the parchment was more valuable than the words it carried. The economics of parchment production made erasure and reuse a practical necessity, not a cultural crime.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>The lunellum</h3>
+<p class="ghost-text" aria-hidden="true">curved blade for scraping</p>
+<p>A crescent-shaped knife used to scrape ink from parchment. The curved blade allowed the scribe to control the depth of the cut, removing ink without piercing the skin.</p>
+</div>
+<div class="layer-card">
+<h3>Pumice stone</h3>
+<p class="ghost-text" aria-hidden="true">abrasion for stubborn marks</p>
+<p>Used for more aggressive erasure when scraping alone was insufficient. Pumice abrades the surface evenly, but it thins the parchment and can create visible patches.</p>
+</div>
+</div>
+
+<blockquote>The scraping is an act of faith in the future. The scribe destroys one text to make room for another, trusting that the new words are worth the loss of the old.</blockquote>

--- a/palimpsest-noir/content/layers/2-the-ghost.md
+++ b/palimpsest-noir/content/layers/2-the-ghost.md
@@ -1,0 +1,41 @@
++++
+title = "The Ghost"
+description = "The traces of erased text that persist beneath the surface."
+tags = ["ghost-text", "traces"]
++++
+
+<p class="manuscript-label">Layer II</p>
+
+# The Ghost
+
+<p class="lede">Beneath every palimpsest lies a ghost: the trace of the erased text that refuses to vanish. Iron gall ink bonds chemically with parchment fibers, and no amount of scraping can break that bond entirely. The ghost text persists as a faint shadow, a memory written into the skin itself.</p>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="40" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#333" font-style="italic" opacity="0.2">these words were meant to disappear but they did not</text>
+<line x1="35" y1="11" x2="380" y2="11" stroke="#2a2a2a" stroke-width="0.2" opacity="0.15"/>
+</svg>
+</div>
+
+## The chemistry of persistence
+
+<p>Iron gall ink, the standard writing ink of the medieval world, is made from oak galls, iron sulfate, and gum arabic. When applied to parchment, the iron ions penetrate the collagen matrix of the animal skin and form stable complexes that darken over time. Scraping removes the surface layer of ink, but the iron that has migrated deeper into the parchment remains, creating a permanent chemical record of the original writing.</p>
+
+## Reading ghosts
+
+<p>For centuries, scholars could see the ghost text of palimpsests only as faint brownish traces visible in raking light or when the parchment was held at an angle. Some early researchers used chemical reagents -- Gioberti's reagent, ammonium hydrogen sulfide -- to darken the iron traces and make them legible. These treatments were often destructive, staining the parchment permanently and sometimes obscuring both the upper and under-texts.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>Iron gall reaction</h3>
+<p class="ghost-text" aria-hidden="true">ink becomes part of skin</p>
+<p>The iron in the ink reacts with the collagen over centuries, producing a permanent brownish discoloration in the shape of the original letters. This reaction is the ghost.</p>
+</div>
+<div class="layer-card">
+<h3>Visible light traces</h3>
+<p class="ghost-text" aria-hidden="true">faint shadow at an angle</p>
+<p>Under normal light, the ghost text appears as a faint difference in the parchment's surface color and texture. The scraped areas are slightly rougher and differently colored.</p>
+</div>
+</div>
+
+<blockquote>The ghost text is not a failure of erasure. It is a property of the medium. Parchment remembers what paper forgets.</blockquote>

--- a/palimpsest-noir/content/layers/3-the-overwrite.md
+++ b/palimpsest-noir/content/layers/3-the-overwrite.md
@@ -1,0 +1,41 @@
++++
+title = "The Overwrite"
+description = "The new text written over the scraped surface."
+tags = ["overwrite", "craft"]
++++
+
+<p class="manuscript-label">Layer III</p>
+
+# The Overwrite
+
+<p class="lede">The overwrite is the text that replaces what was erased. It is the scribe's new purpose for the parchment: a prayer book over a work of mathematics, a theological treatise over a legal code, a saint's life over a pagan poem. The overwrite is the text that the monastery chose to preserve at the expense of the text it chose to forget.</p>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="30" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#333" font-style="italic" opacity="0.2">what was here before was deemed less worthy</text>
+<line x1="25" y1="11" x2="340" y2="11" stroke="#2a2a2a" stroke-width="0.2" opacity="0.15"/>
+</svg>
+</div>
+
+## The politics of replacement
+
+<p>The choice of which texts to erase and which to write in their place was rarely neutral. In many cases, the erased text was a classical work -- Greek philosophy, Roman poetry, pre-Christian literature -- replaced by a Christian devotional text. The palimpsest thus becomes a document of cultural priorities: it records not only what a community chose to write, but what it chose to erase. The under-text is a witness to what was once valued and then abandoned.</p>
+
+## Writing on the scraped surface
+
+<p>Writing on a palimpsest is different from writing on fresh parchment. The scraped surface is rougher, less absorbent in some places and more absorbent in others. The ink behaves differently. The quill catches on the irregular texture. The scribe must adjust technique to compensate for the damaged surface, and the resulting writing often shows subtle variations in line quality that reveal the palimpsest nature of the page.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>Rotation</h3>
+<p class="ghost-text" aria-hidden="true">turned ninety degrees</p>
+<p>Scribes often rotated the parchment 90 degrees before writing the new text, so the new lines ran perpendicular to the old. This made the ghost text less distracting to the reader.</p>
+</div>
+<div class="layer-card">
+<h3>Surface preparation</h3>
+<p class="ghost-text" aria-hidden="true">chalk dust to smooth</p>
+<p>After scraping, the surface was treated with chalk or pounce to fill the roughened grain and create a smoother writing surface. This preparation was rarely perfect.</p>
+</div>
+</div>
+
+<blockquote>Every overwrite is an argument. It says: this text matters more than the one that came before. The palimpsest records the argument even when the loser has been scraped away.</blockquote>

--- a/palimpsest-noir/content/layers/4-the-recovery.md
+++ b/palimpsest-noir/content/layers/4-the-recovery.md
@@ -1,0 +1,41 @@
++++
+title = "The Recovery"
+description = "Modern techniques for reading erased text in palimpsests."
+tags = ["recovery", "technology"]
++++
+
+<p class="manuscript-label">Layer IV</p>
+
+# The Recovery
+
+<p class="lede">For eight centuries, the under-texts of palimpsests were invisible or barely legible. Then modern imaging technology arrived, and what the knife had tried to erase, the camera could read again. Multispectral imaging, X-ray fluorescence, and ultraviolet photography have recovered texts that were thought permanently lost.</p>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="20" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#333" font-style="italic" opacity="0.25">ultraviolet reveals what the eye cannot see</text>
+<line x1="15" y1="11" x2="360" y2="11" stroke="#2a2a2a" stroke-width="0.2" opacity="0.18"/>
+</svg>
+</div>
+
+## The Archimedes Palimpsest
+
+<p>The most famous palimpsest recovery is the Archimedes Palimpsest, a tenth-century Byzantine copy of seven treatises by Archimedes that was scraped and overwritten with a prayer book in Jerusalem around 1229. The mathematical text was partially read in 1906 by Johan Ludvig Heiberg using a magnifying glass and natural light. In 1998, the manuscript was acquired at auction and subjected to extensive multispectral imaging, revealing text that Heiberg had been unable to read -- including the only surviving copy of Archimedes' "Method of Mechanical Theorems."</p>
+
+## Imaging technologies
+
+<p>Modern palimpsest recovery relies on the fact that different inks and different states of parchment respond differently to different wavelengths of light. Multispectral imaging captures the page at dozens of wavelengths from ultraviolet through infrared, then uses computational processing to separate the layers and enhance the contrast of the under-text against the upper text.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>Multispectral imaging</h3>
+<p class="ghost-text" aria-hidden="true">light reveals hidden layers</p>
+<p>Captures images at many wavelengths. Different inks absorb and reflect different wavelengths, allowing computational separation of text layers written centuries apart.</p>
+</div>
+<div class="layer-card">
+<h3>X-ray fluorescence</h3>
+<p class="ghost-text" aria-hidden="true">iron atoms still present</p>
+<p>Detects the iron atoms left by the original ink, even when no visible trace remains. The iron fluoresces under X-ray bombardment, mapping the erased text at atomic resolution.</p>
+</div>
+</div>
+
+<blockquote>The recovery of a palimpsest is not just a technological achievement. It is an act of historical justice: restoring a voice that was silenced, reading a text that someone tried to destroy.</blockquote>

--- a/palimpsest-noir/content/layers/5-the-memory.md
+++ b/palimpsest-noir/content/layers/5-the-memory.md
@@ -1,0 +1,41 @@
++++
+title = "The Memory"
+description = "The palimpsest as a metaphor for cultural memory and forgetting."
+tags = ["memory", "culture"]
++++
+
+<p class="manuscript-label">Layer V</p>
+
+# The Memory
+
+<p class="lede">The palimpsest has become one of the most powerful metaphors in Western thought. It describes any surface or system where traces of the past persist beneath the present: a city built over its own ruins, a landscape shaped by successive cultures, a mind that carries memories it cannot fully access.</p>
+
+<div class="ghost-fragment" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="50" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#333" font-style="italic" opacity="0.2">we are written over what we were before</text>
+<line x1="45" y1="11" x2="350" y2="11" stroke="#2a2a2a" stroke-width="0.2" opacity="0.12"/>
+</svg>
+</div>
+
+## The city as palimpsest
+
+<p>Rome is a palimpsest: medieval churches built on Roman temples, Renaissance palaces incorporating ancient columns, modern roads following the paths of imperial highways. Each layer of construction erases and incorporates the one before, but traces of the earlier city persist in the fabric of the present one. The Pantheon still stands because it was overwritten -- converted to a church in 609 -- while the temples that remained pagan were scraped clean by time and quarrying.</p>
+
+## The mind as palimpsest
+
+<p>Thomas De Quincey, in his 1845 essay "The Palimpsest," argued that the human brain works like a palimpsest: every experience is inscribed on the mind, and no experience is ever truly erased. Later experiences are written over earlier ones, but the earlier memories persist beneath the surface, recoverable under the right conditions -- in dreams, in fever, in the associative leaps of memory.</p>
+
+<div class="layer-grid">
+<div class="layer-card">
+<h3>Urban palimpsest</h3>
+<p class="ghost-text" aria-hidden="true">ruins beneath the pavement</p>
+<p>Every city is built on the traces of earlier cities. Archaeological excavation reads the urban palimpsest by peeling back successive layers of construction, occupation, and destruction.</p>
+</div>
+<div class="layer-card">
+<h3>Digital palimpsest</h3>
+<p class="ghost-text" aria-hidden="true">deleted files leave traces</p>
+<p>Digital storage is a modern palimpsest. Deleted files leave magnetic traces on hard drives. Overwritten data can sometimes be recovered. Nothing digital is ever truly erased.</p>
+</div>
+</div>
+
+<blockquote>The palimpsest teaches us that erasure is never complete. The past persists in the present, not as a clear record but as a ghost -- faint, partial, and recoverable only with effort and the right tools.</blockquote>

--- a/palimpsest-noir/content/layers/_index.md
+++ b/palimpsest-noir/content/layers/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Layers"
+description = "The layers of this palimpsest publication."
++++
+
+<p class="lede">Five layers, each examining a different aspect of the palimpsest tradition. From the physical act of scraping to the modern recovery of lost texts, every layer reveals something hidden.</p>
+
+<p>The layers are arranged from the surface downward, moving from what is visible to what lies beneath.</p>

--- a/palimpsest-noir/static/css/style.css
+++ b/palimpsest-noir/static/css/style.css
@@ -1,0 +1,441 @@
+/* =============================================================================
+   Palimpsest Noir - Dark Overwrite Publication
+   Issue #1548 | book, dark, layered, erased, ghostly
+   Palette: near-black ground, white current text, faint gray ghost text
+   No gradients. Erasure textures + ghost letter fragments as inline SVG.
+   ============================================================================= */
+
+:root {
+  --void: #0e0e0e;
+  --surface: #161616;
+  --surface-raised: #1e1e1e;
+  --surface-edge: #333;
+  --scrape: #2a2a2a;
+  --text: #e0e0e0;
+  --text-soft: #aaa;
+  --text-dim: #666;
+  --ghost: #444;
+  --ghost-faint: #333;
+  --accent: #888;
+  --accent-bright: #bbb;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--void);
+  color: var(--text);
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.parchment-shell {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--surface-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 42px; height: 42px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.logo-sub {
+  font-family: "EB Garamond", serif;
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--text); border-bottom-color: var(--accent); }
+
+/* --- Manuscript page ----------------------------------------------------- */
+.site-main {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.manuscript-page {
+  position: relative;
+  background-color: var(--surface);
+  border: 1px solid var(--surface-edge);
+  min-height: 600px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+}
+
+.manuscript-page-narrow {
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.erasure-border { text-align: center; padding: 1.25rem 1.5rem 0; }
+.erasure-border svg { max-width: 100%; height: 12px; display: block; margin: 0 auto; }
+.erasure-border-bottom { padding: 0 1.5rem 1.25rem; }
+
+.manuscript-body {
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.5rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.manuscript-body h1,
+.manuscript-body h2,
+.manuscript-body h3 {
+  font-family: "Inter", sans-serif;
+  color: var(--text);
+  line-height: 1.25;
+  font-weight: 700;
+}
+.manuscript-body h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0 0 0.3em;
+  letter-spacing: -0.01em;
+}
+.manuscript-body h2 {
+  font-size: 1.3rem;
+  margin: 2.5em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.manuscript-body h3 {
+  font-size: 1rem;
+  margin: 1.5em 0 0.2em;
+  color: var(--accent-bright);
+  text-align: left;
+}
+
+.manuscript-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Inter", sans-serif;
+  font-size: 0.95rem;
+  text-align: left;
+  line-height: 1.72;
+}
+.manuscript-body p.lede {
+  font-family: "EB Garamond", serif;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--text-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 34em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.manuscript-label {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 0.5em;
+}
+
+.manuscript-head { margin-bottom: 2rem; text-align: center; }
+.manuscript-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.manuscript-body a {
+  color: var(--accent-bright);
+  text-decoration: none;
+  border-bottom: 1px solid var(--surface-edge);
+}
+.manuscript-body a:hover { color: var(--text); border-bottom-color: var(--text); }
+
+blockquote {
+  margin: 2rem auto;
+  padding: 0.5rem 1.5rem;
+  border-left: 2px solid var(--accent);
+  background-color: var(--surface-raised);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "EB Garamond", serif;
+  font-size: 1.1rem;
+  text-align: left;
+  max-width: 32em;
+}
+
+.manuscript-body ul,
+.manuscript-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  text-align: left;
+}
+.manuscript-body ul { list-style: disc; }
+.manuscript-body ol { list-style: decimal; }
+.manuscript-body li { padding: 0.2em 0; color: var(--text-soft); }
+
+/* --- Ghost text ---------------------------------------------------------- */
+.ghost-text {
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  color: var(--ghost);
+  font-size: 0.82rem;
+  margin: 0 0 0.4em;
+  letter-spacing: 0.02em;
+  opacity: 0.6;
+}
+
+/* --- Ghost fragment SVG -------------------------------------------------- */
+.ghost-fragment {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.ghost-fragment svg {
+  max-width: 100%;
+  height: 40px;
+  display: inline-block;
+}
+.ghost-fragment-small svg {
+  max-width: 200px;
+  height: 16px;
+}
+
+/* --- Surface display ----------------------------------------------------- */
+.surface-page {
+  padding: clamp(3rem, 8vw, 6rem) 0;
+  text-align: center;
+}
+.surface-display {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2.2rem, 5.5vw, 3.5rem);
+  color: var(--text);
+  letter-spacing: -0.02em;
+  margin: 0 0 0.15em;
+}
+.surface-subtitle {
+  font-family: "EB Garamond", serif;
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* --- Layer card grid ----------------------------------------------------- */
+.layer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+.layer-card {
+  background-color: var(--surface-raised);
+  border: 1px solid var(--surface-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.layer-card h3 {
+  margin: 0 0 0.1em;
+  color: var(--accent-bright);
+  font-size: 0.95rem;
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+}
+.layer-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+.layer-card .ghost-text {
+  margin-bottom: 0.5em;
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2rem 0;
+}
+.colophon-page h1 {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.8rem;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--text-soft);
+}
+.colophon-detail strong {
+  color: var(--text);
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+}
+.colophon-imprint {
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--surface-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Inter", sans-serif;
+}
+.section-list li::before {
+  content: "\00B7";
+  color: var(--accent);
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--text);
+  border: none;
+  font-size: 0.95rem;
+}
+.section-list li a:hover { color: var(--accent-bright); }
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  text-align: left;
+  font-family: "EB Garamond", serif;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--surface-edge);
+  font-family: "Inter", sans-serif;
+  font-size: 0.82rem;
+  color: var(--text-soft);
+  text-decoration: none;
+  background-color: var(--surface-raised);
+}
+nav.pagination a:hover { color: var(--text); border-color: var(--accent); }
+.pagination-current span { color: var(--text); border-color: var(--accent); }
+
+/* --- Footer -------------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 0.8rem;
+}
+.footer-device svg {
+  width: 40px;
+  height: 40px;
+  display: block;
+  margin: 0 auto;
+}
+
+.site-footer {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--surface-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  color: var(--text-soft);
+  margin: 0.2em 0;
+  letter-spacing: 0.01em;
+  font-size: 0.92rem;
+}
+.footer-line-small {
+  font-family: "EB Garamond", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .manuscript-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .manuscript-title, .manuscript-body h1, .surface-display { font-size: 1.8rem; }
+  .manuscript-body h2 { font-size: 1.15rem; }
+  .surface-page { padding: 2.5rem 0; }
+}

--- a/palimpsest-noir/templates/404.html
+++ b/palimpsest-noir/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="manuscript-page manuscript-page-narrow">
+      <div class="manuscript-body">
+        <header class="manuscript-head">
+          <p class="manuscript-label">404</p>
+          <h1 class="manuscript-title">Text erased</h1>
+        </header>
+        <p>This layer has been scraped clean. The text that once lived here has been removed, and no new writing has taken its place. Return to the surface layer.</p>
+        <p><a href="{{ base_url }}/">Back to the surface</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/palimpsest-noir/templates/footer.html
+++ b/palimpsest-noir/templates/footer.html
@@ -1,0 +1,18 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+          <rect x="12" y="10" width="26" height="30" fill="none" stroke="#4a4a4a" stroke-width="0.6"/>
+          <line x1="16" y1="18" x2="34" y2="18" stroke="#333" stroke-width="0.3" opacity="0.25"/>
+          <line x1="16" y1="22" x2="30" y2="22" stroke="#333" stroke-width="0.3" opacity="0.15"/>
+          <text x="25" y="34" font-family="serif" font-size="8" fill="#666" text-anchor="middle" font-style="italic">PN</text>
+        </svg>
+      </div>
+      <p class="footer-line">Palimpsest Noir</p>
+      <p class="footer-line-small">Text over text, memory over memory.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; scraped, overwritten, read again</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/palimpsest-noir/templates/header.html
+++ b/palimpsest-noir/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;1,400;1,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="parchment-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Palimpsest Noir home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="6" y="4" width="36" height="40" fill="none" stroke="#4a4a4a" stroke-width="0.8"/>
+          <line x1="12" y1="12" x2="36" y2="12" stroke="#333" stroke-width="0.4" opacity="0.3"/>
+          <line x1="12" y1="16" x2="32" y2="16" stroke="#333" stroke-width="0.4" opacity="0.2"/>
+          <line x1="12" y1="20" x2="34" y2="20" stroke="#333" stroke-width="0.4" opacity="0.15"/>
+          <text x="24" y="32" font-family="serif" font-size="11" fill="#e0e0e0" text-anchor="middle" font-weight="700">P</text>
+          <line x1="14" y1="36" x2="34" y2="36" stroke="#4a4a4a" stroke-width="0.5"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Palimpsest Noir</span>
+          <span class="logo-sub">Overwritten Layers</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Surface</a>
+        <a href="{{ base_url }}/layers/">Layers</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/palimpsest-noir/templates/page.html
+++ b/palimpsest-noir/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="manuscript-page">
+      <div class="erasure-border" aria-hidden="true">
+        <svg viewBox="0 0 600 12" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="6" x2="600" y2="6" stroke="#3a3a3a" stroke-width="0.5"/>
+          <line x1="50" y1="3" x2="120" y2="3" stroke="#2a2a2a" stroke-width="0.3" opacity="0.4"/>
+          <line x1="200" y1="9" x2="280" y2="9" stroke="#2a2a2a" stroke-width="0.3" opacity="0.3"/>
+          <line x1="400" y1="3" x2="480" y2="3" stroke="#2a2a2a" stroke-width="0.3" opacity="0.25"/>
+        </svg>
+      </div>
+      <div class="manuscript-body">
+        {{ content }}
+      </div>
+      <div class="erasure-border erasure-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 600 12" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="6" x2="600" y2="6" stroke="#3a3a3a" stroke-width="0.5"/>
+          <line x1="100" y1="9" x2="180" y2="9" stroke="#2a2a2a" stroke-width="0.3" opacity="0.3"/>
+          <line x1="350" y1="3" x2="450" y2="3" stroke="#2a2a2a" stroke-width="0.3" opacity="0.2"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/palimpsest-noir/templates/section.html
+++ b/palimpsest-noir/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="manuscript-page">
+      <div class="erasure-border" aria-hidden="true">
+        <svg viewBox="0 0 600 12" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="6" x2="600" y2="6" stroke="#3a3a3a" stroke-width="0.5"/>
+          <line x1="80" y1="3" x2="160" y2="3" stroke="#2a2a2a" stroke-width="0.3" opacity="0.35"/>
+          <line x1="320" y1="9" x2="420" y2="9" stroke="#2a2a2a" stroke-width="0.3" opacity="0.25"/>
+        </svg>
+      </div>
+      <div class="manuscript-body">
+        <header class="manuscript-head">
+          <p class="manuscript-label">Archive</p>
+          <h1 class="manuscript-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/palimpsest-noir/templates/shortcodes/alert.html
+++ b/palimpsest-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #4a4a4a; background-color: #1e1e1e; border-left: 4px solid #666; margin: 1rem 0; color: #ccc;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/palimpsest-noir/templates/taxonomy.html
+++ b/palimpsest-noir/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="manuscript-page manuscript-page-narrow">
+      <div class="manuscript-body">
+        <header class="manuscript-head">
+          <p class="manuscript-label">Index</p>
+          <h1 class="manuscript-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All traces catalogued across the layers:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/palimpsest-noir/templates/taxonomy_term.html
+++ b/palimpsest-noir/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="manuscript-page manuscript-page-narrow">
+      <div class="manuscript-body">
+        <header class="manuscript-head">
+          <p class="manuscript-label">Trace</p>
+          <h1 class="manuscript-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Layers bearing this trace:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3013,6 +3013,13 @@
     "docs",
     "design"
   ],
+  "palimpsest-noir": [
+    "book",
+    "dark",
+    "layered",
+    "erased",
+    "ghostly"
+  ],
   "panopticon": [
     "dark",
     "brutalist",
@@ -3642,17 +3649,17 @@
     "warm",
     "classic"
   ],
-  "ruby-fire": [
-    "dark",
-    "blog",
-    "bold"
-  ],
   "rubric": [
     "book",
     "light",
     "rubricated",
     "two-color",
     "traditional"
+  ],
+  "ruby-fire": [
+    "dark",
+    "blog",
+    "bold"
   ],
   "runbook": [
     "light",


### PR DESCRIPTION
Closes #1548

## Summary
- Add palimpsest-noir (dark overwrite publication) example site
- Dark theme with near-black ground evoking aged, scraped parchment
- SVG scraping/erasure texture patterns showing removed content
- SVG ghost letter fragments (EB Garamond Italic) visible beneath current text (Inter Bold)
- 5 layers covering the scraping, the ghost, the overwrite, the recovery, and the memory
- Tags: book, dark, layered, erased, ghostly

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of dark theme and ghost text layering
- [ ] Verify SVG erasure textures and ghost letter fragments render
- [ ] Check responsive behavior on narrow viewports