### PR TITLE
feat: add folio-gigante example site (closes #1547)

### DIFF
--- a/folio-gigante/AGENTS.md
+++ b/folio-gigante/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/folio-gigante/config.toml
+++ b/folio-gigante/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Folio Gigante - Oversized Publication
+# Issue #1547 | Tags: book, dark, oversized, monumental, maximal
+# =============================================================================
+
+title = "Folio Gigante"
+description = "An oversized, dark publication modeled on the monumental folio gigante format. SVG full-page plate illustrations and oversized ornamental capitals that fill half the viewport. Anton and Tungsten Black at 200px+ for display, Lora and Merriweather at 24px+ for body text."
+base_url = "http://localhost:3000"
+
+sections = ["plates"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/folio-gigante/content/about.md
+++ b/folio-gigante/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About this oversized publication and the folio gigante tradition."
++++
+
+<p class="gigante-label">Reference</p>
+
+# About This Volume
+
+<p class="lede">This publication is a study of the folio gigante: the oversized book format that exists at the boundary between reading and spectacle.</p>
+
+## The monumental format
+
+<p>The folio gigante represents the maximum expression of the book as a physical object. Where the duodecimo fits in a pocket, the folio gigante dominates a room. Where an octavo can be read in a chair, the folio gigante requires a lectern, a table, or a wall. This site is designed to reflect that monumental scale: the type is large, the spaces are vast, and every element is sized for impact rather than economy.</p>
+
+## Design principles
+
+<p>Every element of this site is deliberately oversized. The display type uses Anton at extreme scale -- 200 pixels and above -- to capture the commanding presence of a monumental headline. Even the body text, set in Lora and Merriweather, is larger than the display type of most ordinary publications. The SVG illustrations are designed as full-page plates at poster scale, filling the viewport with ornamental borders and oversized capitals.</p>
+
+<blockquote>A folio gigante is not a book for reading. It is a book for experiencing. You do not hold it; it holds you.</blockquote>

--- a/folio-gigante/content/colophon.md
+++ b/folio-gigante/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "Production details of this oversized publication."
++++
+
+<div class="colophon-page">
+<p class="gigante-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="plate-ornament" aria-hidden="true">
+<svg viewBox="0 0 300 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="10" x2="280" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+<rect x="140" y="4" width="12" height="12" fill="none" stroke="#d4a843" stroke-width="1"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of the folio gigante: the oversized book format that occupies the boundary between publication and spectacle.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Anton, an ultra-heavy condensed face chosen for its commanding presence at extreme scale. Display headings are sized at 200 pixels and above, filling the viewport as a monumental headline fills the facade of a building.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in Lora and Merriweather at 24 pixels and above -- sizes that would be display type in an ordinary publication, but serve as readable body text in the oversized context of the folio gigante.</p>
+
+<p class="colophon-detail"><strong>Plate illustrations</strong> are drawn as inline SVG at poster scale, with ornamental borders, oversized capitals, and decorative frames that fill the viewport. These illustrations follow the tradition of the engraved plate in large-format natural history and architectural publications.</p>
+
+<p class="colophon-detail"><strong>The oversized capitals</strong> that appear on section pages are drawn to fill half the viewport, following the tradition of the decorated initial in manuscript and early printed books, but at a scale that turns the letter itself into an architectural element.</p>
+
+<div class="plate-ornament" aria-hidden="true">
+<svg viewBox="0 0 300 20" xmlns="http://www.w3.org/2000/svg">
+<rect x="130" y="4" width="8" height="8" fill="#8a6d2e"/>
+<rect x="142" y="4" width="8" height="8" fill="#8a6d2e"/>
+<rect x="154" y="4" width="8" height="8" fill="#8a6d2e"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First monumental edition, 2026.</p>
+</div>

--- a/folio-gigante/content/index.md
+++ b/folio-gigante/content/index.md
@@ -1,0 +1,61 @@
++++
+title = "Folio Gigante"
+description = "An oversized publication at monumental scale."
++++
+
+<div class="cover-page">
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 500 400" xmlns="http://www.w3.org/2000/svg">
+<text x="250" y="320" font-family="'Anton', serif" font-size="360" fill="none" stroke="#8a6d2e" stroke-width="2" text-anchor="middle" font-weight="900">F</text>
+<text x="250" y="320" font-family="'Anton', serif" font-size="360" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.15">F</text>
+</svg>
+</div>
+<p class="gigante-label">Folio Gigante</p>
+<h1 class="cover-display">The Oversized Book</h1>
+<p class="cover-subtitle">A Study of the Monumental Format</p>
+</div>
+
+## On the folio gigante
+
+<p class="lede">The folio gigante is the largest standard book format: a single sheet of paper folded once to produce two leaves of maximum size. When the sheet itself is oversized -- an atlas sheet, an elephant folio, a double elephant -- the result is a book of extraordinary physical presence, a volume that demands a table, a stand, or an entire wall.</p>
+
+## The scale of ambition
+
+<p>The folio gigante exists because some subjects cannot be contained in ordinary formats. An atlas of the world requires maps large enough to show coastlines and rivers. A book of botanical illustrations requires plates large enough to depict plants at life size. An architectural treatise requires drawings large enough to show construction details. The folio gigante is the format of ambition: the book that refuses to reduce its subject to fit a smaller page.</p>
+
+## The weight of the object
+
+<p>A folio gigante is not merely a large book. It is a piece of furniture. Audubon's "Birds of America" measures 39.5 by 26.5 inches and weighs over 40 pounds per volume. The Klencke Atlas, presented to Charles II in 1660, measures 5 feet 10 inches by 3 feet 5 inches when open. These are not objects that sit on shelves. They require lecterns, cases, and sometimes multiple people to handle safely.</p>
+
+<div class="plate-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 300" xmlns="http://www.w3.org/2000/svg">
+<rect x="50" y="20" width="700" height="260" fill="none" stroke="#8a6d2e" stroke-width="1.5"/>
+<rect x="65" y="35" width="670" height="230" fill="none" stroke="#5a4a20" stroke-width="0.6"/>
+<line x1="400" y1="50" x2="400" y2="250" stroke="#5a4a20" stroke-width="0.4"/>
+<text x="200" y="155" font-family="serif" font-size="80" fill="#d4a843" text-anchor="middle" opacity="0.2" font-weight="700">PLATE</text>
+<text x="600" y="155" font-family="serif" font-size="80" fill="#d4a843" text-anchor="middle" opacity="0.2" font-weight="700">I</text>
+<line x1="100" y1="80" x2="350" y2="80" stroke="#8a6d2e" stroke-width="0.5"/>
+<line x1="100" y1="220" x2="350" y2="220" stroke="#8a6d2e" stroke-width="0.5"/>
+<line x1="450" y1="80" x2="700" y2="80" stroke="#8a6d2e" stroke-width="0.5"/>
+<line x1="450" y1="220" x2="700" y2="220" stroke="#8a6d2e" stroke-width="0.5"/>
+</svg>
+</div>
+
+<div class="gigante-grid">
+<div class="gigante-card">
+<h3>Double Elephant Folio</h3>
+<p>The largest standard paper size, roughly 40 by 27 inches. Used by Audubon for "Birds of America" to depict birds at life size. Each plate is a poster.</p>
+</div>
+<div class="gigante-card">
+<h3>Atlas Folio</h3>
+<p>Roughly 34 by 24 inches. The standard format for large atlases, architectural drawings, and botanical plates. Too large for most bookshelves.</p>
+</div>
+<div class="gigante-card">
+<h3>Imperial Folio</h3>
+<p>Roughly 30 by 22 inches. Used for large art books, portfolios, and prestige editions. A format that signals importance through sheer physical scale.</p>
+</div>
+</div>
+
+## The typography of scale
+
+<p>When the page is enormous, the type must scale to match. Body text in a folio gigante is set at sizes that would be display type in an ordinary book -- 18 to 24 points or larger. Headlines can reach 72 points, 96 points, or more. The effect is immersive: the reader stands before the open book as before a mural, and the type fills the field of vision.</p>

--- a/folio-gigante/content/plates/1-the-atlas.md
+++ b/folio-gigante/content/plates/1-the-atlas.md
@@ -1,0 +1,38 @@
++++
+title = "The Atlas"
+description = "The oversized map book that required the folio gigante format."
+tags = ["cartography", "scale"]
++++
+
+<p class="gigante-label">Plate I</p>
+
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="none" stroke="#8a6d2e" stroke-width="1.5" text-anchor="middle" font-weight="900">A</text>
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.1">A</text>
+</svg>
+</div>
+
+# The Atlas
+
+<p class="lede">The atlas is the original folio gigante. Maps require scale: a map of a continent must be large enough to show coastlines, rivers, mountain ranges, and cities without collapsing into illegibility. The first great atlases were oversized by necessity, and they established the folio gigante as the format of serious cartography.</p>
+
+## Mercator and Ortelius
+
+<p>Gerard Mercator's "Atlas" of 1595 and Abraham Ortelius's "Theatrum Orbis Terrarum" of 1570 were printed in folio format to accommodate maps large enough for navigation and study. These volumes were reference works for merchants, navigators, and scholars, and their physical size reflected the scale of the world they depicted. A map of the Mediterranean that fit on a quarto page was useful for general reference; a map that filled a folio was useful for planning a voyage.</p>
+
+## The Klencke Atlas
+
+<p>The largest atlas ever produced, the Klencke Atlas was presented to King Charles II of England in 1660. When open, it measures roughly 5 feet 10 inches by 3 feet 5 inches. It contains 41 maps and was intended not for practical use but as a diplomatic gift -- a demonstration of Dutch cartographic skill at monumental scale. The Klencke Atlas is now housed at the British Library, where it requires a specially designed table for display.</p>
+
+<div class="plate-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg">
+<rect x="40" y="10" width="720" height="180" fill="none" stroke="#8a6d2e" stroke-width="1.2"/>
+<ellipse cx="400" cy="100" rx="300" ry="70" fill="none" stroke="#5a4a20" stroke-width="0.6"/>
+<line x1="100" y1="100" x2="700" y2="100" stroke="#5a4a20" stroke-width="0.3"/>
+<line x1="400" y1="30" x2="400" y2="170" stroke="#5a4a20" stroke-width="0.3"/>
+<text x="400" y="107" font-family="serif" font-size="14" fill="#d4a843" text-anchor="middle" opacity="0.5">ORBIS TERRARUM</text>
+</svg>
+</div>
+
+<blockquote>The atlas is proof that some knowledge cannot be miniaturized. A world small enough to hold in your hand is a world without detail, without nuance, without the information that makes it useful.</blockquote>

--- a/folio-gigante/content/plates/2-the-natural-history.md
+++ b/folio-gigante/content/plates/2-the-natural-history.md
@@ -1,0 +1,39 @@
++++
+title = "The Natural History"
+description = "Life-size botanical and ornithological illustrations in folio gigante."
+tags = ["illustration", "science"]
++++
+
+<p class="gigante-label">Plate II</p>
+
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="none" stroke="#8a6d2e" stroke-width="1.5" text-anchor="middle" font-weight="900">N</text>
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.1">N</text>
+</svg>
+</div>
+
+# The Natural History
+
+<p class="lede">The natural history folio exists for one reason: to depict specimens at life size. A hummingbird can be painted at life size on a quarto page. A flamingo requires a double elephant folio. The ambition to show nature at its actual scale drove the creation of the largest and most expensive publications in the history of printing.</p>
+
+## Audubon's masterwork
+
+<p>John James Audubon's "The Birds of America," published between 1827 and 1838, is the most famous folio gigante in natural history. Printed on double elephant folio paper measuring approximately 39.5 by 26.5 inches, each plate depicts a bird species at life size, painted in watercolor by Audubon and engraved by Robert Havell in London. The four volumes contain 435 hand-colored plates showing 1,065 individual birds. A complete set weighs over 160 pounds.</p>
+
+## The economics of spectacle
+
+<p>Audubon's "Birds" was published by subscription at a total cost of approximately $1,000 per set -- roughly $30,000 in today's currency. Only 200 complete sets were printed. The publication nearly bankrupted Audubon, and its survival as a commercial venture depended on the willingness of wealthy collectors to pay for a natural history work that was also a work of art at monumental scale.</p>
+
+<div class="gigante-grid">
+<div class="gigante-card">
+<h3>Life-size illustration</h3>
+<p>The defining principle of the natural history folio. A bird is painted at the size it actually is, so the viewer can study every feather, every claw, every detail without the distortion of reduction.</p>
+</div>
+<div class="gigante-card">
+<h3>Hand coloring</h3>
+<p>Before chromolithography, color plates were printed in black and colored by hand. Audubon employed a team of 50 colorists, each working on one bird per plate, painting thousands of individual feathers.</p>
+</div>
+</div>
+
+<blockquote>Audubon painted the birds of America at the size God made them. The folio gigante was the only format large enough for his ambition.</blockquote>

--- a/folio-gigante/content/plates/3-the-architecture.md
+++ b/folio-gigante/content/plates/3-the-architecture.md
@@ -1,0 +1,39 @@
++++
+title = "The Architecture"
+description = "Architectural treatises and construction drawings at folio scale."
+tags = ["architecture", "drawing"]
++++
+
+<p class="gigante-label">Plate III</p>
+
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="none" stroke="#8a6d2e" stroke-width="1.5" text-anchor="middle" font-weight="900">A</text>
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.1">A</text>
+</svg>
+</div>
+
+# The Architecture
+
+<p class="lede">Architecture is the art of building at full scale, and the architectural treatise has always strained against the limits of the page. A plan of a cathedral cannot be reduced to octavo without losing the dimensional information that makes it useful. The folio gigante is the architect's format: large enough for measured drawings, detailed enough for construction.</p>
+
+## Piranesi's visions
+
+<p>Giovanni Battista Piranesi published his "Vedute di Roma" (Views of Rome) in large folio format between 1748 and 1778. The 135 etched plates measure roughly 27 by 20 inches and depict the architecture of ancient and modern Rome at a scale that captures the grandeur of the buildings themselves. Piranesi's technique -- dramatic perspective, deep shadows, exaggerated scale -- was ideally suited to the large format, where the viewer could be absorbed into the architectural space of the image.</p>
+
+## Construction documents
+
+<p>Beyond the art book, the folio gigante served a practical function in architecture: construction drawings. Before digital printing, architectural plans were drawn by hand at scales that required large sheets. A plan of a building at 1:50 scale requires a sheet large enough to show the entire floor plan with sufficient detail for a builder to follow. The folio gigante was the bound version of the architect's drawing office.</p>
+
+<div class="gigante-grid">
+<div class="gigante-card">
+<h3>Measured drawings</h3>
+<p>Architectural plates include precise measurements and scales. The folio format allows these dimensions to be printed at a size where they remain legible alongside the full drawing.</p>
+</div>
+<div class="gigante-card">
+<h3>Section details</h3>
+<p>Cross-sections, molding profiles, and construction details require space for dimensional annotation. The folio gigante provides room for both the drawing and its technical documentation.</p>
+</div>
+</div>
+
+<blockquote>Architecture exists at full scale. The folio gigante is the closest the printed page can come to the reality of a building.</blockquote>

--- a/folio-gigante/content/plates/4-the-music.md
+++ b/folio-gigante/content/plates/4-the-music.md
@@ -1,0 +1,39 @@
++++
+title = "The Music"
+description = "Choir books and liturgical music at monumental scale."
+tags = ["music", "liturgy"]
++++
+
+<p class="gigante-label">Plate IV</p>
+
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="none" stroke="#8a6d2e" stroke-width="1.5" text-anchor="middle" font-weight="900">M</text>
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.1">M</text>
+</svg>
+</div>
+
+# The Music
+
+<p class="lede">The choir book is perhaps the most functional of all oversized formats. A choir of twenty singers, standing in two rows behind a lectern, must all be able to read from the same book at the same time. The music must be large enough for the singers at the back to read the notes and text from a distance of six or eight feet. The folio gigante is not a luxury in the choir: it is a necessity.</p>
+
+## The antiphonal
+
+<p>The antiphonal, or antiphoner, is the choir book containing the chants for the Divine Office. Medieval antiphonals were produced in folio gigante format with musical notation -- square neumes on a four-line staff -- large enough to be read by an entire choir simultaneously. The pages of a large antiphonal can measure 30 by 20 inches, with individual notes the size of a thumbnail. The decorated initials that begin each chant are often several inches tall, serving as visual landmarks that help the singers navigate the page from a distance.</p>
+
+## Scale as function
+
+<p>Unlike the natural history folio or the atlas, where scale serves accuracy, the choir book's scale serves a communal function. The book is not read by one person but by many, at varying distances, in a dimly lit church. Every design decision -- the thickness of the staff lines, the size of the notes, the weight of the text, the color of the decorated initials -- is optimized for group legibility in poor lighting conditions.</p>
+
+<div class="gigante-grid">
+<div class="gigante-card">
+<h3>Square notation</h3>
+<p>Medieval musical notation uses square-shaped notes (neumes) on a four-line staff. In a choir book, these notes are drawn at maximum size for distance reading.</p>
+</div>
+<div class="gigante-card">
+<h3>Decorated initials</h3>
+<p>Each chant begins with a large decorated initial, often illuminated in gold and color. These initials serve as navigation aids, allowing singers to find their place quickly.</p>
+</div>
+</div>
+
+<blockquote>The choir book is the only format where the size of the page is determined not by the subject but by the audience. The page must be readable by twenty voices at once.</blockquote>

--- a/folio-gigante/content/plates/5-the-spectacle.md
+++ b/folio-gigante/content/plates/5-the-spectacle.md
@@ -1,0 +1,39 @@
++++
+title = "The Spectacle"
+description = "The folio gigante as prestige object and display piece."
+tags = ["spectacle", "culture"]
++++
+
+<p class="gigante-label">Plate V</p>
+
+<div class="oversized-capital" aria-hidden="true">
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="none" stroke="#8a6d2e" stroke-width="1.5" text-anchor="middle" font-weight="900">S</text>
+<text x="200" y="250" font-family="'Anton', serif" font-size="280" fill="#d4a843" text-anchor="middle" font-weight="900" opacity="0.1">S</text>
+</svg>
+</div>
+
+# The Spectacle
+
+<p class="lede">Some folio gigante volumes exist not to be read but to be seen. They are prestige objects, diplomatic gifts, demonstration pieces -- books whose primary function is to impress through sheer physical scale. The spectacle folio is the book as architecture: a structure you enter rather than a text you read.</p>
+
+## The coffee-table ancestor
+
+<p>The modern coffee-table book is a descendant of the spectacle folio. A large-format photography book displayed on a table serves the same social function as an atlas folio displayed in a library: it signals taste, wealth, and cultural engagement. The difference is scale. A coffee-table book might measure 14 by 11 inches. A spectacle folio of the seventeenth century might measure 30 by 20 inches. The ambition is the same; only the dimensions have been reduced.</p>
+
+## The exhibition catalog
+
+<p>The oversized exhibition catalog occupies a middle ground between the spectacle folio and the practical reference. It must be large enough to reproduce artworks at a meaningful scale, detailed enough to serve as a scholarly reference, and beautiful enough to justify its price. The best exhibition catalogs are themselves works of design, where the typography, layout, and paper stock are calibrated to honor the art they document.</p>
+
+<div class="gigante-grid">
+<div class="gigante-card">
+<h3>The prestige edition</h3>
+<p>Limited edition folios produced for collectors. Signed, numbered, printed on handmade paper, and bound in leather or cloth. The book as luxury object, priced by the pound.</p>
+</div>
+<div class="gigante-card">
+<h3>The display copy</h3>
+<p>A book that lives open on a lectern or table, turned to a different page each day. The folio gigante as rotating exhibition, showing one plate at a time to visitors.</p>
+</div>
+</div>
+
+<blockquote>The spectacle folio is not about information. It is about presence. It says: the subject of this book is so important that it deserves to fill a room.</blockquote>

--- a/folio-gigante/content/plates/_index.md
+++ b/folio-gigante/content/plates/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Plates"
+description = "The plates of this oversized publication."
++++
+
+<p class="lede">Five plates, each examining a different aspect of the oversized book. From the natural history folio to the architectural portfolio, the folio gigante has served every subject too large for ordinary pages.</p>
+
+<p>The plates are arranged in the order of increasing ambition, from the merely large to the truly monumental.</p>

--- a/folio-gigante/static/css/style.css
+++ b/folio-gigante/static/css/style.css
@@ -1,0 +1,460 @@
+/* =============================================================================
+   Folio Gigante - Oversized Publication
+   Issue #1547 | book, dark, oversized, monumental, maximal
+   Palette: deep charcoal ground, aged gold accents, warm cream text
+   No gradients. Full-page plates + oversized capitals as inline SVG.
+   ============================================================================= */
+
+:root {
+  --charcoal: #111111;
+  --surface: #181818;
+  --surface-raised: #222;
+  --surface-edge: #3a3520;
+  --text: #e0dcd0;
+  --text-soft: #b8b2a4;
+  --text-dim: #7a7468;
+  --gold: #d4a843;
+  --gold-dark: #8a6d2e;
+  --gold-dim: #5a4a20;
+  --bg: #0c0c0c;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: "Lora", "Merriweather", Georgia, serif;
+  font-size: 24px;
+  line-height: 1.65;
+  min-height: 100vh;
+}
+
+.gigante-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2.5rem 0 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  border-bottom: 2px solid var(--gold-dark);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 64px; height: 64px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  font-size: 1.6rem;
+  letter-spacing: 0.04em;
+  color: var(--gold);
+  text-transform: uppercase;
+}
+.logo-sub {
+  font-family: "Lora", serif;
+  font-weight: 400;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  letter-spacing: 0.06em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.8rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Anton", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-bottom: 2px solid transparent;
+  padding-bottom: 3px;
+}
+.site-nav a:hover { color: var(--gold); border-bottom-color: var(--gold); }
+
+/* --- Gigante page -------------------------------------------------------- */
+.site-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 2rem 4rem;
+}
+
+.gigante-page {
+  position: relative;
+  background-color: var(--surface);
+  border: 2px solid var(--gold-dark);
+  min-height: 700px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.plate-border { text-align: center; padding: 2rem 2.5rem 0; }
+.plate-border svg { max-width: 100%; height: 20px; display: block; margin: 0 auto; }
+.plate-border-bottom { padding: 0 2.5rem 2rem; }
+
+.gigante-body {
+  padding: clamp(2rem, 5vw, 5rem) clamp(2rem, 5vw, 5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.gigante-body h1,
+.gigante-body h2,
+.gigante-body h3 {
+  font-family: "Anton", sans-serif;
+  color: var(--gold);
+  line-height: 1.1;
+  font-weight: 400;
+  text-transform: uppercase;
+}
+.gigante-body h1 {
+  font-size: clamp(3rem, 8vw, 6rem);
+  margin: 0 0 0.2em;
+  letter-spacing: 0.02em;
+}
+.gigante-body h2 {
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  margin: 2em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 2px solid var(--gold-dark);
+  text-align: left;
+}
+.gigante-body h3 {
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
+  margin: 1.5em 0 0.2em;
+  color: var(--gold);
+  text-align: left;
+}
+
+.gigante-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Lora", "Merriweather", serif;
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
+  text-align: left;
+  line-height: 1.65;
+}
+.gigante-body p.lede {
+  font-family: "Merriweather", serif;
+  font-size: clamp(1.3rem, 2.5vw, 1.8rem);
+  line-height: 1.5;
+  color: var(--text-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 36em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.gigante-label {
+  display: inline-block;
+  font-family: "Anton", sans-serif;
+  font-size: clamp(0.75rem, 1.2vw, 1rem);
+  font-weight: 400;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 0.5em;
+}
+
+.gigante-head { margin-bottom: 2.5rem; text-align: center; }
+.gigante-title {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  font-size: clamp(3rem, 8vw, 6rem);
+  margin: 0;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+
+.gigante-body a {
+  color: var(--gold);
+  text-decoration: none;
+  border-bottom: 2px solid var(--gold-dark);
+}
+.gigante-body a:hover { color: var(--text); border-bottom-color: var(--text); }
+
+blockquote {
+  margin: 2.5rem auto;
+  padding: 1rem 2rem;
+  border-left: 4px solid var(--gold);
+  background-color: var(--surface-raised);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "Merriweather", serif;
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
+  text-align: left;
+  max-width: 36em;
+}
+
+.gigante-body ul,
+.gigante-body ol {
+  margin: 1em 0 1em 2rem;
+  padding: 0;
+  text-align: left;
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
+}
+.gigante-body ul { list-style: square; }
+.gigante-body ol { list-style: decimal; }
+.gigante-body li { padding: 0.3em 0; color: var(--text-soft); }
+
+/* --- Cover page display -------------------------------------------------- */
+.cover-page {
+  padding: clamp(2rem, 6vw, 4rem) 0;
+  text-align: center;
+}
+.cover-display {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  color: var(--gold);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  margin: 0 0 0.1em;
+}
+.cover-subtitle {
+  font-family: "Merriweather", serif;
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  font-style: italic;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* --- Oversized capital --------------------------------------------------- */
+.oversized-capital {
+  text-align: center;
+  margin: 1rem 0;
+  overflow: hidden;
+}
+.oversized-capital svg {
+  max-width: 100%;
+  height: auto;
+  max-height: 50vh;
+  display: inline-block;
+}
+
+/* --- Plate illustration -------------------------------------------------- */
+.plate-illustration {
+  text-align: center;
+  margin: 2.5rem 0;
+  overflow: hidden;
+}
+.plate-illustration svg {
+  max-width: 100%;
+  height: auto;
+  display: inline-block;
+}
+
+/* --- Plate ornament ------------------------------------------------------ */
+.plate-ornament {
+  text-align: center;
+  margin: 2rem 0;
+}
+.plate-ornament svg {
+  max-width: 300px;
+  height: 20px;
+  display: inline-block;
+}
+
+/* --- Gigante card grid --------------------------------------------------- */
+.gigante-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0;
+  text-align: left;
+}
+.gigante-card {
+  background-color: var(--surface-raised);
+  border: 2px solid var(--gold-dark);
+  padding: 1.5rem;
+  position: relative;
+}
+.gigante-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--gold);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.gigante-card p {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.3vw, 1.15rem);
+  line-height: 1.55;
+  color: var(--text-soft);
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2.5rem 0;
+}
+.colophon-page h1 {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: clamp(1rem, 1.5vw, 1.25rem);
+  color: var(--text-soft);
+}
+.colophon-detail strong {
+  color: var(--gold);
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.colophon-imprint {
+  font-family: "Merriweather", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: clamp(1rem, 1.5vw, 1.3rem);
+  margin-top: 2.5rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2.5rem 0 0;
+  border-top: 2px solid var(--gold-dark);
+  text-align: left;
+}
+.section-list li {
+  padding: 1rem 0.5rem;
+  border-bottom: 1px solid var(--gold-dark);
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  font-family: "Lora", serif;
+}
+.section-list li::before {
+  content: "\25A0";
+  color: var(--gold-dark);
+  font-size: 0.8em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 700;
+  color: var(--text);
+  border: none;
+  font-size: clamp(1.1rem, 1.8vw, 1.4rem);
+}
+.section-list li a:hover { color: var(--gold); }
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.5rem;
+  text-align: left;
+  font-family: "Merriweather", serif;
+}
+
+nav.pagination { margin-top: 2.5rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.4em 0.8em;
+  border: 2px solid var(--gold-dark);
+  font-family: "Anton", sans-serif;
+  font-size: 0.85rem;
+  color: var(--text-soft);
+  text-decoration: none;
+  background-color: var(--surface-raised);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+nav.pagination a:hover { color: var(--gold); border-color: var(--gold); }
+.pagination-current span { color: var(--gold); border-color: var(--gold); }
+
+/* --- Footer -------------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 1rem;
+}
+.footer-device svg {
+  width: 60px;
+  height: 60px;
+  display: block;
+  margin: 0 auto;
+}
+
+.site-footer {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 2rem 4rem;
+  border-top: 2px solid var(--gold-dark);
+  text-align: center;
+}
+.footer-inner { padding-top: 2rem; }
+.footer-line {
+  font-family: "Anton", sans-serif;
+  font-weight: 400;
+  color: var(--gold);
+  margin: 0.2em 0;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 1.1rem;
+}
+.footer-line-small {
+  font-family: "Merriweather", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 900px) {
+  body { font-size: 20px; }
+  .gigante-body { padding: 2rem 1.5rem 2.5rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1.2rem; }
+  .cover-page { padding: 2rem 0; }
+  .oversized-capital svg { max-height: 30vh; }
+}
+
+@media (max-width: 600px) {
+  body { font-size: 18px; }
+  .gigante-body { padding: 1.5rem 1.25rem 2rem; }
+  .oversized-capital svg { max-height: 25vh; }
+}

--- a/folio-gigante/templates/404.html
+++ b/folio-gigante/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="gigante-page">
+      <div class="gigante-body">
+        <header class="gigante-head">
+          <p class="gigante-label">404</p>
+          <h1 class="gigante-title">Plate Not Found</h1>
+        </header>
+        <p>This plate was never bound into the volume. It may have been too large even for this oversized format. Return to the cover.</p>
+        <p><a href="{{ base_url }}/">Back to the cover</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/folio-gigante/templates/footer.html
+++ b/folio-gigante/templates/footer.html
@@ -1,0 +1,16 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+          <rect x="20" y="15" width="60" height="70" fill="none" stroke="#8a6d2e" stroke-width="1"/>
+          <text x="50" y="62" font-family="serif" font-size="30" fill="#d4a843" text-anchor="middle" font-weight="900">FG</text>
+        </svg>
+      </div>
+      <p class="footer-line">Folio Gigante</p>
+      <p class="footer-line-small">A monumental publication, oversized by design.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; printed at poster scale</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/folio-gigante/templates/header.html
+++ b/folio-gigante/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Merriweather:ital,wght@0,400;0,700;0,900;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="gigante-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Folio Gigante home">
+        <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="8" y="4" width="64" height="72" fill="none" stroke="#d4a843" stroke-width="1.5"/>
+          <rect x="14" y="10" width="52" height="60" fill="none" stroke="#8a6d2e" stroke-width="0.8"/>
+          <text x="40" y="52" font-family="serif" font-size="36" fill="#d4a843" text-anchor="middle" font-weight="900">G</text>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Folio Gigante</span>
+          <span class="logo-sub">Oversized Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Cover</a>
+        <a href="{{ base_url }}/plates/">Plates</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/folio-gigante/templates/page.html
+++ b/folio-gigante/templates/page.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="gigante-page">
+      <div class="plate-border" aria-hidden="true">
+        <svg viewBox="0 0 800 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="10" x2="350" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+          <rect x="360" y="4" width="12" height="12" fill="none" stroke="#d4a843" stroke-width="1"/>
+          <rect x="380" y="6" width="8" height="8" fill="#d4a843"/>
+          <rect x="396" y="4" width="12" height="12" fill="none" stroke="#d4a843" stroke-width="1"/>
+          <line x1="420" y1="10" x2="800" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+        </svg>
+      </div>
+      <div class="gigante-body">
+        {{ content }}
+      </div>
+      <div class="plate-border plate-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 800 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="100" y1="10" x2="700" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+          <rect x="100" y="6" width="8" height="8" fill="#8a6d2e"/>
+          <rect x="692" y="6" width="8" height="8" fill="#8a6d2e"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/folio-gigante/templates/section.html
+++ b/folio-gigante/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="gigante-page">
+      <div class="plate-border" aria-hidden="true">
+        <svg viewBox="0 0 800 20" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="10" x2="350" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+          <rect x="370" y="4" width="12" height="12" fill="none" stroke="#d4a843" stroke-width="1"/>
+          <rect x="396" y="4" width="12" height="12" fill="none" stroke="#d4a843" stroke-width="1"/>
+          <line x1="420" y1="10" x2="800" y2="10" stroke="#8a6d2e" stroke-width="1"/>
+        </svg>
+      </div>
+      <div class="gigante-body">
+        <header class="gigante-head">
+          <p class="gigante-label">Collection</p>
+          <h1 class="gigante-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/folio-gigante/templates/shortcodes/alert.html
+++ b/folio-gigante/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1.5rem; border: 2px solid #d4a843; background-color: #1a1a1a; border-left: 6px solid #d4a843; margin: 2rem 0; color: #e0dcd0; font-size: 1.2rem;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/folio-gigante/templates/taxonomy.html
+++ b/folio-gigante/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="gigante-page">
+      <div class="gigante-body">
+        <header class="gigante-head">
+          <p class="gigante-label">Index</p>
+          <h1 class="gigante-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this oversized volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/folio-gigante/templates/taxonomy_term.html
+++ b/folio-gigante/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="gigante-page">
+      <div class="gigante-body">
+        <header class="gigante-head">
+          <p class="gigante-label">Subject</p>
+          <h1 class="gigante-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Plates filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1548,6 +1548,13 @@
     "docs",
     "design-system"
   ],
+  "folio-gigante": [
+    "book",
+    "dark",
+    "oversized",
+    "monumental",
+    "maximal"
+  ],
   "forge": [
     "light",
     "docs",


### PR DESCRIPTION
Closes #1547

## Summary
- Add folio-gigante (oversized publication) example site
- Dark theme with monumental scale and aged gold accents
- SVG full-page plate illustrations at poster scale
- SVG oversized ornamental capitals that fill half the viewport
- Typography: Anton at 200px+ for display, Lora/Merriweather at 24px+ for body
- 5 plates covering the atlas, natural history, architecture, music, and spectacle
- Tags: book, dark, oversized, monumental, maximal

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of oversized typography and monumental scale
- [ ] Verify SVG plate illustrations and oversized capitals render
- [ ] Check responsive scaling on various viewports