### PR TITLE
feat: add endpaper example site (closes #1546)

### DIFF
--- a/endpaper/AGENTS.md
+++ b/endpaper/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/endpaper/config.toml
+++ b/endpaper/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Endpaper - Book Lining Publication
+# Issue #1546 | Tags: book, dark, decorative, pattern, hidden
+# =============================================================================
+
+title = "Endpaper"
+description = "A dark, decorative publication modeled on the endpapers of fine books. SVG marbled paper patterns (combed, stone, peacock) as page backgrounds and paste paper texture patterns for section dividers. Display headings concealed within patterns, clean serif body text emerging from pattern backgrounds. Source Serif Pro and Noto Serif for body."
+base_url = "http://localhost:3000"
+
+sections = ["patterns"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/endpaper/content/about.md
+++ b/endpaper/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About this book lining publication and the endpaper tradition."
++++
+
+<p class="endpaper-label">Reference</p>
+
+# About This Publication
+
+<p class="lede">This publication is a study of the endpaper: the decorated lining of the book cover, where patterns conceal structure and beauty hides in the hinge of the binding.</p>
+
+## The hidden surface
+
+<p>The design of this site uses a dark background to evoke the interior of a book cover, with SVG marbled paper patterns flowing across page borders and section dividers. The headings are partially concealed within the patterns, reflecting the way endpaper decoration occupies a threshold space -- visible but not prominent, decorative but not dominant.</p>
+
+## Design principles
+
+<p>The typography uses Source Serif Pro and Noto Serif as clean body faces that emerge clearly from the patterned backgrounds, while Cormorant provides display headings that blend into the decorative context. The color palette draws from the traditional pigments of marbling: deep indigo, muted purple, and soft violet on a near-black ground.</p>
+
+<blockquote>The endpaper is the book's secret. It is the art that greets you when you open the cover and says goodbye when you close it. Between those two moments, it waits patiently behind the pages.</blockquote>

--- a/endpaper/content/colophon.md
+++ b/endpaper/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "Production details of this book lining publication."
++++
+
+<div class="colophon-page">
+<p class="endpaper-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="paste-divider" aria-hidden="true">
+<svg viewBox="0 0 300 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="30" y1="10" x2="270" y2="10" stroke="#4a3f6b" stroke-width="0.6"/>
+<circle cx="150" cy="10" r="3" fill="none" stroke="#6b5b8a" stroke-width="0.6"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of the endpaper: the decorated lining of the book cover, where marbled and paste paper patterns conceal the binding structure beneath a field of color and form.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in Source Serif Pro and Noto Serif, clean text serifs chosen for their legibility against the dark, patterned backgrounds. The body text emerges from the decorative context as readable content emerges from the endpaper's ornamental field.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Cormorant, a refined display serif that blends into the pattern backgrounds rather than standing apart from them, reflecting the way endpaper decoration conceals rather than announces.</p>
+
+<p class="colophon-detail"><strong>Marbled patterns</strong> are drawn as inline SVG, representing the three principal marble types: combed (parallel waves), stone (random circles), and peacock (concentric ovals). These patterns appear as page borders and section dividers throughout the publication.</p>
+
+<p class="colophon-detail"><strong>Paste paper textures</strong> appear as section separators, drawn as SVG wave patterns that evoke the rhythmic textures created when a brush or comb is drawn through wet paste on paper.</p>
+
+<div class="paste-divider" aria-hidden="true">
+<svg viewBox="0 0 300 20" xmlns="http://www.w3.org/2000/svg">
+<circle cx="140" cy="10" r="2" fill="#4a3f6b"/>
+<circle cx="150" cy="10" r="2" fill="#4a3f6b"/>
+<circle cx="160" cy="10" r="2" fill="#4a3f6b"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First patterned edition, 2026.</p>
+</div>

--- a/endpaper/content/index.md
+++ b/endpaper/content/index.md
@@ -1,0 +1,75 @@
++++
+title = "Endpaper"
+description = "A decorative publication hidden within the patterns of the book lining."
++++
+
+<div class="cover-page">
+<div class="marble-pattern-large" aria-hidden="true">
+<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
+<rect width="600" height="200" fill="#1a1a2e"/>
+<path d="M0 30 Q75 10 150 40 Q225 70 300 30 Q375 -10 450 40 Q525 70 600 30" fill="none" stroke="#4a3f6b" stroke-width="1" opacity="0.5"/>
+<path d="M0 60 Q75 40 150 70 Q225 100 300 60 Q375 20 450 70 Q525 100 600 60" fill="none" stroke="#6b5b8a" stroke-width="0.8" opacity="0.4"/>
+<path d="M0 90 Q75 70 150 100 Q225 130 300 90 Q375 50 450 100 Q525 130 600 90" fill="none" stroke="#8b6f9e" stroke-width="0.7" opacity="0.35"/>
+<path d="M0 120 Q75 100 150 130 Q225 160 300 120 Q375 80 450 130 Q525 160 600 120" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.3"/>
+<path d="M0 150 Q75 130 150 160 Q225 190 300 150 Q375 110 450 160 Q525 190 600 150" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.25"/>
+<path d="M0 180 Q75 160 150 190 Q225 220 300 180 Q375 140 450 190 Q525 220 600 180" fill="none" stroke="#8b6f9e" stroke-width="0.4" opacity="0.2"/>
+<text x="300" y="110" font-family="'Cormorant', serif" font-size="28" fill="#6b5b8a" text-anchor="middle" font-weight="600" opacity="0.35" font-style="italic">Endpaper</text>
+</svg>
+</div>
+<p class="endpaper-label">Book Lining</p>
+<h1 class="cover-display">Endpaper</h1>
+<p class="cover-subtitle">The Hidden Art of the Book Lining</p>
+</div>
+
+## On the endpaper
+
+<p class="lede">The endpaper is the first and last thing you see when you open a book. Pasted to the inside of the cover and folded over to form a flyleaf, the endpaper conceals the binding structure and provides a transition from the hard cover to the soft pages within. In fine bookmaking, the endpaper is not blank: it is decorated with marbled, printed, or paste paper patterns that transform the inside of the cover into a field of color and form.</p>
+
+## The purpose of decoration
+
+<p>The decorated endpaper serves a dual function. Practically, it reinforces the hinge between the cover board and the text block, protecting the binding from the stress of opening and closing. Aesthetically, it frames the text. The endpaper pattern is the threshold between the outside world and the interior of the book, and its design sets the tone for what follows. A bold Turkish marble suggests passion and movement. A calm combed pattern suggests order and refinement. A blank white endpaper suggests austerity, or economy.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<div class="pattern-sample" aria-hidden="true">
+<svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="80" fill="#1a1a2e"/>
+<path d="M0 20 Q50 10 100 25 Q150 40 200 20" fill="none" stroke="#6b5b8a" stroke-width="0.8" opacity="0.6"/>
+<path d="M0 40 Q50 30 100 45 Q150 60 200 40" fill="none" stroke="#8b6f9e" stroke-width="0.6" opacity="0.5"/>
+<path d="M0 60 Q50 50 100 65 Q150 80 200 60" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.4"/>
+</svg>
+</div>
+<h3>Combed marble</h3>
+<p>Parallel waves drawn through floating pigments with a comb. The most controlled of the marble patterns, producing regular, rhythmic curves.</p>
+</div>
+<div class="pattern-card">
+<div class="pattern-sample" aria-hidden="true">
+<svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="80" fill="#1a1a2e"/>
+<circle cx="50" cy="40" r="25" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.4"/>
+<circle cx="100" cy="30" r="18" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.35"/>
+<circle cx="150" cy="50" r="22" fill="none" stroke="#4a3f6b" stroke-width="0.7" opacity="0.3"/>
+<circle cx="70" cy="60" r="15" fill="none" stroke="#6b5b8a" stroke-width="0.4" opacity="0.25"/>
+</svg>
+</div>
+<h3>Stone marble</h3>
+<p>Random circles and droplets where pigment falls onto the sizing bath. An organic, unpredictable pattern that resembles geological formations.</p>
+</div>
+<div class="pattern-card">
+<div class="pattern-sample" aria-hidden="true">
+<svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="80" fill="#1a1a2e"/>
+<ellipse cx="100" cy="40" rx="60" ry="30" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.5"/>
+<ellipse cx="100" cy="40" rx="45" ry="22" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.4"/>
+<ellipse cx="100" cy="40" rx="30" ry="14" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.35"/>
+<ellipse cx="100" cy="40" rx="15" ry="7" fill="none" stroke="#6b5b8a" stroke-width="0.4" opacity="0.3"/>
+</svg>
+</div>
+<h3>Peacock marble</h3>
+<p>Concentric ovals drawn outward from center points, resembling peacock feathers. The most elaborate of the traditional marble patterns.</p>
+</div>
+</div>
+
+## The concealed art
+
+<p>The endpaper is the most hidden art in the book. It is visible only to those who open the volume, and even then it is glimpsed rather than studied. The binder chooses the pattern knowing that it will be seen for a moment -- a flash of color and form as the cover swings open -- before the reader turns to the text. The endpaper is decoration that does not compete with the content; it frames it.</p>

--- a/endpaper/content/patterns/1-the-combed.md
+++ b/endpaper/content/patterns/1-the-combed.md
@@ -1,0 +1,42 @@
++++
+title = "The Combed"
+description = "Combed marble patterns: parallel waves drawn through floating pigments."
+tags = ["marble", "technique"]
++++
+
+<p class="endpaper-label">Pattern I</p>
+
+# The Combed
+
+<p class="lede">Combed marble is the most disciplined of the marbling patterns. A comb -- a row of evenly spaced pins or teeth -- is drawn through the floating pigments on the surface of the sizing bath, creating parallel waves that undulate across the sheet. The result is a pattern of remarkable regularity: rhythmic, controlled, and endlessly varied within its constraints.</p>
+
+<div class="marble-pattern-inline" aria-hidden="true">
+<svg viewBox="0 0 500 60" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="60" fill="#1a1a2e"/>
+<path d="M0 10 Q62 0 125 15 Q187 30 250 10 Q312 -10 375 15 Q437 30 500 10" fill="none" stroke="#4a3f6b" stroke-width="0.8" opacity="0.6"/>
+<path d="M0 25 Q62 15 125 30 Q187 45 250 25 Q312 5 375 30 Q437 45 500 25" fill="none" stroke="#6b5b8a" stroke-width="0.7" opacity="0.5"/>
+<path d="M0 40 Q62 30 125 45 Q187 60 250 40 Q312 20 375 45 Q437 60 500 40" fill="none" stroke="#8b6f9e" stroke-width="0.6" opacity="0.4"/>
+<path d="M0 55 Q62 45 125 60 Q187 75 250 55 Q312 35 375 60 Q437 75 500 55" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.3"/>
+</svg>
+</div>
+
+## The process
+
+<p>The marbler first prepares the sizing bath: a shallow tray filled with carrageenan or gum tragacanth solution. Pigments mixed with ox gall are sprinkled onto the surface, where they float and spread. The marbler then draws a comb through the floating pigments, creating the characteristic wave pattern. The sheet of paper is laid carefully onto the surface, picking up the pigments in a single contact. The sheet is lifted, rinsed, and dried. Each sheet is unique.</p>
+
+## Variations
+
+<p>The combed pattern has many variations depending on the number and spacing of the comb teeth, the direction of the draw, and the number of passes. A single pass creates simple waves. Two perpendicular passes create a nonpareil pattern. A series of alternating passes creates a bouquet pattern. Each variation requires precise control of timing, pressure, and angle.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<h3>Nonpareil</h3>
+<p>Two perpendicular comb passes create a tight, interlocking pattern of small waves. The most common endpaper marble, used in bookbinding since the seventeenth century.</p>
+</div>
+<div class="pattern-card">
+<h3>Bouquet</h3>
+<p>Multiple alternating passes create a complex, flower-like pattern. More labor-intensive than the nonpareil, and reserved for finer bindings.</p>
+</div>
+</div>
+
+<blockquote>The combed marble is proof that constraint produces beauty. The comb allows only parallel lines, but within that limitation, the marbler creates infinite variation.</blockquote>

--- a/endpaper/content/patterns/2-the-stone.md
+++ b/endpaper/content/patterns/2-the-stone.md
@@ -1,0 +1,45 @@
++++
+title = "The Stone"
+description = "Stone marble patterns: random droplets on the sizing bath."
+tags = ["marble", "organic"]
++++
+
+<p class="endpaper-label">Pattern II</p>
+
+# The Stone
+
+<p class="lede">Stone marble is the oldest and simplest marbling technique. Pigments are sprinkled or flicked onto the sizing bath without manipulation, producing random circles and droplets that resemble the patterns found in natural stone -- agate, jasper, or geological cross-sections. The beauty of stone marble lies in its randomness: no two sheets are alike, and the pattern emerges from physics rather than design.</p>
+
+<div class="marble-pattern-inline" aria-hidden="true">
+<svg viewBox="0 0 500 60" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="60" fill="#1a1a2e"/>
+<circle cx="60" cy="25" r="14" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.4"/>
+<circle cx="140" cy="40" r="10" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.35"/>
+<circle cx="200" cy="15" r="8" fill="none" stroke="#4a3f6b" stroke-width="0.7" opacity="0.3"/>
+<circle cx="280" cy="35" r="16" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.4"/>
+<circle cx="350" cy="20" r="12" fill="none" stroke="#8b6f9e" stroke-width="0.6" opacity="0.3"/>
+<circle cx="420" cy="45" r="9" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.35"/>
+<circle cx="470" cy="18" r="11" fill="none" stroke="#6b5b8a" stroke-width="0.4" opacity="0.25"/>
+</svg>
+</div>
+
+## Natural randomness
+
+<p>When pigment drops onto the sizing surface, it spreads outward in a circle until it meets resistance from neighboring drops. The size of each circle depends on the amount of pigment, the surface tension of the sizing, and the force of the drop. Large drops spread into broad rings. Small flicks produce tight clusters of tiny spots. The marbler controls the overall density and color distribution, but the individual pattern is determined by chance.</p>
+
+## Geological echoes
+
+<p>The name "stone marble" reflects the resemblance of these patterns to natural stone, but the similarity is not coincidental. Both patterns arise from the same physics: the interaction of fluids of different densities and viscosities. The concentric rings in a piece of agate and the rings on a stone-marbled sheet are products of the same natural processes at different scales and timescales.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<h3>Turkish stone</h3>
+<p>The original marbling technique, developed in Central Asia and brought to the Ottoman Empire. Multiple colors are sprinkled in layers, each displacing the previous, creating nested rings.</p>
+</div>
+<div class="pattern-card">
+<h3>Italian stone</h3>
+<p>A single-color variant popular in Italian bookbinding. Fewer colors produce a more restrained pattern, suitable for scholarly and liturgical volumes.</p>
+</div>
+</div>
+
+<blockquote>Stone marble is the pattern that nature would make if nature were a bookbinder. It requires no tools beyond a brush and a flick of the wrist.</blockquote>

--- a/endpaper/content/patterns/3-the-peacock.md
+++ b/endpaper/content/patterns/3-the-peacock.md
@@ -1,0 +1,47 @@
++++
+title = "The Peacock"
+description = "Peacock marble patterns: concentric ovals drawn from center points."
+tags = ["marble", "elaborate"]
++++
+
+<p class="endpaper-label">Pattern III</p>
+
+# The Peacock
+
+<p class="lede">The peacock pattern is the most elaborate of the traditional marble designs. Named for its resemblance to the eye-spots on a peacock's tail feathers, the pattern is created by drawing a stylus outward from the center of each pigment drop, stretching the concentric rings into elongated ovals. The result is a field of feather-like forms, each one unique, radiating color and movement across the sheet.</p>
+
+<div class="marble-pattern-inline" aria-hidden="true">
+<svg viewBox="0 0 500 60" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="60" fill="#1a1a2e"/>
+<ellipse cx="80" cy="30" rx="40" ry="20" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.4"/>
+<ellipse cx="80" cy="30" rx="28" ry="14" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.35"/>
+<ellipse cx="80" cy="30" rx="16" ry="8" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.3"/>
+<ellipse cx="250" cy="30" rx="45" ry="22" fill="none" stroke="#4a3f6b" stroke-width="0.6" opacity="0.4"/>
+<ellipse cx="250" cy="30" rx="32" ry="16" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.35"/>
+<ellipse cx="250" cy="30" rx="18" ry="9" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.3"/>
+<ellipse cx="420" cy="30" rx="38" ry="19" fill="none" stroke="#8b6f9e" stroke-width="0.6" opacity="0.4"/>
+<ellipse cx="420" cy="30" rx="26" ry="13" fill="none" stroke="#4a3f6b" stroke-width="0.5" opacity="0.35"/>
+<ellipse cx="420" cy="30" rx="14" ry="7" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.3"/>
+</svg>
+</div>
+
+## The technique
+
+<p>Creating a peacock pattern begins with a stone marble base: multiple colors are sprinkled onto the sizing bath, forming concentric rings. The marbler then draws a pointed stylus through each ring formation, pulling the center outward and elongating the circles into ovals. The direction and length of each draw determines the shape and orientation of the resulting "feather." Skilled marblers arrange the feathers in regular rows, creating a rhythmic pattern across the entire sheet.</p>
+
+## The prestige pattern
+
+<p>Because of its complexity and the skill required to produce it consistently, the peacock pattern was traditionally reserved for the finest bindings. A peacock-marbled endpaper signals a volume of quality and expense. The pattern requires more pigment, more time, and more skill than simpler marble types, and any error in the drawing stage is immediately visible as a distorted or broken feather.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<h3>French curl</h3>
+<p>A variant where the stylus draws a curved rather than straight line, producing spiral feathers that resemble the curled plumes of a baroque headdress.</p>
+</div>
+<div class="pattern-card">
+<h3>Peacock tail</h3>
+<p>The feathers are arranged in a fan pattern radiating from one edge of the sheet, imitating the spread of a peacock's tail display.</p>
+</div>
+</div>
+
+<blockquote>The peacock pattern is the marbler's showcase. It combines the randomness of stone marble with the precision of the stylus, producing a design that is both natural and deliberate.</blockquote>

--- a/endpaper/content/patterns/4-the-paste.md
+++ b/endpaper/content/patterns/4-the-paste.md
@@ -1,0 +1,43 @@
++++
+title = "The Paste"
+description = "Paste paper patterns: textures brushed into wet paste on paper."
+tags = ["paste-paper", "texture"]
++++
+
+<p class="endpaper-label">Pattern IV</p>
+
+# The Paste
+
+<p class="lede">Paste paper is the other great tradition of endpaper decoration. Where marbled paper captures floating pigments from a bath, paste paper is made by brushing a colored paste directly onto the sheet and then texturing it with tools: combs, sponges, stamps, fingers, crumpled paper, or any implement that leaves a mark. The result is a tactile, dimensional pattern that feels as good as it looks.</p>
+
+<div class="paste-pattern-inline" aria-hidden="true">
+<svg viewBox="0 0 500 60" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="60" fill="#1a1a2e"/>
+<line x1="0" y1="10" x2="500" y2="10" stroke="#4a3f6b" stroke-width="1.5" opacity="0.3"/>
+<line x1="0" y1="20" x2="500" y2="20" stroke="#6b5b8a" stroke-width="1.2" opacity="0.25"/>
+<line x1="0" y1="30" x2="500" y2="30" stroke="#8b6f9e" stroke-width="1" opacity="0.2"/>
+<line x1="0" y1="40" x2="500" y2="40" stroke="#4a3f6b" stroke-width="1.5" opacity="0.3"/>
+<line x1="0" y1="50" x2="500" y2="50" stroke="#6b5b8a" stroke-width="1.2" opacity="0.25"/>
+</svg>
+</div>
+
+## A different process
+
+<p>Paste paper requires no specialized equipment. The maker mixes flour paste or methyl cellulose with pigment, brushes it onto the sheet, and then manipulates the wet paste with any tool that creates a pattern. A comb produces parallel grooves. A sponge produces a stippled texture. A crumpled ball of paper produces an organic, irregular surface. The paste dries with the texture locked in, creating a paper that is both colored and embossed.</p>
+
+## The craft tradition
+
+<p>Paste paper has a longer history as a folk craft than marbled paper. In Germany and Central Europe, paste papers were produced by bookbinders and paper decorators as a cheaper alternative to marbled paper, but the best examples rival marble in their beauty and surpass it in their variety. The technique allows infinite experimentation: any tool that can be pressed into wet paste will produce a unique pattern.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<h3>Combed paste</h3>
+<p>A comb drawn through wet paste creates grooves that reveal the paper beneath. The contrast between the colored paste and the white paper produces bold, graphic patterns.</p>
+</div>
+<div class="pattern-card">
+<h3>Sponge paste</h3>
+<p>A natural sponge pressed into wet paste creates an organic, cloud-like texture. The irregularity of the sponge surface ensures that no two impressions are identical.</p>
+</div>
+</div>
+
+<blockquote>Paste paper is democratic. It requires no bath, no sizing, no specialized pigments. Anyone with flour, water, color, and a tool can make a decorated paper that belongs inside a book.</blockquote>

--- a/endpaper/content/patterns/5-the-hidden.md
+++ b/endpaper/content/patterns/5-the-hidden.md
@@ -1,0 +1,41 @@
++++
+title = "The Hidden"
+description = "The endpaper as concealed art and threshold space."
+tags = ["concealment", "culture"]
++++
+
+<p class="endpaper-label">Pattern V</p>
+
+# The Hidden
+
+<p class="lede">The endpaper occupies a unique position in the book: it is art that is meant to be glimpsed, not studied. It is visible for the brief moment when the cover is open, and then it disappears behind the pages. The endpaper is the most concealed form of book decoration, and its hiddenness is part of its purpose.</p>
+
+<div class="marble-pattern-inline" aria-hidden="true">
+<svg viewBox="0 0 500 60" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="60" fill="#1a1a2e"/>
+<path d="M0 30 Q125 10 250 35 Q375 60 500 30" fill="none" stroke="#4a3f6b" stroke-width="0.8" opacity="0.4"/>
+<path d="M0 30 Q125 50 250 25 Q375 0 500 30" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.3"/>
+<text x="250" y="35" font-family="'Cormorant', serif" font-size="14" fill="#6b5b8a" text-anchor="middle" opacity="0.2" font-style="italic">concealed within the pattern</text>
+</svg>
+</div>
+
+## The threshold
+
+<p>The endpaper is a threshold between the exterior of the book -- the cover, the spine, the title stamped in gold -- and the interior, the text itself. Opening a book with marbled endpapers is like passing through a curtain: the pattern signals the transition from one space to another. The endpaper says: you are leaving the world and entering the book. When you close the volume, the pattern reappears, marking the reverse transition.</p>
+
+## Concealment and revelation
+
+<p>The endpaper also conceals the mechanics of the binding. Beneath the pasted sheet lie the cords or tapes that attach the text block to the cover boards, the turn-ins where the covering material is folded over the edges, and the adhesive that holds the entire structure together. The endpaper's decorative pattern transforms this utilitarian surface into something beautiful, hiding the workmanship behind art.</p>
+
+<div class="pattern-grid">
+<div class="pattern-card">
+<h3>The private art</h3>
+<p>Unlike the cover design, which is public, the endpaper is private. It is seen only by the person who opens the book. The endpaper is the book's secret, shared only with its reader.</p>
+</div>
+<div class="pattern-card">
+<h3>The collector's clue</h3>
+<p>Endpaper patterns help date and locate a binding. Different regions and periods favored different marble types and paste paper styles. The endpaper is a fingerprint of the binder.</p>
+</div>
+</div>
+
+<blockquote>The endpaper is the most generous of all decorative arts. It gives its beauty to the reader and asks nothing in return. It does not demand attention. It simply waits, hidden behind the cover, for the moment the book is opened.</blockquote>

--- a/endpaper/content/patterns/_index.md
+++ b/endpaper/content/patterns/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Patterns"
+description = "The patterns of this book lining publication."
++++
+
+<p class="lede">Five patterns, each examining a different tradition of endpaper decoration. From the marbling tank to the paste brush, these techniques have lined the covers of fine books for five centuries.</p>
+
+<p>The patterns are arranged from the most structured to the most experimental, tracing the evolution of the endpaper from functional lining to decorative art.</p>

--- a/endpaper/static/css/style.css
+++ b/endpaper/static/css/style.css
@@ -1,0 +1,471 @@
+/* =============================================================================
+   Endpaper - Book Lining Publication
+   Issue #1546 | book, dark, decorative, pattern, hidden
+   Palette: deep indigo ground, muted purple/violet, soft lavender text
+   No gradients. Marbled paper patterns + paste textures as inline SVG.
+   ============================================================================= */
+
+:root {
+  --void: #0e0e18;
+  --surface: #151522;
+  --surface-raised: #1a1a2e;
+  --surface-edge: #4a3f6b;
+  --text: #d8d0e8;
+  --text-soft: #b0a8c4;
+  --text-dim: #706890;
+  --marble-dark: #4a3f6b;
+  --marble-mid: #6b5b8a;
+  --marble-light: #8b6f9e;
+  --accent: #9b88b4;
+  --bg: #0a0a14;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: "Source Serif 4", "Noto Serif", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.76;
+  min-height: 100vh;
+}
+
+.endpaper-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--surface-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 42px; height: 42px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+.logo-sub {
+  font-family: "Source Serif 4", serif;
+  font-weight: 400;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* --- Endpaper page ------------------------------------------------------- */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.endpaper-page {
+  position: relative;
+  background-color: var(--surface);
+  border: 1px solid var(--surface-edge);
+  min-height: 600px;
+  box-shadow: 0 8px 28px rgba(10, 10, 20, 0.5);
+}
+
+.endpaper-page-narrow {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.marble-divider { text-align: center; overflow: hidden; }
+.marble-divider svg { max-width: 100%; height: 40px; display: block; margin: 0; }
+
+.endpaper-body {
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.5rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.endpaper-body h1,
+.endpaper-body h2,
+.endpaper-body h3 {
+  font-family: "Cormorant", serif;
+  color: var(--text);
+  line-height: 1.25;
+  font-weight: 600;
+}
+.endpaper-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0 0 0.3em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+}
+.endpaper-body h2 {
+  font-size: 1.35rem;
+  margin: 2.5em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.endpaper-body h3 {
+  font-size: 1.05rem;
+  margin: 1.5em 0 0.2em;
+  color: var(--marble-light);
+  text-align: left;
+}
+
+.endpaper-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Source Serif 4", "Noto Serif", serif;
+  text-align: left;
+  line-height: 1.76;
+}
+.endpaper-body p.lede {
+  font-family: "Cormorant", serif;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--text-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 34em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.endpaper-label {
+  display: inline-block;
+  font-family: "Source Serif 4", serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 0.5em;
+}
+
+.endpaper-head { margin-bottom: 2rem; text-align: center; }
+.endpaper-title {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+}
+
+.endpaper-body a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--marble-dark);
+}
+.endpaper-body a:hover { color: var(--text); border-bottom-color: var(--text); }
+
+blockquote {
+  margin: 2rem auto;
+  padding: 0.5rem 1.5rem;
+  border-left: 2px solid var(--marble-mid);
+  background-color: var(--surface-raised);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "Cormorant", serif;
+  font-size: 1.1rem;
+  text-align: left;
+  max-width: 32em;
+}
+
+.endpaper-body ul,
+.endpaper-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  text-align: left;
+}
+.endpaper-body ul { list-style: disc; }
+.endpaper-body ol { list-style: decimal; }
+.endpaper-body li { padding: 0.2em 0; color: var(--text-soft); }
+
+/* --- Cover page display -------------------------------------------------- */
+.cover-page {
+  padding: clamp(2rem, 6vw, 4rem) 0;
+  text-align: center;
+}
+.cover-display {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: clamp(2.2rem, 5.5vw, 3.5rem);
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  margin: 0 0 0.15em;
+}
+.cover-subtitle {
+  font-family: "Source Serif 4", serif;
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* --- Marble pattern large ------------------------------------------------ */
+.marble-pattern-large {
+  text-align: center;
+  margin: 0 0 1.5rem;
+  overflow: hidden;
+}
+.marble-pattern-large svg {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Marble pattern inline ----------------------------------------------- */
+.marble-pattern-inline {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.marble-pattern-inline svg {
+  max-width: 100%;
+  height: 60px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Paste pattern inline ------------------------------------------------ */
+.paste-pattern-inline {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.paste-pattern-inline svg {
+  max-width: 100%;
+  height: 60px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Paste divider ------------------------------------------------------- */
+.paste-divider {
+  text-align: center;
+  margin: 1.5rem 0;
+}
+.paste-divider svg {
+  max-width: 300px;
+  height: 20px;
+  display: inline-block;
+}
+
+/* --- Pattern card grid --------------------------------------------------- */
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+.pattern-card {
+  background-color: var(--surface-raised);
+  border: 1px solid var(--surface-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.pattern-sample {
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+}
+.pattern-sample svg {
+  max-width: 100%;
+  height: 80px;
+  display: block;
+}
+.pattern-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--marble-light);
+  font-size: 1rem;
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-style: italic;
+}
+.pattern-card p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2rem 0;
+}
+.colophon-page h1 {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  font-size: 2rem;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+.colophon-detail strong {
+  color: var(--text);
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+}
+.colophon-imprint {
+  font-family: "Cormorant", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--surface-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Source Serif 4", serif;
+}
+.section-list li::before {
+  content: "\00B7";
+  color: var(--marble-mid);
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--text);
+  border: none;
+  font-size: 1rem;
+}
+.section-list li a:hover { color: var(--accent); }
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  text-align: left;
+  font-family: "Cormorant", serif;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--surface-edge);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.85rem;
+  color: var(--text-soft);
+  text-decoration: none;
+  background-color: var(--surface-raised);
+}
+nav.pagination a:hover { color: var(--accent); border-color: var(--accent); }
+.pagination-current span { color: var(--accent); border-color: var(--accent); }
+
+/* --- Footer -------------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 0.8rem;
+}
+.footer-device svg {
+  width: 40px;
+  height: 40px;
+  display: block;
+  margin: 0 auto;
+}
+
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--surface-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Cormorant", serif;
+  font-weight: 600;
+  color: var(--text-soft);
+  margin: 0.2em 0;
+  letter-spacing: 0.02em;
+  font-size: 1rem;
+}
+.footer-line-small {
+  font-family: "Source Serif 4", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .endpaper-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .endpaper-title, .endpaper-body h1, .cover-display { font-size: 1.9rem; }
+  .endpaper-body h2 { font-size: 1.2rem; }
+  .cover-page { padding: 2rem 0; }
+}

--- a/endpaper/templates/404.html
+++ b/endpaper/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="endpaper-page endpaper-page-narrow">
+      <div class="endpaper-body">
+        <header class="endpaper-head">
+          <p class="endpaper-label">404</p>
+          <h1 class="endpaper-title">Pattern not found</h1>
+        </header>
+        <p>This pattern was never pasted into the volume. The endpaper here is blank, waiting for a design that never came. Return to the cover.</p>
+        <p><a href="{{ base_url }}/">Back to the cover</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/endpaper/templates/footer.html
+++ b/endpaper/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+          <rect x="10" y="10" width="30" height="30" fill="#1a1a2e" stroke="#4a3f6b" stroke-width="0.6"/>
+          <path d="M14 20 Q22 16 30 22 Q38 28 36 20" fill="none" stroke="#6b5b8a" stroke-width="0.4" opacity="0.5"/>
+          <path d="M14 30 Q22 26 30 32 Q38 38 36 30" fill="none" stroke="#8b6f9e" stroke-width="0.4" opacity="0.4"/>
+        </svg>
+      </div>
+      <p class="footer-line">Endpaper</p>
+      <p class="footer-line-small">Hidden within the patterns of the book lining.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; marbled, pasted, concealed</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/endpaper/templates/header.html
+++ b/endpaper/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Cormorant:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="endpaper-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Endpaper home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="4" y="4" width="40" height="40" fill="#1a1a2e" stroke="#4a3f6b" stroke-width="0.8"/>
+          <path d="M8 12 Q16 8 24 14 Q32 20 40 12" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.6"/>
+          <path d="M8 20 Q16 16 24 22 Q32 28 40 20" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.5"/>
+          <path d="M8 28 Q16 24 24 30 Q32 36 40 28" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.4"/>
+          <path d="M8 36 Q16 32 24 38 Q32 44 40 36" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.3"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Endpaper</span>
+          <span class="logo-sub">Book Lining Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Cover</a>
+        <a href="{{ base_url }}/patterns/">Patterns</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/endpaper/templates/page.html
+++ b/endpaper/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="endpaper-page">
+      <div class="marble-divider" aria-hidden="true">
+        <svg viewBox="0 0 800 40" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+          <rect width="800" height="40" fill="#1a1a2e"/>
+          <path d="M0 10 Q100 0 200 15 Q300 30 400 10 Q500 -5 600 20 Q700 35 800 10" fill="none" stroke="#4a3f6b" stroke-width="0.8" opacity="0.6"/>
+          <path d="M0 20 Q100 10 200 25 Q300 40 400 20 Q500 5 600 30 Q700 45 800 20" fill="none" stroke="#6b5b8a" stroke-width="0.6" opacity="0.4"/>
+          <path d="M0 30 Q100 20 200 35 Q300 50 400 30 Q500 15 600 40 Q700 55 800 30" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.3"/>
+        </svg>
+      </div>
+      <div class="endpaper-body">
+        {{ content }}
+      </div>
+      <div class="marble-divider marble-divider-bottom" aria-hidden="true">
+        <svg viewBox="0 0 800 40" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+          <rect width="800" height="40" fill="#1a1a2e"/>
+          <path d="M0 20 Q200 5 400 25 Q600 45 800 20" fill="none" stroke="#4a3f6b" stroke-width="0.7" opacity="0.5"/>
+          <path d="M0 30 Q200 15 400 35 Q600 55 800 30" fill="none" stroke="#6b5b8a" stroke-width="0.5" opacity="0.3"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/endpaper/templates/section.html
+++ b/endpaper/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="endpaper-page">
+      <div class="marble-divider" aria-hidden="true">
+        <svg viewBox="0 0 800 40" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+          <rect width="800" height="40" fill="#1a1a2e"/>
+          <path d="M0 15 Q150 5 300 20 Q450 35 600 15 Q750 0 800 15" fill="none" stroke="#4a3f6b" stroke-width="0.8" opacity="0.5"/>
+          <path d="M0 25 Q150 15 300 30 Q450 45 600 25 Q750 10 800 25" fill="none" stroke="#8b6f9e" stroke-width="0.5" opacity="0.35"/>
+        </svg>
+      </div>
+      <div class="endpaper-body">
+        <header class="endpaper-head">
+          <p class="endpaper-label">Collection</p>
+          <h1 class="endpaper-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/endpaper/templates/shortcodes/alert.html
+++ b/endpaper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #4a3f6b; background-color: #1a1a2e; border-left: 4px solid #6b5b8a; margin: 1rem 0; color: #c8c0d8;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/endpaper/templates/taxonomy.html
+++ b/endpaper/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="endpaper-page endpaper-page-narrow">
+      <div class="endpaper-body">
+        <header class="endpaper-head">
+          <p class="endpaper-label">Index</p>
+          <h1 class="endpaper-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All motifs hidden within the endpapers:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/endpaper/templates/taxonomy_term.html
+++ b/endpaper/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="endpaper-page endpaper-page-narrow">
+      <div class="endpaper-body">
+        <header class="endpaper-head">
+          <p class="endpaper-label">Motif</p>
+          <h1 class="endpaper-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Patterns bearing this motif:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1363,6 +1363,13 @@
     "encore",
     "emotional"
   ],
+  "endpaper": [
+    "book",
+    "dark",
+    "decorative",
+    "pattern",
+    "hidden"
+  ],
   "enigma": [
     "dark",
     "puzzle",


### PR DESCRIPTION
Closes #1546

## Summary
- Add endpaper (book lining publication) example site
- Dark theme with deep indigo/purple palette evoking marbled endpapers
- SVG marbled paper patterns (combed, stone, peacock) as page backgrounds
- SVG paste paper texture patterns for section dividers
- Display headings in Cormorant that blend into pattern backgrounds
- Body text in Source Serif Pro / Noto Serif emerging from patterns
- 5 patterns covering combed, stone, peacock, paste, and concealment
- Tags: book, dark, decorative, pattern, hidden

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of marbled pattern backgrounds and paste dividers
- [ ] Verify SVG patterns render across page borders
- [ ] Check responsive behavior on narrow viewports