### PR TITLE
feat: add printer-devil example site (closes #1545)

### DIFF
--- a/printer-devil/AGENTS.md
+++ b/printer-devil/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/printer-devil/config.toml
+++ b/printer-devil/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Printer Devil - Apprentice Publication
+# Issue #1545 | Tags: book, dark, error, playful, craft
+# =============================================================================
+
+title = "Printer Devil"
+description = "A dark, playful publication modeled on the misadventures of the printer's devil -- the apprentice who inked the press, sorted the type, and occasionally dropped an entire form. SVG ink roller marks and type-pie scattered letter illustrations. Intentionally mis-set display type with clean Lora and Crimson Pro body text and deliberate dropped characters."
+base_url = "http://localhost:3000"
+
+sections = ["mishaps"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/printer-devil/content/about.md
+++ b/printer-devil/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About this apprentice publication and the printer's devil tradition."
++++
+
+<p class="shop-label">Reference</p>
+
+# About This Publication
+
+<p class="lede">This publication celebrates the printer's devil: the ink-stained apprentice whose errors are the folklore of the print shop.</p>
+
+## The playful error
+
+<p>The design of this site deliberately incorporates the errors of the print shop. Display headings are intentionally mis-set -- mixing wrong sizes and faces, as the devil might have composed them. The body text is clean and readable, as a master compositor would set it, but with occasional dropped characters that suggest the devil's careless hand. The SVG illustrations show ink roller marks and scattered type, the visual evidence of a shop run by its youngest worker.</p>
+
+## Design principles
+
+<p>The body text uses Lora and Crimson Pro, reliable text faces that carry long passages cleanly. The display type mixes several faces at deliberately wrong sizes -- Oswald where EB Garamond should be, Anton where Lora should be -- mimicking the devil's habit of reaching for the wrong case. The dark background represents the ink-stained surfaces of the print shop itself.</p>
+
+<blockquote>The printer's devil is the patron saint of errors. Every mistake he made was a lesson learned, and every lesson learned was a step toward mastery. We celebrate the errors because they are the path to the craft.</blockquote>

--- a/printer-devil/content/colophon.md
+++ b/printer-devil/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "Production details of this apprentice publication."
++++
+
+<div class="colophon-page">
+<p class="shop-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="ink-smear" aria-hidden="true">
+<svg viewBox="0 0 300 12" xmlns="http://www.w3.org/2000/svg">
+<rect x="30" y="4" width="240" height="4" fill="#d44" opacity="0.12"/>
+<rect x="80" y="3" width="60" height="6" fill="#d44" opacity="0.08"/>
+</svg>
+</div>
+
+<p>This publication was designed as a celebration of the printer's devil: the apprentice whose errors are the folklore and the education of the print shop.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in Lora and Crimson Pro, reliable text serifs that represent the master compositor's clean work. The body text is the standard against which the devil's errors become visible.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is intentionally mis-set, mixing Oswald, Anton, and EB Garamond at wrong sizes and wrong weights. This reflects the devil's habit of reaching into the wrong type case and setting whatever he found -- bold where light should be, sans where serif should be, display where text should be.</p>
+
+<p class="colophon-detail"><strong>Ink roller marks</strong> are drawn as inline SVG, representing the over-inked sections where the devil applied too much ink to the roller and left visible marks on the printed page.</p>
+
+<p class="colophon-detail"><strong>Type-pie illustrations</strong> show scattered letters from a dropped form, drawn as SVG text elements rotated and displaced at random angles, representing the catastrophe of pieing the type.</p>
+
+<div class="ink-smear" aria-hidden="true">
+<svg viewBox="0 0 300 12" xmlns="http://www.w3.org/2000/svg">
+<circle cx="140" cy="6" r="2" fill="#d44" opacity="0.3"/>
+<circle cx="150" cy="6" r="2" fill="#d44" opacity="0.3"/>
+<circle cx="160" cy="6" r="2" fill="#d44" opacity="0.3"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First apprentice edition, 2026. Errors included.</p>
+</div>

--- a/printer-devil/content/index.md
+++ b/printer-devil/content/index.md
@@ -1,0 +1,59 @@
++++
+title = "Printer Devil"
+description = "An apprentice publication celebrating the errors and mishaps of the print shop."
++++
+
+<div class="shop-cover">
+<div class="type-pie" aria-hidden="true">
+<svg viewBox="0 0 500 120" xmlns="http://www.w3.org/2000/svg">
+<text x="30" y="40" font-family="serif" font-size="24" fill="#d44" transform="rotate(-12 30 40)" opacity="0.7">P</text>
+<text x="80" y="70" font-family="sans-serif" font-size="18" fill="#888" transform="rotate(25 80 70)" opacity="0.5">r</text>
+<text x="120" y="35" font-family="serif" font-size="30" fill="#666" transform="rotate(-5 120 35)" opacity="0.4">i</text>
+<text x="170" y="80" font-family="sans-serif" font-size="14" fill="#d44" transform="rotate(18 170 80)" opacity="0.6">n</text>
+<text x="210" y="45" font-family="serif" font-size="22" fill="#888" transform="rotate(-20 210 45)" opacity="0.5">t</text>
+<text x="260" y="90" font-family="sans-serif" font-size="26" fill="#666" transform="rotate(10 260 90)" opacity="0.3">e</text>
+<text x="310" y="30" font-family="serif" font-size="16" fill="#d44" transform="rotate(-8 310 30)" opacity="0.5">r</text>
+<text x="360" y="75" font-family="sans-serif" font-size="32" fill="#888" transform="rotate(15 360 75)" opacity="0.4">D</text>
+<text x="420" y="50" font-family="serif" font-size="20" fill="#666" transform="rotate(-22 420 50)" opacity="0.6">v</text>
+<text x="460" y="95" font-family="sans-serif" font-size="12" fill="#d44" transform="rotate(30 460 95)" opacity="0.3">l</text>
+</svg>
+</div>
+<p class="shop-label">The Print Shop</p>
+<h1 class="cover-display">Printer <span class="misset">Devil</span></h1>
+<p class="cover-subtitle">A Catalogue of Errors and Mishaps</p>
+</div>
+
+## On the printer's devil
+
+<p class="lede">The printer's devil was the youngest apprentice in the print shop: the boy who inked the type, fetched the paper, sorted the used type back into its cases, and was blamed for every error that appeared in the finished work. The devil was covered in ink from head to toe, worked the longest hours for the smallest wage, and learned the craft by suffering its consequences.</p>
+
+## Why "devil"?
+
+<p>The origin of the term is disputed. Some say the apprentice was called a devil because of the ink stains that blackened his face and hands, giving him a demonic appearance. Others claim the name comes from the superstition that the printing press itself was the work of the devil -- a machine that could reproduce scripture faster than any monk, and therefore surely diabolical. The most practical explanation is that "devil" was simply shop slang for the lowest-ranking worker, the one who did the dirtiest jobs.</p>
+
+## The errors of the apprentice
+
+<p>The printer's devil was responsible for a remarkable variety of errors. He over-inked the form, producing pages with thick, blotchy type. He under-inked it, producing pages that were pale and illegible. He dropped the form, scattering thousands of individual pieces of type across the shop floor -- a disaster known as "pieing the type." He set the wrong font in the wrong size. He placed letters upside down. He forgot to lock the form, so the type shifted during printing. Every error had a name, a cause, and a consequence.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>Type pie</h3>
+<p>The catastrophe of dropping a composed form. Thousands of individual type pieces scatter across the floor and must be sorted back into their cases letter by letter.</p>
+</div>
+<div class="mishap-card">
+<h3>Over-inking</h3>
+<p>Too much ink on the roller produces thick, smeared type that fills in the counters of letters and turns fine text into an illegible black mass.</p>
+</div>
+<div class="mishap-card">
+<h3>Wrong font</h3>
+<p>A letter from one typeface placed into a line of another. The eye catches it instantly: a roman "a" among italic text, a bold letter in a light line.</p>
+</div>
+<div class="mishap-card">
+<h3>Upside-down type</h3>
+<p>A letter placed inverted in the composing stick. The printed result is a letter that reads as its mirror image, instantly marking the page as the work of an apprentice.</p>
+</div>
+</div>
+
+## The craft of mistakes
+
+<p>The printer's devil learned the craft by making every possible error. Each mistake taught a lesson: the feel of a properly inked roller, the sound of a locked form, the visual rhythm of correctly composed text. The devil who survived his apprenticeship became a journeyman compositor, and eventually a master printer. The errors were the education.</p>

--- a/printer-devil/content/mishaps/1-the-wrong-font.md
+++ b/printer-devil/content/mishaps/1-the-wrong-font.md
@@ -1,0 +1,40 @@
++++
+title = "The Wrong Font"
+description = "When a letter from one typeface appears in a line of another."
+tags = ["composition", "error"]
++++
+
+<p class="shop-label">Mishap I</p>
+
+# The Wrong Font
+
+<p class="lede">The wrong font -- abbreviated "wf" in proofreaders' marks -- is the most common error in hand composition. A letter from one typeface is placed into a line of another: a roman "a" among italic text, a bold "g" in a light line, a letter from an entirely different face hiding among its neighbors. The eye catches it instantly.</p>
+
+<div class="type-pie-small" aria-hidden="true">
+<svg viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg">
+<text x="20" y="35" font-family="'Lora', serif" font-size="18" fill="#ccc">The quick brown </text>
+<text x="215" y="35" font-family="'Anton', sans-serif" font-size="16" fill="#d44">f</text>
+<text x="228" y="35" font-family="'Lora', serif" font-size="18" fill="#ccc">ox jumps</text>
+</svg>
+</div>
+
+## How it happens
+
+<p>In the composing room, typefaces are stored in cases -- wooden drawers divided into compartments, one for each letter. When the devil sorts used type back into its cases, he occasionally places a letter in the wrong compartment. The next compositor who reaches into that compartment finds a stranger: a letter that looks almost right but belongs to a different family. In the rush of composition, the error slips through.</p>
+
+## The proofreader's catch
+
+<p>A trained proofreader can spot a wrong font error at a glance. The weight, the width, the stroke contrast, or the serif style of the interloper differs from its neighbors just enough to create a visual disturbance. The mark "wf" in the margin tells the compositor to replace the offending letter with the correct one from the correct case.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>Roman for italic</h3>
+<p>The most common wf error. Roman and italic sorts are stored in adjacent cases, and the devil often confuses them when distributing type.</p>
+</div>
+<div class="mishap-card">
+<h3>Wrong size</h3>
+<p>A 10-point letter in a line of 12-point type. The letter sits too high or too low on the baseline, creating a visible bump in the line.</p>
+</div>
+</div>
+
+<blockquote>The wrong font is the smallest possible error and the most revealing. It proves that every letter in a line of type was placed there by a human hand, one piece at a time.</blockquote>

--- a/printer-devil/content/mishaps/2-the-over-ink.md
+++ b/printer-devil/content/mishaps/2-the-over-ink.md
@@ -1,0 +1,41 @@
++++
+title = "The Over-Ink"
+description = "When the devil applies too much ink to the roller."
+tags = ["inking", "error"]
++++
+
+<p class="shop-label">Mishap II</p>
+
+# The Over-Ink
+
+<p class="lede">Over-inking is the devil's signature error. The apprentice, eager to produce a dark, crisp impression, applies too much ink to the roller. The excess ink fills the counters of the letters, thickens the strokes, and turns fine text into a heavy, smeared mass. The printed page is dark but illegible -- the opposite of the apprentice's intention.</p>
+
+<div class="ink-roller-large" aria-hidden="true">
+<svg viewBox="0 0 500 30" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="10" width="500" height="10" fill="#d44" opacity="0.18"/>
+<rect x="30" y="8" width="100" height="14" fill="#d44" opacity="0.12"/>
+<rect x="180" y="6" width="140" height="18" fill="#d44" opacity="0.08"/>
+<rect x="380" y="9" width="80" height="12" fill="#d44" opacity="0.1"/>
+</svg>
+</div>
+
+## The ink ball and the roller
+
+<p>In the earliest days of printing, ink was applied with leather ink balls: mushroom-shaped pads that the devil dabbed against the type surface. Controlling ink coverage with balls required skill that the apprentice lacked, and uneven inking was almost guaranteed. The invention of the composition roller in the early nineteenth century improved consistency but did not eliminate over-inking: the devil could still apply too much ink to the roller itself.</p>
+
+## The evidence of excess
+
+<p>Over-inked pages have a distinctive appearance. The type is darker and heavier than intended. The counters of letters like "e," "a," and "o" are partially or fully filled with ink. The serifs are thickened. The word spacing appears tighter because the ink spread makes each letter wider. In extreme cases, the ink bleeds beyond the type area entirely, leaving dark marks in the margins.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>Filled counters</h3>
+<p>The enclosed spaces within letters fill with excess ink. An "e" becomes a "c," an "a" becomes a dark blob. The text becomes a puzzle rather than a page.</p>
+</div>
+<div class="mishap-card">
+<h3>Margin marks</h3>
+<p>Ink from the roller deposits on furniture and spacing material around the type, printing dark bars and rectangles in the margins of the page.</p>
+</div>
+</div>
+
+<blockquote>The over-inked page is the devil's calling card. It says: I was here, I tried too hard, and I have not yet learned that less ink makes better printing.</blockquote>

--- a/printer-devil/content/mishaps/3-the-type-pie.md
+++ b/printer-devil/content/mishaps/3-the-type-pie.md
@@ -1,0 +1,48 @@
++++
+title = "The Type Pie"
+description = "The catastrophe of dropping a composed form."
+tags = ["composition", "catastrophe"]
++++
+
+<p class="shop-label">Mishap III</p>
+
+# The Type Pie
+
+<p class="lede">To "pie" the type is to drop a composed form, scattering thousands of individual pieces of type across the shop floor. It is the printer's greatest catastrophe: hours or days of composition destroyed in a single moment of carelessness. The type lies jumbled on the floor in a heap of mixed letters, sizes, and faces that must be sorted piece by piece back into their cases.</p>
+
+<div class="type-pie" aria-hidden="true">
+<svg viewBox="0 0 500 100" xmlns="http://www.w3.org/2000/svg">
+<text x="40" y="30" font-family="serif" font-size="16" fill="#d44" transform="rotate(-18 40 30)" opacity="0.6">T</text>
+<text x="90" y="60" font-family="sans-serif" font-size="12" fill="#888" transform="rotate(22 90 60)" opacity="0.4">h</text>
+<text x="130" y="25" font-family="serif" font-size="20" fill="#666" transform="rotate(-8 130 25)" opacity="0.5">e</text>
+<text x="180" y="70" font-family="sans-serif" font-size="14" fill="#d44" transform="rotate(15 180 70)" opacity="0.3">t</text>
+<text x="220" y="40" font-family="serif" font-size="18" fill="#888" transform="rotate(-25 220 40)" opacity="0.6">y</text>
+<text x="270" y="80" font-family="sans-serif" font-size="10" fill="#666" transform="rotate(30 270 80)" opacity="0.4">p</text>
+<text x="310" y="35" font-family="serif" font-size="22" fill="#d44" transform="rotate(-12 310 35)" opacity="0.5">e</text>
+<text x="360" y="65" font-family="sans-serif" font-size="16" fill="#888" transform="rotate(8 360 65)" opacity="0.3">i</text>
+<text x="400" y="45" font-family="serif" font-size="14" fill="#666" transform="rotate(-20 400 45)" opacity="0.6">s</text>
+<text x="440" y="85" font-family="sans-serif" font-size="18" fill="#d44" transform="rotate(18 440 85)" opacity="0.4">p</text>
+<text x="470" y="28" font-family="serif" font-size="12" fill="#888" transform="rotate(-5 470 28)" opacity="0.5">d</text>
+</svg>
+</div>
+
+## The weight of a form
+
+<p>A composed page of type is heavy. A full form of text type might weigh ten pounds or more, and it is held together only by the pressure of the chase -- the metal frame that locks the type in place. If the chase is not properly locked, or if the devil lifts the form unevenly, the type breaks free and cascades to the floor. The sound of pieing the type -- a metallic crash followed by the tinkling of thousands of small metal pieces bouncing on stone -- is unmistakable and unforgettable.</p>
+
+## The long recovery
+
+<p>Pieing the type is not just a momentary disaster; it creates hours or days of recovery work. Every piece of type must be sorted back into its correct case, by typeface, by size, and by letter. The devil, who caused the disaster, is usually assigned the task of sorting -- a tedious, eye-straining job that serves as both punishment and education. After sorting ten thousand pieces of type by hand, the devil learns to lock the form properly.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>The cascade</h3>
+<p>Type falls in a cascade, the heavier pieces hitting the floor first and the smaller pieces bouncing and rolling. The spread pattern can cover the entire shop floor.</p>
+</div>
+<div class="mishap-card">
+<h3>The sorting</h3>
+<p>Each piece of type must be identified by face, size, and letter, then returned to the correct compartment in the correct case. A single misplaced sort becomes a future wrong-font error.</p>
+</div>
+</div>
+
+<blockquote>Pieing the type is the printer's original sin. Every apprentice does it once. The wise apprentice does it only once.</blockquote>

--- a/printer-devil/content/mishaps/4-the-upside-down.md
+++ b/printer-devil/content/mishaps/4-the-upside-down.md
@@ -1,0 +1,40 @@
++++
+title = "The Upside Down"
+description = "When a letter is set inverted in the composing stick."
+tags = ["composition", "error"]
++++
+
+<p class="shop-label">Mishap IV</p>
+
+# The Upside Down
+
+<p class="lede">An inverted letter is a letter placed upside down in the composing stick. When printed, it appears as its vertical mirror image: a "p" that reads as a "d," a "b" that reads as a "q," an "n" that reads as a "u." The error is obvious to the reader but invisible to the compositor working with the reversed type.</p>
+
+<div class="type-pie-small" aria-hidden="true">
+<svg viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg">
+<text x="20" y="35" font-family="'Lora', serif" font-size="18" fill="#ccc">The priuter's </text>
+<text x="188" y="35" font-family="'Lora', serif" font-size="18" fill="#d44" transform="scale(1,-1) translate(0,-70)">d</text>
+<text x="200" y="35" font-family="'Lora', serif" font-size="18" fill="#ccc">evil</text>
+</svg>
+</div>
+
+## The nick and the groove
+
+<p>To help compositors orient type correctly, each piece has a nick -- a small groove cut into one edge of the body. When the compositor holds the type in the composing stick, the nick should face upward and toward the compositor. If the nick faces the wrong way, the letter is upside down. The devil, working quickly and in poor light, sometimes ignores the nick or confuses its position, producing inverted letters that are only discovered when the proof is pulled.</p>
+
+## Mirror confusion
+
+<p>Because type is set in reverse (reading right to left as the compositor looks at it), even experienced compositors can be confused by symmetric or near-symmetric letters. The letters "b" and "d," "p" and "q," "n" and "u" are mirror pairs that look identical when inverted. The devil, who has not yet developed the compositor's instinct for letter orientation, is particularly vulnerable to these confusions.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>The nick test</h3>
+<p>A quick check: feel the nick with your thumb. If it faces toward you and upward, the letter is correctly oriented. If not, rotate it. The test takes a fraction of a second.</p>
+</div>
+<div class="mishap-card">
+<h3>The proof catch</h3>
+<p>Inverted letters are almost always caught at the proof stage, when the printed text is read for the first time. The proofreader marks the error with a circled "inv" in the margin.</p>
+</div>
+</div>
+
+<blockquote>The inverted letter is a reminder that type is three-dimensional. It has a top and a bottom, a front and a back, and every orientation matters. The devil learns this one letter at a time.</blockquote>

--- a/printer-devil/content/mishaps/5-the-apprentice.md
+++ b/printer-devil/content/mishaps/5-the-apprentice.md
@@ -1,0 +1,40 @@
++++
+title = "The Apprentice"
+description = "The printer's devil as learner, worker, and eventual master."
+tags = ["craft", "tradition"]
++++
+
+<p class="shop-label">Mishap V</p>
+
+# The Apprentice
+
+<p class="lede">The printer's devil was not merely a source of errors. He was a learner, a worker in training, and eventually a master of the craft. Every error he made was a lesson. Every form he dropped taught him to hold the next one more carefully. Every wrong font he set taught him to read the nick, check the case, and verify the face. The devil was the beginning of every printer's story.</p>
+
+<div class="type-pie-small" aria-hidden="true">
+<svg viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg">
+<text x="50" y="35" font-family="'Lora', serif" font-size="16" fill="#888" opacity="0.4">apprentice</text>
+<text x="80" y="33" font-family="'Lora', serif" font-size="18" fill="#ccc">journeyman</text>
+<text x="120" y="31" font-family="'Lora', serif" font-size="20" fill="#d44" font-weight="700">master</text>
+</svg>
+</div>
+
+## The apprenticeship
+
+<p>A printing apprenticeship lasted seven years in most European countries. The apprentice began as a devil -- inking, cleaning, fetching -- and gradually progressed to composition, presswork, and eventually the management of the shop. During the apprenticeship, the devil was bound to the master printer by a legal contract: the master provided training, room, and board; the apprentice provided labor and obedience. The relationship was formalized and regulated by the guild system.</p>
+
+## From devil to master
+
+<p>The progression from devil to master printer followed a fixed path. After the apprenticeship, the devil became a journeyman -- a skilled worker who could hire himself out to any shop. After years of journeyman work, the best compositors and pressmen could establish their own shops and take on apprentices of their own. The cycle continued: every master printer had once been a devil, and every devil aspired to become a master.</p>
+
+<div class="mishap-grid">
+<div class="mishap-card">
+<h3>The devil's tasks</h3>
+<p>Inking the press, distributing used type, fetching paper, cleaning the shop, running errands. The lowest tasks in the shop, but the foundation of the craft.</p>
+</div>
+<div class="mishap-card">
+<h3>The master's legacy</h3>
+<p>The master printer passes his knowledge to the devil, who passes it to the next generation. The chain of craft knowledge is unbroken from Gutenberg to the present.</p>
+</div>
+</div>
+
+<blockquote>The printer's devil is not a mistake. He is the beginning. Every master printer was once a devil, covered in ink, sorting type, and learning by every error that the craft demands perfection.</blockquote>

--- a/printer-devil/content/mishaps/_index.md
+++ b/printer-devil/content/mishaps/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Mishaps"
+description = "A catalogue of errors and mishaps from the print shop."
++++
+
+<p class="lede">Five mishaps, each a lesson in the craft. The printer's devil learned by error, and the errors he made are the folklore of five centuries of printing.</p>
+
+<p>The mishaps are arranged from the most common to the most catastrophic, as any apprentice would experience them.</p>

--- a/printer-devil/static/css/style.css
+++ b/printer-devil/static/css/style.css
@@ -1,0 +1,476 @@
+/* =============================================================================
+   Printer Devil - Apprentice Publication
+   Issue #1545 | book, dark, error, playful, craft
+   Palette: ink-black ground, printer's red accents, gray type-metal
+   No gradients. Ink roller marks + type-pie scattered letters as inline SVG.
+   ============================================================================= */
+
+:root {
+  --black: #0e0e0e;
+  --surface: #161616;
+  --surface-raised: #1e1e1e;
+  --surface-edge: #3a3a3a;
+  --text: #d0d0d0;
+  --text-soft: #aaa;
+  --text-dim: #666;
+  --red: #d44;
+  --red-dim: #922;
+  --metal: #888;
+  --metal-dim: #555;
+  --bg: #0a0a0a;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: "Lora", "Crimson Pro", Georgia, serif;
+  font-size: 17px;
+  line-height: 1.74;
+  min-height: 100vh;
+}
+
+.shop-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--surface-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 42px; height: 42px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Lora", serif;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.logo-sub {
+  font-family: "Crimson Pro", serif;
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+/* --- Mis-set type class -------------------------------------------------- */
+.misset {
+  font-family: "Oswald", sans-serif;
+  font-weight: 600;
+  font-size: 0.85em;
+  color: var(--red);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.92rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--red); border-bottom-color: var(--red); }
+
+/* --- Shop page ----------------------------------------------------------- */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.shop-page {
+  position: relative;
+  background-color: var(--surface);
+  border: 1px solid var(--surface-edge);
+  min-height: 600px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+}
+
+.shop-page-narrow {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ink-roller { text-align: center; overflow: hidden; }
+.ink-roller svg { max-width: 100%; height: 16px; display: block; margin: 0; }
+
+.shop-body {
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.5rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.shop-body h1,
+.shop-body h2,
+.shop-body h3 {
+  font-family: "Lora", serif;
+  color: var(--text);
+  line-height: 1.25;
+  font-weight: 700;
+}
+.shop-body h1 {
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0 0 0.3em;
+  letter-spacing: 0.01em;
+}
+.shop-body h2 {
+  font-size: 1.35rem;
+  margin: 2.5em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.shop-body h3 {
+  font-size: 1.05rem;
+  margin: 1.5em 0 0.2em;
+  color: var(--red);
+  text-align: left;
+  font-family: "Oswald", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.shop-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Lora", "Crimson Pro", serif;
+  text-align: left;
+  line-height: 1.74;
+}
+.shop-body p.lede {
+  font-family: "Crimson Pro", serif;
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--text-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 34em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.shop-label {
+  display: inline-block;
+  font-family: "Oswald", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 0.5em;
+}
+
+.shop-head { margin-bottom: 2rem; text-align: center; }
+.shop-title {
+  font-family: "Lora", serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  margin: 0;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+
+.shop-body a {
+  color: var(--red);
+  text-decoration: none;
+  border-bottom: 1px solid var(--red-dim);
+}
+.shop-body a:hover { color: var(--text); border-bottom-color: var(--text); }
+
+blockquote {
+  margin: 2rem auto;
+  padding: 0.5rem 1.5rem;
+  border-left: 3px solid var(--red);
+  background-color: var(--surface-raised);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "Crimson Pro", serif;
+  font-size: 1.1rem;
+  text-align: left;
+  max-width: 32em;
+}
+
+.shop-body ul,
+.shop-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  text-align: left;
+}
+.shop-body ul { list-style: disc; }
+.shop-body ol { list-style: decimal; }
+.shop-body li { padding: 0.2em 0; color: var(--text-soft); }
+
+/* --- Cover display ------------------------------------------------------- */
+.shop-cover {
+  padding: clamp(2rem, 6vw, 4rem) 0;
+  text-align: center;
+}
+.cover-display {
+  font-family: "Lora", serif;
+  font-weight: 700;
+  font-size: clamp(2.2rem, 5.5vw, 3.5rem);
+  color: var(--text);
+  letter-spacing: 0.01em;
+  margin: 0 0 0.15em;
+}
+.cover-subtitle {
+  font-family: "Crimson Pro", serif;
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* --- Type-pie SVG -------------------------------------------------------- */
+.type-pie {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.type-pie svg {
+  max-width: 100%;
+  height: auto;
+  display: inline-block;
+}
+
+.type-pie-small {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.type-pie-small svg {
+  max-width: 100%;
+  height: 50px;
+  display: inline-block;
+}
+
+/* --- Ink roller large ---------------------------------------------------- */
+.ink-roller-large {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.ink-roller-large svg {
+  max-width: 100%;
+  height: 30px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* --- Ink smear ----------------------------------------------------------- */
+.ink-smear {
+  text-align: center;
+  margin: 1.5rem 0;
+}
+.ink-smear svg {
+  max-width: 300px;
+  height: 12px;
+  display: inline-block;
+}
+
+/* --- Mishap card grid ---------------------------------------------------- */
+.mishap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+.mishap-card {
+  background-color: var(--surface-raised);
+  border: 1px solid var(--surface-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+  border-left: 3px solid var(--red-dim);
+}
+.mishap-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--red);
+  font-size: 0.95rem;
+  font-family: "Oswald", sans-serif;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mishap-card p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2rem 0;
+}
+.colophon-page h1 {
+  font-family: "Lora", serif;
+  font-weight: 700;
+  font-size: 2rem;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+.colophon-detail strong {
+  color: var(--text);
+  font-family: "Oswald", sans-serif;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.88rem;
+}
+.colophon-imprint {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--surface-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Lora", serif;
+}
+.section-list li::before {
+  content: "\00B7";
+  color: var(--red);
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--text);
+  border: none;
+  font-size: 1rem;
+}
+.section-list li a:hover { color: var(--red); }
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  text-align: left;
+  font-family: "Crimson Pro", serif;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--surface-edge);
+  font-family: "Crimson Pro", serif;
+  font-size: 0.85rem;
+  color: var(--text-soft);
+  text-decoration: none;
+  background-color: var(--surface-raised);
+}
+nav.pagination a:hover { color: var(--red); border-color: var(--red); }
+.pagination-current span { color: var(--red); border-color: var(--red); }
+
+/* --- Footer -------------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 0.8rem;
+}
+.footer-device svg {
+  width: 40px;
+  height: 40px;
+  display: block;
+  margin: 0 auto;
+}
+
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--surface-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Lora", serif;
+  font-weight: 600;
+  color: var(--text-soft);
+  margin: 0.2em 0;
+  letter-spacing: 0.01em;
+  font-size: 1rem;
+}
+.footer-line-small {
+  font-family: "Crimson Pro", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .shop-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .shop-title, .shop-body h1, .cover-display { font-size: 1.9rem; }
+  .shop-body h2 { font-size: 1.2rem; }
+  .shop-cover { padding: 2rem 0; }
+}

--- a/printer-devil/templates/404.html
+++ b/printer-devil/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="shop-page shop-page-narrow">
+      <div class="shop-body">
+        <header class="shop-head">
+          <p class="shop-label">404</p>
+          <h1 class="shop-title">Type Pied</h1>
+        </header>
+        <p>The devil dropped this form. The type is scattered across the shop floor and this page cannot be composed. Return to the press room.</p>
+        <p><a href="{{ base_url }}/">Back to the shop</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/printer-devil/templates/footer.html
+++ b/printer-devil/templates/footer.html
@@ -1,0 +1,17 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+          <rect x="10" y="12" width="30" height="26" fill="#1a1a1a" stroke="#555" stroke-width="0.5"/>
+          <text x="18" y="30" font-family="serif" font-size="10" fill="#d44" transform="rotate(-5 18 30)">P</text>
+          <text x="30" y="28" font-family="serif" font-size="8" fill="#888" transform="rotate(8 30 28)">D</text>
+        </svg>
+      </div>
+      <p class="footer-line">Printer Devil</p>
+      <p class="footer-line-small">An apprentice publication, errors and all.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; set in type, dropped on the floor</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/printer-devil/templates/header.html
+++ b/printer-devil/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Oswald:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=Anton&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="shop-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Printer Devil home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="4" y="8" width="40" height="32" fill="#1a1a1a" stroke="#555" stroke-width="0.8"/>
+          <text x="12" y="28" font-family="serif" font-size="14" fill="#d44" transform="rotate(-8 12 28)">P</text>
+          <text x="22" y="30" font-family="sans-serif" font-size="10" fill="#888" transform="rotate(5 22 30)">d</text>
+          <text x="32" y="26" font-family="serif" font-size="12" fill="#666" transform="rotate(-15 32 26)">e</text>
+          <line x1="8" y1="36" x2="40" y2="36" stroke="#d44" stroke-width="1.5" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Printer <span class="misset">Devil</span></span>
+          <span class="logo-sub">Apprentice Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Shop</a>
+        <a href="{{ base_url }}/mishaps/">Mishaps</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/printer-devil/templates/page.html
+++ b/printer-devil/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="shop-page">
+      <div class="ink-roller" aria-hidden="true">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="6" width="600" height="4" fill="#d44" opacity="0.15"/>
+          <rect x="40" y="4" width="80" height="8" fill="#d44" opacity="0.08"/>
+          <rect x="200" y="5" width="120" height="6" fill="#d44" opacity="0.12"/>
+          <rect x="420" y="3" width="90" height="10" fill="#d44" opacity="0.06"/>
+        </svg>
+      </div>
+      <div class="shop-body">
+        {{ content }}
+      </div>
+      <div class="ink-roller ink-roller-bottom" aria-hidden="true">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="6" width="600" height="4" fill="#d44" opacity="0.1"/>
+          <rect x="100" y="4" width="60" height="8" fill="#d44" opacity="0.06"/>
+          <rect x="300" y="5" width="100" height="6" fill="#d44" opacity="0.08"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/printer-devil/templates/section.html
+++ b/printer-devil/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="shop-page">
+      <div class="ink-roller" aria-hidden="true">
+        <svg viewBox="0 0 600 16" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="6" width="600" height="4" fill="#d44" opacity="0.12"/>
+          <rect x="60" y="4" width="100" height="8" fill="#d44" opacity="0.07"/>
+          <rect x="350" y="5" width="80" height="6" fill="#d44" opacity="0.09"/>
+        </svg>
+      </div>
+      <div class="shop-body">
+        <header class="shop-head">
+          <p class="shop-label">Catalogue</p>
+          <h1 class="shop-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/printer-devil/templates/shortcodes/alert.html
+++ b/printer-devil/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #555; background-color: #1a1a1a; border-left: 4px solid #d44; margin: 1rem 0; color: #ccc;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/printer-devil/templates/taxonomy.html
+++ b/printer-devil/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="shop-page shop-page-narrow">
+      <div class="shop-body">
+        <header class="shop-head">
+          <p class="shop-label">Index</p>
+          <h1 class="shop-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All errors catalogued in this print shop:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/printer-devil/templates/taxonomy_term.html
+++ b/printer-devil/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="shop-page shop-page-narrow">
+      <div class="shop-body">
+        <header class="shop-head">
+          <p class="shop-label">Error Type</p>
+          <h1 class="shop-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Mishaps of this variety:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4612 +1,4619 @@
 {
-    "abstract-noir": [
-        "paper",
-        "dark",
-        "abstract",
-        "bold",
-        "typography"
-    ],
-    "abyss": [
-        "dark",
-        "blog",
-        "deep-sea",
-        "immersive"
-    ],
-    "acid-graphics": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "acme-docs": [
-        "light",
-        "docs"
-    ],
-    "acoustic-soundwaves": [
-        "dark",
-        "blog",
-        "sound",
-        "waveform"
-    ],
-    "adminpanel": [
-        "dark",
-        "dashboard",
-        "admin",
-        "sidebar"
-    ],
-    "aether": [
-        "dark",
-        "blog",
-        "elegant"
-    ],
-    "aetheria": [
-        "dark-mode",
-        "elegant",
-        "portfolio"
-    ],
-    "after-dark": [
-        "blog",
-        "dark",
-        "reading"
-    ],
-    "afterparty": [
-        "event",
-        "party",
-        "nightlife",
-        "club",
-        "late-night"
-    ],
-    "aftershock": [
-        "event",
-        "dark",
-        "post-event",
-        "retrospective",
-        "impact"
-    ],
-    "airwave": [
-        "dark",
-        "blog",
-        "podcast"
-    ],
-    "alexandrite": [
-        "dark",
-        "blog",
-        "glamorous",
-        "gemstone"
-    ],
-    "almanac": [
-        "light",
-        "blog",
-        "calendar"
-    ],
-    "almanac-docs": [
-        "light",
-        "docs",
-        "roadmap"
-    ],
-    "amber-preservation": [
-        "dark",
-        "blog",
-        "amber",
-        "fossil"
-    ],
-    "amethyst": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "anaglyph": [
-        "dark",
-        "blog",
-        "3d",
-        "stereoscopic"
-    ],
-    "analytics": [
-        "light",
-        "dashboard",
-        "analytics"
-    ],
-    "anamorphic": [
-        "dark",
-        "portfolio",
-        "anamorphic",
-        "optical"
-    ],
-    "anatomy-atlas": [
-        "dark",
-        "docs",
-        "medical",
-        "vintage"
-    ],
-    "annotation-layer": [
-        "book",
-        "light",
-        "scholarly",
-        "annotated",
-        "dense"
-    ],
-    "anthology": [
-        "light",
-        "docs",
-        "sdk-reference"
-    ],
-    "antimatter": [
-        "dark",
-        "blog",
-        "experimental",
-        "inverted"
-    ],
-    "anubis": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "anvil": [
-        "dark",
-        "blog",
-        "workshop"
-    ],
-    "apiary": [
-        "light",
-        "docs",
-        "api",
-        "two-column"
-    ],
-    "apolo": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "apothecary": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "appsite": [
-        "light",
-        "landing",
-        "app"
-    ],
-    "aquarium": [
-        "dark",
-        "blog",
-        "marine"
-    ],
-    "aquatint": [
-        "light",
-        "portfolio",
-        "creative",
-        "elegant",
-        "bold"
-    ],
-    "aqueduct": [
-        "light",
-        "blog",
-        "engineering"
-    ],
-    "arbor": [
-        "light",
-        "docs",
-        "git-workflow"
-    ],
-    "archipelago": [
-        "dark",
-        "landing",
-        "hub"
-    ],
-    "archive": [
-        "light",
-        "docs",
-        "archive"
-    ],
-    "archway-docs": [
-        "docs",
-        "light",
-        "architecture"
-    ],
-    "arctic-saas": [
-        "landing",
-        "light",
-        "saas",
-        "minimal"
-    ],
-    "arena": [
-        "dark",
-        "blog",
-        "sports"
-    ],
-    "artdeco": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "artnouveau": [
-        "light",
-        "portfolio",
-        "art-nouveau",
-        "botanical"
-    ],
-    "arxiv-preprint": [
-        "paper",
-        "light",
-        "preprint",
-        "self-published",
-        "raw"
-    ],
-    "ascii": [
-        "dark",
-        "terminal",
-        "ascii"
-    ],
-    "asymmetric": [
-        "light",
-        "portfolio",
-        "grid",
-        "asymmetric"
-    ],
-    "atelier": [
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "athena": [
-        "elegant",
-        "portfolio",
-        "light"
-    ],
-    "atlas": [
-        "light",
-        "blog",
-        "geography"
-    ],
-    "atlas-docs": [
-        "docs",
-        "light",
-        "navigation"
-    ],
-    "aurelia": [
-        "elegant",
-        "minimalist",
-        "blog"
-    ],
-    "aurora": [
-        "dark",
-        "blog",
-        "aurora"
-    ],
-    "aurora-glimmer": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "aurora-launch": [
-        "landing",
-        "dark",
-        "animation"
-    ],
-    "aurum": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "avalanche-event": [
-        "event",
-        "dark",
-        "momentum",
-        "cascading",
-        "overwhelming"
-    ],
-    "axiom": [
-        "light",
-        "design-system",
-        "geometric",
-        "mathematical"
-    ],
-    "bamboo": [
-        "light",
-        "blog",
-        "eco"
-    ],
-    "baroque": [
-        "dark",
-        "blog",
-        "ornamental",
-        "glamorous"
-    ],
-    "bas-relief": [
-        "light",
-        "artistic",
-        "minimal"
-    ],
-    "bastard-title": [
-        "book",
-        "light",
-        "preliminary",
-        "ceremonial",
-        "typography"
-    ],
-    "bastion": [
-        "dark",
-        "docs",
-        "zero-trust"
-    ],
-    "batik": [
-        "light",
-        "blog",
-        "elegant",
-        "batik"
-    ],
-    "bauhaus": [
-        "light",
-        "portfolio",
-        "design",
-        "geometric"
-    ],
-    "bayesian-prior": [
-        "paper",
-        "dark",
-        "bayesian",
-        "probabilistic",
-        "visualization"
-    ],
-    "bazaar": [
-        "light",
-        "landing",
-        "marketplace"
-    ],
-    "beacon": [
-        "dark",
-        "blog",
-        "alert"
-    ],
-    "beacon-docs": [
-        "light",
-        "docs",
-        "feature-flag"
-    ],
-    "beautiful-hwaro": [
-        "light",
-        "blog"
-    ],
-    "bejeweled": [
-        "elegant",
-        "glamorous",
-        "luxury"
-    ],
-    "bell-tower": [
-        "event",
-        "light",
-        "scheduled",
-        "clock",
-        "traditional"
-    ],
-    "bench-report": [
-        "paper",
-        "light",
-        "laboratory",
-        "bench",
-        "experimental"
-    ],
-    "bijou": [
-        "dark",
-        "elegant",
-        "jewelry",
-        "glamorous"
-    ],
-    "bioluminescence": [
-        "dark",
-        "blog",
-        "bioluminescence",
-        "minimal"
-    ],
-    "bismuth": [
-        "dark",
-        "collection",
-        "mineral",
-        "rainbow-metallic"
-    ],
-    "black-box": [
-        "event",
-        "dark",
-        "theater",
-        "intimate",
-        "minimal"
-    ],
-    "black-letter-bible": [
-        "book",
-        "dark",
-        "sacred",
-        "blackletter",
-        "dense"
-    ],
-    "blacklight": [
-        "dark",
-        "fluorescent",
-        "elegant"
-    ],
-    "blast-furnace": [
-        "event",
-        "dark",
-        "workshop",
-        "intense",
-        "industrial"
-    ],
-    "blockade-run": [
-        "event",
-        "dark",
-        "breakthrough",
-        "barriers",
-        "overcome"
-    ],
-    "blueprint": [
-        "dark",
-        "docs",
-        "spec"
-    ],
-    "blueprint-pro": [
-        "landing",
-        "dark",
-        "devtool"
-    ],
-    "bonfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "bonsai": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "book": [
-        "light",
-        "docs"
-    ],
-    "borealis": [
-        "dark",
-        "blog",
-        "aurora",
-        "nordic"
-    ],
-    "botanical-press": [
-        "blog",
-        "light",
-        "botanical",
-        "vintage"
-    ],
-    "boutique": [
-        "light",
-        "store",
-        "fashion",
-        "elegant"
-    ],
-    "box-office": [
-        "event",
-        "tickets",
-        "sales",
-        "urgency",
-        "countdown"
-    ],
-    "bramble": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "breeze": [
-        "landing",
-        "light",
-        "minimal",
-        "one-page"
-    ],
-    "brocade": [
-        "dark",
-        "blog",
-        "glamorous",
-        "luxury"
-    ],
-    "brutalist": [
-        "light",
-        "blog",
-        "brutalist"
-    ],
-    "brutopia": [
-        "dark",
-        "blog",
-        "brutalist",
-        "monospace"
-    ],
-    "bulwark": [
-        "dark",
-        "docs",
-        "disaster-recovery"
-    ],
-    "bureau": [
-        "light",
-        "docs",
-        "governance"
-    ],
-    "burlesque": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "burnt-charcoal": [
-        "dark",
-        "blog",
-        "charcoal",
-        "texture"
-    ],
-    "butterfly-wing": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "trendy",
-        "blog"
-    ],
-    "byzantine": [
-        "light",
-        "blog",
-        "byzantine",
-        "mosaic",
-        "imperial"
-    ],
-    "cabaret": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "cabin": [
-        "dark",
-        "blog",
-        "lifestyle"
-    ],
-    "cactus": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cafe": [
-        "light",
-        "landing",
-        "menu"
-    ],
-    "cage-match": [
-        "event",
-        "dark",
-        "competition",
-        "fight",
-        "enclosed"
-    ],
-    "call-to-stage": [
-        "event",
-        "talent",
-        "open-call",
-        "audition",
-        "stage"
-    ],
-    "calligraphy": [
-        "dark",
-        "blog",
-        "calligraphy",
-        "ink"
-    ],
-    "cameo": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "campfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "cancel-leaf": [
-        "book",
-        "light",
-        "correction",
-        "repair",
-        "visible"
-    ],
-    "canopy": [
-        "light",
-        "blog",
-        "outdoor"
-    ],
-    "canvas-studio": [
-        "landing",
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "carbon-fiber": [
-        "dark",
-        "blog",
-        "tech"
-    ],
-    "carnival": [
-        "dark",
-        "blog",
-        "glamorous",
-        "event"
-    ],
-    "cartograph": [
-        "dark",
-        "docs",
-        "infrastructure"
-    ],
-    "cascade": [
-        "light",
-        "longform",
-        "waterfall",
-        "scroll-driven"
-    ],
-    "case-report": [
-        "paper",
-        "light",
-        "clinical",
-        "case-study",
-        "medical"
-    ],
-    "cassette": [
-        "dark",
-        "blog",
-        "retro",
-        "audio"
-    ],
-    "catacombs": [
-        "dark",
-        "blog",
-        "underground",
-        "adventure"
-    ],
-    "catalyst": [
-        "light",
-        "landing",
-        "science",
-        "chemistry"
-    ],
-    "cathedral": [
-        "light",
-        "portfolio",
-        "architecture"
-    ],
-    "cauldron": [
-        "dark",
-        "wiki",
-        "fantasy",
-        "potion"
-    ],
-    "celebrate": [
-        "light",
-        "landing",
-        "event"
-    ],
-    "celestial-burst": [
-        "dark",
-        "glamorous",
-        "celestial",
-        "trendy"
-    ],
-    "center-stage": [
-        "event",
-        "solo",
-        "show",
-        "spotlight",
-        "centered"
-    ],
-    "chain-reaction": [
-        "event",
-        "dark",
-        "sequential",
-        "cascade",
-        "connected"
-    ],
-    "chalkboard": [
-        "dark",
-        "blog",
-        "education"
-    ],
-    "champagne": [
-        "light",
-        "luxury",
-        "elegant",
-        "champagne"
-    ],
-    "chandelier": [
-        "light",
-        "blog",
-        "crystal",
-        "elegant",
-        "prismatic"
-    ],
-    "changelog": [
-        "dark",
-        "docs",
-        "changelog"
-    ],
-    "chase-frame": [
-        "book",
-        "dark",
-        "letterpress",
-        "mechanical",
-        "craft"
-    ],
-    "chiaroscuro": [
-        "dark",
-        "portfolio",
-        "chiaroscuro",
-        "contrast"
-    ],
-    "chinoiserie": [
-        "light",
-        "blog",
-        "chinese",
-        "porcelain",
-        "elegant"
-    ],
-    "chromatic": [
-        "dark",
-        "photoblog",
-        "chromatic",
-        "lens"
-    ],
-    "chromatic-wave": [
-        "dark",
-        "portfolio",
-        "glamorous",
-        "animation"
-    ],
-    "chromatophore": [
-        "dark",
-        "bold",
-        "minimal",
-        "creative"
-    ],
-    "chrome-pulse": [
-        "minimal",
-        "dark",
-        "landing"
-    ],
-    "chromolithograph": [
-        "book",
-        "light",
-        "color-plate",
-        "print",
-        "illustration"
-    ],
-    "chronicle": [
-        "light",
-        "blog",
-        "traditional",
-        "serif"
-    ],
-    "chronosphere": [
-        "dark",
-        "space",
-        "time"
-    ],
-    "chrysanthemum": [
-        "dark",
-        "blog",
-        "floral",
-        "glamorous"
-    ],
-    "cinder": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cinema": [
-        "dark",
-        "blog",
-        "review"
-    ],
-    "cinema-silent": [
-        "dark",
-        "blog",
-        "retro",
-        "editorial"
-    ],
-    "cipher": [
-        "dark",
-        "docs",
-        "cryptography"
-    ],
-    "citation-graph": [
-        "paper",
-        "dark",
-        "network",
-        "citations",
-        "visualization"
-    ],
-    "clarity-docs": [
-        "docs",
-        "light",
-        "minimal",
-        "typography"
-    ],
-    "clocktower": [
-        "dark",
-        "landing",
-        "countdown"
-    ],
-    "cloisonne": [
-        "dark",
-        "portfolio",
-        "enamel",
-        "ornate"
-    ],
-    "cloister": [
-        "light",
-        "blog",
-        "meditation"
-    ],
-    "closed": [
-        "light",
-        "error",
-        "499",
-        "minimal"
-    ],
-    "cloudnest": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "cobblestone": [
-        "light",
-        "blog",
-        "culture"
-    ],
-    "cockpit": [
-        "dark",
-        "landing",
-        "telemetry"
-    ],
-    "codebook": [
-        "light",
-        "docs",
-        "styleguide"
-    ],
-    "codecraft": [
-        "api",
-        "dark",
-        "developer",
-        "docs"
-    ],
-    "codex": [
-        "light",
-        "blog",
-        "medieval"
-    ],
-    "codex-rotundus": [
-        "book",
-        "dark",
-        "circular",
-        "unusual",
-        "experimental"
-    ],
-    "cohort-study": [
-        "paper",
-        "light",
-        "cohort",
-        "survival",
-        "epidemiological"
-    ],
-    "cold-case": [
-        "paper",
-        "dark",
-        "forensic",
-        "investigation",
-        "reopened"
-    ],
-    "colosseum": [
-        "light",
-        "event",
-        "classical",
-        "grand"
-    ],
-    "comic": [
-        "light",
-        "blog",
-        "comic"
-    ],
-    "command-center": [
-        "docs",
-        "dark",
-        "cli",
-        "developer"
-    ],
-    "compass": [
-        "light",
-        "landing",
-        "career"
-    ],
-    "compass-docs": [
-        "light",
-        "docs",
-        "onboarding"
-    ],
-    "conduit": [
-        "light",
-        "docs",
-        "data-pipeline"
-    ],
-    "conference-poster": [
-        "paper",
-        "dark",
-        "poster",
-        "conference",
-        "visual"
-    ],
-    "confetti": [
-        "celebration",
-        "elegant",
-        "festive"
-    ],
-    "console": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "constellation": [
-        "dark",
-        "blog",
-        "astronomy"
-    ],
-    "controlroom": [
-        "dark",
-        "dashboard",
-        "monitoring"
-    ],
-    "copper-patina": [
-        "dark",
-        "blog",
-        "patina",
-        "industrial"
-    ],
-    "copper-wire": [
-        "blog",
-        "dark",
-        "industrial"
-    ],
-    "copperplate": [
-        "dark",
-        "blog",
-        "copperplate",
-        "engraving"
-    ],
-    "coral": [
-        "light",
-        "documentary",
-        "organic",
-        "ocean"
-    ],
-    "coral-bloom": [
-        "dark",
-        "blog",
-        "elegant",
-        "marine",
-        "glamorous"
-    ],
-    "corrigendum": [
-        "paper",
-        "light",
-        "correction",
-        "errata",
-        "formal"
-    ],
-    "cosmos": [
-        "dark",
-        "magazine",
-        "space",
-        "planetary"
-    ],
-    "cost-effectiveness": [
-        "paper",
-        "light",
-        "economics",
-        "cost-effectiveness",
-        "health"
-    ],
-    "countdown-zero": [
-        "event",
-        "dark",
-        "countdown",
-        "convergence",
-        "climactic"
-    ],
-    "creative-agency": [
-        "dark",
-        "portfolio",
-        "agency",
-        "bold"
-    ],
-    "cross-sectional": [
-        "paper",
-        "light",
-        "cross-sectional",
-        "snapshot",
-        "population"
-    ],
-    "crucible": [
-        "light",
-        "docs",
-        "testing"
-    ],
-    "cruciform": [
-        "light",
-        "design-system",
-        "grid",
-        "swiss"
-    ],
-    "crystalline": [
-        "light",
-        "portfolio",
-        "crystal",
-        "faceted"
-    ],
-    "cuneiform-tablet": [
-        "book",
-        "dark",
-        "ancient",
-        "impressed",
-        "archaeological"
-    ],
-    "curator": [
-        "light",
-        "portfolio",
-        "exhibition"
-    ],
-    "curtain-call": [
-        "event",
-        "dark",
-        "closing",
-        "ceremony",
-        "theatrical"
-    ],
-    "cyanotype": [
-        "light",
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "cyberpunk": [
-        "dark",
-        "magazine",
-        "cyberpunk",
-        "neon"
-    ],
-    "daguerreotype": [
-        "dark",
-        "blog",
-        "photography",
-        "vintage"
-    ],
-    "damask": [
-        "dark",
-        "blog",
-        "luxury",
-        "glamorous"
-    ],
-    "dark-manual": [
-        "docs",
-        "dark",
-        "technical",
-        "manual"
-    ],
-    "darkfolio": [
-        "dark",
-        "portfolio",
-        "developer",
-        "minimal"
-    ],
-    "darkmarket": [
-        "dark",
-        "marketplace",
-        "bold"
-    ],
-    "darkroom": [
-        "dark",
-        "portfolio",
-        "photography"
-    ],
-    "darkwave": [
-        "dark",
-        "blog",
-        "synthwave"
-    ],
-    "dashboard": [
-        "dark",
-        "landing",
-        "dashboard"
-    ],
-    "data-paper": [
-        "paper",
-        "light",
-        "dataset",
-        "schema",
-        "minimal-text"
-    ],
-    "deconstructed": [
-        "light",
-        "agency",
-        "deconstructivism",
-        "architecture"
-    ],
-    "deconstructivist": [
-        "dark",
-        "portfolio",
-        "deconstructivist",
-        "architecture"
-    ],
-    "demolition-derby": [
-        "event",
-        "dark",
-        "competition",
-        "destruction",
-        "chaotic"
-    ],
-    "depot": [
-        "light",
-        "landing",
-        "tracker"
-    ],
-    "devconf": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "devlog": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "devtool": [
-        "dark",
-        "landing",
-        "developer"
-    ],
-    "dewdrop": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "diamond-facet": [
-        "dark",
-        "blog",
-        "glamorous",
-        "prismatic"
-    ],
-    "diary": [
-        "light",
-        "blog",
-        "personal",
-        "journal"
-    ],
-    "diorama": [
-        "dark",
-        "landing",
-        "product"
-    ],
-    "disco-fever": [
-        "dark",
-        "blog",
-        "retro",
-        "disco",
-        "neon"
-    ],
-    "dispatch": [
-        "light",
-        "docs",
-        "event-driven"
-    ],
-    "dockhub": [
-        "dark",
-        "docs",
-        "devops"
-    ],
-    "dojo": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "dose-response": [
-        "paper",
-        "light",
-        "pharmacological",
-        "dose-response",
-        "clinical"
-    ],
-    "double-header": [
-        "event",
-        "dark",
-        "double",
-        "dual",
-        "packed"
-    ],
-    "driftwood": [
-        "light",
-        "blog",
-        "photo"
-    ],
-    "dropzone": [
-        "cloud",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "dune": [
-        "light",
-        "journal",
-        "desert",
-        "travel"
-    ],
-    "duodecimo": [
-        "book",
-        "light",
-        "compact",
-        "portable",
-        "efficient"
-    ],
-    "dusk": [
-        "dark",
-        "blog",
-        "sunset"
-    ],
-    "dynamo": [
-        "dark",
-        "docs",
-        "serverless"
-    ],
-    "easel": [
-        "light",
-        "docs",
-        "art"
-    ],
-    "eclipse": [
-        "dark",
-        "blog",
-        "celestial",
-        "dramatic"
-    ],
-    "editorial-letter": [
-        "paper",
-        "light",
-        "editorial",
-        "authority",
-        "statement"
-    ],
-    "electric-bloom": [
-        "dark",
-        "blog",
-        "glamorous",
-        "neon",
-        "botanical"
-    ],
-    "electroplate": [
-        "dark",
-        "blog",
-        "metallic",
-        "plating"
-    ],
-    "elevate": [
-        "landing",
-        "light",
-        "saas",
-        "enterprise"
-    ],
-    "elysian": [
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "elysium": [
-        "portfolio",
-        "minimal",
-        "dark"
-    ],
-    "elysium-portfolio": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "embargo-lift": [
-        "event",
-        "dark",
-        "embargo",
-        "release",
-        "timed"
-    ],
-    "ember": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "embroidery": [
-        "dark",
-        "blog",
-        "glamorous",
-        "trendy"
-    ],
-    "emerald": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "empyrean": [
-        "light",
-        "landing",
-        "divine",
-        "ethereal"
-    ],
-    "encaustic": [
-        "light",
-        "blog",
-        "art",
-        "painting"
-    ],
-    "encore": [
-        "event",
-        "dark",
-        "repeat",
-        "popular",
-        "demanded"
-    ],
-    "encore-night": [
-        "event",
-        "concert",
-        "farewell",
-        "encore",
-        "emotional"
-    ],
-    "endpaper": [
-        "book",
-        "dark",
-        "decorative",
-        "pattern",
-        "hidden"
-    ],
-    "enigma": [
-        "dark",
-        "puzzle",
-        "cryptography",
-        "mechanical"
-    ],
-    "entropy": [
-        "dual",
-        "magazine",
-        "experimental",
-        "asymmetric"
-    ],
-    "errata-sheet": [
-        "paper",
-        "light",
-        "errata",
-        "correction",
-        "transparent"
-    ],
-    "etching": [
-        "dark",
-        "blog",
-        "etching",
-        "printmaking"
-    ],
-    "ethereal-canvas": [
-        "blog",
-        "dark",
-        "elegant",
-        "minimal",
-        "portfolio"
-    ],
-    "ethereal-vapor": [
-        "light",
-        "blog",
-        "ethereal",
-        "translucent"
-    ],
-    "ethos": [
-        "light",
-        "docs",
-        "culture"
-    ],
-    "even": [
-        "light",
-        "blog"
-    ],
-    "evergreen-docs": [
-        "docs",
-        "light",
-        "enterprise",
-        "classic"
-    ],
-    "experiment-log": [
-        "paper",
-        "dark",
-        "experimental",
-        "sequential",
-        "iterative"
-    ],
-    "faberge": [
-        "light",
-        "blog",
-        "luxury",
-        "jeweled",
-        "ornate"
-    ],
-    "faq": [
-        "light",
-        "docs",
-        "faq"
-    ],
-    "fascicle": [
-        "book",
-        "light",
-        "serial",
-        "unbound",
-        "installment"
-    ],
-    "fault-siren": [
-        "event",
-        "dark",
-        "warning",
-        "preparedness",
-        "civil-defense"
-    ],
-    "fauvist-wild": [
-        "dark",
-        "blog",
-        "fauvist",
-        "colorful"
-    ],
-    "ferrofluid": [
-        "dark",
-        "blog",
-        "ferrofluid",
-        "magnetic"
-    ],
-    "festival": [
-        "dark",
-        "event",
-        "elegant",
-        "glow",
-        "bold"
-    ],
-    "festival-ground": [
-        "event",
-        "festival",
-        "outdoor",
-        "grounds",
-        "map"
-    ],
-    "field-report": [
-        "paper",
-        "dark",
-        "field",
-        "expedition",
-        "rugged"
-    ],
-    "fiesta": [
-        "light",
-        "blog",
-        "colorful",
-        "celebration"
-    ],
-    "filigree": [
-        "dark",
-        "blog",
-        "filigree",
-        "metalwork"
-    ],
-    "fintech-pulse": [
-        "landing",
-        "dark",
-        "fintech",
-        "data-viz"
-    ],
-    "fireside": [
-        "dark",
-        "blog",
-        "book-review"
-    ],
-    "fireworks": [
-        "dark",
-        "elegant",
-        "animation",
-        "glow"
-    ],
-    "firing-range": [
-        "event",
-        "dark",
-        "precision",
-        "target",
-        "competitive"
-    ],
-    "fjord": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "flamingo": [
-        "light",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "flowsync": [
-        "dark",
-        "landing"
-    ],
-    "fluorescent": [
-        "dark",
-        "blog",
-        "neon",
-        "pop-art"
-    ],
-    "folio": [
-        "light",
-        "portfolio"
-    ],
-    "folio-docs": [
-        "light",
-        "docs",
-        "design-system"
-    ],
-    "folio-gigante": [
-        "book",
-        "dark",
-        "oversized",
-        "monumental",
-        "maximal"
-    ],
-    "forge": [
-        "light",
-        "docs",
-        "opensource"
-    ],
-    "formulary": [
-        "light",
-        "docs",
-        "math"
-    ],
-    "forty": [
-        "dark",
-        "portfolio",
-        "gallery"
-    ],
-    "foundry": [
-        "dark",
-        "blog",
-        "maker"
-    ],
-    "foxhole": [
-        "dark",
-        "blog",
-        "security"
-    ],
-    "fractal": [
-        "dark",
-        "gallery",
-        "generative",
-        "mathematical"
-    ],
-    "frequency": [
-        "dark",
-        "blog",
-        "radio"
-    ],
-    "frottage": [
-        "light",
-        "minimal",
-        "art",
-        "clean"
-    ],
-    "frutiger-aero": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "furnace": [
-        "dark",
-        "docs",
-        "performance"
-    ],
-    "gala": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "garden": [
-        "light",
-        "blog",
-        "garden"
-    ],
-    "garnet": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "garrison": [
-        "dark",
-        "docs",
-        "firewall"
-    ],
-    "gateway": [
-        "dark",
-        "docs",
-        "auth"
-    ],
-    "gauntlet-run": [
-        "event",
-        "dark",
-        "endurance",
-        "challenge",
-        "sequential"
-    ],
-    "gazebo": [
-        "light",
-        "blog",
-        "event"
-    ],
-    "gazette": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "generative-art": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "glamorous"
-    ],
-    "genome-paper": [
-        "paper",
-        "dark",
-        "genomics",
-        "bioinformatics",
-        "data-intensive"
-    ],
-    "geodesic": [
-        "light",
-        "landing",
-        "geometric"
-    ],
-    "gilded": [
-        "dark",
-        "blog",
-        "luxury",
-        "gold"
-    ],
-    "gilt-edge": [
-        "book",
-        "dark",
-        "luxury",
-        "gilded",
-        "opulent"
-    ],
-    "glacial-blog": [
-        "blog",
-        "light",
-        "cool",
-        "minimal"
-    ],
-    "glacial-ice": [
-        "dark",
-        "blog",
-        "ice",
-        "frost"
-    ],
-    "glacier": [
-        "light",
-        "blog",
-        "tech"
-    ],
-    "glam-rock": [
-        "dark",
-        "blog",
-        "rock",
-        "glam",
-        "metallic"
-    ],
-    "glassmorphism": [
-        "dark",
-        "blog",
-        "glassmorphism"
-    ],
-    "glitch": [
-        "dark",
-        "blog",
-        "experimental",
-        "glitch-art"
-    ],
-    "glitch-elegance": [
-        "dark",
-        "blog",
-        "glitch",
-        "elegant"
-    ],
-    "glow-reef": [
-        "dark",
-        "blog",
-        "elegant",
-        "neon"
-    ],
-    "glyphic": [
-        "dark",
-        "blog",
-        "glyph",
-        "carved"
-    ],
-    "gong-show": [
-        "event",
-        "dark",
-        "competition",
-        "judgment",
-        "dramatic"
-    ],
-    "gossamer": [
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "gothic": [
-        "dark",
-        "blog",
-        "gothic",
-        "medieval"
-    ],
-    "gradient-mesh": [
-        "dark",
-        "blog",
-        "gradient"
-    ],
-    "graffiti": [
-        "dark",
-        "blog",
-        "street-art",
-        "urban"
-    ],
-    "grand-finale": [
-        "event",
-        "festival",
-        "finale",
-        "closing",
-        "spectacular"
-    ],
-    "grant-proposal": [
-        "paper",
-        "light",
-        "proposal",
-        "funding",
-        "persuasive"
-    ],
-    "graphite-docs": [
-        "docs",
-        "dark",
-        "technical"
-    ],
-    "greenhouse": [
-        "light",
-        "blog",
-        "plant"
-    ],
-    "grisaille": [
-        "dark",
-        "blog",
-        "minimal",
-        "monochrome"
-    ],
-    "ground-zero": [
-        "event",
-        "dark",
-        "origin",
-        "impact",
-        "transformative"
-    ],
-    "guidebook": [
-        "light",
-        "docs",
-        "guide"
-    ],
-    "gunmetal": [
-        "dark",
-        "elegant",
-        "industrial",
-        "metallic"
-    ],
-    "gyroscope": [
-        "dark",
-        "dashboard",
-        "motion-sensor",
-        "3d-rotation"
-    ],
-    "habitat": [
-        "light",
-        "landing",
-        "listing"
-    ],
-    "hacker": [
-        "dark",
-        "blog"
-    ],
-    "hall-of-voices": [
-        "event",
-        "poetry",
-        "spoken-word",
-        "slam",
-        "voices"
-    ],
-    "hammer-drop": [
-        "event",
-        "light",
-        "auction",
-        "bidding",
-        "final"
-    ],
-    "hammock": [
-        "light",
-        "blog",
-        "slowlife"
-    ],
-    "handbook": [
-        "light",
-        "docs",
-        "corporate"
-    ],
-    "hangar": [
-        "dark",
-        "blog",
-        "aviation"
-    ],
-    "hardcore-pit": [
-        "event",
-        "punk",
-        "hardcore",
-        "show",
-        "chaotic"
-    ],
-    "haute-couture": [
-        "elegant",
-        "fashion",
-        "magazine"
-    ],
-    "headliner-bold": [
-        "event",
-        "festival",
-        "lineup",
-        "headliner",
-        "hierarchy"
-    ],
-    "hearth": [
-        "light",
-        "blog",
-        "traditional",
-        "elegant"
-    ],
-    "heavy-curtain": [
-        "event",
-        "theater",
-        "drama",
-        "production",
-        "heavy"
-    ],
-    "heliograph": [
-        "dark",
-        "blog",
-        "heliograph",
-        "sun-print"
-    ],
-    "helix": [
-        "light",
-        "landing",
-        "biotech",
-        "3d"
-    ],
-    "helix-docs": [
-        "docs",
-        "light",
-        "science"
-    ],
-    "herald": [
-        "light",
-        "magazine",
-        "editorial",
-        "news"
-    ],
-    "hermit": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "hibiscus": [
-        "dark",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "hologram": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "holographic": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "horizon-ai": [
-        "landing",
-        "dark",
-        "ai",
-        "futuristic"
-    ],
-    "house-lights": [
-        "event",
-        "venue",
-        "concert",
-        "lighting",
-        "technical"
-    ],
-    "hwaro.386": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "hwaronight": [
-        "dark",
-        "blog"
-    ],
-    "hypercube": [
-        "dark",
-        "docs",
-        "3d",
-        "wireframe"
-    ],
-    "hyperpop": [
-        "dark",
-        "glamorous",
-        "neon",
-        "trendy",
-        "elegant"
-    ],
-    "igloo": [
-        "light",
-        "blog",
-        "nordic"
-    ],
-    "ignite": [
-        "landing",
-        "dark",
-        "startup"
-    ],
-    "ignition-sequence": [
-        "event",
-        "dark",
-        "phased",
-        "launch",
-        "sequential"
-    ],
-    "impasto": [
-        "light",
-        "blog",
-        "bold",
-        "artistic"
-    ],
-    "incunabula-noir": [
-        "book",
-        "dark",
-        "incunabulum",
-        "early-print",
-        "revolutionary"
-    ],
-    "inferno": [
-        "dark",
-        "community",
-        "fire",
-        "gaming"
-    ],
-    "infographic": [
-        "light",
-        "landing",
-        "infographic",
-        "data-viz"
-    ],
-    "ink-seoul": [
-        "light",
-        "blog",
-        "monochrome",
-        "seoul",
-        "minimal"
-    ],
-    "inkdrop-docs": [
-        "docs",
-        "dark",
-        "elegant",
-        "animation"
-    ],
-    "inkwell": [
-        "light",
-        "blog",
-        "poetry"
-    ],
-    "intaglio": [
-        "dark",
-        "portfolio",
-        "engraving",
-        "minimal"
-    ],
-    "intarsia": [
-        "light",
-        "portfolio",
-        "bold",
-        "clean",
-        "geometric"
-    ],
-    "interferogram": [
-        "dark",
-        "blog",
-        "interference",
-        "optical"
-    ],
-    "inventory": [
-        "light",
-        "dashboard",
-        "management"
-    ],
-    "iridescent-oil": [
-        "dark",
-        "blog",
-        "iridescent",
-        "oil"
-    ],
-    "iron-stage": [
-        "event",
-        "festival",
-        "metal",
-        "industrial",
-        "heavy"
-    ],
-    "ironclad": [
-        "dark",
-        "landing",
-        "metallic",
-        "security"
-    ],
-    "ironworks": [
-        "dark",
-        "blog",
-        "history"
-    ],
-    "isometric": [
-        "light",
-        "3d",
-        "dashboard",
-        "ui"
-    ],
-    "isthmus": [
-        "light",
-        "hub",
-        "bridge",
-        "horizontal-scroll"
-    ],
-    "jade-palace": [
-        "dark",
-        "blog",
-        "luxury",
-        "eastern"
-    ],
-    "japanese-industrial": [
-        "dark",
-        "blog",
-        "japanese",
-        "industrial"
-    ],
-    "jewel-tone": [
-        "dark",
-        "glamorous",
-        "jewel",
-        "elegant"
-    ],
-    "jugendstil": [
-        "light",
-        "blog",
-        "art-nouveau",
-        "organic",
-        "nature"
-    ],
-    "kaleidoscope": [
-        "light",
-        "event",
-        "psychedelic",
-        "pattern"
-    ],
-    "ketubah": [
-        "book",
-        "light",
-        "ceremonial",
-        "decorated",
-        "formal"
-    ],
-    "keynote-blast": [
-        "event",
-        "dark",
-        "conference",
-        "keynote",
-        "explosive"
-    ],
-    "keystone": [
-        "light",
-        "docs",
-        "architecture"
-    ],
-    "kiln": [
-        "light",
-        "portfolio",
-        "craft"
-    ],
-    "kinetic": [
-        "dark",
-        "agency",
-        "physics",
-        "interactive"
-    ],
-    "kinetic-mobile": [
-        "dark",
-        "blog",
-        "kinetic",
-        "mobile"
-    ],
-    "kinetic-typography": [
-        "dark",
-        "blog",
-        "kinetic",
-        "typography"
-    ],
-    "kintsugi": [
-        "dark",
-        "blog",
-        "kintsugi",
-        "gold-repair"
-    ],
-    "lab": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "lab-notebook": [
-        "paper",
-        "light",
-        "laboratory",
-        "raw",
-        "observational"
-    ],
-    "labyrinth": [
-        "dark",
-        "portfolio",
-        "maze",
-        "gamification"
-    ],
-    "lagoon": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "laser-show": [
-        "dark",
-        "blog",
-        "landing",
-        "concert",
-        "glamorous"
-    ],
-    "last-call": [
-        "event",
-        "dark",
-        "closing",
-        "final",
-        "urgent"
-    ],
-    "lattice": [
-        "light",
-        "docs",
-        "graph-db"
-    ],
-    "launchpad": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "launchpad-event": [
-        "event",
-        "dark",
-        "launch",
-        "space",
-        "countdown"
-    ],
-    "lava-flow": [
-        "dark",
-        "blog",
-        "lava",
-        "volcanic"
-    ],
-    "layered-docs": [
-        "light",
-        "docs",
-        "enterprise"
-    ],
-    "ledger": [
-        "light",
-        "docs",
-        "finance"
-    ],
-    "letter-to-editor": [
-        "paper",
-        "light",
-        "correspondence",
-        "urgent",
-        "brief"
-    ],
-    "letterbox": [
-        "light",
-        "blog",
-        "newsletter"
-    ],
-    "lexicon": [
-        "light",
-        "docs",
-        "glossary"
-    ],
-    "lichen-moss": [
-        "dark",
-        "blog",
-        "lichen",
-        "organic"
-    ],
-    "lighthouse": [
-        "light",
-        "docs",
-        "directory"
-    ],
-    "linktree": [
-        "dark",
-        "landing",
-        "links"
-    ],
-    "linocut": [
-        "light",
-        "printmaking",
-        "bold",
-        "creative"
-    ],
-    "liquid": [
-        "dark",
-        "interactive",
-        "gooey",
-        "svg"
-    ],
-    "liquid-chrome": [
-        "dark",
-        "blog",
-        "metallic",
-        "glamorous"
-    ],
-    "lithium": [
-        "dark",
-        "landing",
-        "electric",
-        "tech"
-    ],
-    "lithograph": [
-        "dark",
-        "blog",
-        "lithograph",
-        "printmaking"
-    ],
-    "logbook": [
-        "light",
-        "docs",
-        "compliance"
-    ],
-    "longitudinal": [
-        "paper",
-        "dark",
-        "longitudinal",
-        "temporal",
-        "tracking"
-    ],
-    "lookbook": [
-        "dark",
-        "portfolio",
-        "lookbook",
-        "fashion"
-    ],
-    "loom": [
-        "light",
-        "portfolio",
-        "fashion"
-    ],
-    "lumiere": [
-        "dark",
-        "elegant",
-        "minimal",
-        "luminescent"
-    ],
-    "lumina": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "luminary": [
-        "light",
-        "elegant",
-        "portfolio"
-    ],
-    "luminescent-mesh": [
-        "dark",
-        "blog",
-        "luminescent",
-        "mesh"
-    ],
-    "lumos": [
-        "blog",
-        "elegant",
-        "light",
-        "minimal"
-    ],
-    "lunar-base": [
-        "elegant",
-        "portfolio",
-        "dark"
-    ],
-    "lunar-breeze": [
-        "dark",
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "luxe-noir": [
-        "dark",
-        "glamorous",
-        "luxury",
-        "elegant"
-    ],
-    "luxury-horology": [
-        "dark",
-        "portfolio",
-        "horology",
-        "luxury"
-    ],
-    "macro-snowflake": [
-        "dark",
-        "blog",
-        "snowflake",
-        "crystalline"
-    ],
-    "madhubani": [
-        "light",
-        "blog",
-        "indian",
-        "folk-art",
-        "geometric"
-    ],
-    "magenta-sunset": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "magma": [
-        "dark",
-        "dashboard",
-        "volcanic",
-        "animation"
-    ],
-    "magnetar": [
-        "dark",
-        "blog",
-        "magnetar",
-        "cosmic"
-    ],
-    "main-act": [
-        "event",
-        "concert",
-        "headline",
-        "performer",
-        "dramatic"
-    ],
-    "mainstage": [
-        "event",
-        "dark",
-        "performance",
-        "stage",
-        "dramatic"
-    ],
-    "manifesto": [
-        "dark",
-        "blog",
-        "opinion"
-    ],
-    "manifold": [
-        "light",
-        "docs",
-        "saas"
-    ],
-    "marble": [
-        "light",
-        "gallery",
-        "luxury",
-        "marble-texture"
-    ],
-    "marbled-paper": [
-        "dark",
-        "blog",
-        "marbled",
-        "paper"
-    ],
-    "mardi-gras": [
-        "glamorous",
-        "trendy",
-        "bold",
-        "purple",
-        "gold",
-        "green"
-    ],
-    "marketplace": [
-        "light",
-        "store",
-        "marketplace"
-    ],
-    "marquetry": [
-        "light",
-        "portfolio",
-        "geometric",
-        "minimal"
-    ],
-    "masquerade": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "luxury",
-        "mystery"
-    ],
-    "matcha": [
-        "blog",
-        "light",
-        "minimal",
-        "zen"
-    ],
-    "matrix": [
-        "light",
-        "docs",
-        "compatibility"
-    ],
-    "maximal-bloom": [
-        "elegant",
-        "floral",
-        "bold",
-        "glamorous"
-    ],
-    "maximalist": [
-        "dark",
-        "blog",
-        "bold",
-        "glamorous"
-    ],
-    "mayan-geometry": [
-        "dark",
-        "blog",
-        "mayan",
-        "geometric"
-    ],
-    "meadow": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "medieval-manuscript": [
-        "dark",
-        "blog",
-        "medieval",
-        "manuscript"
-    ],
-    "memoir": [
-        "light",
-        "blog",
-        "longform"
-    ],
-    "memphis": [
-        "light",
-        "retro",
-        "colorful",
-        "bold",
-        "portfolio"
-    ],
-    "mercury": [
-        "dark",
-        "blog",
-        "minimal",
-        "metallic",
-        "elegant"
-    ],
-    "meridian": [
-        "dark",
-        "landing",
-        "timezone"
-    ],
-    "meridian-docs": [
-        "light",
-        "docs",
-        "scheduling"
-    ],
-    "meridiem": [
-        "dual",
-        "dashboard",
-        "time-based",
-        "auto-theme"
-    ],
-    "meta-analysis": [
-        "paper",
-        "light",
-        "statistical",
-        "synthesis",
-        "evidence"
-    ],
-    "meteor": [
-        "dark",
-        "interactive",
-        "meteor-shower",
-        "cosmic"
-    ],
-    "methods-paper": [
-        "paper",
-        "light",
-        "methods",
-        "protocol",
-        "technical"
-    ],
-    "metronome": [
-        "dark",
-        "blog",
-        "music-production",
-        "rhythm"
-    ],
-    "mezzotint": [
-        "light",
-        "blog",
-        "bold",
-        "clean",
-        "monochrome"
-    ],
-    "micro": [
-        "light",
-        "blog",
-        "microblog"
-    ],
-    "midnight-blog": [
-        "dark",
-        "blog",
-        "reading"
-    ],
-    "midnight-launch": [
-        "landing",
-        "dark",
-        "animation",
-        "product"
-    ],
-    "migration": [
-        "light",
-        "docs",
-        "database"
-    ],
-    "minifolio": [
-        "light",
-        "portfolio",
-        "minimal"
-    ],
-    "minimalzen": [
-        "light",
-        "blog",
-        "minimal",
-        "zen"
-    ],
-    "mint-fresh": [
-        "landing",
-        "light",
-        "saas"
-    ],
-    "mirage": [
-        "light",
-        "gallery",
-        "desert",
-        "distortion"
-    ],
-    "misprint": [
-        "book",
-        "dark",
-        "error",
-        "accidental",
-        "artistic"
-    ],
-    "mixed-methods": [
-        "paper",
-        "light",
-        "mixed-methods",
-        "convergent",
-        "dual"
-    ],
-    "modern-blog": [
-        "dark",
-        "blog",
-        "modern"
-    ],
-    "molten": [
-        "dark",
-        "blog",
-        "metalwork",
-        "melting"
-    ],
-    "molten-gold": [
-        "elegant",
-        "gold",
-        "trendy"
-    ],
-    "monochrome": [
-        "light",
-        "photo-essay",
-        "monochrome",
-        "grayscale"
-    ],
-    "monograph": [
-        "book",
-        "light",
-        "academic",
-        "thorough",
-        "reference"
-    ],
-    "monolith": [
-        "dark",
-        "landing",
-        "onepage"
-    ],
-    "monolithic-dark": [
-        "dark",
-        "blog",
-        "monolithic",
-        "bold"
-    ],
-    "monoprint": [
-        "light",
-        "monoprint",
-        "bold",
-        "creative"
-    ],
-    "monorepo-docs": [
-        "docs",
-        "dark",
-        "developer",
-        "monorepo"
-    ],
-    "moonrise": [
-        "dark",
-        "blog",
-        "essay"
-    ],
-    "moonstone": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "moroccan-zellige": [
-        "light",
-        "blog",
-        "moroccan",
-        "mosaic",
-        "geometric"
-    ],
-    "morphogenesis": [
-        "dark",
-        "blog",
-        "generative",
-        "biology",
-        "patterns"
-    ],
-    "mortar": [
-        "dark",
-        "docs",
-        "build-system"
-    ],
-    "mosaic": [
-        "light",
-        "blog",
-        "magazine"
-    ],
-    "mosh-pit": [
-        "event",
-        "dark",
-        "punk",
-        "chaotic",
-        "raw"
-    ],
-    "mosstown": [
-        "light",
-        "blog",
-        "cozy"
-    ],
-    "mughal": [
-        "light",
-        "blog",
-        "mughal",
-        "ornate",
-        "gold"
-    ],
-    "murano-glass": [
-        "light",
-        "blog",
-        "glass",
-        "translucent",
-        "venetian"
-    ],
-    "mycelium": [
-        "dark",
-        "blog",
-        "mycelium",
-        "fungal"
-    ],
-    "nadir": [
-        "dark",
-        "blog",
-        "minimal",
-        "oled-black"
-    ],
-    "nautical": [
-        "dark",
-        "blog",
-        "nautical"
-    ],
-    "nebula": [
-        "dark",
-        "gallery",
-        "space",
-        "ethereal"
-    ],
-    "neo-deco": [
-        "dark",
-        "portfolio",
-        "artdeco",
-        "elegant"
-    ],
-    "neo-memphis-dark": [
-        "dark",
-        "blog",
-        "memphis",
-        "neo-memphis"
-    ],
-    "neobrutal": [
-        "light",
-        "landing",
-        "neo-brutalism",
-        "bold"
-    ],
-    "neoclassical": [
-        "light",
-        "gallery",
-        "marble-texture",
-        "elegant"
-    ],
-    "neon": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "neon-jungle": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "neon"
-    ],
-    "neon-marquee": [
-        "event",
-        "theater",
-        "marquee",
-        "vintage",
-        "retro"
-    ],
-    "neon-tokyo": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "tokyo",
-        "glamorous"
-    ],
-    "network-meta": [
-        "paper",
-        "dark",
-        "network",
-        "meta-analysis",
-        "comparative"
-    ],
-    "neumorphism": [
-        "light",
-        "ui",
-        "soft",
-        "shadow"
-    ],
-    "neural-bloom": [
-        "dark",
-        "blog",
-        "neural",
-        "ai",
-        "synaptic"
-    ],
-    "newspaper": [
-        "light",
-        "blog",
-        "editorial",
-        "newspaper"
-    ],
-    "nexus": [
-        "dark",
-        "docs",
-        "microservice"
-    ],
-    "nexus-docs": [
-        "docs",
-        "dark",
-        "developer"
-    ],
-    "niello": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "no-style-please": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "noctis": [
-        "landing",
-        "dark",
-        "glassmorphism",
-        "neon"
-    ],
-    "nocturne": [
-        "dark",
-        "blog",
-        "classical-music",
-        "piano"
-    ],
-    "noir": [
-        "dark",
-        "blog",
-        "noir"
-    ],
-    "northern-lights": [
-        "dark",
-        "blog",
-        "aurora",
-        "arctic",
-        "atmospheric"
-    ],
-    "notebook": [
-        "light",
-        "blog",
-        "journal"
-    ],
-    "null-result": [
-        "paper",
-        "light",
-        "null",
-        "negative",
-        "honest"
-    ],
-    "oasis": [
-        "light",
-        "blog",
-        "relaxation"
-    ],
-    "obelisk": [
-        "light",
-        "one-page",
-        "monumental",
-        "vertical"
-    ],
-    "oblique": [
-        "light",
-        "blog",
-        "bold",
-        "angular"
-    ],
-    "oblong-quarto": [
-        "book",
-        "light",
-        "landscape",
-        "panoramic",
-        "unusual"
-    ],
-    "observatory": [
-        "dark",
-        "blog",
-        "space"
-    ],
-    "obsidian": [
-        "dark",
-        "wiki",
-        "glass",
-        "oled"
-    ],
-    "obsidian-docs": [
-        "docs",
-        "dark",
-        "wiki",
-        "knowledge"
-    ],
-    "obsidian-mirror": [
-        "dark",
-        "blog",
-        "obsidian",
-        "reflective"
-    ],
-    "old-map-cartography": [
-        "dark",
-        "blog",
-        "cartography",
-        "vintage"
-    ],
-    "onyx": [
-        "landing",
-        "dark",
-        "minimal",
-        "luxury"
-    ],
-    "op-art": [
-        "dark",
-        "blog",
-        "geometric",
-        "optical-illusion"
-    ],
-    "opalescent": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "opening-act": [
-        "event",
-        "opening",
-        "season",
-        "premiere",
-        "fresh"
-    ],
-    "opening-night": [
-        "event",
-        "dark",
-        "premiere",
-        "formal",
-        "electric"
-    ],
-    "opulent": [
-        "light",
-        "elegant",
-        "luxury",
-        "portfolio",
-        "bold"
-    ],
-    "orchard": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "orchid": [
-        "dark",
-        "blog",
-        "glamorous",
-        "botanical"
-    ],
-    "origami": [
-        "light",
-        "blog",
-        "material"
-    ],
-    "oscilloscope": [
-        "dark",
-        "blog",
-        "oscilloscope",
-        "retro"
-    ],
-    "overture": [
-        "event",
-        "dark",
-        "opening",
-        "orchestral",
-        "grand"
-    ],
-    "oxidation": [
-        "dark",
-        "blog",
-        "oxidation",
-        "rust"
-    ],
-    "oxide": [
-        "dark",
-        "gallery",
-        "industrial",
-        "rust-texture"
-    ],
-    "pagoda": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "palette": [
-        "light",
-        "docs",
-        "design"
-    ],
-    "palimpsest-noir": [
-        "book",
-        "dark",
-        "layered",
-        "erased",
-        "ghostly"
-    ],
-    "panopticon": [
-        "dark",
-        "brutalist",
-        "radial",
-        "experimental"
-    ],
-    "pantry": [
-        "light",
-        "docs",
-        "package-manager"
-    ],
-    "paper": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "paper-art": [
-        "light",
-        "blog",
-        "paper",
-        "collage"
-    ],
-    "papermod": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "parallax": [
-        "light",
-        "storytelling",
-        "parallax",
-        "cinematic"
-    ],
-    "parallax-heavy": [
-        "dark",
-        "landing",
-        "gallery",
-        "parallax"
-    ],
-    "parchment": [
-        "light",
-        "docs",
-        "fantasy"
-    ],
-    "parquetry": [
-        "dark",
-        "blog",
-        "parquetry",
-        "woodwork"
-    ],
-    "particle-storm": [
-        "dark",
-        "blog",
-        "neon",
-        "particles",
-        "energy"
-    ],
-    "pastel-docs": [
-        "docs",
-        "light",
-        "friendly"
-    ],
-    "patina": [
-        "dark",
-        "blog",
-        "minimal",
-        "craft"
-    ],
-    "peacock": [
-        "elegant",
-        "glamorous",
-        "portfolio"
-    ],
-    "pearlescent": [
-        "light",
-        "blog",
-        "iridescent",
-        "luxury",
-        "soft"
-    ],
-    "peer-review": [
-        "paper",
-        "light",
-        "academic",
-        "review",
-        "transparent"
-    ],
-    "pendulum": [
-        "dark",
-        "blog",
-        "productivity"
-    ],
-    "pentimento": [
-        "light",
-        "portfolio",
-        "elegant",
-        "bold",
-        "clean"
-    ],
-    "permafrost": [
-        "light",
-        "archive",
-        "ice",
-        "frozen"
-    ],
-    "persian-carpet": [
-        "light",
-        "blog",
-        "persian",
-        "carpet",
-        "ornate"
-    ],
-    "perspective-piece": [
-        "paper",
-        "dark",
-        "opinion",
-        "viewpoint",
-        "argumentative"
-    ],
-    "petrified-wood": [
-        "dark",
-        "blog",
-        "fossil",
-        "wood"
-    ],
-    "phantom": [
-        "dark",
-        "blog",
-        "ghost",
-        "translucent"
-    ],
-    "phosphor": [
-        "dark",
-        "gallery",
-        "bioluminescence",
-        "glow"
-    ],
-    "photoblog": [
-        "dark",
-        "blog",
-        "photography",
-        "gallery"
-    ],
-    "photon": [
-        "dark",
-        "elegant",
-        "luminescent",
-        "portfolio"
-    ],
-    "pietra-dura": [
-        "dark",
-        "creative",
-        "bold",
-        "stone"
-    ],
-    "pinecone": [
-        "dark",
-        "blog",
-        "nature"
-    ],
-    "pipeline": [
-        "light",
-        "docs",
-        "cicd"
-    ],
-    "pit-stop": [
-        "event",
-        "dark",
-        "motorsport",
-        "speed",
-        "frantic"
-    ],
-    "pixel": [
-        "dark",
-        "blog",
-        "gaming"
-    ],
-    "plasma": [
-        "dark",
-        "science",
-        "plasma",
-        "visualization"
-    ],
-    "platinum": [
-        "light",
-        "minimal",
-        "luxury",
-        "portfolio"
-    ],
-    "playlist": [
-        "dark",
-        "blog",
-        "music"
-    ],
-    "podcast-fm": [
-        "dark",
-        "media",
-        "podcast"
-    ],
-    "podium-rush": [
-        "event",
-        "competition",
-        "awards",
-        "victory",
-        "podium"
-    ],
-    "pointillism": [
-        "dark",
-        "blog",
-        "pointillism",
-        "dots"
-    ],
-    "poison": [
-        "dark",
-        "blog",
-        "sidebar"
-    ],
-    "polaris": [
-        "dark",
-        "guide",
-        "astronomy",
-        "constellation"
-    ],
-    "polaroid": [
-        "light",
-        "blog",
-        "gallery"
-    ],
-    "pop-surreal": [
-        "dark",
-        "glamorous",
-        "elegant",
-        "surreal",
-        "trendy"
-    ],
-    "pop-up-page": [
-        "book",
-        "light",
-        "dimensional",
-        "paper-engineering",
-        "interactive"
-    ],
-    "portfolio-blog": [
-        "dark",
-        "blog",
-        "portfolio"
-    ],
-    "portico": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "position-paper": [
-        "paper",
-        "dark",
-        "position",
-        "argumentative",
-        "bold"
-    ],
-    "postcard": [
-        "light",
-        "blog",
-        "postcard"
-    ],
-    "powder-burn": [
-        "event",
-        "dark",
-        "rapid-fire",
-        "flash",
-        "quick"
-    ],
-    "prairie": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "preprint-rush": [
-        "paper",
-        "light",
-        "preprint",
-        "urgent",
-        "draft"
-    ],
-    "pressure-cooker": [
-        "event",
-        "dark",
-        "hackathon",
-        "pressure",
-        "deadline"
-    ],
-    "pricetable": [
-        "light",
-        "landing",
-        "saas",
-        "pricing"
-    ],
-    "primer": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "prism": [
-        "dark",
-        "docs",
-        "data"
-    ],
-    "prism-docs": [
-        "docs",
-        "light",
-        "colorful"
-    ],
-    "prism-refraction": [
-        "dark",
-        "blog",
-        "prism",
-        "refraction"
-    ],
-    "prismify": [
-        "glassmorphism",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "proof-sheet": [
-        "book",
-        "light",
-        "proof",
-        "unfinished",
-        "editorial"
-    ],
-    "protocol": [
-        "dark",
-        "docs",
-        "networking"
-    ],
-    "protocol-paper": [
-        "paper",
-        "light",
-        "protocol",
-        "pre-registration",
-        "rigorous"
-    ],
-    "psychedelic": [
-        "dark",
-        "minimal",
-        "elegant",
-        "glamorous"
-    ],
-    "pulp-fiction": [
-        "book",
-        "dark",
-        "pulp",
-        "lurid",
-        "cheap"
-    ],
-    "pulsar": [
-        "dark",
-        "blog",
-        "cosmic",
-        "pulse-animation"
-    ],
-    "pulse-api": [
-        "dark",
-        "docs"
-    ],
-    "pyrite": [
-        "dark",
-        "showcase",
-        "metallic",
-        "luxury"
-    ],
-    "pyrotechnic": [
-        "event",
-        "show",
-        "pyrotechnics",
-        "fireworks",
-        "explosive"
-    ],
-    "qualitative-study": [
-        "paper",
-        "light",
-        "qualitative",
-        "thematic",
-        "interpretive"
-    ],
-    "quantum": [
-        "dark",
-        "blog",
-        "quantum",
-        "science"
-    ],
-    "quarry": [
-        "dark",
-        "docs",
-        "data-warehouse"
-    ],
-    "quasar": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "quill": [
-        "light",
-        "blog",
-        "fiction"
-    ],
-    "radiolaria": [
-        "dark",
-        "blog",
-        "radiolaria",
-        "skeletal"
-    ],
-    "rainbow-cascade": [
-        "elegant",
-        "glowing",
-        "box-shadow"
-    ],
-    "ramble": [
-        "light",
-        "blog",
-        "hiking"
-    ],
-    "randomized-trial": [
-        "paper",
-        "light",
-        "rct",
-        "clinical-trial",
-        "rigorous"
-    ],
-    "rave": [
-        "dark",
-        "blog",
-        "acid",
-        "rave",
-        "neon"
-    ],
-    "raw-data": [
-        "paper",
-        "light",
-        "raw",
-        "data",
-        "tables"
-    ],
-    "reactor": [
-        "dark",
-        "docs",
-        "reactive"
-    ],
-    "realty": [
-        "light",
-        "realestate",
-        "luxury",
-        "elegant"
-    ],
-    "recipe": [
-        "light",
-        "blog",
-        "recipe"
-    ],
-    "red-alert": [
-        "event",
-        "dark",
-        "emergency",
-        "crisis",
-        "urgent"
-    ],
-    "red-carpet": [
-        "event",
-        "premiere",
-        "celebrity",
-        "glamour",
-        "fashion"
-    ],
-    "reef": [
-        "dark",
-        "blog",
-        "diving"
-    ],
-    "relay": [
-        "light",
-        "docs",
-        "integration"
-    ],
-    "remainder-bin": [
-        "book",
-        "light",
-        "secondhand",
-        "discount",
-        "worn"
-    ],
-    "remedy": [
-        "light",
-        "docs",
-        "troubleshooting"
-    ],
-    "renaissance": [
-        "light",
-        "art",
-        "classic",
-        "serif",
-        "elegant"
-    ],
-    "repousse": [
-        "dark",
-        "blog",
-        "repousse",
-        "metalwork"
-    ],
-    "reproducibility": [
-        "paper",
-        "light",
-        "replication",
-        "comparison",
-        "verdict"
-    ],
-    "resume": [
-        "light",
-        "resume"
-    ],
-    "retraction-notice": [
-        "paper",
-        "light",
-        "retracted",
-        "warning",
-        "editorial"
-    ],
-    "retro-radar": [
-        "dark",
-        "blog",
-        "radar",
-        "retro"
-    ],
-    "retromac": [
-        "light",
-        "mac",
-        "os9",
-        "retro",
-        "system"
-    ],
-    "retrowave": [
-        "dark",
-        "blog",
-        "retro",
-        "synthwave"
-    ],
-    "reveille": [
-        "event",
-        "dark",
-        "military",
-        "assembly",
-        "urgent"
-    ],
-    "review-article": [
-        "paper",
-        "light",
-        "review",
-        "literature",
-        "synthesis"
-    ],
-    "ridgeline": [
-        "dark",
-        "blog",
-        "outdoor"
-    ],
-    "riftzone": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "dimensional"
-    ],
-    "ring-bell": [
-        "event",
-        "dark",
-        "boxing",
-        "fight",
-        "intense"
-    ],
-    "riverbank": [
-        "light",
-        "blog",
-        "nature-journal"
-    ],
-    "rococo": [
-        "light",
-        "blog",
-        "pastel",
-        "elegant"
-    ],
-    "roll-call": [
-        "event",
-        "light",
-        "assembly",
-        "formal",
-        "attendance"
-    ],
-    "roll-scroll": [
-        "book",
-        "light",
-        "scroll",
-        "continuous",
-        "ancient"
-    ],
-    "rooftop": [
-        "dark",
-        "blog",
-        "urban"
-    ],
-    "rose-gold": [
-        "elegant",
-        "luxury",
-        "minimal"
-    ],
-    "rosemary": [
-        "light",
-        "blog",
-        "cooking"
-    ],
-    "rosetta": [
-        "light",
-        "docs",
-        "i18n"
-    ],
-    "rosewood": [
-        "blog",
-        "dark",
-        "warm",
-        "classic"
-    ],
-    "rubric": [
-        "book",
-        "light",
-        "rubricated",
-        "two-color",
-        "traditional"
-    ],
-    "ruby-fire": [
-        "dark",
-        "blog",
-        "bold"
-    ],
-    "runbook": [
-        "light",
-        "docs",
-        "operations"
-    ],
-    "rune": [
-        "dark",
-        "archive",
-        "viking",
-        "mystic"
-    ],
-    "saffron": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "sage-guide": [
-        "docs",
-        "light",
-        "tutorial",
-        "guide"
-    ],
-    "sakura-storm": [
-        "dark",
-        "blog",
-        "glamorous",
-        "sakura"
-    ],
-    "sandcastle": [
-        "light",
-        "blog",
-        "sand",
-        "beach"
-    ],
-    "sandstone": [
-        "light",
-        "blog",
-        "architecture"
-    ],
-    "sandstorm": [
-        "dark",
-        "blog",
-        "desert",
-        "particles"
-    ],
-    "sapphire": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "savanna": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "sawmill": [
-        "light",
-        "blog",
-        "woodworking"
-    ],
-    "scaffold": [
-        "dark",
-        "landing",
-        "comingsoon"
-    ],
-    "scaffold-docs": [
-        "dark",
-        "docs",
-        "scaffolding"
-    ],
-    "schematic": [
-        "light",
-        "docs",
-        "hardware"
-    ],
-    "scientific-journal": [
-        "dark",
-        "docs",
-        "scientific",
-        "academic"
-    ],
-    "scoping-review": [
-        "paper",
-        "light",
-        "scoping",
-        "mapping",
-        "landscape"
-    ],
-    "scrimshaw": [
-        "bold",
-        "elegant",
-        "clean",
-        "blog"
-    ],
-    "sentinel": [
-        "dark",
-        "docs",
-        "monitoring"
-    ],
-    "seraph": [
-        "minimal",
-        "elegant",
-        "portfolio"
-    ],
-    "serenity": [
-        "light",
-        "blog",
-        "elegant"
-    ],
-    "sextant": [
-        "light",
-        "docs",
-        "metrics"
-    ],
-    "sfumato": [
-        "dark",
-        "blog",
-        "atmospheric",
-        "minimal"
-    ],
-    "sgraffito": [
-        "dark",
-        "blog",
-        "sgraffito",
-        "scratched"
-    ],
-    "shutout": [
-        "event",
-        "dark",
-        "competition",
-        "dominant",
-        "perfect"
-    ],
-    "silhouette": [
-        "dark",
-        "landing",
-        "silhouette",
-        "dramatic"
-    ],
-    "silk-road": [
-        "elegant",
-        "glamorous",
-        "silk",
-        "cultural"
-    ],
-    "simulation-paper": [
-        "paper",
-        "dark",
-        "computational",
-        "simulation",
-        "model"
-    ],
-    "sketch": [
-        "light",
-        "blog",
-        "handdrawn"
-    ],
-    "skeuomorphic": [
-        "light",
-        "blog",
-        "skeuomorphic",
-        "realistic"
-    ],
-    "slide": [
-        "dark",
-        "docs",
-        "presentation"
-    ],
-    "snowfall": [
-        "light",
-        "blog",
-        "winter"
-    ],
-    "solar-punk": [
-        "light",
-        "blog",
-        "solarpunk",
-        "sustainable"
-    ],
-    "solarflare": [
-        "dark",
-        "landing",
-        "solar",
-        "energy"
-    ],
-    "solaris": [
-        "dark",
-        "dashboard",
-        "solar-system",
-        "space-mission"
-    ],
-    "solarium": [
-        "blog",
-        "light",
-        "warm"
-    ],
-    "solstice": [
-        "dual",
-        "blog",
-        "seasonal",
-        "time-based"
-    ],
-    "sonar": [
-        "dark",
-        "hub",
-        "radar",
-        "discovery"
-    ],
-    "spectra": [
-        "dark",
-        "data-science",
-        "spectrum",
-        "rainbow"
-    ],
-    "spectrum": [
-        "light",
-        "blog",
-        "a11y"
-    ],
-    "spectrum-docs": [
-        "light",
-        "docs",
-        "accessibility"
-    ],
-    "spire": [
-        "dark",
-        "blog",
-        "architecture"
-    ],
-    "split-tone": [
-        "light",
-        "blog",
-        "photography",
-        "cinematic",
-        "toning"
-    ],
-    "stained-glass": [
-        "light",
-        "blog",
-        "cathedral",
-        "colorful",
-        "gothic"
-    ],
-    "standing-ovation": [
-        "event",
-        "light",
-        "awards",
-        "acclaim",
-        "celebration"
-    ],
-    "starlight": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "minimal"
-    ],
-    "starting-gun": [
-        "event",
-        "dark",
-        "race",
-        "competition",
-        "explosive"
-    ],
-    "statuspage": [
-        "light",
-        "landing",
-        "status"
-    ],
-    "stellar-launch": [
-        "landing",
-        "dark",
-        "parallax",
-        "animation"
-    ],
-    "stipple": [
-        "light",
-        "artistic",
-        "dot-art",
-        "gallery"
-    ],
-    "storefront": [
-        "light",
-        "landing",
-        "shop"
-    ],
-    "stratum": [
-        "dark",
-        "timeline",
-        "geological",
-        "layered"
-    ],
-    "strobe": [
-        "dark",
-        "event",
-        "club",
-        "strobe"
-    ],
-    "studio": [
-        "dark",
-        "landing",
-        "portfolio"
-    ],
-    "subzero": [
-        "dark",
-        "research",
-        "cryogenic",
-        "frozen"
-    ],
-    "summit": [
-        "dark",
-        "landing",
-        "conference"
-    ],
-    "summit-event": [
-        "conference",
-        "dark",
-        "event",
-        "landing"
-    ],
-    "summit-strike": [
-        "event",
-        "dark",
-        "conference",
-        "summit",
-        "ascending"
-    ],
-    "sunburst": [
-        "light",
-        "blog",
-        "warm",
-        "golden",
-        "radiant"
-    ],
-    "sundew": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "supernova": [
-        "dark",
-        "landing",
-        "cosmic",
-        "particles"
-    ],
-    "supplementary": [
-        "paper",
-        "light",
-        "supplementary",
-        "data-heavy",
-        "exhaustive"
-    ],
-    "supreme-sun": [
-        "light",
-        "blog",
-        "community"
-    ],
-    "survey-instrument": [
-        "paper",
-        "light",
-        "survey",
-        "instrument",
-        "psychometric"
-    ],
-    "synthwave": [
-        "dark",
-        "retro",
-        "glamorous",
-        "trendy"
-    ],
-    "systematic-review": [
-        "paper",
-        "light",
-        "systematic",
-        "evidence",
-        "methodology"
-    ],
-    "tactile-fabric": [
-        "light",
-        "blog",
-        "fabric",
-        "textile"
-    ],
-    "talavera": [
-        "light",
-        "blog",
-        "mexican",
-        "pottery",
-        "colorful"
-    ],
-    "tale": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "tangram": [
-        "light",
-        "portfolio",
-        "puzzle",
-        "geometric"
-    ],
-    "tapestry": [
-        "light",
-        "blog",
-        "timeline"
-    ],
-    "taskboard": [
-        "light",
-        "dashboard",
-        "kanban"
-    ],
-    "tavern": [
-        "dark",
-        "blog",
-        "rpg"
-    ],
-    "techbyte": [
-        "light",
-        "blog",
-        "tech",
-        "card"
-    ],
-    "technical-report": [
-        "paper",
-        "light",
-        "institutional",
-        "technical-report",
-        "formal"
-    ],
-    "tectonic": [
-        "dark",
-        "hub",
-        "geological",
-        "interactive"
-    ],
-    "telegraph": [
-        "light",
-        "blog",
-        "news"
-    ],
-    "tempera": [
-        "dark",
-        "blog",
-        "tempera",
-        "painting"
-    ],
-    "tempest": [
-        "dark",
-        "magazine",
-        "storm",
-        "dramatic"
-    ],
-    "tenebrism": [
-        "dark",
-        "creative",
-        "bold",
-        "clean"
-    ],
-    "terminal": [
-        "dark",
-        "blog"
-    ],
-    "terrace": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "terracotta-studio": [
-        "landing",
-        "light",
-        "creative",
-        "artisan"
-    ],
-    "terracotta-tiles": [
-        "dark",
-        "blog",
-        "terracotta",
-        "tile"
-    ],
-    "terraform": [
-        "dark",
-        "dashboard",
-        "sci-fi",
-        "terraforming"
-    ],
-    "terraform-docs": [
-        "docs",
-        "dark",
-        "infra",
-        "devops"
-    ],
-    "terrarium": [
-        "light",
-        "portfolio",
-        "miniature"
-    ],
-    "terrazzo": [
-        "light",
-        "portfolio",
-        "terrazzo",
-        "speckled"
-    ],
-    "terrazzo-blog": [
-        "blog",
-        "light",
-        "colorful",
-        "memphis"
-    ],
-    "tessellation": [
-        "light",
-        "gallery",
-        "escher",
-        "pattern-art"
-    ],
-    "tesseract": [
-        "dark",
-        "education",
-        "4d",
-        "mathematical"
-    ],
-    "thermal": [
-        "dark",
-        "dashboard",
-        "thermal",
-        "heatmap"
-    ],
-    "thesis": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "thesis-defense": [
-        "paper",
-        "dark",
-        "thesis",
-        "formal",
-        "institutional"
-    ],
-    "thunderdome": [
-        "event",
-        "dark",
-        "arena",
-        "competition",
-        "ultimate"
-    ],
-    "ticker-board": [
-        "event",
-        "dark",
-        "transit",
-        "departure",
-        "mechanical"
-    ],
-    "ticker-tape": [
-        "event",
-        "light",
-        "celebration",
-        "parade",
-        "festive"
-    ],
-    "tidal": [
-        "light",
-        "blog",
-        "ocean",
-        "wellness"
-    ],
-    "timber": [
-        "light",
-        "blog",
-        "craft"
-    ],
-    "titanium": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ],
-    "topaz": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "topographic-gradient": [
-        "dark",
-        "blog",
-        "topographic",
-        "contour"
-    ],
-    "topographic-sand": [
-        "dark",
-        "blog",
-        "topographic",
-        "sand"
-    ],
-    "topography": [
-        "light",
-        "blog",
-        "topographic",
-        "outdoor"
-    ],
-    "torchlight": [
-        "dark",
-        "blog",
-        "adventure"
-    ],
-    "totem": [
-        "dark",
-        "portfolio",
-        "tribal",
-        "vertical-stack"
-    ],
-    "tremor": [
-        "dark",
-        "dashboard",
-        "seismic",
-        "data-viz"
-    ],
-    "trompe-loeil": [
-        "light",
-        "portfolio",
-        "creative",
-        "bold",
-        "illusion"
-    ],
-    "tropical-paradise": [
-        "elegant",
-        "vivid",
-        "botanical"
-    ],
-    "tundra": [
-        "dark",
-        "blog",
-        "expedition"
-    ],
-    "turbine": [
-        "light",
-        "corporate",
-        "energy",
-        "rotation"
-    ],
-    "turret": [
-        "dark",
-        "docs",
-        "waf"
-    ],
-    "twilight": [
-        "dark",
-        "blog",
-        "photo-essay"
-    ],
-    "typeface": [
-        "blog",
-        "light",
-        "typography",
-        "minimal"
-    ],
-    "typewriter": [
-        "light",
-        "blog",
-        "vintage"
-    ],
-    "typhoon": [
-        "dark",
-        "magazine",
-        "storm",
-        "spiral"
-    ],
-    "ukiyo-e": [
-        "light",
-        "blog",
-        "japanese",
-        "woodblock",
-        "traditional"
-    ],
-    "ultraviolet": [
-        "dark",
-        "blog",
-        "ultraviolet",
-        "neon"
-    ],
-    "umbra": [
-        "dark",
-        "portfolio",
-        "monochrome",
-        "shadow"
-    ],
-    "vapor": [
-        "light",
-        "blog",
-        "vaporwave",
-        "surreal"
-    ],
-    "vault": [
-        "dark",
-        "docs",
-        "security"
-    ],
-    "vellum": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "velocity": [
-        "landing",
-        "dark",
-        "saas"
-    ],
-    "velvet": [
-        "dark",
-        "landing",
-        "luxury"
-    ],
-    "velvet-rope": [
-        "event",
-        "gala",
-        "exclusive",
-        "luxury",
-        "velvet"
-    ],
-    "venetian": [
-        "light",
-        "blog",
-        "renaissance",
-        "venetian",
-        "ornate"
-    ],
-    "verdigris": [
-        "dark",
-        "blog",
-        "editorial"
-    ],
-    "versailles": [
-        "dark",
-        "elegant",
-        "classic",
-        "luxury"
-    ],
-    "vertigo": [
-        "dark",
-        "one-page",
-        "experimental",
-        "perspective"
-    ],
-    "vibrant-brutalism": [
-        "dark",
-        "blog",
-        "brutalist",
-        "vibrant"
-    ],
-    "victorian": [
-        "dark",
-        "blog",
-        "gothic",
-        "classic"
-    ],
-    "vineyard": [
-        "dark",
-        "blog",
-        "wine"
-    ],
-    "vintage": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "vintagetv": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "vinyl": [
-        "dark",
-        "blog",
-        "vinyl"
-    ],
-    "voltage": [
-        "dark",
-        "blog",
-        "electric",
-        "sparks"
-    ],
-    "volumetric": [
-        "dark",
-        "blog",
-        "3d",
-        "glow",
-        "atmospheric"
-    ],
-    "vortex": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "animation"
-    ],
-    "wanderlust": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "war-room": [
-        "event",
-        "dark",
-        "strategy",
-        "military",
-        "command"
-    ],
-    "warpzone": [
-        "dark",
-        "portfolio",
-        "warp",
-        "gaming"
-    ],
-    "washi-bound": [
-        "book",
-        "light",
-        "japanese",
-        "stab-binding",
-        "paper"
-    ],
-    "wavelength": [
-        "audio",
-        "dark",
-        "landing",
-        "music"
-    ],
-    "weathervane": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "wedding": [
-        "light",
-        "wedding",
-        "elegant",
-        "event"
-    ],
-    "white-paper-noir": [
-        "paper",
-        "dark",
-        "industry",
-        "executive",
-        "authoritative"
-    ],
-    "wiki": [
-        "light",
-        "docs",
-        "wiki"
-    ],
-    "willow": [
-        "light",
-        "blog",
-        "literature"
-    ],
-    "windmill": [
-        "light",
-        "blog",
-        "european"
-    ],
-    "windows95": [
-        "light",
-        "retro",
-        "os",
-        "nostalgia"
-    ],
-    "woodblock": [
-        "dark",
-        "blog",
-        "woodblock",
-        "printmaking"
-    ],
-    "working-paper": [
-        "paper",
-        "light",
-        "working",
-        "in-progress",
-        "honest"
-    ],
-    "woven-tapestry": [
-        "dark",
-        "blog",
-        "tapestry",
-        "textile"
-    ],
-    "x-ray": [
-        "dark",
-        "blog",
-        "x-ray",
-        "transparent"
-    ],
-    "xerograph": [
-        "dark",
-        "blog",
-        "minimal",
-        "photocopy"
-    ],
-    "y2k": [
-        "dark",
-        "cyber",
-        "metallic",
-        "retro"
-    ],
-    "zen": [
-        "light",
-        "blog",
-        "zen"
-    ],
-    "zenith": [
-        "light",
-        "landing",
-        "minimal",
-        "altitude"
-    ],
-    "zenithpoint": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ]
+  "abstract-noir": [
+    "paper",
+    "dark",
+    "abstract",
+    "bold",
+    "typography"
+  ],
+  "abyss": [
+    "dark",
+    "blog",
+    "deep-sea",
+    "immersive"
+  ],
+  "acid-graphics": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "acme-docs": [
+    "light",
+    "docs"
+  ],
+  "acoustic-soundwaves": [
+    "dark",
+    "blog",
+    "sound",
+    "waveform"
+  ],
+  "adminpanel": [
+    "dark",
+    "dashboard",
+    "admin",
+    "sidebar"
+  ],
+  "aether": [
+    "dark",
+    "blog",
+    "elegant"
+  ],
+  "aetheria": [
+    "dark-mode",
+    "elegant",
+    "portfolio"
+  ],
+  "after-dark": [
+    "blog",
+    "dark",
+    "reading"
+  ],
+  "afterparty": [
+    "event",
+    "party",
+    "nightlife",
+    "club",
+    "late-night"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
+  ],
+  "airwave": [
+    "dark",
+    "blog",
+    "podcast"
+  ],
+  "alexandrite": [
+    "dark",
+    "blog",
+    "glamorous",
+    "gemstone"
+  ],
+  "almanac": [
+    "light",
+    "blog",
+    "calendar"
+  ],
+  "almanac-docs": [
+    "light",
+    "docs",
+    "roadmap"
+  ],
+  "amber-preservation": [
+    "dark",
+    "blog",
+    "amber",
+    "fossil"
+  ],
+  "amethyst": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "anaglyph": [
+    "dark",
+    "blog",
+    "3d",
+    "stereoscopic"
+  ],
+  "analytics": [
+    "light",
+    "dashboard",
+    "analytics"
+  ],
+  "anamorphic": [
+    "dark",
+    "portfolio",
+    "anamorphic",
+    "optical"
+  ],
+  "anatomy-atlas": [
+    "dark",
+    "docs",
+    "medical",
+    "vintage"
+  ],
+  "annotation-layer": [
+    "book",
+    "light",
+    "scholarly",
+    "annotated",
+    "dense"
+  ],
+  "anthology": [
+    "light",
+    "docs",
+    "sdk-reference"
+  ],
+  "antimatter": [
+    "dark",
+    "blog",
+    "experimental",
+    "inverted"
+  ],
+  "anubis": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "anvil": [
+    "dark",
+    "blog",
+    "workshop"
+  ],
+  "apiary": [
+    "light",
+    "docs",
+    "api",
+    "two-column"
+  ],
+  "apolo": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "apothecary": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "appsite": [
+    "light",
+    "landing",
+    "app"
+  ],
+  "aquarium": [
+    "dark",
+    "blog",
+    "marine"
+  ],
+  "aquatint": [
+    "light",
+    "portfolio",
+    "creative",
+    "elegant",
+    "bold"
+  ],
+  "aqueduct": [
+    "light",
+    "blog",
+    "engineering"
+  ],
+  "arbor": [
+    "light",
+    "docs",
+    "git-workflow"
+  ],
+  "archipelago": [
+    "dark",
+    "landing",
+    "hub"
+  ],
+  "archive": [
+    "light",
+    "docs",
+    "archive"
+  ],
+  "archway-docs": [
+    "docs",
+    "light",
+    "architecture"
+  ],
+  "arctic-saas": [
+    "landing",
+    "light",
+    "saas",
+    "minimal"
+  ],
+  "arena": [
+    "dark",
+    "blog",
+    "sports"
+  ],
+  "artdeco": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "artnouveau": [
+    "light",
+    "portfolio",
+    "art-nouveau",
+    "botanical"
+  ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
+  ],
+  "ascii": [
+    "dark",
+    "terminal",
+    "ascii"
+  ],
+  "asymmetric": [
+    "light",
+    "portfolio",
+    "grid",
+    "asymmetric"
+  ],
+  "atelier": [
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "athena": [
+    "elegant",
+    "portfolio",
+    "light"
+  ],
+  "atlas": [
+    "light",
+    "blog",
+    "geography"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
+  ],
+  "aurelia": [
+    "elegant",
+    "minimalist",
+    "blog"
+  ],
+  "aurora": [
+    "dark",
+    "blog",
+    "aurora"
+  ],
+  "aurora-glimmer": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "aurora-launch": [
+    "landing",
+    "dark",
+    "animation"
+  ],
+  "aurum": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "avalanche-event": [
+    "event",
+    "dark",
+    "momentum",
+    "cascading",
+    "overwhelming"
+  ],
+  "axiom": [
+    "light",
+    "design-system",
+    "geometric",
+    "mathematical"
+  ],
+  "bamboo": [
+    "light",
+    "blog",
+    "eco"
+  ],
+  "baroque": [
+    "dark",
+    "blog",
+    "ornamental",
+    "glamorous"
+  ],
+  "bas-relief": [
+    "light",
+    "artistic",
+    "minimal"
+  ],
+  "bastard-title": [
+    "book",
+    "light",
+    "preliminary",
+    "ceremonial",
+    "typography"
+  ],
+  "bastion": [
+    "dark",
+    "docs",
+    "zero-trust"
+  ],
+  "batik": [
+    "light",
+    "blog",
+    "elegant",
+    "batik"
+  ],
+  "bauhaus": [
+    "light",
+    "portfolio",
+    "design",
+    "geometric"
+  ],
+  "bayesian-prior": [
+    "paper",
+    "dark",
+    "bayesian",
+    "probabilistic",
+    "visualization"
+  ],
+  "bazaar": [
+    "light",
+    "landing",
+    "marketplace"
+  ],
+  "beacon": [
+    "dark",
+    "blog",
+    "alert"
+  ],
+  "beacon-docs": [
+    "light",
+    "docs",
+    "feature-flag"
+  ],
+  "beautiful-hwaro": [
+    "light",
+    "blog"
+  ],
+  "bejeweled": [
+    "elegant",
+    "glamorous",
+    "luxury"
+  ],
+  "bell-tower": [
+    "event",
+    "light",
+    "scheduled",
+    "clock",
+    "traditional"
+  ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
+  ],
+  "bijou": [
+    "dark",
+    "elegant",
+    "jewelry",
+    "glamorous"
+  ],
+  "bioluminescence": [
+    "dark",
+    "blog",
+    "bioluminescence",
+    "minimal"
+  ],
+  "bismuth": [
+    "dark",
+    "collection",
+    "mineral",
+    "rainbow-metallic"
+  ],
+  "black-box": [
+    "event",
+    "dark",
+    "theater",
+    "intimate",
+    "minimal"
+  ],
+  "black-letter-bible": [
+    "book",
+    "dark",
+    "sacred",
+    "blackletter",
+    "dense"
+  ],
+  "blacklight": [
+    "dark",
+    "fluorescent",
+    "elegant"
+  ],
+  "blast-furnace": [
+    "event",
+    "dark",
+    "workshop",
+    "intense",
+    "industrial"
+  ],
+  "blockade-run": [
+    "event",
+    "dark",
+    "breakthrough",
+    "barriers",
+    "overcome"
+  ],
+  "blueprint": [
+    "dark",
+    "docs",
+    "spec"
+  ],
+  "blueprint-pro": [
+    "landing",
+    "dark",
+    "devtool"
+  ],
+  "bonfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "bonsai": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "book": [
+    "light",
+    "docs"
+  ],
+  "borealis": [
+    "dark",
+    "blog",
+    "aurora",
+    "nordic"
+  ],
+  "botanical-press": [
+    "blog",
+    "light",
+    "botanical",
+    "vintage"
+  ],
+  "boutique": [
+    "light",
+    "store",
+    "fashion",
+    "elegant"
+  ],
+  "box-office": [
+    "event",
+    "tickets",
+    "sales",
+    "urgency",
+    "countdown"
+  ],
+  "bramble": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "breeze": [
+    "landing",
+    "light",
+    "minimal",
+    "one-page"
+  ],
+  "brocade": [
+    "dark",
+    "blog",
+    "glamorous",
+    "luxury"
+  ],
+  "brutalist": [
+    "light",
+    "blog",
+    "brutalist"
+  ],
+  "brutopia": [
+    "dark",
+    "blog",
+    "brutalist",
+    "monospace"
+  ],
+  "bulwark": [
+    "dark",
+    "docs",
+    "disaster-recovery"
+  ],
+  "bureau": [
+    "light",
+    "docs",
+    "governance"
+  ],
+  "burlesque": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "burnt-charcoal": [
+    "dark",
+    "blog",
+    "charcoal",
+    "texture"
+  ],
+  "butterfly-wing": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "trendy",
+    "blog"
+  ],
+  "byzantine": [
+    "light",
+    "blog",
+    "byzantine",
+    "mosaic",
+    "imperial"
+  ],
+  "cabaret": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "cabin": [
+    "dark",
+    "blog",
+    "lifestyle"
+  ],
+  "cactus": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cafe": [
+    "light",
+    "landing",
+    "menu"
+  ],
+  "cage-match": [
+    "event",
+    "dark",
+    "competition",
+    "fight",
+    "enclosed"
+  ],
+  "call-to-stage": [
+    "event",
+    "talent",
+    "open-call",
+    "audition",
+    "stage"
+  ],
+  "calligraphy": [
+    "dark",
+    "blog",
+    "calligraphy",
+    "ink"
+  ],
+  "cameo": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "campfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "cancel-leaf": [
+    "book",
+    "light",
+    "correction",
+    "repair",
+    "visible"
+  ],
+  "canopy": [
+    "light",
+    "blog",
+    "outdoor"
+  ],
+  "canvas-studio": [
+    "landing",
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "carbon-fiber": [
+    "dark",
+    "blog",
+    "tech"
+  ],
+  "carnival": [
+    "dark",
+    "blog",
+    "glamorous",
+    "event"
+  ],
+  "cartograph": [
+    "dark",
+    "docs",
+    "infrastructure"
+  ],
+  "cascade": [
+    "light",
+    "longform",
+    "waterfall",
+    "scroll-driven"
+  ],
+  "case-report": [
+    "paper",
+    "light",
+    "clinical",
+    "case-study",
+    "medical"
+  ],
+  "cassette": [
+    "dark",
+    "blog",
+    "retro",
+    "audio"
+  ],
+  "catacombs": [
+    "dark",
+    "blog",
+    "underground",
+    "adventure"
+  ],
+  "catalyst": [
+    "light",
+    "landing",
+    "science",
+    "chemistry"
+  ],
+  "cathedral": [
+    "light",
+    "portfolio",
+    "architecture"
+  ],
+  "cauldron": [
+    "dark",
+    "wiki",
+    "fantasy",
+    "potion"
+  ],
+  "celebrate": [
+    "light",
+    "landing",
+    "event"
+  ],
+  "celestial-burst": [
+    "dark",
+    "glamorous",
+    "celestial",
+    "trendy"
+  ],
+  "center-stage": [
+    "event",
+    "solo",
+    "show",
+    "spotlight",
+    "centered"
+  ],
+  "chain-reaction": [
+    "event",
+    "dark",
+    "sequential",
+    "cascade",
+    "connected"
+  ],
+  "chalkboard": [
+    "dark",
+    "blog",
+    "education"
+  ],
+  "champagne": [
+    "light",
+    "luxury",
+    "elegant",
+    "champagne"
+  ],
+  "chandelier": [
+    "light",
+    "blog",
+    "crystal",
+    "elegant",
+    "prismatic"
+  ],
+  "changelog": [
+    "dark",
+    "docs",
+    "changelog"
+  ],
+  "chase-frame": [
+    "book",
+    "dark",
+    "letterpress",
+    "mechanical",
+    "craft"
+  ],
+  "chiaroscuro": [
+    "dark",
+    "portfolio",
+    "chiaroscuro",
+    "contrast"
+  ],
+  "chinoiserie": [
+    "light",
+    "blog",
+    "chinese",
+    "porcelain",
+    "elegant"
+  ],
+  "chromatic": [
+    "dark",
+    "photoblog",
+    "chromatic",
+    "lens"
+  ],
+  "chromatic-wave": [
+    "dark",
+    "portfolio",
+    "glamorous",
+    "animation"
+  ],
+  "chromatophore": [
+    "dark",
+    "bold",
+    "minimal",
+    "creative"
+  ],
+  "chrome-pulse": [
+    "minimal",
+    "dark",
+    "landing"
+  ],
+  "chromolithograph": [
+    "book",
+    "light",
+    "color-plate",
+    "print",
+    "illustration"
+  ],
+  "chronicle": [
+    "light",
+    "blog",
+    "traditional",
+    "serif"
+  ],
+  "chronosphere": [
+    "dark",
+    "space",
+    "time"
+  ],
+  "chrysanthemum": [
+    "dark",
+    "blog",
+    "floral",
+    "glamorous"
+  ],
+  "cinder": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cinema": [
+    "dark",
+    "blog",
+    "review"
+  ],
+  "cinema-silent": [
+    "dark",
+    "blog",
+    "retro",
+    "editorial"
+  ],
+  "cipher": [
+    "dark",
+    "docs",
+    "cryptography"
+  ],
+  "citation-graph": [
+    "paper",
+    "dark",
+    "network",
+    "citations",
+    "visualization"
+  ],
+  "clarity-docs": [
+    "docs",
+    "light",
+    "minimal",
+    "typography"
+  ],
+  "clocktower": [
+    "dark",
+    "landing",
+    "countdown"
+  ],
+  "cloisonne": [
+    "dark",
+    "portfolio",
+    "enamel",
+    "ornate"
+  ],
+  "cloister": [
+    "light",
+    "blog",
+    "meditation"
+  ],
+  "closed": [
+    "light",
+    "error",
+    "499",
+    "minimal"
+  ],
+  "cloudnest": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "cobblestone": [
+    "light",
+    "blog",
+    "culture"
+  ],
+  "cockpit": [
+    "dark",
+    "landing",
+    "telemetry"
+  ],
+  "codebook": [
+    "light",
+    "docs",
+    "styleguide"
+  ],
+  "codecraft": [
+    "api",
+    "dark",
+    "developer",
+    "docs"
+  ],
+  "codex": [
+    "light",
+    "blog",
+    "medieval"
+  ],
+  "codex-rotundus": [
+    "book",
+    "dark",
+    "circular",
+    "unusual",
+    "experimental"
+  ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
+  ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
+  ],
+  "colosseum": [
+    "light",
+    "event",
+    "classical",
+    "grand"
+  ],
+  "comic": [
+    "light",
+    "blog",
+    "comic"
+  ],
+  "command-center": [
+    "docs",
+    "dark",
+    "cli",
+    "developer"
+  ],
+  "compass": [
+    "light",
+    "landing",
+    "career"
+  ],
+  "compass-docs": [
+    "light",
+    "docs",
+    "onboarding"
+  ],
+  "conduit": [
+    "light",
+    "docs",
+    "data-pipeline"
+  ],
+  "conference-poster": [
+    "paper",
+    "dark",
+    "poster",
+    "conference",
+    "visual"
+  ],
+  "confetti": [
+    "celebration",
+    "elegant",
+    "festive"
+  ],
+  "console": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "constellation": [
+    "dark",
+    "blog",
+    "astronomy"
+  ],
+  "controlroom": [
+    "dark",
+    "dashboard",
+    "monitoring"
+  ],
+  "copper-patina": [
+    "dark",
+    "blog",
+    "patina",
+    "industrial"
+  ],
+  "copper-wire": [
+    "blog",
+    "dark",
+    "industrial"
+  ],
+  "copperplate": [
+    "dark",
+    "blog",
+    "copperplate",
+    "engraving"
+  ],
+  "coral": [
+    "light",
+    "documentary",
+    "organic",
+    "ocean"
+  ],
+  "coral-bloom": [
+    "dark",
+    "blog",
+    "elegant",
+    "marine",
+    "glamorous"
+  ],
+  "corrigendum": [
+    "paper",
+    "light",
+    "correction",
+    "errata",
+    "formal"
+  ],
+  "cosmos": [
+    "dark",
+    "magazine",
+    "space",
+    "planetary"
+  ],
+  "cost-effectiveness": [
+    "paper",
+    "light",
+    "economics",
+    "cost-effectiveness",
+    "health"
+  ],
+  "countdown-zero": [
+    "event",
+    "dark",
+    "countdown",
+    "convergence",
+    "climactic"
+  ],
+  "creative-agency": [
+    "dark",
+    "portfolio",
+    "agency",
+    "bold"
+  ],
+  "cross-sectional": [
+    "paper",
+    "light",
+    "cross-sectional",
+    "snapshot",
+    "population"
+  ],
+  "crucible": [
+    "light",
+    "docs",
+    "testing"
+  ],
+  "cruciform": [
+    "light",
+    "design-system",
+    "grid",
+    "swiss"
+  ],
+  "crystalline": [
+    "light",
+    "portfolio",
+    "crystal",
+    "faceted"
+  ],
+  "cuneiform-tablet": [
+    "book",
+    "dark",
+    "ancient",
+    "impressed",
+    "archaeological"
+  ],
+  "curator": [
+    "light",
+    "portfolio",
+    "exhibition"
+  ],
+  "curtain-call": [
+    "event",
+    "dark",
+    "closing",
+    "ceremony",
+    "theatrical"
+  ],
+  "cyanotype": [
+    "light",
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "cyberpunk": [
+    "dark",
+    "magazine",
+    "cyberpunk",
+    "neon"
+  ],
+  "daguerreotype": [
+    "dark",
+    "blog",
+    "photography",
+    "vintage"
+  ],
+  "damask": [
+    "dark",
+    "blog",
+    "luxury",
+    "glamorous"
+  ],
+  "dark-manual": [
+    "docs",
+    "dark",
+    "technical",
+    "manual"
+  ],
+  "darkfolio": [
+    "dark",
+    "portfolio",
+    "developer",
+    "minimal"
+  ],
+  "darkmarket": [
+    "dark",
+    "marketplace",
+    "bold"
+  ],
+  "darkroom": [
+    "dark",
+    "portfolio",
+    "photography"
+  ],
+  "darkwave": [
+    "dark",
+    "blog",
+    "synthwave"
+  ],
+  "dashboard": [
+    "dark",
+    "landing",
+    "dashboard"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
+  ],
+  "deconstructed": [
+    "light",
+    "agency",
+    "deconstructivism",
+    "architecture"
+  ],
+  "deconstructivist": [
+    "dark",
+    "portfolio",
+    "deconstructivist",
+    "architecture"
+  ],
+  "demolition-derby": [
+    "event",
+    "dark",
+    "competition",
+    "destruction",
+    "chaotic"
+  ],
+  "depot": [
+    "light",
+    "landing",
+    "tracker"
+  ],
+  "devconf": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "devlog": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "devtool": [
+    "dark",
+    "landing",
+    "developer"
+  ],
+  "dewdrop": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "diamond-facet": [
+    "dark",
+    "blog",
+    "glamorous",
+    "prismatic"
+  ],
+  "diary": [
+    "light",
+    "blog",
+    "personal",
+    "journal"
+  ],
+  "diorama": [
+    "dark",
+    "landing",
+    "product"
+  ],
+  "disco-fever": [
+    "dark",
+    "blog",
+    "retro",
+    "disco",
+    "neon"
+  ],
+  "dispatch": [
+    "light",
+    "docs",
+    "event-driven"
+  ],
+  "dockhub": [
+    "dark",
+    "docs",
+    "devops"
+  ],
+  "dojo": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "dose-response": [
+    "paper",
+    "light",
+    "pharmacological",
+    "dose-response",
+    "clinical"
+  ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
+  ],
+  "driftwood": [
+    "light",
+    "blog",
+    "photo"
+  ],
+  "dropzone": [
+    "cloud",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "dune": [
+    "light",
+    "journal",
+    "desert",
+    "travel"
+  ],
+  "duodecimo": [
+    "book",
+    "light",
+    "compact",
+    "portable",
+    "efficient"
+  ],
+  "dusk": [
+    "dark",
+    "blog",
+    "sunset"
+  ],
+  "dynamo": [
+    "dark",
+    "docs",
+    "serverless"
+  ],
+  "easel": [
+    "light",
+    "docs",
+    "art"
+  ],
+  "eclipse": [
+    "dark",
+    "blog",
+    "celestial",
+    "dramatic"
+  ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
+  ],
+  "electric-bloom": [
+    "dark",
+    "blog",
+    "glamorous",
+    "neon",
+    "botanical"
+  ],
+  "electroplate": [
+    "dark",
+    "blog",
+    "metallic",
+    "plating"
+  ],
+  "elevate": [
+    "landing",
+    "light",
+    "saas",
+    "enterprise"
+  ],
+  "elysian": [
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "elysium": [
+    "portfolio",
+    "minimal",
+    "dark"
+  ],
+  "elysium-portfolio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "embargo-lift": [
+    "event",
+    "dark",
+    "embargo",
+    "release",
+    "timed"
+  ],
+  "ember": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "embroidery": [
+    "dark",
+    "blog",
+    "glamorous",
+    "trendy"
+  ],
+  "emerald": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "empyrean": [
+    "light",
+    "landing",
+    "divine",
+    "ethereal"
+  ],
+  "encaustic": [
+    "light",
+    "blog",
+    "art",
+    "painting"
+  ],
+  "encore": [
+    "event",
+    "dark",
+    "repeat",
+    "popular",
+    "demanded"
+  ],
+  "encore-night": [
+    "event",
+    "concert",
+    "farewell",
+    "encore",
+    "emotional"
+  ],
+  "endpaper": [
+    "book",
+    "dark",
+    "decorative",
+    "pattern",
+    "hidden"
+  ],
+  "enigma": [
+    "dark",
+    "puzzle",
+    "cryptography",
+    "mechanical"
+  ],
+  "entropy": [
+    "dual",
+    "magazine",
+    "experimental",
+    "asymmetric"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
+  ],
+  "etching": [
+    "dark",
+    "blog",
+    "etching",
+    "printmaking"
+  ],
+  "ethereal-canvas": [
+    "blog",
+    "dark",
+    "elegant",
+    "minimal",
+    "portfolio"
+  ],
+  "ethereal-vapor": [
+    "light",
+    "blog",
+    "ethereal",
+    "translucent"
+  ],
+  "ethos": [
+    "light",
+    "docs",
+    "culture"
+  ],
+  "even": [
+    "light",
+    "blog"
+  ],
+  "evergreen-docs": [
+    "docs",
+    "light",
+    "enterprise",
+    "classic"
+  ],
+  "experiment-log": [
+    "paper",
+    "dark",
+    "experimental",
+    "sequential",
+    "iterative"
+  ],
+  "faberge": [
+    "light",
+    "blog",
+    "luxury",
+    "jeweled",
+    "ornate"
+  ],
+  "faq": [
+    "light",
+    "docs",
+    "faq"
+  ],
+  "fascicle": [
+    "book",
+    "light",
+    "serial",
+    "unbound",
+    "installment"
+  ],
+  "fault-siren": [
+    "event",
+    "dark",
+    "warning",
+    "preparedness",
+    "civil-defense"
+  ],
+  "fauvist-wild": [
+    "dark",
+    "blog",
+    "fauvist",
+    "colorful"
+  ],
+  "ferrofluid": [
+    "dark",
+    "blog",
+    "ferrofluid",
+    "magnetic"
+  ],
+  "festival": [
+    "dark",
+    "event",
+    "elegant",
+    "glow",
+    "bold"
+  ],
+  "festival-ground": [
+    "event",
+    "festival",
+    "outdoor",
+    "grounds",
+    "map"
+  ],
+  "field-report": [
+    "paper",
+    "dark",
+    "field",
+    "expedition",
+    "rugged"
+  ],
+  "fiesta": [
+    "light",
+    "blog",
+    "colorful",
+    "celebration"
+  ],
+  "filigree": [
+    "dark",
+    "blog",
+    "filigree",
+    "metalwork"
+  ],
+  "fintech-pulse": [
+    "landing",
+    "dark",
+    "fintech",
+    "data-viz"
+  ],
+  "fireside": [
+    "dark",
+    "blog",
+    "book-review"
+  ],
+  "fireworks": [
+    "dark",
+    "elegant",
+    "animation",
+    "glow"
+  ],
+  "firing-range": [
+    "event",
+    "dark",
+    "precision",
+    "target",
+    "competitive"
+  ],
+  "fjord": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "flamingo": [
+    "light",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "flowsync": [
+    "dark",
+    "landing"
+  ],
+  "fluorescent": [
+    "dark",
+    "blog",
+    "neon",
+    "pop-art"
+  ],
+  "folio": [
+    "light",
+    "portfolio"
+  ],
+  "folio-docs": [
+    "light",
+    "docs",
+    "design-system"
+  ],
+  "folio-gigante": [
+    "book",
+    "dark",
+    "oversized",
+    "monumental",
+    "maximal"
+  ],
+  "forge": [
+    "light",
+    "docs",
+    "opensource"
+  ],
+  "formulary": [
+    "light",
+    "docs",
+    "math"
+  ],
+  "forty": [
+    "dark",
+    "portfolio",
+    "gallery"
+  ],
+  "foundry": [
+    "dark",
+    "blog",
+    "maker"
+  ],
+  "foxhole": [
+    "dark",
+    "blog",
+    "security"
+  ],
+  "fractal": [
+    "dark",
+    "gallery",
+    "generative",
+    "mathematical"
+  ],
+  "frequency": [
+    "dark",
+    "blog",
+    "radio"
+  ],
+  "frottage": [
+    "light",
+    "minimal",
+    "art",
+    "clean"
+  ],
+  "frutiger-aero": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "furnace": [
+    "dark",
+    "docs",
+    "performance"
+  ],
+  "gala": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "garden": [
+    "light",
+    "blog",
+    "garden"
+  ],
+  "garnet": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "garrison": [
+    "dark",
+    "docs",
+    "firewall"
+  ],
+  "gateway": [
+    "dark",
+    "docs",
+    "auth"
+  ],
+  "gauntlet-run": [
+    "event",
+    "dark",
+    "endurance",
+    "challenge",
+    "sequential"
+  ],
+  "gazebo": [
+    "light",
+    "blog",
+    "event"
+  ],
+  "gazette": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "generative-art": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "glamorous"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
+  ],
+  "geodesic": [
+    "light",
+    "landing",
+    "geometric"
+  ],
+  "gilded": [
+    "dark",
+    "blog",
+    "luxury",
+    "gold"
+  ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
+  ],
+  "glacial-blog": [
+    "blog",
+    "light",
+    "cool",
+    "minimal"
+  ],
+  "glacial-ice": [
+    "dark",
+    "blog",
+    "ice",
+    "frost"
+  ],
+  "glacier": [
+    "light",
+    "blog",
+    "tech"
+  ],
+  "glam-rock": [
+    "dark",
+    "blog",
+    "rock",
+    "glam",
+    "metallic"
+  ],
+  "glassmorphism": [
+    "dark",
+    "blog",
+    "glassmorphism"
+  ],
+  "glitch": [
+    "dark",
+    "blog",
+    "experimental",
+    "glitch-art"
+  ],
+  "glitch-elegance": [
+    "dark",
+    "blog",
+    "glitch",
+    "elegant"
+  ],
+  "glow-reef": [
+    "dark",
+    "blog",
+    "elegant",
+    "neon"
+  ],
+  "glyphic": [
+    "dark",
+    "blog",
+    "glyph",
+    "carved"
+  ],
+  "gong-show": [
+    "event",
+    "dark",
+    "competition",
+    "judgment",
+    "dramatic"
+  ],
+  "gossamer": [
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "gothic": [
+    "dark",
+    "blog",
+    "gothic",
+    "medieval"
+  ],
+  "gradient-mesh": [
+    "dark",
+    "blog",
+    "gradient"
+  ],
+  "graffiti": [
+    "dark",
+    "blog",
+    "street-art",
+    "urban"
+  ],
+  "grand-finale": [
+    "event",
+    "festival",
+    "finale",
+    "closing",
+    "spectacular"
+  ],
+  "grant-proposal": [
+    "paper",
+    "light",
+    "proposal",
+    "funding",
+    "persuasive"
+  ],
+  "graphite-docs": [
+    "docs",
+    "dark",
+    "technical"
+  ],
+  "greenhouse": [
+    "light",
+    "blog",
+    "plant"
+  ],
+  "grisaille": [
+    "dark",
+    "blog",
+    "minimal",
+    "monochrome"
+  ],
+  "ground-zero": [
+    "event",
+    "dark",
+    "origin",
+    "impact",
+    "transformative"
+  ],
+  "guidebook": [
+    "light",
+    "docs",
+    "guide"
+  ],
+  "gunmetal": [
+    "dark",
+    "elegant",
+    "industrial",
+    "metallic"
+  ],
+  "gyroscope": [
+    "dark",
+    "dashboard",
+    "motion-sensor",
+    "3d-rotation"
+  ],
+  "habitat": [
+    "light",
+    "landing",
+    "listing"
+  ],
+  "hacker": [
+    "dark",
+    "blog"
+  ],
+  "hall-of-voices": [
+    "event",
+    "poetry",
+    "spoken-word",
+    "slam",
+    "voices"
+  ],
+  "hammer-drop": [
+    "event",
+    "light",
+    "auction",
+    "bidding",
+    "final"
+  ],
+  "hammock": [
+    "light",
+    "blog",
+    "slowlife"
+  ],
+  "handbook": [
+    "light",
+    "docs",
+    "corporate"
+  ],
+  "hangar": [
+    "dark",
+    "blog",
+    "aviation"
+  ],
+  "hardcore-pit": [
+    "event",
+    "punk",
+    "hardcore",
+    "show",
+    "chaotic"
+  ],
+  "haute-couture": [
+    "elegant",
+    "fashion",
+    "magazine"
+  ],
+  "headliner-bold": [
+    "event",
+    "festival",
+    "lineup",
+    "headliner",
+    "hierarchy"
+  ],
+  "hearth": [
+    "light",
+    "blog",
+    "traditional",
+    "elegant"
+  ],
+  "heavy-curtain": [
+    "event",
+    "theater",
+    "drama",
+    "production",
+    "heavy"
+  ],
+  "heliograph": [
+    "dark",
+    "blog",
+    "heliograph",
+    "sun-print"
+  ],
+  "helix": [
+    "light",
+    "landing",
+    "biotech",
+    "3d"
+  ],
+  "helix-docs": [
+    "docs",
+    "light",
+    "science"
+  ],
+  "herald": [
+    "light",
+    "magazine",
+    "editorial",
+    "news"
+  ],
+  "hermit": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "hibiscus": [
+    "dark",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "hologram": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "holographic": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "horizon-ai": [
+    "landing",
+    "dark",
+    "ai",
+    "futuristic"
+  ],
+  "house-lights": [
+    "event",
+    "venue",
+    "concert",
+    "lighting",
+    "technical"
+  ],
+  "hwaro.386": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "hwaronight": [
+    "dark",
+    "blog"
+  ],
+  "hypercube": [
+    "dark",
+    "docs",
+    "3d",
+    "wireframe"
+  ],
+  "hyperpop": [
+    "dark",
+    "glamorous",
+    "neon",
+    "trendy",
+    "elegant"
+  ],
+  "igloo": [
+    "light",
+    "blog",
+    "nordic"
+  ],
+  "ignite": [
+    "landing",
+    "dark",
+    "startup"
+  ],
+  "ignition-sequence": [
+    "event",
+    "dark",
+    "phased",
+    "launch",
+    "sequential"
+  ],
+  "impasto": [
+    "light",
+    "blog",
+    "bold",
+    "artistic"
+  ],
+  "incunabula-noir": [
+    "book",
+    "dark",
+    "incunabulum",
+    "early-print",
+    "revolutionary"
+  ],
+  "inferno": [
+    "dark",
+    "community",
+    "fire",
+    "gaming"
+  ],
+  "infographic": [
+    "light",
+    "landing",
+    "infographic",
+    "data-viz"
+  ],
+  "ink-seoul": [
+    "light",
+    "blog",
+    "monochrome",
+    "seoul",
+    "minimal"
+  ],
+  "inkdrop-docs": [
+    "docs",
+    "dark",
+    "elegant",
+    "animation"
+  ],
+  "inkwell": [
+    "light",
+    "blog",
+    "poetry"
+  ],
+  "intaglio": [
+    "dark",
+    "portfolio",
+    "engraving",
+    "minimal"
+  ],
+  "intarsia": [
+    "light",
+    "portfolio",
+    "bold",
+    "clean",
+    "geometric"
+  ],
+  "interferogram": [
+    "dark",
+    "blog",
+    "interference",
+    "optical"
+  ],
+  "inventory": [
+    "light",
+    "dashboard",
+    "management"
+  ],
+  "iridescent-oil": [
+    "dark",
+    "blog",
+    "iridescent",
+    "oil"
+  ],
+  "iron-stage": [
+    "event",
+    "festival",
+    "metal",
+    "industrial",
+    "heavy"
+  ],
+  "ironclad": [
+    "dark",
+    "landing",
+    "metallic",
+    "security"
+  ],
+  "ironworks": [
+    "dark",
+    "blog",
+    "history"
+  ],
+  "isometric": [
+    "light",
+    "3d",
+    "dashboard",
+    "ui"
+  ],
+  "isthmus": [
+    "light",
+    "hub",
+    "bridge",
+    "horizontal-scroll"
+  ],
+  "jade-palace": [
+    "dark",
+    "blog",
+    "luxury",
+    "eastern"
+  ],
+  "japanese-industrial": [
+    "dark",
+    "blog",
+    "japanese",
+    "industrial"
+  ],
+  "jewel-tone": [
+    "dark",
+    "glamorous",
+    "jewel",
+    "elegant"
+  ],
+  "jugendstil": [
+    "light",
+    "blog",
+    "art-nouveau",
+    "organic",
+    "nature"
+  ],
+  "kaleidoscope": [
+    "light",
+    "event",
+    "psychedelic",
+    "pattern"
+  ],
+  "ketubah": [
+    "book",
+    "light",
+    "ceremonial",
+    "decorated",
+    "formal"
+  ],
+  "keynote-blast": [
+    "event",
+    "dark",
+    "conference",
+    "keynote",
+    "explosive"
+  ],
+  "keystone": [
+    "light",
+    "docs",
+    "architecture"
+  ],
+  "kiln": [
+    "light",
+    "portfolio",
+    "craft"
+  ],
+  "kinetic": [
+    "dark",
+    "agency",
+    "physics",
+    "interactive"
+  ],
+  "kinetic-mobile": [
+    "dark",
+    "blog",
+    "kinetic",
+    "mobile"
+  ],
+  "kinetic-typography": [
+    "dark",
+    "blog",
+    "kinetic",
+    "typography"
+  ],
+  "kintsugi": [
+    "dark",
+    "blog",
+    "kintsugi",
+    "gold-repair"
+  ],
+  "lab": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
+  ],
+  "labyrinth": [
+    "dark",
+    "portfolio",
+    "maze",
+    "gamification"
+  ],
+  "lagoon": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "laser-show": [
+    "dark",
+    "blog",
+    "landing",
+    "concert",
+    "glamorous"
+  ],
+  "last-call": [
+    "event",
+    "dark",
+    "closing",
+    "final",
+    "urgent"
+  ],
+  "lattice": [
+    "light",
+    "docs",
+    "graph-db"
+  ],
+  "launchpad": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "launchpad-event": [
+    "event",
+    "dark",
+    "launch",
+    "space",
+    "countdown"
+  ],
+  "lava-flow": [
+    "dark",
+    "blog",
+    "lava",
+    "volcanic"
+  ],
+  "layered-docs": [
+    "light",
+    "docs",
+    "enterprise"
+  ],
+  "ledger": [
+    "light",
+    "docs",
+    "finance"
+  ],
+  "letter-to-editor": [
+    "paper",
+    "light",
+    "correspondence",
+    "urgent",
+    "brief"
+  ],
+  "letterbox": [
+    "light",
+    "blog",
+    "newsletter"
+  ],
+  "lexicon": [
+    "light",
+    "docs",
+    "glossary"
+  ],
+  "lichen-moss": [
+    "dark",
+    "blog",
+    "lichen",
+    "organic"
+  ],
+  "lighthouse": [
+    "light",
+    "docs",
+    "directory"
+  ],
+  "linktree": [
+    "dark",
+    "landing",
+    "links"
+  ],
+  "linocut": [
+    "light",
+    "printmaking",
+    "bold",
+    "creative"
+  ],
+  "liquid": [
+    "dark",
+    "interactive",
+    "gooey",
+    "svg"
+  ],
+  "liquid-chrome": [
+    "dark",
+    "blog",
+    "metallic",
+    "glamorous"
+  ],
+  "lithium": [
+    "dark",
+    "landing",
+    "electric",
+    "tech"
+  ],
+  "lithograph": [
+    "dark",
+    "blog",
+    "lithograph",
+    "printmaking"
+  ],
+  "logbook": [
+    "light",
+    "docs",
+    "compliance"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
+  ],
+  "lookbook": [
+    "dark",
+    "portfolio",
+    "lookbook",
+    "fashion"
+  ],
+  "loom": [
+    "light",
+    "portfolio",
+    "fashion"
+  ],
+  "lumiere": [
+    "dark",
+    "elegant",
+    "minimal",
+    "luminescent"
+  ],
+  "lumina": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "luminary": [
+    "light",
+    "elegant",
+    "portfolio"
+  ],
+  "luminescent-mesh": [
+    "dark",
+    "blog",
+    "luminescent",
+    "mesh"
+  ],
+  "lumos": [
+    "blog",
+    "elegant",
+    "light",
+    "minimal"
+  ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
+  "lunar-breeze": [
+    "dark",
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "luxe-noir": [
+    "dark",
+    "glamorous",
+    "luxury",
+    "elegant"
+  ],
+  "luxury-horology": [
+    "dark",
+    "portfolio",
+    "horology",
+    "luxury"
+  ],
+  "macro-snowflake": [
+    "dark",
+    "blog",
+    "snowflake",
+    "crystalline"
+  ],
+  "madhubani": [
+    "light",
+    "blog",
+    "indian",
+    "folk-art",
+    "geometric"
+  ],
+  "magenta-sunset": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "magma": [
+    "dark",
+    "dashboard",
+    "volcanic",
+    "animation"
+  ],
+  "magnetar": [
+    "dark",
+    "blog",
+    "magnetar",
+    "cosmic"
+  ],
+  "main-act": [
+    "event",
+    "concert",
+    "headline",
+    "performer",
+    "dramatic"
+  ],
+  "mainstage": [
+    "event",
+    "dark",
+    "performance",
+    "stage",
+    "dramatic"
+  ],
+  "manifesto": [
+    "dark",
+    "blog",
+    "opinion"
+  ],
+  "manifold": [
+    "light",
+    "docs",
+    "saas"
+  ],
+  "marble": [
+    "light",
+    "gallery",
+    "luxury",
+    "marble-texture"
+  ],
+  "marbled-paper": [
+    "dark",
+    "blog",
+    "marbled",
+    "paper"
+  ],
+  "mardi-gras": [
+    "glamorous",
+    "trendy",
+    "bold",
+    "purple",
+    "gold",
+    "green"
+  ],
+  "marketplace": [
+    "light",
+    "store",
+    "marketplace"
+  ],
+  "marquetry": [
+    "light",
+    "portfolio",
+    "geometric",
+    "minimal"
+  ],
+  "masquerade": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "luxury",
+    "mystery"
+  ],
+  "matcha": [
+    "blog",
+    "light",
+    "minimal",
+    "zen"
+  ],
+  "matrix": [
+    "light",
+    "docs",
+    "compatibility"
+  ],
+  "maximal-bloom": [
+    "elegant",
+    "floral",
+    "bold",
+    "glamorous"
+  ],
+  "maximalist": [
+    "dark",
+    "blog",
+    "bold",
+    "glamorous"
+  ],
+  "mayan-geometry": [
+    "dark",
+    "blog",
+    "mayan",
+    "geometric"
+  ],
+  "meadow": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "medieval-manuscript": [
+    "dark",
+    "blog",
+    "medieval",
+    "manuscript"
+  ],
+  "memoir": [
+    "light",
+    "blog",
+    "longform"
+  ],
+  "memphis": [
+    "light",
+    "retro",
+    "colorful",
+    "bold",
+    "portfolio"
+  ],
+  "mercury": [
+    "dark",
+    "blog",
+    "minimal",
+    "metallic",
+    "elegant"
+  ],
+  "meridian": [
+    "dark",
+    "landing",
+    "timezone"
+  ],
+  "meridian-docs": [
+    "light",
+    "docs",
+    "scheduling"
+  ],
+  "meridiem": [
+    "dual",
+    "dashboard",
+    "time-based",
+    "auto-theme"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
+  ],
+  "meteor": [
+    "dark",
+    "interactive",
+    "meteor-shower",
+    "cosmic"
+  ],
+  "methods-paper": [
+    "paper",
+    "light",
+    "methods",
+    "protocol",
+    "technical"
+  ],
+  "metronome": [
+    "dark",
+    "blog",
+    "music-production",
+    "rhythm"
+  ],
+  "mezzotint": [
+    "light",
+    "blog",
+    "bold",
+    "clean",
+    "monochrome"
+  ],
+  "micro": [
+    "light",
+    "blog",
+    "microblog"
+  ],
+  "midnight-blog": [
+    "dark",
+    "blog",
+    "reading"
+  ],
+  "midnight-launch": [
+    "landing",
+    "dark",
+    "animation",
+    "product"
+  ],
+  "migration": [
+    "light",
+    "docs",
+    "database"
+  ],
+  "minifolio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "minimalzen": [
+    "light",
+    "blog",
+    "minimal",
+    "zen"
+  ],
+  "mint-fresh": [
+    "landing",
+    "light",
+    "saas"
+  ],
+  "mirage": [
+    "light",
+    "gallery",
+    "desert",
+    "distortion"
+  ],
+  "misprint": [
+    "book",
+    "dark",
+    "error",
+    "accidental",
+    "artistic"
+  ],
+  "mixed-methods": [
+    "paper",
+    "light",
+    "mixed-methods",
+    "convergent",
+    "dual"
+  ],
+  "modern-blog": [
+    "dark",
+    "blog",
+    "modern"
+  ],
+  "molten": [
+    "dark",
+    "blog",
+    "metalwork",
+    "melting"
+  ],
+  "molten-gold": [
+    "elegant",
+    "gold",
+    "trendy"
+  ],
+  "monochrome": [
+    "light",
+    "photo-essay",
+    "monochrome",
+    "grayscale"
+  ],
+  "monograph": [
+    "book",
+    "light",
+    "academic",
+    "thorough",
+    "reference"
+  ],
+  "monolith": [
+    "dark",
+    "landing",
+    "onepage"
+  ],
+  "monolithic-dark": [
+    "dark",
+    "blog",
+    "monolithic",
+    "bold"
+  ],
+  "monoprint": [
+    "light",
+    "monoprint",
+    "bold",
+    "creative"
+  ],
+  "monorepo-docs": [
+    "docs",
+    "dark",
+    "developer",
+    "monorepo"
+  ],
+  "moonrise": [
+    "dark",
+    "blog",
+    "essay"
+  ],
+  "moonstone": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "moroccan-zellige": [
+    "light",
+    "blog",
+    "moroccan",
+    "mosaic",
+    "geometric"
+  ],
+  "morphogenesis": [
+    "dark",
+    "blog",
+    "generative",
+    "biology",
+    "patterns"
+  ],
+  "mortar": [
+    "dark",
+    "docs",
+    "build-system"
+  ],
+  "mosaic": [
+    "light",
+    "blog",
+    "magazine"
+  ],
+  "mosh-pit": [
+    "event",
+    "dark",
+    "punk",
+    "chaotic",
+    "raw"
+  ],
+  "mosstown": [
+    "light",
+    "blog",
+    "cozy"
+  ],
+  "mughal": [
+    "light",
+    "blog",
+    "mughal",
+    "ornate",
+    "gold"
+  ],
+  "murano-glass": [
+    "light",
+    "blog",
+    "glass",
+    "translucent",
+    "venetian"
+  ],
+  "mycelium": [
+    "dark",
+    "blog",
+    "mycelium",
+    "fungal"
+  ],
+  "nadir": [
+    "dark",
+    "blog",
+    "minimal",
+    "oled-black"
+  ],
+  "nautical": [
+    "dark",
+    "blog",
+    "nautical"
+  ],
+  "nebula": [
+    "dark",
+    "gallery",
+    "space",
+    "ethereal"
+  ],
+  "neo-deco": [
+    "dark",
+    "portfolio",
+    "artdeco",
+    "elegant"
+  ],
+  "neo-memphis-dark": [
+    "dark",
+    "blog",
+    "memphis",
+    "neo-memphis"
+  ],
+  "neobrutal": [
+    "light",
+    "landing",
+    "neo-brutalism",
+    "bold"
+  ],
+  "neoclassical": [
+    "light",
+    "gallery",
+    "marble-texture",
+    "elegant"
+  ],
+  "neon": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "neon-jungle": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "neon"
+  ],
+  "neon-marquee": [
+    "event",
+    "theater",
+    "marquee",
+    "vintage",
+    "retro"
+  ],
+  "neon-tokyo": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "tokyo",
+    "glamorous"
+  ],
+  "network-meta": [
+    "paper",
+    "dark",
+    "network",
+    "meta-analysis",
+    "comparative"
+  ],
+  "neumorphism": [
+    "light",
+    "ui",
+    "soft",
+    "shadow"
+  ],
+  "neural-bloom": [
+    "dark",
+    "blog",
+    "neural",
+    "ai",
+    "synaptic"
+  ],
+  "newspaper": [
+    "light",
+    "blog",
+    "editorial",
+    "newspaper"
+  ],
+  "nexus": [
+    "dark",
+    "docs",
+    "microservice"
+  ],
+  "nexus-docs": [
+    "docs",
+    "dark",
+    "developer"
+  ],
+  "niello": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "no-style-please": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "noctis": [
+    "landing",
+    "dark",
+    "glassmorphism",
+    "neon"
+  ],
+  "nocturne": [
+    "dark",
+    "blog",
+    "classical-music",
+    "piano"
+  ],
+  "noir": [
+    "dark",
+    "blog",
+    "noir"
+  ],
+  "northern-lights": [
+    "dark",
+    "blog",
+    "aurora",
+    "arctic",
+    "atmospheric"
+  ],
+  "notebook": [
+    "light",
+    "blog",
+    "journal"
+  ],
+  "null-result": [
+    "paper",
+    "light",
+    "null",
+    "negative",
+    "honest"
+  ],
+  "oasis": [
+    "light",
+    "blog",
+    "relaxation"
+  ],
+  "obelisk": [
+    "light",
+    "one-page",
+    "monumental",
+    "vertical"
+  ],
+  "oblique": [
+    "light",
+    "blog",
+    "bold",
+    "angular"
+  ],
+  "oblong-quarto": [
+    "book",
+    "light",
+    "landscape",
+    "panoramic",
+    "unusual"
+  ],
+  "observatory": [
+    "dark",
+    "blog",
+    "space"
+  ],
+  "obsidian": [
+    "dark",
+    "wiki",
+    "glass",
+    "oled"
+  ],
+  "obsidian-docs": [
+    "docs",
+    "dark",
+    "wiki",
+    "knowledge"
+  ],
+  "obsidian-mirror": [
+    "dark",
+    "blog",
+    "obsidian",
+    "reflective"
+  ],
+  "old-map-cartography": [
+    "dark",
+    "blog",
+    "cartography",
+    "vintage"
+  ],
+  "onyx": [
+    "landing",
+    "dark",
+    "minimal",
+    "luxury"
+  ],
+  "op-art": [
+    "dark",
+    "blog",
+    "geometric",
+    "optical-illusion"
+  ],
+  "opalescent": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "opening-act": [
+    "event",
+    "opening",
+    "season",
+    "premiere",
+    "fresh"
+  ],
+  "opening-night": [
+    "event",
+    "dark",
+    "premiere",
+    "formal",
+    "electric"
+  ],
+  "opulent": [
+    "light",
+    "elegant",
+    "luxury",
+    "portfolio",
+    "bold"
+  ],
+  "orchard": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "orchid": [
+    "dark",
+    "blog",
+    "glamorous",
+    "botanical"
+  ],
+  "origami": [
+    "light",
+    "blog",
+    "material"
+  ],
+  "oscilloscope": [
+    "dark",
+    "blog",
+    "oscilloscope",
+    "retro"
+  ],
+  "overture": [
+    "event",
+    "dark",
+    "opening",
+    "orchestral",
+    "grand"
+  ],
+  "oxidation": [
+    "dark",
+    "blog",
+    "oxidation",
+    "rust"
+  ],
+  "oxide": [
+    "dark",
+    "gallery",
+    "industrial",
+    "rust-texture"
+  ],
+  "pagoda": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "palette": [
+    "light",
+    "docs",
+    "design"
+  ],
+  "palimpsest-noir": [
+    "book",
+    "dark",
+    "layered",
+    "erased",
+    "ghostly"
+  ],
+  "panopticon": [
+    "dark",
+    "brutalist",
+    "radial",
+    "experimental"
+  ],
+  "pantry": [
+    "light",
+    "docs",
+    "package-manager"
+  ],
+  "paper": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "paper-art": [
+    "light",
+    "blog",
+    "paper",
+    "collage"
+  ],
+  "papermod": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "parallax": [
+    "light",
+    "storytelling",
+    "parallax",
+    "cinematic"
+  ],
+  "parallax-heavy": [
+    "dark",
+    "landing",
+    "gallery",
+    "parallax"
+  ],
+  "parchment": [
+    "light",
+    "docs",
+    "fantasy"
+  ],
+  "parquetry": [
+    "dark",
+    "blog",
+    "parquetry",
+    "woodwork"
+  ],
+  "particle-storm": [
+    "dark",
+    "blog",
+    "neon",
+    "particles",
+    "energy"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
+  ],
+  "patina": [
+    "dark",
+    "blog",
+    "minimal",
+    "craft"
+  ],
+  "peacock": [
+    "elegant",
+    "glamorous",
+    "portfolio"
+  ],
+  "pearlescent": [
+    "light",
+    "blog",
+    "iridescent",
+    "luxury",
+    "soft"
+  ],
+  "peer-review": [
+    "paper",
+    "light",
+    "academic",
+    "review",
+    "transparent"
+  ],
+  "pendulum": [
+    "dark",
+    "blog",
+    "productivity"
+  ],
+  "pentimento": [
+    "light",
+    "portfolio",
+    "elegant",
+    "bold",
+    "clean"
+  ],
+  "permafrost": [
+    "light",
+    "archive",
+    "ice",
+    "frozen"
+  ],
+  "persian-carpet": [
+    "light",
+    "blog",
+    "persian",
+    "carpet",
+    "ornate"
+  ],
+  "perspective-piece": [
+    "paper",
+    "dark",
+    "opinion",
+    "viewpoint",
+    "argumentative"
+  ],
+  "petrified-wood": [
+    "dark",
+    "blog",
+    "fossil",
+    "wood"
+  ],
+  "phantom": [
+    "dark",
+    "blog",
+    "ghost",
+    "translucent"
+  ],
+  "phosphor": [
+    "dark",
+    "gallery",
+    "bioluminescence",
+    "glow"
+  ],
+  "photoblog": [
+    "dark",
+    "blog",
+    "photography",
+    "gallery"
+  ],
+  "photon": [
+    "dark",
+    "elegant",
+    "luminescent",
+    "portfolio"
+  ],
+  "pietra-dura": [
+    "dark",
+    "creative",
+    "bold",
+    "stone"
+  ],
+  "pinecone": [
+    "dark",
+    "blog",
+    "nature"
+  ],
+  "pipeline": [
+    "light",
+    "docs",
+    "cicd"
+  ],
+  "pit-stop": [
+    "event",
+    "dark",
+    "motorsport",
+    "speed",
+    "frantic"
+  ],
+  "pixel": [
+    "dark",
+    "blog",
+    "gaming"
+  ],
+  "plasma": [
+    "dark",
+    "science",
+    "plasma",
+    "visualization"
+  ],
+  "platinum": [
+    "light",
+    "minimal",
+    "luxury",
+    "portfolio"
+  ],
+  "playlist": [
+    "dark",
+    "blog",
+    "music"
+  ],
+  "podcast-fm": [
+    "dark",
+    "media",
+    "podcast"
+  ],
+  "podium-rush": [
+    "event",
+    "competition",
+    "awards",
+    "victory",
+    "podium"
+  ],
+  "pointillism": [
+    "dark",
+    "blog",
+    "pointillism",
+    "dots"
+  ],
+  "poison": [
+    "dark",
+    "blog",
+    "sidebar"
+  ],
+  "polaris": [
+    "dark",
+    "guide",
+    "astronomy",
+    "constellation"
+  ],
+  "polaroid": [
+    "light",
+    "blog",
+    "gallery"
+  ],
+  "pop-surreal": [
+    "dark",
+    "glamorous",
+    "elegant",
+    "surreal",
+    "trendy"
+  ],
+  "pop-up-page": [
+    "book",
+    "light",
+    "dimensional",
+    "paper-engineering",
+    "interactive"
+  ],
+  "portfolio-blog": [
+    "dark",
+    "blog",
+    "portfolio"
+  ],
+  "portico": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
+  ],
+  "postcard": [
+    "light",
+    "blog",
+    "postcard"
+  ],
+  "powder-burn": [
+    "event",
+    "dark",
+    "rapid-fire",
+    "flash",
+    "quick"
+  ],
+  "prairie": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "preprint-rush": [
+    "paper",
+    "light",
+    "preprint",
+    "urgent",
+    "draft"
+  ],
+  "pressure-cooker": [
+    "event",
+    "dark",
+    "hackathon",
+    "pressure",
+    "deadline"
+  ],
+  "pricetable": [
+    "light",
+    "landing",
+    "saas",
+    "pricing"
+  ],
+  "primer": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "printer-devil": [
+    "book",
+    "dark",
+    "error",
+    "playful",
+    "craft"
+  ],
+  "prism": [
+    "dark",
+    "docs",
+    "data"
+  ],
+  "prism-docs": [
+    "docs",
+    "light",
+    "colorful"
+  ],
+  "prism-refraction": [
+    "dark",
+    "blog",
+    "prism",
+    "refraction"
+  ],
+  "prismify": [
+    "glassmorphism",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "proof-sheet": [
+    "book",
+    "light",
+    "proof",
+    "unfinished",
+    "editorial"
+  ],
+  "protocol": [
+    "dark",
+    "docs",
+    "networking"
+  ],
+  "protocol-paper": [
+    "paper",
+    "light",
+    "protocol",
+    "pre-registration",
+    "rigorous"
+  ],
+  "psychedelic": [
+    "dark",
+    "minimal",
+    "elegant",
+    "glamorous"
+  ],
+  "pulp-fiction": [
+    "book",
+    "dark",
+    "pulp",
+    "lurid",
+    "cheap"
+  ],
+  "pulsar": [
+    "dark",
+    "blog",
+    "cosmic",
+    "pulse-animation"
+  ],
+  "pulse-api": [
+    "dark",
+    "docs"
+  ],
+  "pyrite": [
+    "dark",
+    "showcase",
+    "metallic",
+    "luxury"
+  ],
+  "pyrotechnic": [
+    "event",
+    "show",
+    "pyrotechnics",
+    "fireworks",
+    "explosive"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
+  ],
+  "quantum": [
+    "dark",
+    "blog",
+    "quantum",
+    "science"
+  ],
+  "quarry": [
+    "dark",
+    "docs",
+    "data-warehouse"
+  ],
+  "quasar": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
+  "radiolaria": [
+    "dark",
+    "blog",
+    "radiolaria",
+    "skeletal"
+  ],
+  "rainbow-cascade": [
+    "elegant",
+    "glowing",
+    "box-shadow"
+  ],
+  "ramble": [
+    "light",
+    "blog",
+    "hiking"
+  ],
+  "randomized-trial": [
+    "paper",
+    "light",
+    "rct",
+    "clinical-trial",
+    "rigorous"
+  ],
+  "rave": [
+    "dark",
+    "blog",
+    "acid",
+    "rave",
+    "neon"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
+  ],
+  "reactor": [
+    "dark",
+    "docs",
+    "reactive"
+  ],
+  "realty": [
+    "light",
+    "realestate",
+    "luxury",
+    "elegant"
+  ],
+  "recipe": [
+    "light",
+    "blog",
+    "recipe"
+  ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
+  ],
+  "red-carpet": [
+    "event",
+    "premiere",
+    "celebrity",
+    "glamour",
+    "fashion"
+  ],
+  "reef": [
+    "dark",
+    "blog",
+    "diving"
+  ],
+  "relay": [
+    "light",
+    "docs",
+    "integration"
+  ],
+  "remainder-bin": [
+    "book",
+    "light",
+    "secondhand",
+    "discount",
+    "worn"
+  ],
+  "remedy": [
+    "light",
+    "docs",
+    "troubleshooting"
+  ],
+  "renaissance": [
+    "light",
+    "art",
+    "classic",
+    "serif",
+    "elegant"
+  ],
+  "repousse": [
+    "dark",
+    "blog",
+    "repousse",
+    "metalwork"
+  ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
+  ],
+  "resume": [
+    "light",
+    "resume"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
+  ],
+  "retro-radar": [
+    "dark",
+    "blog",
+    "radar",
+    "retro"
+  ],
+  "retromac": [
+    "light",
+    "mac",
+    "os9",
+    "retro",
+    "system"
+  ],
+  "retrowave": [
+    "dark",
+    "blog",
+    "retro",
+    "synthwave"
+  ],
+  "reveille": [
+    "event",
+    "dark",
+    "military",
+    "assembly",
+    "urgent"
+  ],
+  "review-article": [
+    "paper",
+    "light",
+    "review",
+    "literature",
+    "synthesis"
+  ],
+  "ridgeline": [
+    "dark",
+    "blog",
+    "outdoor"
+  ],
+  "riftzone": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "dimensional"
+  ],
+  "ring-bell": [
+    "event",
+    "dark",
+    "boxing",
+    "fight",
+    "intense"
+  ],
+  "riverbank": [
+    "light",
+    "blog",
+    "nature-journal"
+  ],
+  "rococo": [
+    "light",
+    "blog",
+    "pastel",
+    "elegant"
+  ],
+  "roll-call": [
+    "event",
+    "light",
+    "assembly",
+    "formal",
+    "attendance"
+  ],
+  "roll-scroll": [
+    "book",
+    "light",
+    "scroll",
+    "continuous",
+    "ancient"
+  ],
+  "rooftop": [
+    "dark",
+    "blog",
+    "urban"
+  ],
+  "rose-gold": [
+    "elegant",
+    "luxury",
+    "minimal"
+  ],
+  "rosemary": [
+    "light",
+    "blog",
+    "cooking"
+  ],
+  "rosetta": [
+    "light",
+    "docs",
+    "i18n"
+  ],
+  "rosewood": [
+    "blog",
+    "dark",
+    "warm",
+    "classic"
+  ],
+  "rubric": [
+    "book",
+    "light",
+    "rubricated",
+    "two-color",
+    "traditional"
+  ],
+  "ruby-fire": [
+    "dark",
+    "blog",
+    "bold"
+  ],
+  "runbook": [
+    "light",
+    "docs",
+    "operations"
+  ],
+  "rune": [
+    "dark",
+    "archive",
+    "viking",
+    "mystic"
+  ],
+  "saffron": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "sage-guide": [
+    "docs",
+    "light",
+    "tutorial",
+    "guide"
+  ],
+  "sakura-storm": [
+    "dark",
+    "blog",
+    "glamorous",
+    "sakura"
+  ],
+  "sandcastle": [
+    "light",
+    "blog",
+    "sand",
+    "beach"
+  ],
+  "sandstone": [
+    "light",
+    "blog",
+    "architecture"
+  ],
+  "sandstorm": [
+    "dark",
+    "blog",
+    "desert",
+    "particles"
+  ],
+  "sapphire": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "savanna": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "sawmill": [
+    "light",
+    "blog",
+    "woodworking"
+  ],
+  "scaffold": [
+    "dark",
+    "landing",
+    "comingsoon"
+  ],
+  "scaffold-docs": [
+    "dark",
+    "docs",
+    "scaffolding"
+  ],
+  "schematic": [
+    "light",
+    "docs",
+    "hardware"
+  ],
+  "scientific-journal": [
+    "dark",
+    "docs",
+    "scientific",
+    "academic"
+  ],
+  "scoping-review": [
+    "paper",
+    "light",
+    "scoping",
+    "mapping",
+    "landscape"
+  ],
+  "scrimshaw": [
+    "bold",
+    "elegant",
+    "clean",
+    "blog"
+  ],
+  "sentinel": [
+    "dark",
+    "docs",
+    "monitoring"
+  ],
+  "seraph": [
+    "minimal",
+    "elegant",
+    "portfolio"
+  ],
+  "serenity": [
+    "light",
+    "blog",
+    "elegant"
+  ],
+  "sextant": [
+    "light",
+    "docs",
+    "metrics"
+  ],
+  "sfumato": [
+    "dark",
+    "blog",
+    "atmospheric",
+    "minimal"
+  ],
+  "sgraffito": [
+    "dark",
+    "blog",
+    "sgraffito",
+    "scratched"
+  ],
+  "shutout": [
+    "event",
+    "dark",
+    "competition",
+    "dominant",
+    "perfect"
+  ],
+  "silhouette": [
+    "dark",
+    "landing",
+    "silhouette",
+    "dramatic"
+  ],
+  "silk-road": [
+    "elegant",
+    "glamorous",
+    "silk",
+    "cultural"
+  ],
+  "simulation-paper": [
+    "paper",
+    "dark",
+    "computational",
+    "simulation",
+    "model"
+  ],
+  "sketch": [
+    "light",
+    "blog",
+    "handdrawn"
+  ],
+  "skeuomorphic": [
+    "light",
+    "blog",
+    "skeuomorphic",
+    "realistic"
+  ],
+  "slide": [
+    "dark",
+    "docs",
+    "presentation"
+  ],
+  "snowfall": [
+    "light",
+    "blog",
+    "winter"
+  ],
+  "solar-punk": [
+    "light",
+    "blog",
+    "solarpunk",
+    "sustainable"
+  ],
+  "solarflare": [
+    "dark",
+    "landing",
+    "solar",
+    "energy"
+  ],
+  "solaris": [
+    "dark",
+    "dashboard",
+    "solar-system",
+    "space-mission"
+  ],
+  "solarium": [
+    "blog",
+    "light",
+    "warm"
+  ],
+  "solstice": [
+    "dual",
+    "blog",
+    "seasonal",
+    "time-based"
+  ],
+  "sonar": [
+    "dark",
+    "hub",
+    "radar",
+    "discovery"
+  ],
+  "spectra": [
+    "dark",
+    "data-science",
+    "spectrum",
+    "rainbow"
+  ],
+  "spectrum": [
+    "light",
+    "blog",
+    "a11y"
+  ],
+  "spectrum-docs": [
+    "light",
+    "docs",
+    "accessibility"
+  ],
+  "spire": [
+    "dark",
+    "blog",
+    "architecture"
+  ],
+  "split-tone": [
+    "light",
+    "blog",
+    "photography",
+    "cinematic",
+    "toning"
+  ],
+  "stained-glass": [
+    "light",
+    "blog",
+    "cathedral",
+    "colorful",
+    "gothic"
+  ],
+  "standing-ovation": [
+    "event",
+    "light",
+    "awards",
+    "acclaim",
+    "celebration"
+  ],
+  "starlight": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "minimal"
+  ],
+  "starting-gun": [
+    "event",
+    "dark",
+    "race",
+    "competition",
+    "explosive"
+  ],
+  "statuspage": [
+    "light",
+    "landing",
+    "status"
+  ],
+  "stellar-launch": [
+    "landing",
+    "dark",
+    "parallax",
+    "animation"
+  ],
+  "stipple": [
+    "light",
+    "artistic",
+    "dot-art",
+    "gallery"
+  ],
+  "storefront": [
+    "light",
+    "landing",
+    "shop"
+  ],
+  "stratum": [
+    "dark",
+    "timeline",
+    "geological",
+    "layered"
+  ],
+  "strobe": [
+    "dark",
+    "event",
+    "club",
+    "strobe"
+  ],
+  "studio": [
+    "dark",
+    "landing",
+    "portfolio"
+  ],
+  "subzero": [
+    "dark",
+    "research",
+    "cryogenic",
+    "frozen"
+  ],
+  "summit": [
+    "dark",
+    "landing",
+    "conference"
+  ],
+  "summit-event": [
+    "conference",
+    "dark",
+    "event",
+    "landing"
+  ],
+  "summit-strike": [
+    "event",
+    "dark",
+    "conference",
+    "summit",
+    "ascending"
+  ],
+  "sunburst": [
+    "light",
+    "blog",
+    "warm",
+    "golden",
+    "radiant"
+  ],
+  "sundew": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "supernova": [
+    "dark",
+    "landing",
+    "cosmic",
+    "particles"
+  ],
+  "supplementary": [
+    "paper",
+    "light",
+    "supplementary",
+    "data-heavy",
+    "exhaustive"
+  ],
+  "supreme-sun": [
+    "light",
+    "blog",
+    "community"
+  ],
+  "survey-instrument": [
+    "paper",
+    "light",
+    "survey",
+    "instrument",
+    "psychometric"
+  ],
+  "synthwave": [
+    "dark",
+    "retro",
+    "glamorous",
+    "trendy"
+  ],
+  "systematic-review": [
+    "paper",
+    "light",
+    "systematic",
+    "evidence",
+    "methodology"
+  ],
+  "tactile-fabric": [
+    "light",
+    "blog",
+    "fabric",
+    "textile"
+  ],
+  "talavera": [
+    "light",
+    "blog",
+    "mexican",
+    "pottery",
+    "colorful"
+  ],
+  "tale": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "tangram": [
+    "light",
+    "portfolio",
+    "puzzle",
+    "geometric"
+  ],
+  "tapestry": [
+    "light",
+    "blog",
+    "timeline"
+  ],
+  "taskboard": [
+    "light",
+    "dashboard",
+    "kanban"
+  ],
+  "tavern": [
+    "dark",
+    "blog",
+    "rpg"
+  ],
+  "techbyte": [
+    "light",
+    "blog",
+    "tech",
+    "card"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
+  ],
+  "tectonic": [
+    "dark",
+    "hub",
+    "geological",
+    "interactive"
+  ],
+  "telegraph": [
+    "light",
+    "blog",
+    "news"
+  ],
+  "tempera": [
+    "dark",
+    "blog",
+    "tempera",
+    "painting"
+  ],
+  "tempest": [
+    "dark",
+    "magazine",
+    "storm",
+    "dramatic"
+  ],
+  "tenebrism": [
+    "dark",
+    "creative",
+    "bold",
+    "clean"
+  ],
+  "terminal": [
+    "dark",
+    "blog"
+  ],
+  "terrace": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "terracotta-studio": [
+    "landing",
+    "light",
+    "creative",
+    "artisan"
+  ],
+  "terracotta-tiles": [
+    "dark",
+    "blog",
+    "terracotta",
+    "tile"
+  ],
+  "terraform": [
+    "dark",
+    "dashboard",
+    "sci-fi",
+    "terraforming"
+  ],
+  "terraform-docs": [
+    "docs",
+    "dark",
+    "infra",
+    "devops"
+  ],
+  "terrarium": [
+    "light",
+    "portfolio",
+    "miniature"
+  ],
+  "terrazzo": [
+    "light",
+    "portfolio",
+    "terrazzo",
+    "speckled"
+  ],
+  "terrazzo-blog": [
+    "blog",
+    "light",
+    "colorful",
+    "memphis"
+  ],
+  "tessellation": [
+    "light",
+    "gallery",
+    "escher",
+    "pattern-art"
+  ],
+  "tesseract": [
+    "dark",
+    "education",
+    "4d",
+    "mathematical"
+  ],
+  "thermal": [
+    "dark",
+    "dashboard",
+    "thermal",
+    "heatmap"
+  ],
+  "thesis": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "thesis-defense": [
+    "paper",
+    "dark",
+    "thesis",
+    "formal",
+    "institutional"
+  ],
+  "thunderdome": [
+    "event",
+    "dark",
+    "arena",
+    "competition",
+    "ultimate"
+  ],
+  "ticker-board": [
+    "event",
+    "dark",
+    "transit",
+    "departure",
+    "mechanical"
+  ],
+  "ticker-tape": [
+    "event",
+    "light",
+    "celebration",
+    "parade",
+    "festive"
+  ],
+  "tidal": [
+    "light",
+    "blog",
+    "ocean",
+    "wellness"
+  ],
+  "timber": [
+    "light",
+    "blog",
+    "craft"
+  ],
+  "titanium": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ],
+  "topaz": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "topographic-gradient": [
+    "dark",
+    "blog",
+    "topographic",
+    "contour"
+  ],
+  "topographic-sand": [
+    "dark",
+    "blog",
+    "topographic",
+    "sand"
+  ],
+  "topography": [
+    "light",
+    "blog",
+    "topographic",
+    "outdoor"
+  ],
+  "torchlight": [
+    "dark",
+    "blog",
+    "adventure"
+  ],
+  "totem": [
+    "dark",
+    "portfolio",
+    "tribal",
+    "vertical-stack"
+  ],
+  "tremor": [
+    "dark",
+    "dashboard",
+    "seismic",
+    "data-viz"
+  ],
+  "trompe-loeil": [
+    "light",
+    "portfolio",
+    "creative",
+    "bold",
+    "illusion"
+  ],
+  "tropical-paradise": [
+    "elegant",
+    "vivid",
+    "botanical"
+  ],
+  "tundra": [
+    "dark",
+    "blog",
+    "expedition"
+  ],
+  "turbine": [
+    "light",
+    "corporate",
+    "energy",
+    "rotation"
+  ],
+  "turret": [
+    "dark",
+    "docs",
+    "waf"
+  ],
+  "twilight": [
+    "dark",
+    "blog",
+    "photo-essay"
+  ],
+  "typeface": [
+    "blog",
+    "light",
+    "typography",
+    "minimal"
+  ],
+  "typewriter": [
+    "light",
+    "blog",
+    "vintage"
+  ],
+  "typhoon": [
+    "dark",
+    "magazine",
+    "storm",
+    "spiral"
+  ],
+  "ukiyo-e": [
+    "light",
+    "blog",
+    "japanese",
+    "woodblock",
+    "traditional"
+  ],
+  "ultraviolet": [
+    "dark",
+    "blog",
+    "ultraviolet",
+    "neon"
+  ],
+  "umbra": [
+    "dark",
+    "portfolio",
+    "monochrome",
+    "shadow"
+  ],
+  "vapor": [
+    "light",
+    "blog",
+    "vaporwave",
+    "surreal"
+  ],
+  "vault": [
+    "dark",
+    "docs",
+    "security"
+  ],
+  "vellum": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "velocity": [
+    "landing",
+    "dark",
+    "saas"
+  ],
+  "velvet": [
+    "dark",
+    "landing",
+    "luxury"
+  ],
+  "velvet-rope": [
+    "event",
+    "gala",
+    "exclusive",
+    "luxury",
+    "velvet"
+  ],
+  "venetian": [
+    "light",
+    "blog",
+    "renaissance",
+    "venetian",
+    "ornate"
+  ],
+  "verdigris": [
+    "dark",
+    "blog",
+    "editorial"
+  ],
+  "versailles": [
+    "dark",
+    "elegant",
+    "classic",
+    "luxury"
+  ],
+  "vertigo": [
+    "dark",
+    "one-page",
+    "experimental",
+    "perspective"
+  ],
+  "vibrant-brutalism": [
+    "dark",
+    "blog",
+    "brutalist",
+    "vibrant"
+  ],
+  "victorian": [
+    "dark",
+    "blog",
+    "gothic",
+    "classic"
+  ],
+  "vineyard": [
+    "dark",
+    "blog",
+    "wine"
+  ],
+  "vintage": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "vintagetv": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "vinyl": [
+    "dark",
+    "blog",
+    "vinyl"
+  ],
+  "voltage": [
+    "dark",
+    "blog",
+    "electric",
+    "sparks"
+  ],
+  "volumetric": [
+    "dark",
+    "blog",
+    "3d",
+    "glow",
+    "atmospheric"
+  ],
+  "vortex": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "animation"
+  ],
+  "wanderlust": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "war-room": [
+    "event",
+    "dark",
+    "strategy",
+    "military",
+    "command"
+  ],
+  "warpzone": [
+    "dark",
+    "portfolio",
+    "warp",
+    "gaming"
+  ],
+  "washi-bound": [
+    "book",
+    "light",
+    "japanese",
+    "stab-binding",
+    "paper"
+  ],
+  "wavelength": [
+    "audio",
+    "dark",
+    "landing",
+    "music"
+  ],
+  "weathervane": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "wedding": [
+    "light",
+    "wedding",
+    "elegant",
+    "event"
+  ],
+  "white-paper-noir": [
+    "paper",
+    "dark",
+    "industry",
+    "executive",
+    "authoritative"
+  ],
+  "wiki": [
+    "light",
+    "docs",
+    "wiki"
+  ],
+  "willow": [
+    "light",
+    "blog",
+    "literature"
+  ],
+  "windmill": [
+    "light",
+    "blog",
+    "european"
+  ],
+  "windows95": [
+    "light",
+    "retro",
+    "os",
+    "nostalgia"
+  ],
+  "woodblock": [
+    "dark",
+    "blog",
+    "woodblock",
+    "printmaking"
+  ],
+  "working-paper": [
+    "paper",
+    "light",
+    "working",
+    "in-progress",
+    "honest"
+  ],
+  "woven-tapestry": [
+    "dark",
+    "blog",
+    "tapestry",
+    "textile"
+  ],
+  "x-ray": [
+    "dark",
+    "blog",
+    "x-ray",
+    "transparent"
+  ],
+  "xerograph": [
+    "dark",
+    "blog",
+    "minimal",
+    "photocopy"
+  ],
+  "y2k": [
+    "dark",
+    "cyber",
+    "metallic",
+    "retro"
+  ],
+  "zen": [
+    "light",
+    "blog",
+    "zen"
+  ],
+  "zenith": [
+    "light",
+    "landing",
+    "minimal",
+    "altitude"
+  ],
+  "zenithpoint": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ]
 }


### PR DESCRIPTION
Closes #1545

## Summary
- Add printer-devil (apprentice publication) example site
- Dark theme with ink-black ground and printer's red accents
- SVG ink roller marks where the devil over-inked sections
- SVG type-pie scattered letter illustrations from a dropped form
- Intentionally mis-set display type (wrong sizes, wrong faces mixed in)
- Clean base text in Lora/Crimson Pro with deliberate dropped characters
- 5 mishaps covering wrong font, over-ink, type pie, upside-down, and the apprentice
- Tags: book, dark, error, playful, craft

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of mis-set type and ink roller marks
- [ ] Verify SVG type-pie scattered letters render
- [ ] Check responsive behavior on narrow viewports