### PR TITLE
feat: add manifesto-press example site (closes #1539)

### DIFF
--- a/manifesto-press/AGENTS.md
+++ b/manifesto-press/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/manifesto-press/config.toml
+++ b/manifesto-press/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Manifesto Press - Revolutionary Tract Publication
+# Issue #1539 | Tags: book, dark, revolutionary, bold, political
+# =============================================================================
+
+title = "Manifesto Press"
+description = "A dark, bold publication inspired by revolutionary tract printing. SVG raised fist illustrations for chapter openers and banner patterns for section headers. Heavy condensed display type for demands and declarations, strong sans for argument text."
+base_url = "http://localhost:3000"
+
+sections = ["demands"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/manifesto-press/content/about.md
+++ b/manifesto-press/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "About this revolutionary tract publication."
++++
+
+<p class="tract-label">Statement</p>
+
+# About This Publication
+
+<p class="lede">Manifesto Press is a study of revolutionary printing: the forms, the methods, and the courage required to put forbidden words on paper and distribute them to the people.</p>
+
+## Purpose
+
+<p>This publication examines the printed tract as a political instrument. From the broadsides of the English Civil War to the samizdat of the Soviet Union, the printing press has been the most powerful tool available to those who seek to challenge authority. Each section of this publication takes one form of revolutionary printing and examines its history, its methods, and its consequences.</p>
+
+## Design principles
+
+<p>The design of this publication follows the aesthetic of the revolutionary tract: bold condensed type for headlines and demands, strong sans-serif body text for sustained argument, and a dark palette that recalls the ink-stained pages of underground printing. The SVG illustrations depict the raised fist and banner motifs of revolutionary visual culture, rendered as simple line drawings in the tradition of woodcut and linocut political art.</p>
+
+## The forms
+
+<p>Five forms of revolutionary printing are examined here: the broadside, the pamphlet, the manifesto, the underground press, and the printed word itself as an instrument of change. Each form has its own history and its own tactical advantages. Together they represent the full arsenal of the revolutionary printer.</p>

--- a/manifesto-press/content/colophon.md
+++ b/manifesto-press/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "The colophon of this publication: type, design, and construction."
++++
+
+<div class="colophon-page">
+<p class="tract-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="banner-rule" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="8" x2="180" y2="8" stroke="#c41a1a" stroke-width="0.8"/>
+<rect x="94" y="4" width="12" height="8" fill="none" stroke="#c41a1a" stroke-width="0.8"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of revolutionary tract printing: the broadside, the pamphlet, the manifesto, and the underground press. Every element of the design serves the theme of bold political declaration.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Bebas Neue and Oswald Black, heavy condensed sans-serif faces chosen for their commanding presence at large sizes. These are the typefaces of demands and declarations: tall, narrow, and impossible to ignore.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in Archivo SemiBold and Work Sans Medium, strong sans-serif text faces that carry sustained argument without fatigue. The weight is deliberately heavier than typical body text, reinforcing the urgency of the content.</p>
+
+<p class="colophon-detail"><strong>Illustrations</strong> are drawn as inline SVG in a style inspired by woodcut and linocut political art. The raised fist motif marks chapter openers; banner and flag patterns serve as section dividers. All decorative elements use only stroke and fill -- no gradients, no photographic effects.</p>
+
+<p class="colophon-detail"><strong>The press mark</strong> appears in the footer: a circle bearing the initials "MP" for Manifesto Press, in the tradition of the printer's device on the colophon page of the revolutionary pamphlet.</p>
+
+<div class="banner-rule" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<rect x="88" y="5" width="6" height="6" fill="#c41a1a"/>
+<rect x="98" y="5" width="6" height="6" fill="#c41a1a"/>
+<rect x="108" y="5" width="6" height="6" fill="#c41a1a"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First digital edition, 2026. Printed without permission.</p>
+</div>

--- a/manifesto-press/content/demands/1-the-broadside.md
+++ b/manifesto-press/content/demands/1-the-broadside.md
@@ -1,0 +1,64 @@
++++
+title = "The Broadside"
+description = "The broadside: a single sheet printed on one side, posted in public for all to read."
+tags = ["broadside", "printing"]
++++
+
+<p class="tract-label">Demand I</p>
+
+# The Broadside
+
+<p class="lede">A single sheet of paper, printed on one side only, posted on a wall or a door or a market cross for the public to read. The broadside is the most direct, most immediate, most democratic form of revolutionary printing.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#0e0e0e"/>
+<g fill="none" stroke="#c41a1a" stroke-width="2">
+  <path d="M280,100 L280,60"/>
+  <path d="M300,100 L300,50"/>
+  <path d="M320,100 L320,60"/>
+  <rect x="268" y="48" width="64" height="16" rx="3"/>
+  <path d="M272,48 L272,30 Q272,22 280,22 Q288,22 288,30 L288,48"/>
+  <path d="M288,48 L288,24 Q288,16 296,16 Q304,16 304,24 L304,48"/>
+  <path d="M304,48 L304,30 Q304,22 312,22 Q320,22 320,30 L320,48"/>
+  <path d="M268,48 L264,38 Q262,32 268,28"/>
+</g>
+<g fill="#c41a1a" opacity="0.1">
+  <rect x="40" y="20" width="160" height="80" rx="1"/>
+  <rect x="400" y="20" width="160" height="80" rx="1"/>
+</g>
+<g fill="#c41a1a" opacity="0.2">
+  <rect x="60" y="35" width="120" height="3"/>
+  <rect x="70" y="45" width="100" height="2"/>
+  <rect x="65" y="53" width="110" height="2"/>
+  <rect x="420" y="35" width="120" height="3"/>
+  <rect x="430" y="45" width="100" height="2"/>
+  <rect x="425" y="53" width="110" height="2"/>
+</g>
+</svg>
+</div>
+
+## The form
+
+<p>The broadside requires no binding, no stitching, no folding beyond what is needed to carry it to the site of posting. It is printed on one side of a single sheet, typically in a large format so that it can be read from a distance. The type is set large and bold -- the broadside must compete with every other surface in the public space for the attention of the passerby.</p>
+
+## History of the broadside
+
+<p>The broadside is as old as the printing press itself. Within decades of Gutenberg's invention, broadsides were being used to announce decrees, advertise indulgences, and -- crucially -- to challenge authority. Luther's Ninety-Five Theses, whether or not they were literally nailed to a church door, circulated as printed broadsides throughout Germany within weeks of their composition. The form was perfect for the purpose: a single sheet could be printed quickly, in large quantities, and distributed before the authorities could respond.</p>
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>Speed</h3>
+<p>A broadside can be set, printed, and posted within hours of the event it responds to. No other printed form matches its speed of production.</p>
+</div>
+<div class="demand-card">
+<h3>Reach</h3>
+<p>Posted in a public place, a broadside reaches every literate person who passes by. It does not require purchase or distribution. It simply exists in public space.</p>
+</div>
+<div class="demand-card">
+<h3>Anonymity</h3>
+<p>A broadside can be posted at night and read by hundreds before the authorities discover it. The printer and the poster need never be identified.</p>
+</div>
+</div>
+
+<blockquote>The broadside is the voice of the street: loud, public, and impossible to silence without tearing it from the wall -- and by then, it has already been read.</blockquote>

--- a/manifesto-press/content/demands/2-the-pamphlet.md
+++ b/manifesto-press/content/demands/2-the-pamphlet.md
@@ -1,0 +1,72 @@
++++
+title = "The Pamphlet"
+description = "The political pamphlet: a few pages, stitched or folded, passed from hand to hand."
+tags = ["pamphlet", "printing"]
++++
+
+<p class="tract-label">Demand II</p>
+
+# The Pamphlet
+
+<p class="lede">A small publication of a few pages, unbound or loosely stitched, cheap enough to give away and small enough to conceal. The political pamphlet is the most effective instrument of persuasion ever devised by the printing press.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#0e0e0e"/>
+<g fill="none" stroke="#c41a1a" stroke-width="1.5" opacity="0.25">
+  <rect x="50" y="15" width="80" height="90" rx="1"/>
+  <rect x="160" y="15" width="80" height="90" rx="1"/>
+  <rect x="360" y="15" width="80" height="90" rx="1"/>
+  <rect x="470" y="15" width="80" height="90" rx="1"/>
+</g>
+<g fill="#c41a1a" opacity="0.15">
+  <rect x="60" y="30" width="60" height="2"/>
+  <rect x="60" y="38" width="55" height="2"/>
+  <rect x="60" y="46" width="58" height="2"/>
+  <rect x="60" y="54" width="50" height="2"/>
+  <rect x="170" y="30" width="60" height="2"/>
+  <rect x="170" y="38" width="55" height="2"/>
+  <rect x="170" y="46" width="58" height="2"/>
+  <rect x="370" y="30" width="60" height="2"/>
+  <rect x="370" y="38" width="55" height="2"/>
+  <rect x="370" y="46" width="58" height="2"/>
+  <rect x="480" y="30" width="60" height="2"/>
+  <rect x="480" y="38" width="55" height="2"/>
+</g>
+<g fill="none" stroke="#c41a1a" stroke-width="2">
+  <path d="M280,100 L280,60"/>
+  <path d="M300,100 L300,50"/>
+  <path d="M320,100 L320,60"/>
+  <rect x="268" y="48" width="64" height="16" rx="3"/>
+  <path d="M272,48 L272,30 Q272,22 280,22 Q288,22 288,30 L288,48"/>
+  <path d="M288,48 L288,24 Q288,16 296,16 Q304,16 304,24 L304,48"/>
+  <path d="M304,48 L304,30 Q304,22 312,22 Q320,22 320,30 L320,48"/>
+  <path d="M268,48 L264,38 Q262,32 268,28"/>
+</g>
+</svg>
+</div>
+
+## The form
+
+<p>The pamphlet occupies the territory between the broadside and the book. It is longer than a single sheet -- typically eight to forty-eight pages -- but shorter and cheaper than a bound volume. It is designed for a single argument, a single cause, a single moment of political urgency. The pamphlet does not aspire to permanence. It aspires to immediate effect.</p>
+
+## The pamphlet in revolution
+
+<p>Thomas Paine's Common Sense sold over 500,000 copies in a population of 2.5 million. It was a pamphlet: forty-seven pages of plain argument that the American colonies should declare independence from Britain. No book, no newspaper, no broadside could have achieved the same effect. The pamphlet was the right form for the right moment: long enough to make a sustained argument, short enough to read in a single sitting, cheap enough for every literate citizen to own a copy.</p>
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>Argument</h3>
+<p>Unlike the broadside, the pamphlet has room for sustained argument. It can present evidence, answer objections, and build to a conclusion.</p>
+</div>
+<div class="demand-card">
+<h3>Portability</h3>
+<p>A pamphlet fits in a pocket. It can be passed from person to person, read aloud in a tavern, smuggled across a border, hidden under a floorboard.</p>
+</div>
+<div class="demand-card">
+<h3>Economy</h3>
+<p>A pamphlet costs almost nothing to produce. A single press run can produce thousands of copies in a day. The economics of the pamphlet favor the insurgent, not the establishment.</p>
+</div>
+</div>
+
+<blockquote>The pamphlet is the book that does not wait for a library. It goes to the reader, not the reader to it. It is the printed word in its most mobile, most dangerous form.</blockquote>

--- a/manifesto-press/content/demands/3-the-manifesto.md
+++ b/manifesto-press/content/demands/3-the-manifesto.md
@@ -1,0 +1,62 @@
++++
+title = "The Manifesto"
+description = "The manifesto as a literary and political form: a declaration of principles and demands."
+tags = ["manifesto", "declaration"]
++++
+
+<p class="tract-label">Demand III</p>
+
+# The Manifesto
+
+<p class="lede">A public declaration of intentions, motives, and demands. The manifesto announces a break with the existing order and a program for the new. It is the most ambitious, most confrontational, most world-shaking form of political printing.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#0e0e0e"/>
+<g fill="#c41a1a" opacity="0.08">
+  <polygon points="100,10 140,10 120,110"/>
+  <polygon points="200,10 240,10 220,110"/>
+  <polygon points="360,10 400,10 380,110"/>
+  <polygon points="460,10 500,10 480,110"/>
+</g>
+<g fill="none" stroke="#c41a1a" stroke-width="2.5">
+  <path d="M280,108 L280,60"/>
+  <path d="M300,108 L300,46"/>
+  <path d="M320,108 L320,60"/>
+  <rect x="266" y="44" width="68" height="18" rx="4"/>
+  <path d="M270,44 L270,28 Q270,18 280,18 Q290,18 290,28 L290,44"/>
+  <path d="M290,44 L290,20 Q290,10 300,10 Q310,10 310,20 L310,44"/>
+  <path d="M310,44 L310,28 Q310,18 320,18 Q330,18 330,28 L330,44"/>
+  <path d="M266,44 L262,34 Q260,26 266,22"/>
+</g>
+<g fill="#c41a1a" opacity="0.25">
+  <rect x="0" y="0" width="600" height="3"/>
+  <rect x="0" y="117" width="600" height="3"/>
+</g>
+</svg>
+</div>
+
+## The form
+
+<p>The manifesto is not merely a pamphlet with a grander title. It is a distinct literary and political form with its own conventions and its own rhetoric. A manifesto begins with a diagnosis of the present crisis. It identifies the forces responsible for that crisis. It declares the principles on which a new order will be built. And it issues demands -- specific, non-negotiable, often impossible demands -- that serve as both a political program and a test of commitment.</p>
+
+## The manifesto tradition
+
+<p>The most famous manifesto in history begins: "A spectre is haunting Europe." Marx and Engels published the Communist Manifesto in 1848, and it became the model for every political manifesto that followed. But the form is older than Marx. The Declaration of Independence is a manifesto. The Declaration of the Rights of Man is a manifesto. The Levellers' Agreement of the People is a manifesto. Wherever a group has declared its break with the existing order and its vision for a new one, the manifesto has been the chosen form.</p>
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>Diagnosis</h3>
+<p>Every manifesto begins with an analysis of what is wrong. The present order is unjust, unsustainable, intolerable. The manifesto names the problem and names those responsible.</p>
+</div>
+<div class="demand-card">
+<h3>Declaration</h3>
+<p>The manifesto declares the principles of the new order. It does not argue or persuade -- it proclaims. The tone is absolute, the language is bold, the demands are unconditional.</p>
+</div>
+<div class="demand-card">
+<h3>Program</h3>
+<p>A manifesto without a program is merely a complaint. The true manifesto lists specific demands and specific actions. It tells the reader not only what to believe but what to do.</p>
+</div>
+</div>
+
+<blockquote>The manifesto does not ask permission to exist. It announces itself. It declares its principles. It issues its demands. And it dares the reader to choose a side.</blockquote>

--- a/manifesto-press/content/demands/4-the-press.md
+++ b/manifesto-press/content/demands/4-the-press.md
@@ -1,0 +1,64 @@
++++
+title = "The Press"
+description = "The underground printing press: hidden, illegal, and indispensable to every revolutionary movement."
+tags = ["press", "underground"]
++++
+
+<p class="tract-label">Demand IV</p>
+
+# The Press
+
+<p class="lede">Hidden in cellars and attics, operated at night by lamplight, seized and destroyed by the authorities and rebuilt the next day in a new location. The underground printing press is the engine of every revolutionary movement.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#0e0e0e"/>
+<g fill="none" stroke="#c41a1a" stroke-width="1.5" opacity="0.2">
+  <rect x="30" y="40" width="120" height="60"/>
+  <rect x="450" y="40" width="120" height="60"/>
+  <line x1="30" y1="60" x2="150" y2="60"/>
+  <line x1="450" y1="60" x2="570" y2="60"/>
+  <circle cx="90" cy="80" r="12"/>
+  <circle cx="510" cy="80" r="12"/>
+</g>
+<g fill="none" stroke="#c41a1a" stroke-width="2">
+  <path d="M280,108 L280,60"/>
+  <path d="M300,108 L300,46"/>
+  <path d="M320,108 L320,60"/>
+  <rect x="266" y="44" width="68" height="18" rx="4"/>
+  <path d="M270,44 L270,28 Q270,18 280,18 Q290,18 290,28 L290,44"/>
+  <path d="M290,44 L290,20 Q290,10 300,10 Q310,10 310,20 L310,44"/>
+  <path d="M310,44 L310,28 Q310,18 320,18 Q330,18 330,28 L330,44"/>
+  <path d="M266,44 L262,34 Q260,26 266,22"/>
+</g>
+<g fill="#c41a1a" opacity="0.1">
+  <rect x="180" y="10" width="240" height="4"/>
+  <rect x="200" y="20" width="200" height="4"/>
+</g>
+</svg>
+</div>
+
+## The machine
+
+<p>A printing press is a heavy, noisy, conspicuous machine. It requires ink, paper, and type -- all of which must be obtained, stored, and concealed. Operating an underground press is an act of sustained logistical defiance. The press must be hidden from the police, the paper must be smuggled past inspectors, the printed sheets must be dried, folded, and distributed through clandestine networks. Every person involved risks imprisonment or worse.</p>
+
+## A history of underground presses
+
+<p>The underground press has a continuous history from the sixteenth century to the present day. The Protestant reformers operated illegal presses throughout Catholic Europe. The French philosophes printed their most dangerous works in Holland and Switzerland and smuggled them across the border. The Russian revolutionaries maintained a network of underground presses that the Tsarist police could never fully suppress. In occupied Europe during the Second World War, resistance movements published underground newspapers on stolen presses with stolen paper. In the Soviet Union, samizdat -- self-published works typed on carbon paper and passed from reader to reader -- continued the tradition when even the possession of a duplicating machine was a criminal offense.</p>
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>Concealment</h3>
+<p>The press must be hidden. A cellar, an attic, a false wall behind a shop. The location changes when the authorities get close. The press itself may be dismantled and reassembled in a new location overnight.</p>
+</div>
+<div class="demand-card">
+<h3>Supply</h3>
+<p>Paper and ink must be obtained without attracting suspicion. Bulk purchases are dangerous. The underground printer buys small quantities from many sources, or steals supplies from legitimate print shops.</p>
+</div>
+<div class="demand-card">
+<h3>Distribution</h3>
+<p>The printed material must reach the public. Bundles are left at prearranged locations, passed through chains of trusted contacts, slipped under doors at night. Every link in the chain is a point of vulnerability.</p>
+</div>
+</div>
+
+<blockquote>Destroy the press and another will appear. Arrest the printer and another will take their place. The underground press cannot be permanently suppressed because the demand for forbidden truth is inexhaustible.</blockquote>

--- a/manifesto-press/content/demands/5-the-word.md
+++ b/manifesto-press/content/demands/5-the-word.md
@@ -1,0 +1,64 @@
++++
+title = "The Word"
+description = "The power of the printed word in revolution: why ink on paper changes the world."
+tags = ["word", "revolution"]
++++
+
+<p class="tract-label">Demand V</p>
+
+# The Word
+
+<p class="lede">Before the printed word, revolution was local. After it, revolution became contagious. The printing press did not merely record revolutionary ideas -- it multiplied them, accelerated them, and made them impossible to contain.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#0e0e0e"/>
+<g fill="#c41a1a" opacity="0.06">
+  <text x="20" y="30" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">LIBERTY</text>
+  <text x="120" y="55" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">JUSTICE</text>
+  <text x="400" y="30" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">FREEDOM</text>
+  <text x="480" y="70" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">TRUTH</text>
+  <text x="60" y="95" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">EQUALITY</text>
+  <text x="380" y="100" font-family="Bebas Neue, sans-serif" font-size="14" letter-spacing="4">SOLIDARITY</text>
+</g>
+<g fill="none" stroke="#c41a1a" stroke-width="2.5">
+  <path d="M280,108 L280,58"/>
+  <path d="M300,108 L300,44"/>
+  <path d="M320,108 L320,58"/>
+  <rect x="264" y="42" width="72" height="20" rx="4"/>
+  <path d="M268,42 L268,26 Q268,16 278,16 Q288,16 288,26 L288,42"/>
+  <path d="M288,42 L288,18 Q288,8 298,8 Q308,8 308,18 L308,42"/>
+  <path d="M308,42 L308,26 Q308,16 318,16 Q328,16 328,26 L328,42"/>
+  <path d="M264,42 L260,32 Q258,24 264,20"/>
+</g>
+<g fill="#c41a1a" opacity="0.3">
+  <rect x="0" y="0" width="600" height="4"/>
+  <rect x="0" y="116" width="600" height="4"/>
+</g>
+</svg>
+</div>
+
+## The multiplication of ideas
+
+<p>Before the printing press, a revolutionary idea could be spoken in a marketplace, written in a letter, copied by a scribe. Each of these methods was slow, limited in reach, and easy to suppress. The printing press changed everything. A single typesetting could produce hundreds or thousands of identical copies in a single day. Each copy could be carried to a different city, a different country. An idea that once took years to spread across Europe could now travel in weeks.</p>
+
+## Why print endures
+
+<p>The printed word has advantages that no other medium has fully replicated. A printed pamphlet requires no electricity, no network connection, no device. It cannot be remotely deleted or altered. It does not require a username or a password. It cannot be algorithmically suppressed. It can be read by anyone who is literate, anywhere, at any time. It can survive for centuries in a cellar or a library. The printed word is the most resilient, most democratic, most dangerous medium of communication ever invented.</p>
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>Permanence</h3>
+<p>A printed page endures. It cannot be edited after the fact, recalled by the publisher, or silently altered. What is printed is printed. The word stands as it was set in type.</p>
+</div>
+<div class="demand-card">
+<h3>Multiplication</h3>
+<p>One press, one typesetting, thousands of copies. The economics of printing favor the spread of ideas. The marginal cost of each additional copy approaches zero.</p>
+</div>
+<div class="demand-card">
+<h3>Autonomy</h3>
+<p>A printed pamphlet in the reader's hand is beyond the reach of censorship. It has already been distributed, already been read. The authorities can burn copies, but they cannot unread what has been read.</p>
+</div>
+</div>
+
+<blockquote>The word, once printed, belongs to everyone. It cannot be taken back. It cannot be unsaid. The printed word is the one weapon that grows stronger the more it is shared.</blockquote>

--- a/manifesto-press/content/demands/_index.md
+++ b/manifesto-press/content/demands/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Demands"
+description = "Five tracts on revolutionary printing and the power of the printed word."
++++
+
+<p class="lede">Five demands, each examining a different form of revolutionary printing. From the broadside nailed to the church door to the manifesto that declares a new world, these tracts chart the history and power of the political press.</p>
+
+<p>The demands are arranged in order of escalation: from the single sheet to the sustained argument to the declaration of total transformation.</p>

--- a/manifesto-press/content/index.md
+++ b/manifesto-press/content/index.md
@@ -1,0 +1,64 @@
++++
+title = "Manifesto Press"
+description = "A revolutionary tract publication printed in defiance."
++++
+
+<p class="tract-label">Declaration</p>
+
+# Manifesto Press
+
+<p class="lede">A publication devoted to the revolutionary printed word: the broadside nailed to the door, the pamphlet passed hand to hand, the manifesto that shakes the foundations. This is the press that prints what power forbids.</p>
+
+<div class="fist-illustration" aria-hidden="true">
+<svg viewBox="0 0 400 260" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="400" height="260" fill="#0e0e0e"/>
+<g fill="none" stroke="#c41a1a" stroke-width="2.5">
+  <path d="M200,240 L200,140"/>
+  <path d="M180,240 L180,140"/>
+  <path d="M220,240 L220,140"/>
+  <rect x="165" y="130" width="70" height="20" rx="4"/>
+  <path d="M170,130 L170,90 Q170,75 180,75 L185,75 Q190,75 190,90 L190,130"/>
+  <path d="M190,130 L190,70 Q190,55 200,55 L200,55 Q210,55 210,70 L210,130"/>
+  <path d="M210,130 L210,80 Q210,65 220,65 L220,65 Q230,65 230,80 L230,130"/>
+  <path d="M165,130 L160,110 Q158,100 165,95 L168,93"/>
+</g>
+<g fill="#c41a1a" opacity="0.12">
+  <rect x="80" y="30" width="240" height="4"/>
+  <rect x="100" y="42" width="200" height="4"/>
+  <rect x="120" y="54" width="160" height="4"/>
+</g>
+<g fill="none" stroke="#c41a1a" stroke-width="1" opacity="0.3">
+  <line x1="60" y1="20" x2="60" y2="260"/>
+  <line x1="340" y1="20" x2="340" y2="260"/>
+</g>
+</svg>
+</div>
+
+## The revolutionary press
+
+<p>For as long as there has been a printing press, there have been those who used it against the established order. The broadside, the pamphlet, the manifesto -- these are the weapons of the literate revolutionary. Cheap to produce, easy to distribute, impossible to suppress entirely. Each copy is an act of defiance, each reader a potential ally.</p>
+
+## What this publication contains
+
+<div class="demand-grid">
+<div class="demand-card">
+<h3>The Broadside</h3>
+<p>A single sheet, printed on one side, posted in public for all to read. The most direct form of revolutionary printing.</p>
+</div>
+<div class="demand-card">
+<h3>The Pamphlet</h3>
+<p>A few pages, stitched or folded, small enough to hide in a coat pocket. The political pamphlet has toppled governments.</p>
+</div>
+<div class="demand-card">
+<h3>The Manifesto</h3>
+<p>A declaration of principles and demands. The manifesto announces itself as a break with the past and a program for the future.</p>
+</div>
+<div class="demand-card">
+<h3>The Press</h3>
+<p>The underground printing press itself: hidden in cellars, operated at night, producing the literature that the authorities cannot tolerate.</p>
+</div>
+</div>
+
+## Read the demands
+
+<p>Navigate to the <a href="/demands/">demands index</a> to read the five tracts on revolutionary printing. Each tract examines a different form of the printed word as a tool of political change.</p>

--- a/manifesto-press/static/css/style.css
+++ b/manifesto-press/static/css/style.css
@@ -1,0 +1,443 @@
+/* =============================================================================
+   Manifesto Press - Revolutionary Tract Publication
+   Issue #1539 | book, dark, revolutionary, bold, political
+   Palette: near-black background, bold red on black, off-white text
+   No gradients. Raised fist + banner/flag patterns as inline SVG.
+   ============================================================================= */
+
+:root {
+  --bg: #0a0a0a;
+  --bg-surface: #0e0e0e;
+  --bg-card: #141414;
+  --bg-card-hover: #1a1a1a;
+  --border: #2a1010;
+  --border-strong: #3a1010;
+  --red: #c41a1a;
+  --red-dim: #8a1212;
+  --red-faint: #3a1010;
+  --text: #d8d0c8;
+  --text-strong: #f0ece6;
+  --text-dim: #8a8278;
+  --text-muted: #5a5450;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: "Archivo", "Work Sans", -apple-system, sans-serif;
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.74;
+  min-height: 100vh;
+}
+
+/* --- Shell container ----------------------------------------------------- */
+.press-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 2px solid var(--red);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--text-strong);
+}
+.logo-mark { width: 40px; height: 48px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-weight: 400;
+  font-size: 1.5rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-strong);
+}
+.logo-sub {
+  font-family: "Oswald", "Archivo", sans-serif;
+  font-weight: 500;
+  font-size: 0.72rem;
+  color: var(--red);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-dim);
+  font-family: "Oswald", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover {
+  color: var(--red);
+  border-bottom-color: var(--red);
+}
+
+/* --- Main page area ------------------------------------------------------ */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+}
+
+.tract {
+  position: relative;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
+  min-height: 400px;
+}
+
+.tract-narrow {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.banner-divider { width: 100%; }
+.banner-divider svg { width: 100%; display: block; }
+
+.tract-body {
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1.25rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.tract-body h1,
+.tract-body h2,
+.tract-body h3 {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  color: var(--text-strong);
+  line-height: 1.2;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.tract-body h1 {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  margin: 0 0 0.2em;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  border-bottom: 3px solid var(--red);
+  padding-bottom: 0.15em;
+  display: inline-block;
+}
+.tract-body h2 {
+  font-size: 1.6rem;
+  margin: 2.2em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--border-strong);
+  letter-spacing: 0.06em;
+  color: var(--red);
+}
+.tract-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.3em;
+  color: var(--red);
+  letter-spacing: 0.04em;
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 600;
+}
+
+.tract-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Archivo", "Work Sans", sans-serif;
+  font-weight: 500;
+  max-width: 65ch;
+}
+.tract-body p.lede {
+  font-family: "Work Sans", "Archivo", sans-serif;
+  font-size: 1.12rem;
+  line-height: 1.6;
+  color: var(--text-dim);
+  font-weight: 500;
+  font-style: italic;
+  max-width: 58ch;
+  border-left: 3px solid var(--red-dim);
+  padding-left: 1rem;
+}
+
+.tract-label {
+  display: inline-block;
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-size: 0.8rem;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--red);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.8em;
+  background-color: var(--red-faint);
+  border: 1px solid var(--border-strong);
+}
+
+.tract-head { margin-bottom: 2rem; }
+.tract-title {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-weight: 400;
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-strong);
+  border-bottom: 3px solid var(--red);
+  padding-bottom: 0.1em;
+  display: inline-block;
+}
+
+.tract-body a {
+  color: var(--red);
+  text-decoration: none;
+  border-bottom: 1px solid var(--red-dim);
+}
+.tract-body a:hover {
+  color: var(--text-strong);
+  border-bottom-color: var(--text-strong);
+}
+
+blockquote {
+  margin: 2rem 0;
+  padding: 0.75rem 1.5rem;
+  border-left: 4px solid var(--red);
+  background-color: var(--bg-card);
+  font-style: italic;
+  color: var(--text-dim);
+  font-family: "Work Sans", "Archivo", sans-serif;
+  font-size: 1.05rem;
+  font-weight: 500;
+  max-width: 58ch;
+}
+
+.tract-body ul,
+.tract-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+}
+.tract-body ul { list-style: square; }
+.tract-body ol { list-style: decimal; }
+.tract-body li {
+  padding: 0.2em 0;
+  max-width: 65ch;
+  color: var(--text);
+}
+
+/* --- Fist illustrations -------------------------------------------------- */
+.fist-illustration {
+  margin: 1.5rem 0;
+  border: 1px solid var(--border);
+}
+.fist-illustration svg {
+  width: 100%;
+  display: block;
+}
+
+/* --- Demand card grid ---------------------------------------------------- */
+.demand-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.demand-card {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  padding: 1rem 1.1rem;
+  position: relative;
+  border-top: 3px solid var(--red-dim);
+}
+.demand-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--red);
+  font-size: 0.95rem;
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.demand-card p {
+  margin: 0;
+  font-size: 0.93rem;
+  line-height: 1.55;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+/* --- Colophon ------------------------------------------------------------ */
+.colophon-page {
+  max-width: 600px;
+}
+.colophon-detail {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--text-dim);
+}
+.colophon-detail strong {
+  color: var(--text-strong);
+  font-weight: 700;
+}
+.colophon-imprint {
+  font-family: "Oswald", sans-serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--red-dim);
+  margin-top: 2rem;
+}
+.banner-rule {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+.banner-rule svg {
+  width: 200px;
+  display: inline-block;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 2px solid var(--red-dim);
+}
+.section-list li {
+  padding: 0.8rem 0.25rem;
+  border-bottom: 1px solid var(--border-strong);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Oswald", sans-serif;
+}
+.section-list li::before {
+  content: "\25A0";
+  color: var(--red);
+  flex-shrink: 0;
+  font-size: 0.7rem;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--text-strong);
+  border: none;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+.section-list li a:hover {
+  color: var(--red);
+}
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+/* --- Pagination ---------------------------------------------------------- */
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.7em;
+  border: 1px solid var(--border-strong);
+  font-family: "Oswald", sans-serif;
+  font-size: 0.85rem;
+  color: var(--text);
+  text-decoration: none;
+  background-color: var(--bg-card);
+  letter-spacing: 0.04em;
+}
+nav.pagination a:hover {
+  color: var(--red);
+  border-color: var(--red);
+}
+.pagination-current span {
+  color: var(--red);
+  border-color: var(--red);
+}
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  border-top: 2px solid var(--red);
+  text-align: center;
+}
+.footer-inner { padding-top: 1rem; }
+.footer-device {
+  margin-bottom: 1rem;
+}
+.footer-device svg {
+  width: 48px;
+  height: 48px;
+  display: inline-block;
+}
+.footer-line {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-weight: 400;
+  color: var(--text-strong);
+  margin: 0.2em 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 1.1rem;
+}
+.footer-line-small {
+  font-family: "Work Sans", "Archivo", sans-serif;
+  font-weight: 500;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 640px) {
+  .tract-body { padding: 1.25rem 1rem 2rem; }
+  .site-header {
+    padding: 1.5rem 0 1rem;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .site-nav { gap: 1rem; }
+  .tract-title, .tract-body h1 { font-size: 1.9rem; }
+  .tract-body h2 { font-size: 1.3rem; }
+  .tract-body p, .tract-body li { max-width: none; }
+  .press-shell { max-width: 100%; }
+  .demand-grid { grid-template-columns: 1fr; }
+}

--- a/manifesto-press/templates/404.html
+++ b/manifesto-press/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tract tract-narrow">
+      <div class="tract-body">
+        <header class="tract-head">
+          <p class="tract-label">404</p>
+          <h1 class="tract-title">Page not found</h1>
+        </header>
+        <p>This tract has been seized or destroyed. The page you seek does not exist in this archive. Return to the press and begin again.</p>
+        <p><a href="{{ base_url }}/">Back to the press</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/manifesto-press/templates/footer.html
+++ b/manifesto-press/templates/footer.html
@@ -1,0 +1,16 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="30" cy="30" r="28" fill="none" stroke="#c41a1a" stroke-width="1.5"/>
+          <text x="30" y="34" text-anchor="middle" font-family="Bebas Neue, sans-serif" font-size="16" fill="#c41a1a" letter-spacing="2">MP</text>
+        </svg>
+      </div>
+      <p class="footer-line">Manifesto Press</p>
+      <p class="footer-line-small">Revolutionary tract publication, printed in defiance.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; no authority unquestioned</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/manifesto-press/templates/header.html
+++ b/manifesto-press/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Oswald:wght@400;500;600;700&family=Archivo:wght@400;500;600;700&family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="press-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Manifesto Press home">
+        <svg viewBox="0 0 40 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="0" y="0" width="40" height="48" fill="#0e0e0e"/>
+          <rect x="2" y="2" width="36" height="44" fill="none" stroke="#c41a1a" stroke-width="1.5"/>
+          <path d="M20,10 L20,38" stroke="#c41a1a" stroke-width="2"/>
+          <path d="M12,26 L20,10 L28,26" fill="none" stroke="#c41a1a" stroke-width="1.5"/>
+          <rect x="14" y="30" width="12" height="2" fill="#c41a1a"/>
+          <rect x="16" y="34" width="8" height="2" fill="#c41a1a"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Manifesto Press</span>
+          <span class="logo-sub">Revolutionary Tract Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/demands/">Demands</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/manifesto-press/templates/page.html
+++ b/manifesto-press/templates/page.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tract">
+      <div class="banner-divider" aria-hidden="true">
+        <svg viewBox="0 0 800 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="800" height="40" fill="#0e0e0e"/>
+          <rect x="0" y="0" width="800" height="3" fill="#c41a1a"/>
+          <rect x="0" y="37" width="800" height="3" fill="#c41a1a"/>
+          <g fill="#c41a1a" opacity="0.15">
+            <rect x="40" y="12" width="60" height="16"/>
+            <rect x="140" y="12" width="60" height="16"/>
+            <rect x="240" y="12" width="60" height="16"/>
+            <rect x="340" y="12" width="60" height="16"/>
+            <rect x="440" y="12" width="60" height="16"/>
+            <rect x="540" y="12" width="60" height="16"/>
+            <rect x="640" y="12" width="60" height="16"/>
+            <rect x="740" y="12" width="60" height="16"/>
+          </g>
+        </svg>
+      </div>
+      <div class="tract-body">
+        {{ content }}
+      </div>
+      <div class="banner-divider" aria-hidden="true">
+        <svg viewBox="0 0 800 24" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="800" height="24" fill="#0e0e0e"/>
+          <rect x="0" y="10" width="800" height="3" fill="#c41a1a"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/manifesto-press/templates/section.html
+++ b/manifesto-press/templates/section.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tract">
+      <div class="banner-divider" aria-hidden="true">
+        <svg viewBox="0 0 800 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="800" height="40" fill="#0e0e0e"/>
+          <rect x="0" y="0" width="800" height="3" fill="#c41a1a"/>
+          <rect x="0" y="37" width="800" height="3" fill="#c41a1a"/>
+          <g fill="#c41a1a" opacity="0.15">
+            <rect x="40" y="12" width="60" height="16"/>
+            <rect x="140" y="12" width="60" height="16"/>
+            <rect x="240" y="12" width="60" height="16"/>
+            <rect x="340" y="12" width="60" height="16"/>
+            <rect x="440" y="12" width="60" height="16"/>
+            <rect x="540" y="12" width="60" height="16"/>
+            <rect x="640" y="12" width="60" height="16"/>
+            <rect x="740" y="12" width="60" height="16"/>
+          </g>
+        </svg>
+      </div>
+      <div class="tract-body">
+        <header class="tract-head">
+          <p class="tract-label">Index of Demands</p>
+          <h1 class="tract-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/manifesto-press/templates/shortcodes/alert.html
+++ b/manifesto-press/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #3a1010; background-color: #1a0a0a; border-left: 5px solid #c41a1a; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/manifesto-press/templates/taxonomy.html
+++ b/manifesto-press/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tract tract-narrow">
+      <div class="tract-body">
+        <header class="tract-head">
+          <p class="tract-label">Index</p>
+          <h1 class="tract-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this revolutionary archive:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/manifesto-press/templates/taxonomy_term.html
+++ b/manifesto-press/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="tract tract-narrow">
+      <div class="tract-body">
+        <header class="tract-head">
+          <p class="tract-label">Subject</p>
+          <h1 class="tract-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Tracts filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4626 +1,4633 @@
 {
-    "abstract-noir": [
-        "paper",
-        "dark",
-        "abstract",
-        "bold",
-        "typography"
-    ],
-    "abyss": [
-        "dark",
-        "blog",
-        "deep-sea",
-        "immersive"
-    ],
-    "acid-graphics": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "acme-docs": [
-        "light",
-        "docs"
-    ],
-    "acoustic-soundwaves": [
-        "dark",
-        "blog",
-        "sound",
-        "waveform"
-    ],
-    "adminpanel": [
-        "dark",
-        "dashboard",
-        "admin",
-        "sidebar"
-    ],
-    "aether": [
-        "dark",
-        "blog",
-        "elegant"
-    ],
-    "aetheria": [
-        "dark-mode",
-        "elegant",
-        "portfolio"
-    ],
-    "after-dark": [
-        "blog",
-        "dark",
-        "reading"
-    ],
-    "afterparty": [
-        "event",
-        "party",
-        "nightlife",
-        "club",
-        "late-night"
-    ],
-    "aftershock": [
-        "event",
-        "dark",
-        "post-event",
-        "retrospective",
-        "impact"
-    ],
-    "airwave": [
-        "dark",
-        "blog",
-        "podcast"
-    ],
-    "alexandrite": [
-        "dark",
-        "blog",
-        "glamorous",
-        "gemstone"
-    ],
-    "almanac": [
-        "light",
-        "blog",
-        "calendar"
-    ],
-    "almanac-docs": [
-        "light",
-        "docs",
-        "roadmap"
-    ],
-    "amber-preservation": [
-        "dark",
-        "blog",
-        "amber",
-        "fossil"
-    ],
-    "amethyst": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "anaglyph": [
-        "dark",
-        "blog",
-        "3d",
-        "stereoscopic"
-    ],
-    "analytics": [
-        "light",
-        "dashboard",
-        "analytics"
-    ],
-    "anamorphic": [
-        "dark",
-        "portfolio",
-        "anamorphic",
-        "optical"
-    ],
-    "anatomy-atlas": [
-        "dark",
-        "docs",
-        "medical",
-        "vintage"
-    ],
-    "annotation-layer": [
-        "book",
-        "light",
-        "scholarly",
-        "annotated",
-        "dense"
-    ],
-    "anthology": [
-        "light",
-        "docs",
-        "sdk-reference"
-    ],
-    "antimatter": [
-        "dark",
-        "blog",
-        "experimental",
-        "inverted"
-    ],
-    "anubis": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "anvil": [
-        "dark",
-        "blog",
-        "workshop"
-    ],
-    "apiary": [
-        "light",
-        "docs",
-        "api",
-        "two-column"
-    ],
-    "apolo": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "apothecary": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "appsite": [
-        "light",
-        "landing",
-        "app"
-    ],
-    "aquarium": [
-        "dark",
-        "blog",
-        "marine"
-    ],
-    "aquatint": [
-        "light",
-        "portfolio",
-        "creative",
-        "elegant",
-        "bold"
-    ],
-    "aqueduct": [
-        "light",
-        "blog",
-        "engineering"
-    ],
-    "arbor": [
-        "light",
-        "docs",
-        "git-workflow"
-    ],
-    "archipelago": [
-        "dark",
-        "landing",
-        "hub"
-    ],
-    "archive": [
-        "light",
-        "docs",
-        "archive"
-    ],
-    "archway-docs": [
-        "docs",
-        "light",
-        "architecture"
-    ],
-    "arctic-saas": [
-        "landing",
-        "light",
-        "saas",
-        "minimal"
-    ],
-    "arena": [
-        "dark",
-        "blog",
-        "sports"
-    ],
-    "artdeco": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "artnouveau": [
-        "light",
-        "portfolio",
-        "art-nouveau",
-        "botanical"
-    ],
-    "arxiv-preprint": [
-        "paper",
-        "light",
-        "preprint",
-        "self-published",
-        "raw"
-    ],
-    "ascii": [
-        "dark",
-        "terminal",
-        "ascii"
-    ],
-    "asymmetric": [
-        "light",
-        "portfolio",
-        "grid",
-        "asymmetric"
-    ],
-    "atelier": [
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "athena": [
-        "elegant",
-        "portfolio",
-        "light"
-    ],
-    "atlas": [
-        "light",
-        "blog",
-        "geography"
-    ],
-    "atlas-docs": [
-        "docs",
-        "light",
-        "navigation"
-    ],
-    "aurelia": [
-        "elegant",
-        "minimalist",
-        "blog"
-    ],
-    "aurora": [
-        "dark",
-        "blog",
-        "aurora"
-    ],
-    "aurora-glimmer": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "aurora-launch": [
-        "landing",
-        "dark",
-        "animation"
-    ],
-    "aurum": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "avalanche-event": [
-        "event",
-        "dark",
-        "momentum",
-        "cascading",
-        "overwhelming"
-    ],
-    "axiom": [
-        "light",
-        "design-system",
-        "geometric",
-        "mathematical"
-    ],
-    "bamboo": [
-        "light",
-        "blog",
-        "eco"
-    ],
-    "baroque": [
-        "dark",
-        "blog",
-        "ornamental",
-        "glamorous"
-    ],
-    "bas-relief": [
-        "light",
-        "artistic",
-        "minimal"
-    ],
-    "bastard-title": [
-        "book",
-        "light",
-        "preliminary",
-        "ceremonial",
-        "typography"
-    ],
-    "bastion": [
-        "dark",
-        "docs",
-        "zero-trust"
-    ],
-    "batik": [
-        "light",
-        "blog",
-        "elegant",
-        "batik"
-    ],
-    "bauhaus": [
-        "light",
-        "portfolio",
-        "design",
-        "geometric"
-    ],
-    "bayesian-prior": [
-        "paper",
-        "dark",
-        "bayesian",
-        "probabilistic",
-        "visualization"
-    ],
-    "bazaar": [
-        "light",
-        "landing",
-        "marketplace"
-    ],
-    "beacon": [
-        "dark",
-        "blog",
-        "alert"
-    ],
-    "beacon-docs": [
-        "light",
-        "docs",
-        "feature-flag"
-    ],
-    "beautiful-hwaro": [
-        "light",
-        "blog"
-    ],
-    "bejeweled": [
-        "elegant",
-        "glamorous",
-        "luxury"
-    ],
-    "bell-tower": [
-        "event",
-        "light",
-        "scheduled",
-        "clock",
-        "traditional"
-    ],
-    "bench-report": [
-        "paper",
-        "light",
-        "laboratory",
-        "bench",
-        "experimental"
-    ],
-    "bijou": [
-        "dark",
-        "elegant",
-        "jewelry",
-        "glamorous"
-    ],
-    "bioluminescence": [
-        "dark",
-        "blog",
-        "bioluminescence",
-        "minimal"
-    ],
-    "bismuth": [
-        "dark",
-        "collection",
-        "mineral",
-        "rainbow-metallic"
-    ],
-    "black-box": [
-        "event",
-        "dark",
-        "theater",
-        "intimate",
-        "minimal"
-    ],
-    "black-letter-bible": [
-        "book",
-        "dark",
-        "sacred",
-        "blackletter",
-        "dense"
-    ],
-    "blacklight": [
-        "dark",
-        "fluorescent",
-        "elegant"
-    ],
-    "blast-furnace": [
-        "event",
-        "dark",
-        "workshop",
-        "intense",
-        "industrial"
-    ],
-    "blockade-run": [
-        "event",
-        "dark",
-        "breakthrough",
-        "barriers",
-        "overcome"
-    ],
-    "blueprint": [
-        "dark",
-        "docs",
-        "spec"
-    ],
-    "blueprint-pro": [
-        "landing",
-        "dark",
-        "devtool"
-    ],
-    "bonfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "bonsai": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "book": [
-        "light",
-        "docs"
-    ],
-    "borealis": [
-        "dark",
-        "blog",
-        "aurora",
-        "nordic"
-    ],
-    "botanical-press": [
-        "blog",
-        "light",
-        "botanical",
-        "vintage"
-    ],
-    "boutique": [
-        "light",
-        "store",
-        "fashion",
-        "elegant"
-    ],
-    "box-office": [
-        "event",
-        "tickets",
-        "sales",
-        "urgency",
-        "countdown"
-    ],
-    "bramble": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "breeze": [
-        "landing",
-        "light",
-        "minimal",
-        "one-page"
-    ],
-    "brocade": [
-        "dark",
-        "blog",
-        "glamorous",
-        "luxury"
-    ],
-    "brutalist": [
-        "light",
-        "blog",
-        "brutalist"
-    ],
-    "brutopia": [
-        "dark",
-        "blog",
-        "brutalist",
-        "monospace"
-    ],
-    "bulwark": [
-        "dark",
-        "docs",
-        "disaster-recovery"
-    ],
-    "bureau": [
-        "light",
-        "docs",
-        "governance"
-    ],
-    "burlesque": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "burnt-charcoal": [
-        "dark",
-        "blog",
-        "charcoal",
-        "texture"
-    ],
-    "butterfly-wing": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "trendy",
-        "blog"
-    ],
-    "byzantine": [
-        "light",
-        "blog",
-        "byzantine",
-        "mosaic",
-        "imperial"
-    ],
-    "cabaret": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "cabin": [
-        "dark",
-        "blog",
-        "lifestyle"
-    ],
-    "cactus": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cafe": [
-        "light",
-        "landing",
-        "menu"
-    ],
-    "cage-match": [
-        "event",
-        "dark",
-        "competition",
-        "fight",
-        "enclosed"
-    ],
-    "call-to-stage": [
-        "event",
-        "talent",
-        "open-call",
-        "audition",
-        "stage"
-    ],
-    "calligraphy": [
-        "dark",
-        "blog",
-        "calligraphy",
-        "ink"
-    ],
-    "cameo": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "campfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "cancel-leaf": [
-        "book",
-        "light",
-        "correction",
-        "repair",
-        "visible"
-    ],
-    "canopy": [
-        "light",
-        "blog",
-        "outdoor"
-    ],
-    "canvas-studio": [
-        "landing",
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "carbon-fiber": [
-        "dark",
-        "blog",
-        "tech"
-    ],
-    "carnival": [
-        "dark",
-        "blog",
-        "glamorous",
-        "event"
-    ],
-    "cartograph": [
-        "dark",
-        "docs",
-        "infrastructure"
-    ],
-    "cascade": [
-        "light",
-        "longform",
-        "waterfall",
-        "scroll-driven"
-    ],
-    "case-report": [
-        "paper",
-        "light",
-        "clinical",
-        "case-study",
-        "medical"
-    ],
-    "cassette": [
-        "dark",
-        "blog",
-        "retro",
-        "audio"
-    ],
-    "catacombs": [
-        "dark",
-        "blog",
-        "underground",
-        "adventure"
-    ],
-    "catalyst": [
-        "light",
-        "landing",
-        "science",
-        "chemistry"
-    ],
-    "cathedral": [
-        "light",
-        "portfolio",
-        "architecture"
-    ],
-    "cauldron": [
-        "dark",
-        "wiki",
-        "fantasy",
-        "potion"
-    ],
-    "celebrate": [
-        "light",
-        "landing",
-        "event"
-    ],
-    "celestial-burst": [
-        "dark",
-        "glamorous",
-        "celestial",
-        "trendy"
-    ],
-    "center-stage": [
-        "event",
-        "solo",
-        "show",
-        "spotlight",
-        "centered"
-    ],
-    "chain-reaction": [
-        "event",
-        "dark",
-        "sequential",
-        "cascade",
-        "connected"
-    ],
-    "chalkboard": [
-        "dark",
-        "blog",
-        "education"
-    ],
-    "champagne": [
-        "light",
-        "luxury",
-        "elegant",
-        "champagne"
-    ],
-    "chandelier": [
-        "light",
-        "blog",
-        "crystal",
-        "elegant",
-        "prismatic"
-    ],
-    "changelog": [
-        "dark",
-        "docs",
-        "changelog"
-    ],
-    "chase-frame": [
-        "book",
-        "dark",
-        "letterpress",
-        "mechanical",
-        "craft"
-    ],
-    "chiaroscuro": [
-        "dark",
-        "portfolio",
-        "chiaroscuro",
-        "contrast"
-    ],
-    "chinoiserie": [
-        "light",
-        "blog",
-        "chinese",
-        "porcelain",
-        "elegant"
-    ],
-    "chromatic": [
-        "dark",
-        "photoblog",
-        "chromatic",
-        "lens"
-    ],
-    "chromatic-wave": [
-        "dark",
-        "portfolio",
-        "glamorous",
-        "animation"
-    ],
-    "chromatophore": [
-        "dark",
-        "bold",
-        "minimal",
-        "creative"
-    ],
-    "chrome-pulse": [
-        "minimal",
-        "dark",
-        "landing"
-    ],
-    "chromolithograph": [
-        "book",
-        "light",
-        "color-plate",
-        "print",
-        "illustration"
-    ],
-    "chronicle": [
-        "light",
-        "blog",
-        "traditional",
-        "serif"
-    ],
-    "chronosphere": [
-        "dark",
-        "space",
-        "time"
-    ],
-    "chrysanthemum": [
-        "dark",
-        "blog",
-        "floral",
-        "glamorous"
-    ],
-    "cinder": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cinema": [
-        "dark",
-        "blog",
-        "review"
-    ],
-    "cinema-silent": [
-        "dark",
-        "blog",
-        "retro",
-        "editorial"
-    ],
-    "cipher": [
-        "dark",
-        "docs",
-        "cryptography"
-    ],
-    "citation-graph": [
-        "paper",
-        "dark",
-        "network",
-        "citations",
-        "visualization"
-    ],
-    "clarity-docs": [
-        "docs",
-        "light",
-        "minimal",
-        "typography"
-    ],
-    "clocktower": [
-        "dark",
-        "landing",
-        "countdown"
-    ],
-    "cloisonne": [
-        "dark",
-        "portfolio",
-        "enamel",
-        "ornate"
-    ],
-    "cloister": [
-        "light",
-        "blog",
-        "meditation"
-    ],
-    "closed": [
-        "light",
-        "error",
-        "499",
-        "minimal"
-    ],
-    "cloudnest": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "cobblestone": [
-        "light",
-        "blog",
-        "culture"
-    ],
-    "cockpit": [
-        "dark",
-        "landing",
-        "telemetry"
-    ],
-    "codebook": [
-        "light",
-        "docs",
-        "styleguide"
-    ],
-    "codecraft": [
-        "api",
-        "dark",
-        "developer",
-        "docs"
-    ],
-    "codex": [
-        "light",
-        "blog",
-        "medieval"
-    ],
-    "codex-rotundus": [
-        "book",
-        "dark",
-        "circular",
-        "unusual",
-        "experimental"
-    ],
-    "cohort-study": [
-        "paper",
-        "light",
-        "cohort",
-        "survival",
-        "epidemiological"
-    ],
-    "cold-case": [
-        "paper",
-        "dark",
-        "forensic",
-        "investigation",
-        "reopened"
-    ],
-    "colosseum": [
-        "light",
-        "event",
-        "classical",
-        "grand"
-    ],
-    "comic": [
-        "light",
-        "blog",
-        "comic"
-    ],
-    "command-center": [
-        "docs",
-        "dark",
-        "cli",
-        "developer"
-    ],
-    "compass": [
-        "light",
-        "landing",
-        "career"
-    ],
-    "compass-docs": [
-        "light",
-        "docs",
-        "onboarding"
-    ],
-    "conduit": [
-        "light",
-        "docs",
-        "data-pipeline"
-    ],
-    "conference-poster": [
-        "paper",
-        "dark",
-        "poster",
-        "conference",
-        "visual"
-    ],
-    "confetti": [
-        "celebration",
-        "elegant",
-        "festive"
-    ],
-    "console": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "constellation": [
-        "dark",
-        "blog",
-        "astronomy"
-    ],
-    "controlroom": [
-        "dark",
-        "dashboard",
-        "monitoring"
-    ],
-    "copper-patina": [
-        "dark",
-        "blog",
-        "patina",
-        "industrial"
-    ],
-    "copper-wire": [
-        "blog",
-        "dark",
-        "industrial"
-    ],
-    "copperplate": [
-        "dark",
-        "blog",
-        "copperplate",
-        "engraving"
-    ],
-    "coral": [
-        "light",
-        "documentary",
-        "organic",
-        "ocean"
-    ],
-    "coral-bloom": [
-        "dark",
-        "blog",
-        "elegant",
-        "marine",
-        "glamorous"
-    ],
-    "corrigendum": [
-        "paper",
-        "light",
-        "correction",
-        "errata",
-        "formal"
-    ],
-    "cosmos": [
-        "dark",
-        "magazine",
-        "space",
-        "planetary"
-    ],
-    "cost-effectiveness": [
-        "paper",
-        "light",
-        "economics",
-        "cost-effectiveness",
-        "health"
-    ],
-    "countdown-zero": [
-        "event",
-        "dark",
-        "countdown",
-        "convergence",
-        "climactic"
-    ],
-    "creative-agency": [
-        "dark",
-        "portfolio",
-        "agency",
-        "bold"
-    ],
-    "cross-sectional": [
-        "paper",
-        "light",
-        "cross-sectional",
-        "snapshot",
-        "population"
-    ],
-    "crucible": [
-        "light",
-        "docs",
-        "testing"
-    ],
-    "cruciform": [
-        "light",
-        "design-system",
-        "grid",
-        "swiss"
-    ],
-    "crystalline": [
-        "light",
-        "portfolio",
-        "crystal",
-        "faceted"
-    ],
-    "cuneiform-tablet": [
-        "book",
-        "dark",
-        "ancient",
-        "impressed",
-        "archaeological"
-    ],
-    "curator": [
-        "light",
-        "portfolio",
-        "exhibition"
-    ],
-    "curtain-call": [
-        "event",
-        "dark",
-        "closing",
-        "ceremony",
-        "theatrical"
-    ],
-    "cyanotype": [
-        "light",
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "cyberpunk": [
-        "dark",
-        "magazine",
-        "cyberpunk",
-        "neon"
-    ],
-    "daguerreotype": [
-        "dark",
-        "blog",
-        "photography",
-        "vintage"
-    ],
-    "damask": [
-        "dark",
-        "blog",
-        "luxury",
-        "glamorous"
-    ],
-    "dark-manual": [
-        "docs",
-        "dark",
-        "technical",
-        "manual"
-    ],
-    "darkfolio": [
-        "dark",
-        "portfolio",
-        "developer",
-        "minimal"
-    ],
-    "darkmarket": [
-        "dark",
-        "marketplace",
-        "bold"
-    ],
-    "darkroom": [
-        "dark",
-        "portfolio",
-        "photography"
-    ],
-    "darkwave": [
-        "dark",
-        "blog",
-        "synthwave"
-    ],
-    "dashboard": [
-        "dark",
-        "landing",
-        "dashboard"
-    ],
-    "data-paper": [
-        "paper",
-        "light",
-        "dataset",
-        "schema",
-        "minimal-text"
-    ],
-    "deckle-edge": [
-        "book",
-        "light",
-        "craft",
-        "handmade",
-        "texture"
-    ],
-    "deconstructed": [
-        "light",
-        "agency",
-        "deconstructivism",
-        "architecture"
-    ],
-    "deconstructivist": [
-        "dark",
-        "portfolio",
-        "deconstructivist",
-        "architecture"
-    ],
-    "demolition-derby": [
-        "event",
-        "dark",
-        "competition",
-        "destruction",
-        "chaotic"
-    ],
-    "depot": [
-        "light",
-        "landing",
-        "tracker"
-    ],
-    "devconf": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "devlog": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "devtool": [
-        "dark",
-        "landing",
-        "developer"
-    ],
-    "dewdrop": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "diamond-facet": [
-        "dark",
-        "blog",
-        "glamorous",
-        "prismatic"
-    ],
-    "diary": [
-        "light",
-        "blog",
-        "personal",
-        "journal"
-    ],
-    "diorama": [
-        "dark",
-        "landing",
-        "product"
-    ],
-    "disco-fever": [
-        "dark",
-        "blog",
-        "retro",
-        "disco",
-        "neon"
-    ],
-    "dispatch": [
-        "light",
-        "docs",
-        "event-driven"
-    ],
-    "dockhub": [
-        "dark",
-        "docs",
-        "devops"
-    ],
-    "dojo": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "dose-response": [
-        "paper",
-        "light",
-        "pharmacological",
-        "dose-response",
-        "clinical"
-    ],
-    "double-header": [
-        "event",
-        "dark",
-        "double",
-        "dual",
-        "packed"
-    ],
-    "driftwood": [
-        "light",
-        "blog",
-        "photo"
-    ],
-    "dropzone": [
-        "cloud",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "dune": [
-        "light",
-        "journal",
-        "desert",
-        "travel"
-    ],
-    "duodecimo": [
-        "book",
-        "light",
-        "compact",
-        "portable",
-        "efficient"
-    ],
-    "dusk": [
-        "dark",
-        "blog",
-        "sunset"
-    ],
-    "dynamo": [
-        "dark",
-        "docs",
-        "serverless"
-    ],
-    "easel": [
-        "light",
-        "docs",
-        "art"
-    ],
-    "eclipse": [
-        "dark",
-        "blog",
-        "celestial",
-        "dramatic"
-    ],
-    "editorial-letter": [
-        "paper",
-        "light",
-        "editorial",
-        "authority",
-        "statement"
-    ],
-    "electric-bloom": [
-        "dark",
-        "blog",
-        "glamorous",
-        "neon",
-        "botanical"
-    ],
-    "electroplate": [
-        "dark",
-        "blog",
-        "metallic",
-        "plating"
-    ],
-    "elevate": [
-        "landing",
-        "light",
-        "saas",
-        "enterprise"
-    ],
-    "elysian": [
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "elysium": [
-        "portfolio",
-        "minimal",
-        "dark"
-    ],
-    "elysium-portfolio": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "embargo-lift": [
-        "event",
-        "dark",
-        "embargo",
-        "release",
-        "timed"
-    ],
-    "ember": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "embroidery": [
-        "dark",
-        "blog",
-        "glamorous",
-        "trendy"
-    ],
-    "emerald": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "empyrean": [
-        "light",
-        "landing",
-        "divine",
-        "ethereal"
-    ],
-    "encaustic": [
-        "light",
-        "blog",
-        "art",
-        "painting"
-    ],
-    "encore": [
-        "event",
-        "dark",
-        "repeat",
-        "popular",
-        "demanded"
-    ],
-    "encore-night": [
-        "event",
-        "concert",
-        "farewell",
-        "encore",
-        "emotional"
-    ],
-    "endpaper": [
-        "book",
-        "dark",
-        "decorative",
-        "pattern",
-        "hidden"
-    ],
-    "enigma": [
-        "dark",
-        "puzzle",
-        "cryptography",
-        "mechanical"
-    ],
-    "entropy": [
-        "dual",
-        "magazine",
-        "experimental",
-        "asymmetric"
-    ],
-    "errata-sheet": [
-        "paper",
-        "light",
-        "errata",
-        "correction",
-        "transparent"
-    ],
-    "etching": [
-        "dark",
-        "blog",
-        "etching",
-        "printmaking"
-    ],
-    "ethereal-canvas": [
-        "blog",
-        "dark",
-        "elegant",
-        "minimal",
-        "portfolio"
-    ],
-    "ethereal-vapor": [
-        "light",
-        "blog",
-        "ethereal",
-        "translucent"
-    ],
-    "ethos": [
-        "light",
-        "docs",
-        "culture"
-    ],
-    "even": [
-        "light",
-        "blog"
-    ],
-    "evergreen-docs": [
-        "docs",
-        "light",
-        "enterprise",
-        "classic"
-    ],
-    "experiment-log": [
-        "paper",
-        "dark",
-        "experimental",
-        "sequential",
-        "iterative"
-    ],
-    "faberge": [
-        "light",
-        "blog",
-        "luxury",
-        "jeweled",
-        "ornate"
-    ],
-    "faq": [
-        "light",
-        "docs",
-        "faq"
-    ],
-    "fascicle": [
-        "book",
-        "light",
-        "serial",
-        "unbound",
-        "installment"
-    ],
-    "fault-siren": [
-        "event",
-        "dark",
-        "warning",
-        "preparedness",
-        "civil-defense"
-    ],
-    "fauvist-wild": [
-        "dark",
-        "blog",
-        "fauvist",
-        "colorful"
-    ],
-    "ferrofluid": [
-        "dark",
-        "blog",
-        "ferrofluid",
-        "magnetic"
-    ],
-    "festival": [
-        "dark",
-        "event",
-        "elegant",
-        "glow",
-        "bold"
-    ],
-    "festival-ground": [
-        "event",
-        "festival",
-        "outdoor",
-        "grounds",
-        "map"
-    ],
-    "field-report": [
-        "paper",
-        "dark",
-        "field",
-        "expedition",
-        "rugged"
-    ],
-    "fiesta": [
-        "light",
-        "blog",
-        "colorful",
-        "celebration"
-    ],
-    "filigree": [
-        "dark",
-        "blog",
-        "filigree",
-        "metalwork"
-    ],
-    "fintech-pulse": [
-        "landing",
-        "dark",
-        "fintech",
-        "data-viz"
-    ],
-    "fireside": [
-        "dark",
-        "blog",
-        "book-review"
-    ],
-    "fireworks": [
-        "dark",
-        "elegant",
-        "animation",
-        "glow"
-    ],
-    "firing-range": [
-        "event",
-        "dark",
-        "precision",
-        "target",
-        "competitive"
-    ],
-    "fjord": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "flamingo": [
-        "light",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "flowsync": [
-        "dark",
-        "landing"
-    ],
-    "fluorescent": [
-        "dark",
-        "blog",
-        "neon",
-        "pop-art"
-    ],
-    "folio": [
-        "light",
-        "portfolio"
-    ],
-    "folio-docs": [
-        "light",
-        "docs",
-        "design-system"
-    ],
-    "folio-gigante": [
-        "book",
-        "dark",
-        "oversized",
-        "monumental",
-        "maximal"
-    ],
-    "forge": [
-        "light",
-        "docs",
-        "opensource"
-    ],
-    "formulary": [
-        "light",
-        "docs",
-        "math"
-    ],
-    "forty": [
-        "dark",
-        "portfolio",
-        "gallery"
-    ],
-    "foundry": [
-        "dark",
-        "blog",
-        "maker"
-    ],
-    "foxhole": [
-        "dark",
-        "blog",
-        "security"
-    ],
-    "fractal": [
-        "dark",
-        "gallery",
-        "generative",
-        "mathematical"
-    ],
-    "frequency": [
-        "dark",
-        "blog",
-        "radio"
-    ],
-    "frottage": [
-        "light",
-        "minimal",
-        "art",
-        "clean"
-    ],
-    "frutiger-aero": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "furnace": [
-        "dark",
-        "docs",
-        "performance"
-    ],
-    "gala": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "garden": [
-        "light",
-        "blog",
-        "garden"
-    ],
-    "garnet": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "garrison": [
-        "dark",
-        "docs",
-        "firewall"
-    ],
-    "gateway": [
-        "dark",
-        "docs",
-        "auth"
-    ],
-    "gauntlet-run": [
-        "event",
-        "dark",
-        "endurance",
-        "challenge",
-        "sequential"
-    ],
-    "gazebo": [
-        "light",
-        "blog",
-        "event"
-    ],
-    "gazette": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "generative-art": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "glamorous"
-    ],
-    "genome-paper": [
-        "paper",
-        "dark",
-        "genomics",
-        "bioinformatics",
-        "data-intensive"
-    ],
-    "geodesic": [
-        "light",
-        "landing",
-        "geometric"
-    ],
-    "gilded": [
-        "dark",
-        "blog",
-        "luxury",
-        "gold"
-    ],
-    "gilt-edge": [
-        "book",
-        "dark",
-        "luxury",
-        "gilded",
-        "opulent"
-    ],
-    "glacial-blog": [
-        "blog",
-        "light",
-        "cool",
-        "minimal"
-    ],
-    "glacial-ice": [
-        "dark",
-        "blog",
-        "ice",
-        "frost"
-    ],
-    "glacier": [
-        "light",
-        "blog",
-        "tech"
-    ],
-    "glam-rock": [
-        "dark",
-        "blog",
-        "rock",
-        "glam",
-        "metallic"
-    ],
-    "glassmorphism": [
-        "dark",
-        "blog",
-        "glassmorphism"
-    ],
-    "glitch": [
-        "dark",
-        "blog",
-        "experimental",
-        "glitch-art"
-    ],
-    "glitch-elegance": [
-        "dark",
-        "blog",
-        "glitch",
-        "elegant"
-    ],
-    "glow-reef": [
-        "dark",
-        "blog",
-        "elegant",
-        "neon"
-    ],
-    "glyphic": [
-        "dark",
-        "blog",
-        "glyph",
-        "carved"
-    ],
-    "gong-show": [
-        "event",
-        "dark",
-        "competition",
-        "judgment",
-        "dramatic"
-    ],
-    "gossamer": [
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "gothic": [
-        "dark",
-        "blog",
-        "gothic",
-        "medieval"
-    ],
-    "gradient-mesh": [
-        "dark",
-        "blog",
-        "gradient"
-    ],
-    "graffiti": [
-        "dark",
-        "blog",
-        "street-art",
-        "urban"
-    ],
-    "grand-finale": [
-        "event",
-        "festival",
-        "finale",
-        "closing",
-        "spectacular"
-    ],
-    "grant-proposal": [
-        "paper",
-        "light",
-        "proposal",
-        "funding",
-        "persuasive"
-    ],
-    "graphite-docs": [
-        "docs",
-        "dark",
-        "technical"
-    ],
-    "greenhouse": [
-        "light",
-        "blog",
-        "plant"
-    ],
-    "grisaille": [
-        "dark",
-        "blog",
-        "minimal",
-        "monochrome"
-    ],
-    "ground-zero": [
-        "event",
-        "dark",
-        "origin",
-        "impact",
-        "transformative"
-    ],
-    "guidebook": [
-        "light",
-        "docs",
-        "guide"
-    ],
-    "gunmetal": [
-        "dark",
-        "elegant",
-        "industrial",
-        "metallic"
-    ],
-    "gyroscope": [
-        "dark",
-        "dashboard",
-        "motion-sensor",
-        "3d-rotation"
-    ],
-    "habitat": [
-        "light",
-        "landing",
-        "listing"
-    ],
-    "hacker": [
-        "dark",
-        "blog"
-    ],
-    "hall-of-voices": [
-        "event",
-        "poetry",
-        "spoken-word",
-        "slam",
-        "voices"
-    ],
-    "hammer-drop": [
-        "event",
-        "light",
-        "auction",
-        "bidding",
-        "final"
-    ],
-    "hammock": [
-        "light",
-        "blog",
-        "slowlife"
-    ],
-    "handbook": [
-        "light",
-        "docs",
-        "corporate"
-    ],
-    "hangar": [
-        "dark",
-        "blog",
-        "aviation"
-    ],
-    "hardcore-pit": [
-        "event",
-        "punk",
-        "hardcore",
-        "show",
-        "chaotic"
-    ],
-    "haute-couture": [
-        "elegant",
-        "fashion",
-        "magazine"
-    ],
-    "headliner-bold": [
-        "event",
-        "festival",
-        "lineup",
-        "headliner",
-        "hierarchy"
-    ],
-    "hearth": [
-        "light",
-        "blog",
-        "traditional",
-        "elegant"
-    ],
-    "heavy-curtain": [
-        "event",
-        "theater",
-        "drama",
-        "production",
-        "heavy"
-    ],
-    "heliograph": [
-        "dark",
-        "blog",
-        "heliograph",
-        "sun-print"
-    ],
-    "helix": [
-        "light",
-        "landing",
-        "biotech",
-        "3d"
-    ],
-    "helix-docs": [
-        "docs",
-        "light",
-        "science"
-    ],
-    "herald": [
-        "light",
-        "magazine",
-        "editorial",
-        "news"
-    ],
-    "hermit": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "hibiscus": [
-        "dark",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "hologram": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "holographic": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "horizon-ai": [
-        "landing",
-        "dark",
-        "ai",
-        "futuristic"
-    ],
-    "house-lights": [
-        "event",
-        "venue",
-        "concert",
-        "lighting",
-        "technical"
-    ],
-    "hwaro.386": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "hwaronight": [
-        "dark",
-        "blog"
-    ],
-    "hypercube": [
-        "dark",
-        "docs",
-        "3d",
-        "wireframe"
-    ],
-    "hyperpop": [
-        "dark",
-        "glamorous",
-        "neon",
-        "trendy",
-        "elegant"
-    ],
-    "igloo": [
-        "light",
-        "blog",
-        "nordic"
-    ],
-    "ignite": [
-        "landing",
-        "dark",
-        "startup"
-    ],
-    "ignition-sequence": [
-        "event",
-        "dark",
-        "phased",
-        "launch",
-        "sequential"
-    ],
-    "impasto": [
-        "light",
-        "blog",
-        "bold",
-        "artistic"
-    ],
-    "incunabula-noir": [
-        "book",
-        "dark",
-        "incunabulum",
-        "early-print",
-        "revolutionary"
-    ],
-    "inferno": [
-        "dark",
-        "community",
-        "fire",
-        "gaming"
-    ],
-    "infographic": [
-        "light",
-        "landing",
-        "infographic",
-        "data-viz"
-    ],
-    "ink-seoul": [
-        "light",
-        "blog",
-        "monochrome",
-        "seoul",
-        "minimal"
-    ],
-    "inkdrop-docs": [
-        "docs",
-        "dark",
-        "elegant",
-        "animation"
-    ],
-    "inkwell": [
-        "light",
-        "blog",
-        "poetry"
-    ],
-    "intaglio": [
-        "dark",
-        "portfolio",
-        "engraving",
-        "minimal"
-    ],
-    "intarsia": [
-        "light",
-        "portfolio",
-        "bold",
-        "clean",
-        "geometric"
-    ],
-    "interferogram": [
-        "dark",
-        "blog",
-        "interference",
-        "optical"
-    ],
-    "inventory": [
-        "light",
-        "dashboard",
-        "management"
-    ],
-    "iridescent-oil": [
-        "dark",
-        "blog",
-        "iridescent",
-        "oil"
-    ],
-    "iron-stage": [
-        "event",
-        "festival",
-        "metal",
-        "industrial",
-        "heavy"
-    ],
-    "ironclad": [
-        "dark",
-        "landing",
-        "metallic",
-        "security"
-    ],
-    "ironworks": [
-        "dark",
-        "blog",
-        "history"
-    ],
-    "isometric": [
-        "light",
-        "3d",
-        "dashboard",
-        "ui"
-    ],
-    "isthmus": [
-        "light",
-        "hub",
-        "bridge",
-        "horizontal-scroll"
-    ],
-    "jade-palace": [
-        "dark",
-        "blog",
-        "luxury",
-        "eastern"
-    ],
-    "japanese-industrial": [
-        "dark",
-        "blog",
-        "japanese",
-        "industrial"
-    ],
-    "jewel-tone": [
-        "dark",
-        "glamorous",
-        "jewel",
-        "elegant"
-    ],
-    "jugendstil": [
-        "light",
-        "blog",
-        "art-nouveau",
-        "organic",
-        "nature"
-    ],
-    "kaleidoscope": [
-        "light",
-        "event",
-        "psychedelic",
-        "pattern"
-    ],
-    "ketubah": [
-        "book",
-        "light",
-        "ceremonial",
-        "decorated",
-        "formal"
-    ],
-    "keynote-blast": [
-        "event",
-        "dark",
-        "conference",
-        "keynote",
-        "explosive"
-    ],
-    "keystone": [
-        "light",
-        "docs",
-        "architecture"
-    ],
-    "kiln": [
-        "light",
-        "portfolio",
-        "craft"
-    ],
-    "kinetic": [
-        "dark",
-        "agency",
-        "physics",
-        "interactive"
-    ],
-    "kinetic-mobile": [
-        "dark",
-        "blog",
-        "kinetic",
-        "mobile"
-    ],
-    "kinetic-typography": [
-        "dark",
-        "blog",
-        "kinetic",
-        "typography"
-    ],
-    "kintsugi": [
-        "dark",
-        "blog",
-        "kintsugi",
-        "gold-repair"
-    ],
-    "lab": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "lab-notebook": [
-        "paper",
-        "light",
-        "laboratory",
-        "raw",
-        "observational"
-    ],
-    "labyrinth": [
-        "dark",
-        "portfolio",
-        "maze",
-        "gamification"
-    ],
-    "lagoon": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "laser-show": [
-        "dark",
-        "blog",
-        "landing",
-        "concert",
-        "glamorous"
-    ],
-    "last-call": [
-        "event",
-        "dark",
-        "closing",
-        "final",
-        "urgent"
-    ],
-    "lattice": [
-        "light",
-        "docs",
-        "graph-db"
-    ],
-    "launchpad": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "launchpad-event": [
-        "event",
-        "dark",
-        "launch",
-        "space",
-        "countdown"
-    ],
-    "lava-flow": [
-        "dark",
-        "blog",
-        "lava",
-        "volcanic"
-    ],
-    "layered-docs": [
-        "light",
-        "docs",
-        "enterprise"
-    ],
-    "ledger": [
-        "light",
-        "docs",
-        "finance"
-    ],
-    "letter-to-editor": [
-        "paper",
-        "light",
-        "correspondence",
-        "urgent",
-        "brief"
-    ],
-    "letterbox": [
-        "light",
-        "blog",
-        "newsletter"
-    ],
-    "lexicon": [
-        "light",
-        "docs",
-        "glossary"
-    ],
-    "lichen-moss": [
-        "dark",
-        "blog",
-        "lichen",
-        "organic"
-    ],
-    "lighthouse": [
-        "light",
-        "docs",
-        "directory"
-    ],
-    "linktree": [
-        "dark",
-        "landing",
-        "links"
-    ],
-    "linocut": [
-        "light",
-        "printmaking",
-        "bold",
-        "creative"
-    ],
-    "liquid": [
-        "dark",
-        "interactive",
-        "gooey",
-        "svg"
-    ],
-    "liquid-chrome": [
-        "dark",
-        "blog",
-        "metallic",
-        "glamorous"
-    ],
-    "lithium": [
-        "dark",
-        "landing",
-        "electric",
-        "tech"
-    ],
-    "lithograph": [
-        "dark",
-        "blog",
-        "lithograph",
-        "printmaking"
-    ],
-    "logbook": [
-        "light",
-        "docs",
-        "compliance"
-    ],
-    "longitudinal": [
-        "paper",
-        "dark",
-        "longitudinal",
-        "temporal",
-        "tracking"
-    ],
-    "lookbook": [
-        "dark",
-        "portfolio",
-        "lookbook",
-        "fashion"
-    ],
-    "loom": [
-        "light",
-        "portfolio",
-        "fashion"
-    ],
-    "lumiere": [
-        "dark",
-        "elegant",
-        "minimal",
-        "luminescent"
-    ],
-    "lumina": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "luminary": [
-        "light",
-        "elegant",
-        "portfolio"
-    ],
-    "luminescent-mesh": [
-        "dark",
-        "blog",
-        "luminescent",
-        "mesh"
-    ],
-    "lumos": [
-        "blog",
-        "elegant",
-        "light",
-        "minimal"
-    ],
-    "lunar-base": [
-        "elegant",
-        "portfolio",
-        "dark"
-    ],
-    "lunar-breeze": [
-        "dark",
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "luxe-noir": [
-        "dark",
-        "glamorous",
-        "luxury",
-        "elegant"
-    ],
-    "luxury-horology": [
-        "dark",
-        "portfolio",
-        "horology",
-        "luxury"
-    ],
-    "macro-snowflake": [
-        "dark",
-        "blog",
-        "snowflake",
-        "crystalline"
-    ],
-    "madhubani": [
-        "light",
-        "blog",
-        "indian",
-        "folk-art",
-        "geometric"
-    ],
-    "magenta-sunset": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "magma": [
-        "dark",
-        "dashboard",
-        "volcanic",
-        "animation"
-    ],
-    "magnetar": [
-        "dark",
-        "blog",
-        "magnetar",
-        "cosmic"
-    ],
-    "main-act": [
-        "event",
-        "concert",
-        "headline",
-        "performer",
-        "dramatic"
-    ],
-    "mainstage": [
-        "event",
-        "dark",
-        "performance",
-        "stage",
-        "dramatic"
-    ],
-    "manifesto": [
-        "dark",
-        "blog",
-        "opinion"
-    ],
-    "manifold": [
-        "light",
-        "docs",
-        "saas"
-    ],
-    "marble": [
-        "light",
-        "gallery",
-        "luxury",
-        "marble-texture"
-    ],
-    "marbled-paper": [
-        "dark",
-        "blog",
-        "marbled",
-        "paper"
-    ],
-    "mardi-gras": [
-        "glamorous",
-        "trendy",
-        "bold",
-        "purple",
-        "gold",
-        "green"
-    ],
-    "marketplace": [
-        "light",
-        "store",
-        "marketplace"
-    ],
-    "marquetry": [
-        "light",
-        "portfolio",
-        "geometric",
-        "minimal"
-    ],
-    "masquerade": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "luxury",
-        "mystery"
-    ],
-    "matcha": [
-        "blog",
-        "light",
-        "minimal",
-        "zen"
-    ],
-    "matrix": [
-        "light",
-        "docs",
-        "compatibility"
-    ],
-    "maximal-bloom": [
-        "elegant",
-        "floral",
-        "bold",
-        "glamorous"
-    ],
-    "maximalist": [
-        "dark",
-        "blog",
-        "bold",
-        "glamorous"
-    ],
-    "mayan-geometry": [
-        "dark",
-        "blog",
-        "mayan",
-        "geometric"
-    ],
-    "meadow": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "medieval-manuscript": [
-        "dark",
-        "blog",
-        "medieval",
-        "manuscript"
-    ],
-    "memoir": [
-        "light",
-        "blog",
-        "longform"
-    ],
-    "memphis": [
-        "light",
-        "retro",
-        "colorful",
-        "bold",
-        "portfolio"
-    ],
-    "mercury": [
-        "dark",
-        "blog",
-        "minimal",
-        "metallic",
-        "elegant"
-    ],
-    "meridian": [
-        "dark",
-        "landing",
-        "timezone"
-    ],
-    "meridian-docs": [
-        "light",
-        "docs",
-        "scheduling"
-    ],
-    "meridiem": [
-        "dual",
-        "dashboard",
-        "time-based",
-        "auto-theme"
-    ],
-    "meta-analysis": [
-        "paper",
-        "light",
-        "statistical",
-        "synthesis",
-        "evidence"
-    ],
-    "meteor": [
-        "dark",
-        "interactive",
-        "meteor-shower",
-        "cosmic"
-    ],
-    "methods-paper": [
-        "paper",
-        "light",
-        "methods",
-        "protocol",
-        "technical"
-    ],
-    "metronome": [
-        "dark",
-        "blog",
-        "music-production",
-        "rhythm"
-    ],
-    "mezzotint": [
-        "light",
-        "blog",
-        "bold",
-        "clean",
-        "monochrome"
-    ],
-    "micro": [
-        "light",
-        "blog",
-        "microblog"
-    ],
-    "midnight-blog": [
-        "dark",
-        "blog",
-        "reading"
-    ],
-    "midnight-launch": [
-        "landing",
-        "dark",
-        "animation",
-        "product"
-    ],
-    "migration": [
-        "light",
-        "docs",
-        "database"
-    ],
-    "minifolio": [
-        "light",
-        "portfolio",
-        "minimal"
-    ],
-    "minimalzen": [
-        "light",
-        "blog",
-        "minimal",
-        "zen"
-    ],
-    "mint-fresh": [
-        "landing",
-        "light",
-        "saas"
-    ],
-    "mirage": [
-        "light",
-        "gallery",
-        "desert",
-        "distortion"
-    ],
-    "misprint": [
-        "book",
-        "dark",
-        "error",
-        "accidental",
-        "artistic"
-    ],
-    "mixed-methods": [
-        "paper",
-        "light",
-        "mixed-methods",
-        "convergent",
-        "dual"
-    ],
-    "modern-blog": [
-        "dark",
-        "blog",
-        "modern"
-    ],
-    "molten": [
-        "dark",
-        "blog",
-        "metalwork",
-        "melting"
-    ],
-    "molten-gold": [
-        "elegant",
-        "gold",
-        "trendy"
-    ],
-    "monochrome": [
-        "light",
-        "photo-essay",
-        "monochrome",
-        "grayscale"
-    ],
-    "monograph": [
-        "book",
-        "light",
-        "academic",
-        "thorough",
-        "reference"
-    ],
-    "monolith": [
-        "dark",
-        "landing",
-        "onepage"
-    ],
-    "monolithic-dark": [
-        "dark",
-        "blog",
-        "monolithic",
-        "bold"
-    ],
-    "monoprint": [
-        "light",
-        "monoprint",
-        "bold",
-        "creative"
-    ],
-    "monorepo-docs": [
-        "docs",
-        "dark",
-        "developer",
-        "monorepo"
-    ],
-    "moonrise": [
-        "dark",
-        "blog",
-        "essay"
-    ],
-    "moonstone": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "moroccan-zellige": [
-        "light",
-        "blog",
-        "moroccan",
-        "mosaic",
-        "geometric"
-    ],
-    "morphogenesis": [
-        "dark",
-        "blog",
-        "generative",
-        "biology",
-        "patterns"
-    ],
-    "mortar": [
-        "dark",
-        "docs",
-        "build-system"
-    ],
-    "mosaic": [
-        "light",
-        "blog",
-        "magazine"
-    ],
-    "mosh-pit": [
-        "event",
-        "dark",
-        "punk",
-        "chaotic",
-        "raw"
-    ],
-    "mosstown": [
-        "light",
-        "blog",
-        "cozy"
-    ],
-    "mughal": [
-        "light",
-        "blog",
-        "mughal",
-        "ornate",
-        "gold"
-    ],
-    "murano-glass": [
-        "light",
-        "blog",
-        "glass",
-        "translucent",
-        "venetian"
-    ],
-    "mycelium": [
-        "dark",
-        "blog",
-        "mycelium",
-        "fungal"
-    ],
-    "nadir": [
-        "dark",
-        "blog",
-        "minimal",
-        "oled-black"
-    ],
-    "nautical": [
-        "dark",
-        "blog",
-        "nautical"
-    ],
-    "nebula": [
-        "dark",
-        "gallery",
-        "space",
-        "ethereal"
-    ],
-    "neo-deco": [
-        "dark",
-        "portfolio",
-        "artdeco",
-        "elegant"
-    ],
-    "neo-memphis-dark": [
-        "dark",
-        "blog",
-        "memphis",
-        "neo-memphis"
-    ],
-    "neobrutal": [
-        "light",
-        "landing",
-        "neo-brutalism",
-        "bold"
-    ],
-    "neoclassical": [
-        "light",
-        "gallery",
-        "marble-texture",
-        "elegant"
-    ],
-    "neon": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "neon-jungle": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "neon"
-    ],
-    "neon-marquee": [
-        "event",
-        "theater",
-        "marquee",
-        "vintage",
-        "retro"
-    ],
-    "neon-tokyo": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "tokyo",
-        "glamorous"
-    ],
-    "network-meta": [
-        "paper",
-        "dark",
-        "network",
-        "meta-analysis",
-        "comparative"
-    ],
-    "neumorphism": [
-        "light",
-        "ui",
-        "soft",
-        "shadow"
-    ],
-    "neural-bloom": [
-        "dark",
-        "blog",
-        "neural",
-        "ai",
-        "synaptic"
-    ],
-    "newspaper": [
-        "light",
-        "blog",
-        "editorial",
-        "newspaper"
-    ],
-    "nexus": [
-        "dark",
-        "docs",
-        "microservice"
-    ],
-    "nexus-docs": [
-        "docs",
-        "dark",
-        "developer"
-    ],
-    "niello": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "no-style-please": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "noctis": [
-        "landing",
-        "dark",
-        "glassmorphism",
-        "neon"
-    ],
-    "nocturne": [
-        "dark",
-        "blog",
-        "classical-music",
-        "piano"
-    ],
-    "noir": [
-        "dark",
-        "blog",
-        "noir"
-    ],
-    "northern-lights": [
-        "dark",
-        "blog",
-        "aurora",
-        "arctic",
-        "atmospheric"
-    ],
-    "notebook": [
-        "light",
-        "blog",
-        "journal"
-    ],
-    "null-result": [
-        "paper",
-        "light",
-        "null",
-        "negative",
-        "honest"
-    ],
-    "oasis": [
-        "light",
-        "blog",
-        "relaxation"
-    ],
-    "obelisk": [
-        "light",
-        "one-page",
-        "monumental",
-        "vertical"
-    ],
-    "oblique": [
-        "light",
-        "blog",
-        "bold",
-        "angular"
-    ],
-    "oblong-quarto": [
-        "book",
-        "light",
-        "landscape",
-        "panoramic",
-        "unusual"
-    ],
-    "observatory": [
-        "dark",
-        "blog",
-        "space"
-    ],
-    "obsidian": [
-        "dark",
-        "wiki",
-        "glass",
-        "oled"
-    ],
-    "obsidian-docs": [
-        "docs",
-        "dark",
-        "wiki",
-        "knowledge"
-    ],
-    "obsidian-mirror": [
-        "dark",
-        "blog",
-        "obsidian",
-        "reflective"
-    ],
-    "old-map-cartography": [
-        "dark",
-        "blog",
-        "cartography",
-        "vintage"
-    ],
-    "onyx": [
-        "landing",
-        "dark",
-        "minimal",
-        "luxury"
-    ],
-    "op-art": [
-        "dark",
-        "blog",
-        "geometric",
-        "optical-illusion"
-    ],
-    "opalescent": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "opening-act": [
-        "event",
-        "opening",
-        "season",
-        "premiere",
-        "fresh"
-    ],
-    "opening-night": [
-        "event",
-        "dark",
-        "premiere",
-        "formal",
-        "electric"
-    ],
-    "opulent": [
-        "light",
-        "elegant",
-        "luxury",
-        "portfolio",
-        "bold"
-    ],
-    "orchard": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "orchid": [
-        "dark",
-        "blog",
-        "glamorous",
-        "botanical"
-    ],
-    "origami": [
-        "light",
-        "blog",
-        "material"
-    ],
-    "oscilloscope": [
-        "dark",
-        "blog",
-        "oscilloscope",
-        "retro"
-    ],
-    "overture": [
-        "event",
-        "dark",
-        "opening",
-        "orchestral",
-        "grand"
-    ],
-    "oxidation": [
-        "dark",
-        "blog",
-        "oxidation",
-        "rust"
-    ],
-    "oxide": [
-        "dark",
-        "gallery",
-        "industrial",
-        "rust-texture"
-    ],
-    "pagoda": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "palette": [
-        "light",
-        "docs",
-        "design"
-    ],
-    "palimpsest-noir": [
-        "book",
-        "dark",
-        "layered",
-        "erased",
-        "ghostly"
-    ],
-    "panopticon": [
-        "dark",
-        "brutalist",
-        "radial",
-        "experimental"
-    ],
-    "pantry": [
-        "light",
-        "docs",
-        "package-manager"
-    ],
-    "paper": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "paper-art": [
-        "light",
-        "blog",
-        "paper",
-        "collage"
-    ],
-    "papermod": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "parallax": [
-        "light",
-        "storytelling",
-        "parallax",
-        "cinematic"
-    ],
-    "parallax-heavy": [
-        "dark",
-        "landing",
-        "gallery",
-        "parallax"
-    ],
-    "parchment": [
-        "light",
-        "docs",
-        "fantasy"
-    ],
-    "parquetry": [
-        "dark",
-        "blog",
-        "parquetry",
-        "woodwork"
-    ],
-    "particle-storm": [
-        "dark",
-        "blog",
-        "neon",
-        "particles",
-        "energy"
-    ],
-    "pastel-docs": [
-        "docs",
-        "light",
-        "friendly"
-    ],
-    "patina": [
-        "dark",
-        "blog",
-        "minimal",
-        "craft"
-    ],
-    "peacock": [
-        "elegant",
-        "glamorous",
-        "portfolio"
-    ],
-    "pearlescent": [
-        "light",
-        "blog",
-        "iridescent",
-        "luxury",
-        "soft"
-    ],
-    "peer-review": [
-        "paper",
-        "light",
-        "academic",
-        "review",
-        "transparent"
-    ],
-    "pendulum": [
-        "dark",
-        "blog",
-        "productivity"
-    ],
-    "pentimento": [
-        "light",
-        "portfolio",
-        "elegant",
-        "bold",
-        "clean"
-    ],
-    "permafrost": [
-        "light",
-        "archive",
-        "ice",
-        "frozen"
-    ],
-    "persian-carpet": [
-        "light",
-        "blog",
-        "persian",
-        "carpet",
-        "ornate"
-    ],
-    "perspective-piece": [
-        "paper",
-        "dark",
-        "opinion",
-        "viewpoint",
-        "argumentative"
-    ],
-    "petrified-wood": [
-        "dark",
-        "blog",
-        "fossil",
-        "wood"
-    ],
-    "phantom": [
-        "dark",
-        "blog",
-        "ghost",
-        "translucent"
-    ],
-    "phosphor": [
-        "dark",
-        "gallery",
-        "bioluminescence",
-        "glow"
-    ],
-    "photoblog": [
-        "dark",
-        "blog",
-        "photography",
-        "gallery"
-    ],
-    "photon": [
-        "dark",
-        "elegant",
-        "luminescent",
-        "portfolio"
-    ],
-    "pietra-dura": [
-        "dark",
-        "creative",
-        "bold",
-        "stone"
-    ],
-    "pinecone": [
-        "dark",
-        "blog",
-        "nature"
-    ],
-    "pipeline": [
-        "light",
-        "docs",
-        "cicd"
-    ],
-    "pit-stop": [
-        "event",
-        "dark",
-        "motorsport",
-        "speed",
-        "frantic"
-    ],
-    "pixel": [
-        "dark",
-        "blog",
-        "gaming"
-    ],
-    "plasma": [
-        "dark",
-        "science",
-        "plasma",
-        "visualization"
-    ],
-    "platinum": [
-        "light",
-        "minimal",
-        "luxury",
-        "portfolio"
-    ],
-    "playlist": [
-        "dark",
-        "blog",
-        "music"
-    ],
-    "podcast-fm": [
-        "dark",
-        "media",
-        "podcast"
-    ],
-    "podium-rush": [
-        "event",
-        "competition",
-        "awards",
-        "victory",
-        "podium"
-    ],
-    "pointillism": [
-        "dark",
-        "blog",
-        "pointillism",
-        "dots"
-    ],
-    "poison": [
-        "dark",
-        "blog",
-        "sidebar"
-    ],
-    "polaris": [
-        "dark",
-        "guide",
-        "astronomy",
-        "constellation"
-    ],
-    "polaroid": [
-        "light",
-        "blog",
-        "gallery"
-    ],
-    "pop-surreal": [
-        "dark",
-        "glamorous",
-        "elegant",
-        "surreal",
-        "trendy"
-    ],
-    "pop-up-page": [
-        "book",
-        "light",
-        "dimensional",
-        "paper-engineering",
-        "interactive"
-    ],
-    "portfolio-blog": [
-        "dark",
-        "blog",
-        "portfolio"
-    ],
-    "portico": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "position-paper": [
-        "paper",
-        "dark",
-        "position",
-        "argumentative",
-        "bold"
-    ],
-    "postcard": [
-        "light",
-        "blog",
-        "postcard"
-    ],
-    "powder-burn": [
-        "event",
-        "dark",
-        "rapid-fire",
-        "flash",
-        "quick"
-    ],
-    "prairie": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "preprint-rush": [
-        "paper",
-        "light",
-        "preprint",
-        "urgent",
-        "draft"
-    ],
-    "pressure-cooker": [
-        "event",
-        "dark",
-        "hackathon",
-        "pressure",
-        "deadline"
-    ],
-    "pricetable": [
-        "light",
-        "landing",
-        "saas",
-        "pricing"
-    ],
-    "primer": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "printer-devil": [
-        "book",
-        "dark",
-        "error",
-        "playful",
-        "craft"
-    ],
-    "prism": [
-        "dark",
-        "docs",
-        "data"
-    ],
-    "prism-docs": [
-        "docs",
-        "light",
-        "colorful"
-    ],
-    "prism-refraction": [
-        "dark",
-        "blog",
-        "prism",
-        "refraction"
-    ],
-    "prismify": [
-        "glassmorphism",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "proof-sheet": [
-        "book",
-        "light",
-        "proof",
-        "unfinished",
-        "editorial"
-    ],
-    "protocol": [
-        "dark",
-        "docs",
-        "networking"
-    ],
-    "protocol-paper": [
-        "paper",
-        "light",
-        "protocol",
-        "pre-registration",
-        "rigorous"
-    ],
-    "psychedelic": [
-        "dark",
-        "minimal",
-        "elegant",
-        "glamorous"
-    ],
-    "pulp-fiction": [
-        "book",
-        "dark",
-        "pulp",
-        "lurid",
-        "cheap"
-    ],
-    "pulsar": [
-        "dark",
-        "blog",
-        "cosmic",
-        "pulse-animation"
-    ],
-    "pulse-api": [
-        "dark",
-        "docs"
-    ],
-    "pyrite": [
-        "dark",
-        "showcase",
-        "metallic",
-        "luxury"
-    ],
-    "pyrotechnic": [
-        "event",
-        "show",
-        "pyrotechnics",
-        "fireworks",
-        "explosive"
-    ],
-    "qualitative-study": [
-        "paper",
-        "light",
-        "qualitative",
-        "thematic",
-        "interpretive"
-    ],
-    "quantum": [
-        "dark",
-        "blog",
-        "quantum",
-        "science"
-    ],
-    "quarry": [
-        "dark",
-        "docs",
-        "data-warehouse"
-    ],
-    "quasar": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "quill": [
-        "light",
-        "blog",
-        "fiction"
-    ],
-    "radiolaria": [
-        "dark",
-        "blog",
-        "radiolaria",
-        "skeletal"
-    ],
-    "rainbow-cascade": [
-        "elegant",
-        "glowing",
-        "box-shadow"
-    ],
-    "ramble": [
-        "light",
-        "blog",
-        "hiking"
-    ],
-    "randomized-trial": [
-        "paper",
-        "light",
-        "rct",
-        "clinical-trial",
-        "rigorous"
-    ],
-    "rave": [
-        "dark",
-        "blog",
-        "acid",
-        "rave",
-        "neon"
-    ],
-    "raw-data": [
-        "paper",
-        "light",
-        "raw",
-        "data",
-        "tables"
-    ],
-    "reactor": [
-        "dark",
-        "docs",
-        "reactive"
-    ],
-    "realty": [
-        "light",
-        "realestate",
-        "luxury",
-        "elegant"
-    ],
-    "recipe": [
-        "light",
-        "blog",
-        "recipe"
-    ],
-    "red-alert": [
-        "event",
-        "dark",
-        "emergency",
-        "crisis",
-        "urgent"
-    ],
-    "red-carpet": [
-        "event",
-        "premiere",
-        "celebrity",
-        "glamour",
-        "fashion"
-    ],
-    "reef": [
-        "dark",
-        "blog",
-        "diving"
-    ],
-    "relay": [
-        "light",
-        "docs",
-        "integration"
-    ],
-    "remainder-bin": [
-        "book",
-        "light",
-        "secondhand",
-        "discount",
-        "worn"
-    ],
-    "remedy": [
-        "light",
-        "docs",
-        "troubleshooting"
-    ],
-    "renaissance": [
-        "light",
-        "art",
-        "classic",
-        "serif",
-        "elegant"
-    ],
-    "repousse": [
-        "dark",
-        "blog",
-        "repousse",
-        "metalwork"
-    ],
-    "reproducibility": [
-        "paper",
-        "light",
-        "replication",
-        "comparison",
-        "verdict"
-    ],
-    "resume": [
-        "light",
-        "resume"
-    ],
-    "retraction-notice": [
-        "paper",
-        "light",
-        "retracted",
-        "warning",
-        "editorial"
-    ],
-    "retro-radar": [
-        "dark",
-        "blog",
-        "radar",
-        "retro"
-    ],
-    "retromac": [
-        "light",
-        "mac",
-        "os9",
-        "retro",
-        "system"
-    ],
-    "retrowave": [
-        "dark",
-        "blog",
-        "retro",
-        "synthwave"
-    ],
-    "reveille": [
-        "event",
-        "dark",
-        "military",
-        "assembly",
-        "urgent"
-    ],
-    "review-article": [
-        "paper",
-        "light",
-        "review",
-        "literature",
-        "synthesis"
-    ],
-    "ridgeline": [
-        "dark",
-        "blog",
-        "outdoor"
-    ],
-    "riftzone": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "dimensional"
-    ],
-    "ring-bell": [
-        "event",
-        "dark",
-        "boxing",
-        "fight",
-        "intense"
-    ],
-    "riverbank": [
-        "light",
-        "blog",
-        "nature-journal"
-    ],
-    "rococo": [
-        "light",
-        "blog",
-        "pastel",
-        "elegant"
-    ],
-    "roll-call": [
-        "event",
-        "light",
-        "assembly",
-        "formal",
-        "attendance"
-    ],
-    "roll-scroll": [
-        "book",
-        "light",
-        "scroll",
-        "continuous",
-        "ancient"
-    ],
-    "rooftop": [
-        "dark",
-        "blog",
-        "urban"
-    ],
-    "rose-gold": [
-        "elegant",
-        "luxury",
-        "minimal"
-    ],
-    "rosemary": [
-        "light",
-        "blog",
-        "cooking"
-    ],
-    "rosetta": [
-        "light",
-        "docs",
-        "i18n"
-    ],
-    "rosewood": [
-        "blog",
-        "dark",
-        "warm",
-        "classic"
-    ],
-    "rubric": [
-        "book",
-        "light",
-        "rubricated",
-        "two-color",
-        "traditional"
-    ],
-    "ruby-fire": [
-        "dark",
-        "blog",
-        "bold"
-    ],
-    "runbook": [
-        "light",
-        "docs",
-        "operations"
-    ],
-    "rune": [
-        "dark",
-        "archive",
-        "viking",
-        "mystic"
-    ],
-    "saffron": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "sage-guide": [
-        "docs",
-        "light",
-        "tutorial",
-        "guide"
-    ],
-    "sakura-storm": [
-        "dark",
-        "blog",
-        "glamorous",
-        "sakura"
-    ],
-    "sandcastle": [
-        "light",
-        "blog",
-        "sand",
-        "beach"
-    ],
-    "sandstone": [
-        "light",
-        "blog",
-        "architecture"
-    ],
-    "sandstorm": [
-        "dark",
-        "blog",
-        "desert",
-        "particles"
-    ],
-    "sapphire": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "savanna": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "sawmill": [
-        "light",
-        "blog",
-        "woodworking"
-    ],
-    "scaffold": [
-        "dark",
-        "landing",
-        "comingsoon"
-    ],
-    "scaffold-docs": [
-        "dark",
-        "docs",
-        "scaffolding"
-    ],
-    "schematic": [
-        "light",
-        "docs",
-        "hardware"
-    ],
-    "scientific-journal": [
-        "dark",
-        "docs",
-        "scientific",
-        "academic"
-    ],
-    "scoping-review": [
-        "paper",
-        "light",
-        "scoping",
-        "mapping",
-        "landscape"
-    ],
-    "scrimshaw": [
-        "bold",
-        "elegant",
-        "clean",
-        "blog"
-    ],
-    "sentinel": [
-        "dark",
-        "docs",
-        "monitoring"
-    ],
-    "seraph": [
-        "minimal",
-        "elegant",
-        "portfolio"
-    ],
-    "serenity": [
-        "light",
-        "blog",
-        "elegant"
-    ],
-    "sextant": [
-        "light",
-        "docs",
-        "metrics"
-    ],
-    "sfumato": [
-        "dark",
-        "blog",
-        "atmospheric",
-        "minimal"
-    ],
-    "sgraffito": [
-        "dark",
-        "blog",
-        "sgraffito",
-        "scratched"
-    ],
-    "shutout": [
-        "event",
-        "dark",
-        "competition",
-        "dominant",
-        "perfect"
-    ],
-    "silhouette": [
-        "dark",
-        "landing",
-        "silhouette",
-        "dramatic"
-    ],
-    "silk-road": [
-        "elegant",
-        "glamorous",
-        "silk",
-        "cultural"
-    ],
-    "simulation-paper": [
-        "paper",
-        "dark",
-        "computational",
-        "simulation",
-        "model"
-    ],
-    "sketch": [
-        "light",
-        "blog",
-        "handdrawn"
-    ],
-    "skeuomorphic": [
-        "light",
-        "blog",
-        "skeuomorphic",
-        "realistic"
-    ],
-    "slide": [
-        "dark",
-        "docs",
-        "presentation"
-    ],
-    "snowfall": [
-        "light",
-        "blog",
-        "winter"
-    ],
-    "solar-punk": [
-        "light",
-        "blog",
-        "solarpunk",
-        "sustainable"
-    ],
-    "solarflare": [
-        "dark",
-        "landing",
-        "solar",
-        "energy"
-    ],
-    "solaris": [
-        "dark",
-        "dashboard",
-        "solar-system",
-        "space-mission"
-    ],
-    "solarium": [
-        "blog",
-        "light",
-        "warm"
-    ],
-    "solstice": [
-        "dual",
-        "blog",
-        "seasonal",
-        "time-based"
-    ],
-    "sonar": [
-        "dark",
-        "hub",
-        "radar",
-        "discovery"
-    ],
-    "spectra": [
-        "dark",
-        "data-science",
-        "spectrum",
-        "rainbow"
-    ],
-    "spectrum": [
-        "light",
-        "blog",
-        "a11y"
-    ],
-    "spectrum-docs": [
-        "light",
-        "docs",
-        "accessibility"
-    ],
-    "spire": [
-        "dark",
-        "blog",
-        "architecture"
-    ],
-    "split-tone": [
-        "light",
-        "blog",
-        "photography",
-        "cinematic",
-        "toning"
-    ],
-    "stained-glass": [
-        "light",
-        "blog",
-        "cathedral",
-        "colorful",
-        "gothic"
-    ],
-    "standing-ovation": [
-        "event",
-        "light",
-        "awards",
-        "acclaim",
-        "celebration"
-    ],
-    "starlight": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "minimal"
-    ],
-    "starting-gun": [
-        "event",
-        "dark",
-        "race",
-        "competition",
-        "explosive"
-    ],
-    "statuspage": [
-        "light",
-        "landing",
-        "status"
-    ],
-    "stellar-launch": [
-        "landing",
-        "dark",
-        "parallax",
-        "animation"
-    ],
-    "stipple": [
-        "light",
-        "artistic",
-        "dot-art",
-        "gallery"
-    ],
-    "storefront": [
-        "light",
-        "landing",
-        "shop"
-    ],
-    "stratum": [
-        "dark",
-        "timeline",
-        "geological",
-        "layered"
-    ],
-    "strobe": [
-        "dark",
-        "event",
-        "club",
-        "strobe"
-    ],
-    "studio": [
-        "dark",
-        "landing",
-        "portfolio"
-    ],
-    "subzero": [
-        "dark",
-        "research",
-        "cryogenic",
-        "frozen"
-    ],
-    "summit": [
-        "dark",
-        "landing",
-        "conference"
-    ],
-    "summit-event": [
-        "conference",
-        "dark",
-        "event",
-        "landing"
-    ],
-    "summit-strike": [
-        "event",
-        "dark",
-        "conference",
-        "summit",
-        "ascending"
-    ],
-    "sunburst": [
-        "light",
-        "blog",
-        "warm",
-        "golden",
-        "radiant"
-    ],
-    "sundew": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "supernova": [
-        "dark",
-        "landing",
-        "cosmic",
-        "particles"
-    ],
-    "supplementary": [
-        "paper",
-        "light",
-        "supplementary",
-        "data-heavy",
-        "exhaustive"
-    ],
-    "supreme-sun": [
-        "light",
-        "blog",
-        "community"
-    ],
-    "survey-instrument": [
-        "paper",
-        "light",
-        "survey",
-        "instrument",
-        "psychometric"
-    ],
-    "synthwave": [
-        "dark",
-        "retro",
-        "glamorous",
-        "trendy"
-    ],
-    "systematic-review": [
-        "paper",
-        "light",
-        "systematic",
-        "evidence",
-        "methodology"
-    ],
-    "tactile-fabric": [
-        "light",
-        "blog",
-        "fabric",
-        "textile"
-    ],
-    "talavera": [
-        "light",
-        "blog",
-        "mexican",
-        "pottery",
-        "colorful"
-    ],
-    "tale": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "tangram": [
-        "light",
-        "portfolio",
-        "puzzle",
-        "geometric"
-    ],
-    "tapestry": [
-        "light",
-        "blog",
-        "timeline"
-    ],
-    "taskboard": [
-        "light",
-        "dashboard",
-        "kanban"
-    ],
-    "tavern": [
-        "dark",
-        "blog",
-        "rpg"
-    ],
-    "techbyte": [
-        "light",
-        "blog",
-        "tech",
-        "card"
-    ],
-    "technical-report": [
-        "paper",
-        "light",
-        "institutional",
-        "technical-report",
-        "formal"
-    ],
-    "tectonic": [
-        "dark",
-        "hub",
-        "geological",
-        "interactive"
-    ],
-    "telegraph": [
-        "light",
-        "blog",
-        "news"
-    ],
-    "tempera": [
-        "dark",
-        "blog",
-        "tempera",
-        "painting"
-    ],
-    "tempest": [
-        "dark",
-        "magazine",
-        "storm",
-        "dramatic"
-    ],
-    "tenebrism": [
-        "dark",
-        "creative",
-        "bold",
-        "clean"
-    ],
-    "terminal": [
-        "dark",
-        "blog"
-    ],
-    "terrace": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "terracotta-studio": [
-        "landing",
-        "light",
-        "creative",
-        "artisan"
-    ],
-    "terracotta-tiles": [
-        "dark",
-        "blog",
-        "terracotta",
-        "tile"
-    ],
-    "terraform": [
-        "dark",
-        "dashboard",
-        "sci-fi",
-        "terraforming"
-    ],
-    "terraform-docs": [
-        "docs",
-        "dark",
-        "infra",
-        "devops"
-    ],
-    "terrarium": [
-        "light",
-        "portfolio",
-        "miniature"
-    ],
-    "terrazzo": [
-        "light",
-        "portfolio",
-        "terrazzo",
-        "speckled"
-    ],
-    "terrazzo-blog": [
-        "blog",
-        "light",
-        "colorful",
-        "memphis"
-    ],
-    "tessellation": [
-        "light",
-        "gallery",
-        "escher",
-        "pattern-art"
-    ],
-    "tesseract": [
-        "dark",
-        "education",
-        "4d",
-        "mathematical"
-    ],
-    "thermal": [
-        "dark",
-        "dashboard",
-        "thermal",
-        "heatmap"
-    ],
-    "thesis": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "thesis-defense": [
-        "paper",
-        "dark",
-        "thesis",
-        "formal",
-        "institutional"
-    ],
-    "thunderdome": [
-        "event",
-        "dark",
-        "arena",
-        "competition",
-        "ultimate"
-    ],
-    "ticker-board": [
-        "event",
-        "dark",
-        "transit",
-        "departure",
-        "mechanical"
-    ],
-    "ticker-tape": [
-        "event",
-        "light",
-        "celebration",
-        "parade",
-        "festive"
-    ],
-    "tidal": [
-        "light",
-        "blog",
-        "ocean",
-        "wellness"
-    ],
-    "timber": [
-        "light",
-        "blog",
-        "craft"
-    ],
-    "titanium": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ],
-    "topaz": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "topographic-gradient": [
-        "dark",
-        "blog",
-        "topographic",
-        "contour"
-    ],
-    "topographic-sand": [
-        "dark",
-        "blog",
-        "topographic",
-        "sand"
-    ],
-    "topography": [
-        "light",
-        "blog",
-        "topographic",
-        "outdoor"
-    ],
-    "torchlight": [
-        "dark",
-        "blog",
-        "adventure"
-    ],
-    "totem": [
-        "dark",
-        "portfolio",
-        "tribal",
-        "vertical-stack"
-    ],
-    "tremor": [
-        "dark",
-        "dashboard",
-        "seismic",
-        "data-viz"
-    ],
-    "trompe-loeil": [
-        "light",
-        "portfolio",
-        "creative",
-        "bold",
-        "illusion"
-    ],
-    "tropical-paradise": [
-        "elegant",
-        "vivid",
-        "botanical"
-    ],
-    "tundra": [
-        "dark",
-        "blog",
-        "expedition"
-    ],
-    "turbine": [
-        "light",
-        "corporate",
-        "energy",
-        "rotation"
-    ],
-    "turret": [
-        "dark",
-        "docs",
-        "waf"
-    ],
-    "twilight": [
-        "dark",
-        "blog",
-        "photo-essay"
-    ],
-    "typeface": [
-        "blog",
-        "light",
-        "typography",
-        "minimal"
-    ],
-    "typewriter": [
-        "light",
-        "blog",
-        "vintage"
-    ],
-    "typhoon": [
-        "dark",
-        "magazine",
-        "storm",
-        "spiral"
-    ],
-    "ukiyo-e": [
-        "light",
-        "blog",
-        "japanese",
-        "woodblock",
-        "traditional"
-    ],
-    "ultraviolet": [
-        "dark",
-        "blog",
-        "ultraviolet",
-        "neon"
-    ],
-    "umbra": [
-        "dark",
-        "portfolio",
-        "monochrome",
-        "shadow"
-    ],
-    "vapor": [
-        "light",
-        "blog",
-        "vaporwave",
-        "surreal"
-    ],
-    "vault": [
-        "dark",
-        "docs",
-        "security"
-    ],
-    "vellum": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "velocity": [
-        "landing",
-        "dark",
-        "saas"
-    ],
-    "velvet": [
-        "dark",
-        "landing",
-        "luxury"
-    ],
-    "velvet-rope": [
-        "event",
-        "gala",
-        "exclusive",
-        "luxury",
-        "velvet"
-    ],
-    "venetian": [
-        "light",
-        "blog",
-        "renaissance",
-        "venetian",
-        "ornate"
-    ],
-    "verdigris": [
-        "dark",
-        "blog",
-        "editorial"
-    ],
-    "versailles": [
-        "dark",
-        "elegant",
-        "classic",
-        "luxury"
-    ],
-    "vertigo": [
-        "dark",
-        "one-page",
-        "experimental",
-        "perspective"
-    ],
-    "vibrant-brutalism": [
-        "dark",
-        "blog",
-        "brutalist",
-        "vibrant"
-    ],
-    "victorian": [
-        "dark",
-        "blog",
-        "gothic",
-        "classic"
-    ],
-    "vineyard": [
-        "dark",
-        "blog",
-        "wine"
-    ],
-    "vintage": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "vintagetv": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "vinyl": [
-        "dark",
-        "blog",
-        "vinyl"
-    ],
-    "voltage": [
-        "dark",
-        "blog",
-        "electric",
-        "sparks"
-    ],
-    "volumetric": [
-        "dark",
-        "blog",
-        "3d",
-        "glow",
-        "atmospheric"
-    ],
-    "vortex": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "animation"
-    ],
-    "wanderlust": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "war-room": [
-        "event",
-        "dark",
-        "strategy",
-        "military",
-        "command"
-    ],
-    "warpzone": [
-        "dark",
-        "portfolio",
-        "warp",
-        "gaming"
-    ],
-    "washi-bound": [
-        "book",
-        "light",
-        "japanese",
-        "stab-binding",
-        "paper"
-    ],
-    "wavelength": [
-        "audio",
-        "dark",
-        "landing",
-        "music"
-    ],
-    "weathervane": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "wedding": [
-        "light",
-        "wedding",
-        "elegant",
-        "event"
-    ],
-    "white-paper-noir": [
-        "paper",
-        "dark",
-        "industry",
-        "executive",
-        "authoritative"
-    ],
-    "wiki": [
-        "light",
-        "docs",
-        "wiki"
-    ],
-    "willow": [
-        "light",
-        "blog",
-        "literature"
-    ],
-    "windmill": [
-        "light",
-        "blog",
-        "european"
-    ],
-    "windows95": [
-        "light",
-        "retro",
-        "os",
-        "nostalgia"
-    ],
-    "woodblock": [
-        "dark",
-        "blog",
-        "woodblock",
-        "printmaking"
-    ],
-    "working-paper": [
-        "paper",
-        "light",
-        "working",
-        "in-progress",
-        "honest"
-    ],
-    "woven-tapestry": [
-        "dark",
-        "blog",
-        "tapestry",
-        "textile"
-    ],
-    "x-ray": [
-        "dark",
-        "blog",
-        "x-ray",
-        "transparent"
-    ],
-    "xerograph": [
-        "dark",
-        "blog",
-        "minimal",
-        "photocopy"
-    ],
-    "y2k": [
-        "dark",
-        "cyber",
-        "metallic",
-        "retro"
-    ],
-    "zen": [
-        "light",
-        "blog",
-        "zen"
-    ],
-    "zenith": [
-        "light",
-        "landing",
-        "minimal",
-        "altitude"
-    ],
-    "zenithpoint": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ]
+  "abstract-noir": [
+    "paper",
+    "dark",
+    "abstract",
+    "bold",
+    "typography"
+  ],
+  "abyss": [
+    "dark",
+    "blog",
+    "deep-sea",
+    "immersive"
+  ],
+  "acid-graphics": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "acme-docs": [
+    "light",
+    "docs"
+  ],
+  "acoustic-soundwaves": [
+    "dark",
+    "blog",
+    "sound",
+    "waveform"
+  ],
+  "adminpanel": [
+    "dark",
+    "dashboard",
+    "admin",
+    "sidebar"
+  ],
+  "aether": [
+    "dark",
+    "blog",
+    "elegant"
+  ],
+  "aetheria": [
+    "dark-mode",
+    "elegant",
+    "portfolio"
+  ],
+  "after-dark": [
+    "blog",
+    "dark",
+    "reading"
+  ],
+  "afterparty": [
+    "event",
+    "party",
+    "nightlife",
+    "club",
+    "late-night"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
+  ],
+  "airwave": [
+    "dark",
+    "blog",
+    "podcast"
+  ],
+  "alexandrite": [
+    "dark",
+    "blog",
+    "glamorous",
+    "gemstone"
+  ],
+  "almanac": [
+    "light",
+    "blog",
+    "calendar"
+  ],
+  "almanac-docs": [
+    "light",
+    "docs",
+    "roadmap"
+  ],
+  "amber-preservation": [
+    "dark",
+    "blog",
+    "amber",
+    "fossil"
+  ],
+  "amethyst": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "anaglyph": [
+    "dark",
+    "blog",
+    "3d",
+    "stereoscopic"
+  ],
+  "analytics": [
+    "light",
+    "dashboard",
+    "analytics"
+  ],
+  "anamorphic": [
+    "dark",
+    "portfolio",
+    "anamorphic",
+    "optical"
+  ],
+  "anatomy-atlas": [
+    "dark",
+    "docs",
+    "medical",
+    "vintage"
+  ],
+  "annotation-layer": [
+    "book",
+    "light",
+    "scholarly",
+    "annotated",
+    "dense"
+  ],
+  "anthology": [
+    "light",
+    "docs",
+    "sdk-reference"
+  ],
+  "antimatter": [
+    "dark",
+    "blog",
+    "experimental",
+    "inverted"
+  ],
+  "anubis": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "anvil": [
+    "dark",
+    "blog",
+    "workshop"
+  ],
+  "apiary": [
+    "light",
+    "docs",
+    "api",
+    "two-column"
+  ],
+  "apolo": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "apothecary": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "appsite": [
+    "light",
+    "landing",
+    "app"
+  ],
+  "aquarium": [
+    "dark",
+    "blog",
+    "marine"
+  ],
+  "aquatint": [
+    "light",
+    "portfolio",
+    "creative",
+    "elegant",
+    "bold"
+  ],
+  "aqueduct": [
+    "light",
+    "blog",
+    "engineering"
+  ],
+  "arbor": [
+    "light",
+    "docs",
+    "git-workflow"
+  ],
+  "archipelago": [
+    "dark",
+    "landing",
+    "hub"
+  ],
+  "archive": [
+    "light",
+    "docs",
+    "archive"
+  ],
+  "archway-docs": [
+    "docs",
+    "light",
+    "architecture"
+  ],
+  "arctic-saas": [
+    "landing",
+    "light",
+    "saas",
+    "minimal"
+  ],
+  "arena": [
+    "dark",
+    "blog",
+    "sports"
+  ],
+  "artdeco": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "artnouveau": [
+    "light",
+    "portfolio",
+    "art-nouveau",
+    "botanical"
+  ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
+  ],
+  "ascii": [
+    "dark",
+    "terminal",
+    "ascii"
+  ],
+  "asymmetric": [
+    "light",
+    "portfolio",
+    "grid",
+    "asymmetric"
+  ],
+  "atelier": [
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "athena": [
+    "elegant",
+    "portfolio",
+    "light"
+  ],
+  "atlas": [
+    "light",
+    "blog",
+    "geography"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
+  ],
+  "aurelia": [
+    "elegant",
+    "minimalist",
+    "blog"
+  ],
+  "aurora": [
+    "dark",
+    "blog",
+    "aurora"
+  ],
+  "aurora-glimmer": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "aurora-launch": [
+    "landing",
+    "dark",
+    "animation"
+  ],
+  "aurum": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "avalanche-event": [
+    "event",
+    "dark",
+    "momentum",
+    "cascading",
+    "overwhelming"
+  ],
+  "axiom": [
+    "light",
+    "design-system",
+    "geometric",
+    "mathematical"
+  ],
+  "bamboo": [
+    "light",
+    "blog",
+    "eco"
+  ],
+  "baroque": [
+    "dark",
+    "blog",
+    "ornamental",
+    "glamorous"
+  ],
+  "bas-relief": [
+    "light",
+    "artistic",
+    "minimal"
+  ],
+  "bastard-title": [
+    "book",
+    "light",
+    "preliminary",
+    "ceremonial",
+    "typography"
+  ],
+  "bastion": [
+    "dark",
+    "docs",
+    "zero-trust"
+  ],
+  "batik": [
+    "light",
+    "blog",
+    "elegant",
+    "batik"
+  ],
+  "bauhaus": [
+    "light",
+    "portfolio",
+    "design",
+    "geometric"
+  ],
+  "bayesian-prior": [
+    "paper",
+    "dark",
+    "bayesian",
+    "probabilistic",
+    "visualization"
+  ],
+  "bazaar": [
+    "light",
+    "landing",
+    "marketplace"
+  ],
+  "beacon": [
+    "dark",
+    "blog",
+    "alert"
+  ],
+  "beacon-docs": [
+    "light",
+    "docs",
+    "feature-flag"
+  ],
+  "beautiful-hwaro": [
+    "light",
+    "blog"
+  ],
+  "bejeweled": [
+    "elegant",
+    "glamorous",
+    "luxury"
+  ],
+  "bell-tower": [
+    "event",
+    "light",
+    "scheduled",
+    "clock",
+    "traditional"
+  ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
+  ],
+  "bijou": [
+    "dark",
+    "elegant",
+    "jewelry",
+    "glamorous"
+  ],
+  "bioluminescence": [
+    "dark",
+    "blog",
+    "bioluminescence",
+    "minimal"
+  ],
+  "bismuth": [
+    "dark",
+    "collection",
+    "mineral",
+    "rainbow-metallic"
+  ],
+  "black-box": [
+    "event",
+    "dark",
+    "theater",
+    "intimate",
+    "minimal"
+  ],
+  "black-letter-bible": [
+    "book",
+    "dark",
+    "sacred",
+    "blackletter",
+    "dense"
+  ],
+  "blacklight": [
+    "dark",
+    "fluorescent",
+    "elegant"
+  ],
+  "blast-furnace": [
+    "event",
+    "dark",
+    "workshop",
+    "intense",
+    "industrial"
+  ],
+  "blockade-run": [
+    "event",
+    "dark",
+    "breakthrough",
+    "barriers",
+    "overcome"
+  ],
+  "blueprint": [
+    "dark",
+    "docs",
+    "spec"
+  ],
+  "blueprint-pro": [
+    "landing",
+    "dark",
+    "devtool"
+  ],
+  "bonfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "bonsai": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "book": [
+    "light",
+    "docs"
+  ],
+  "borealis": [
+    "dark",
+    "blog",
+    "aurora",
+    "nordic"
+  ],
+  "botanical-press": [
+    "blog",
+    "light",
+    "botanical",
+    "vintage"
+  ],
+  "boutique": [
+    "light",
+    "store",
+    "fashion",
+    "elegant"
+  ],
+  "box-office": [
+    "event",
+    "tickets",
+    "sales",
+    "urgency",
+    "countdown"
+  ],
+  "bramble": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "breeze": [
+    "landing",
+    "light",
+    "minimal",
+    "one-page"
+  ],
+  "brocade": [
+    "dark",
+    "blog",
+    "glamorous",
+    "luxury"
+  ],
+  "brutalist": [
+    "light",
+    "blog",
+    "brutalist"
+  ],
+  "brutopia": [
+    "dark",
+    "blog",
+    "brutalist",
+    "monospace"
+  ],
+  "bulwark": [
+    "dark",
+    "docs",
+    "disaster-recovery"
+  ],
+  "bureau": [
+    "light",
+    "docs",
+    "governance"
+  ],
+  "burlesque": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "burnt-charcoal": [
+    "dark",
+    "blog",
+    "charcoal",
+    "texture"
+  ],
+  "butterfly-wing": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "trendy",
+    "blog"
+  ],
+  "byzantine": [
+    "light",
+    "blog",
+    "byzantine",
+    "mosaic",
+    "imperial"
+  ],
+  "cabaret": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "cabin": [
+    "dark",
+    "blog",
+    "lifestyle"
+  ],
+  "cactus": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cafe": [
+    "light",
+    "landing",
+    "menu"
+  ],
+  "cage-match": [
+    "event",
+    "dark",
+    "competition",
+    "fight",
+    "enclosed"
+  ],
+  "call-to-stage": [
+    "event",
+    "talent",
+    "open-call",
+    "audition",
+    "stage"
+  ],
+  "calligraphy": [
+    "dark",
+    "blog",
+    "calligraphy",
+    "ink"
+  ],
+  "cameo": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "campfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "cancel-leaf": [
+    "book",
+    "light",
+    "correction",
+    "repair",
+    "visible"
+  ],
+  "canopy": [
+    "light",
+    "blog",
+    "outdoor"
+  ],
+  "canvas-studio": [
+    "landing",
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "carbon-fiber": [
+    "dark",
+    "blog",
+    "tech"
+  ],
+  "carnival": [
+    "dark",
+    "blog",
+    "glamorous",
+    "event"
+  ],
+  "cartograph": [
+    "dark",
+    "docs",
+    "infrastructure"
+  ],
+  "cascade": [
+    "light",
+    "longform",
+    "waterfall",
+    "scroll-driven"
+  ],
+  "case-report": [
+    "paper",
+    "light",
+    "clinical",
+    "case-study",
+    "medical"
+  ],
+  "cassette": [
+    "dark",
+    "blog",
+    "retro",
+    "audio"
+  ],
+  "catacombs": [
+    "dark",
+    "blog",
+    "underground",
+    "adventure"
+  ],
+  "catalyst": [
+    "light",
+    "landing",
+    "science",
+    "chemistry"
+  ],
+  "cathedral": [
+    "light",
+    "portfolio",
+    "architecture"
+  ],
+  "cauldron": [
+    "dark",
+    "wiki",
+    "fantasy",
+    "potion"
+  ],
+  "celebrate": [
+    "light",
+    "landing",
+    "event"
+  ],
+  "celestial-burst": [
+    "dark",
+    "glamorous",
+    "celestial",
+    "trendy"
+  ],
+  "center-stage": [
+    "event",
+    "solo",
+    "show",
+    "spotlight",
+    "centered"
+  ],
+  "chain-reaction": [
+    "event",
+    "dark",
+    "sequential",
+    "cascade",
+    "connected"
+  ],
+  "chalkboard": [
+    "dark",
+    "blog",
+    "education"
+  ],
+  "champagne": [
+    "light",
+    "luxury",
+    "elegant",
+    "champagne"
+  ],
+  "chandelier": [
+    "light",
+    "blog",
+    "crystal",
+    "elegant",
+    "prismatic"
+  ],
+  "changelog": [
+    "dark",
+    "docs",
+    "changelog"
+  ],
+  "chase-frame": [
+    "book",
+    "dark",
+    "letterpress",
+    "mechanical",
+    "craft"
+  ],
+  "chiaroscuro": [
+    "dark",
+    "portfolio",
+    "chiaroscuro",
+    "contrast"
+  ],
+  "chinoiserie": [
+    "light",
+    "blog",
+    "chinese",
+    "porcelain",
+    "elegant"
+  ],
+  "chromatic": [
+    "dark",
+    "photoblog",
+    "chromatic",
+    "lens"
+  ],
+  "chromatic-wave": [
+    "dark",
+    "portfolio",
+    "glamorous",
+    "animation"
+  ],
+  "chromatophore": [
+    "dark",
+    "bold",
+    "minimal",
+    "creative"
+  ],
+  "chrome-pulse": [
+    "minimal",
+    "dark",
+    "landing"
+  ],
+  "chromolithograph": [
+    "book",
+    "light",
+    "color-plate",
+    "print",
+    "illustration"
+  ],
+  "chronicle": [
+    "light",
+    "blog",
+    "traditional",
+    "serif"
+  ],
+  "chronosphere": [
+    "dark",
+    "space",
+    "time"
+  ],
+  "chrysanthemum": [
+    "dark",
+    "blog",
+    "floral",
+    "glamorous"
+  ],
+  "cinder": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cinema": [
+    "dark",
+    "blog",
+    "review"
+  ],
+  "cinema-silent": [
+    "dark",
+    "blog",
+    "retro",
+    "editorial"
+  ],
+  "cipher": [
+    "dark",
+    "docs",
+    "cryptography"
+  ],
+  "citation-graph": [
+    "paper",
+    "dark",
+    "network",
+    "citations",
+    "visualization"
+  ],
+  "clarity-docs": [
+    "docs",
+    "light",
+    "minimal",
+    "typography"
+  ],
+  "clocktower": [
+    "dark",
+    "landing",
+    "countdown"
+  ],
+  "cloisonne": [
+    "dark",
+    "portfolio",
+    "enamel",
+    "ornate"
+  ],
+  "cloister": [
+    "light",
+    "blog",
+    "meditation"
+  ],
+  "closed": [
+    "light",
+    "error",
+    "499",
+    "minimal"
+  ],
+  "cloudnest": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "cobblestone": [
+    "light",
+    "blog",
+    "culture"
+  ],
+  "cockpit": [
+    "dark",
+    "landing",
+    "telemetry"
+  ],
+  "codebook": [
+    "light",
+    "docs",
+    "styleguide"
+  ],
+  "codecraft": [
+    "api",
+    "dark",
+    "developer",
+    "docs"
+  ],
+  "codex": [
+    "light",
+    "blog",
+    "medieval"
+  ],
+  "codex-rotundus": [
+    "book",
+    "dark",
+    "circular",
+    "unusual",
+    "experimental"
+  ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
+  ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
+  ],
+  "colosseum": [
+    "light",
+    "event",
+    "classical",
+    "grand"
+  ],
+  "comic": [
+    "light",
+    "blog",
+    "comic"
+  ],
+  "command-center": [
+    "docs",
+    "dark",
+    "cli",
+    "developer"
+  ],
+  "compass": [
+    "light",
+    "landing",
+    "career"
+  ],
+  "compass-docs": [
+    "light",
+    "docs",
+    "onboarding"
+  ],
+  "conduit": [
+    "light",
+    "docs",
+    "data-pipeline"
+  ],
+  "conference-poster": [
+    "paper",
+    "dark",
+    "poster",
+    "conference",
+    "visual"
+  ],
+  "confetti": [
+    "celebration",
+    "elegant",
+    "festive"
+  ],
+  "console": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "constellation": [
+    "dark",
+    "blog",
+    "astronomy"
+  ],
+  "controlroom": [
+    "dark",
+    "dashboard",
+    "monitoring"
+  ],
+  "copper-patina": [
+    "dark",
+    "blog",
+    "patina",
+    "industrial"
+  ],
+  "copper-wire": [
+    "blog",
+    "dark",
+    "industrial"
+  ],
+  "copperplate": [
+    "dark",
+    "blog",
+    "copperplate",
+    "engraving"
+  ],
+  "coral": [
+    "light",
+    "documentary",
+    "organic",
+    "ocean"
+  ],
+  "coral-bloom": [
+    "dark",
+    "blog",
+    "elegant",
+    "marine",
+    "glamorous"
+  ],
+  "corrigendum": [
+    "paper",
+    "light",
+    "correction",
+    "errata",
+    "formal"
+  ],
+  "cosmos": [
+    "dark",
+    "magazine",
+    "space",
+    "planetary"
+  ],
+  "cost-effectiveness": [
+    "paper",
+    "light",
+    "economics",
+    "cost-effectiveness",
+    "health"
+  ],
+  "countdown-zero": [
+    "event",
+    "dark",
+    "countdown",
+    "convergence",
+    "climactic"
+  ],
+  "creative-agency": [
+    "dark",
+    "portfolio",
+    "agency",
+    "bold"
+  ],
+  "cross-sectional": [
+    "paper",
+    "light",
+    "cross-sectional",
+    "snapshot",
+    "population"
+  ],
+  "crucible": [
+    "light",
+    "docs",
+    "testing"
+  ],
+  "cruciform": [
+    "light",
+    "design-system",
+    "grid",
+    "swiss"
+  ],
+  "crystalline": [
+    "light",
+    "portfolio",
+    "crystal",
+    "faceted"
+  ],
+  "cuneiform-tablet": [
+    "book",
+    "dark",
+    "ancient",
+    "impressed",
+    "archaeological"
+  ],
+  "curator": [
+    "light",
+    "portfolio",
+    "exhibition"
+  ],
+  "curtain-call": [
+    "event",
+    "dark",
+    "closing",
+    "ceremony",
+    "theatrical"
+  ],
+  "cyanotype": [
+    "light",
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "cyberpunk": [
+    "dark",
+    "magazine",
+    "cyberpunk",
+    "neon"
+  ],
+  "daguerreotype": [
+    "dark",
+    "blog",
+    "photography",
+    "vintage"
+  ],
+  "damask": [
+    "dark",
+    "blog",
+    "luxury",
+    "glamorous"
+  ],
+  "dark-manual": [
+    "docs",
+    "dark",
+    "technical",
+    "manual"
+  ],
+  "darkfolio": [
+    "dark",
+    "portfolio",
+    "developer",
+    "minimal"
+  ],
+  "darkmarket": [
+    "dark",
+    "marketplace",
+    "bold"
+  ],
+  "darkroom": [
+    "dark",
+    "portfolio",
+    "photography"
+  ],
+  "darkwave": [
+    "dark",
+    "blog",
+    "synthwave"
+  ],
+  "dashboard": [
+    "dark",
+    "landing",
+    "dashboard"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
+  ],
+  "deckle-edge": [
+    "book",
+    "light",
+    "craft",
+    "handmade",
+    "texture"
+  ],
+  "deconstructed": [
+    "light",
+    "agency",
+    "deconstructivism",
+    "architecture"
+  ],
+  "deconstructivist": [
+    "dark",
+    "portfolio",
+    "deconstructivist",
+    "architecture"
+  ],
+  "demolition-derby": [
+    "event",
+    "dark",
+    "competition",
+    "destruction",
+    "chaotic"
+  ],
+  "depot": [
+    "light",
+    "landing",
+    "tracker"
+  ],
+  "devconf": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "devlog": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "devtool": [
+    "dark",
+    "landing",
+    "developer"
+  ],
+  "dewdrop": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "diamond-facet": [
+    "dark",
+    "blog",
+    "glamorous",
+    "prismatic"
+  ],
+  "diary": [
+    "light",
+    "blog",
+    "personal",
+    "journal"
+  ],
+  "diorama": [
+    "dark",
+    "landing",
+    "product"
+  ],
+  "disco-fever": [
+    "dark",
+    "blog",
+    "retro",
+    "disco",
+    "neon"
+  ],
+  "dispatch": [
+    "light",
+    "docs",
+    "event-driven"
+  ],
+  "dockhub": [
+    "dark",
+    "docs",
+    "devops"
+  ],
+  "dojo": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "dose-response": [
+    "paper",
+    "light",
+    "pharmacological",
+    "dose-response",
+    "clinical"
+  ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
+  ],
+  "driftwood": [
+    "light",
+    "blog",
+    "photo"
+  ],
+  "dropzone": [
+    "cloud",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "dune": [
+    "light",
+    "journal",
+    "desert",
+    "travel"
+  ],
+  "duodecimo": [
+    "book",
+    "light",
+    "compact",
+    "portable",
+    "efficient"
+  ],
+  "dusk": [
+    "dark",
+    "blog",
+    "sunset"
+  ],
+  "dynamo": [
+    "dark",
+    "docs",
+    "serverless"
+  ],
+  "easel": [
+    "light",
+    "docs",
+    "art"
+  ],
+  "eclipse": [
+    "dark",
+    "blog",
+    "celestial",
+    "dramatic"
+  ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
+  ],
+  "electric-bloom": [
+    "dark",
+    "blog",
+    "glamorous",
+    "neon",
+    "botanical"
+  ],
+  "electroplate": [
+    "dark",
+    "blog",
+    "metallic",
+    "plating"
+  ],
+  "elevate": [
+    "landing",
+    "light",
+    "saas",
+    "enterprise"
+  ],
+  "elysian": [
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "elysium": [
+    "portfolio",
+    "minimal",
+    "dark"
+  ],
+  "elysium-portfolio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "embargo-lift": [
+    "event",
+    "dark",
+    "embargo",
+    "release",
+    "timed"
+  ],
+  "ember": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "embroidery": [
+    "dark",
+    "blog",
+    "glamorous",
+    "trendy"
+  ],
+  "emerald": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "empyrean": [
+    "light",
+    "landing",
+    "divine",
+    "ethereal"
+  ],
+  "encaustic": [
+    "light",
+    "blog",
+    "art",
+    "painting"
+  ],
+  "encore": [
+    "event",
+    "dark",
+    "repeat",
+    "popular",
+    "demanded"
+  ],
+  "encore-night": [
+    "event",
+    "concert",
+    "farewell",
+    "encore",
+    "emotional"
+  ],
+  "endpaper": [
+    "book",
+    "dark",
+    "decorative",
+    "pattern",
+    "hidden"
+  ],
+  "enigma": [
+    "dark",
+    "puzzle",
+    "cryptography",
+    "mechanical"
+  ],
+  "entropy": [
+    "dual",
+    "magazine",
+    "experimental",
+    "asymmetric"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
+  ],
+  "etching": [
+    "dark",
+    "blog",
+    "etching",
+    "printmaking"
+  ],
+  "ethereal-canvas": [
+    "blog",
+    "dark",
+    "elegant",
+    "minimal",
+    "portfolio"
+  ],
+  "ethereal-vapor": [
+    "light",
+    "blog",
+    "ethereal",
+    "translucent"
+  ],
+  "ethos": [
+    "light",
+    "docs",
+    "culture"
+  ],
+  "even": [
+    "light",
+    "blog"
+  ],
+  "evergreen-docs": [
+    "docs",
+    "light",
+    "enterprise",
+    "classic"
+  ],
+  "experiment-log": [
+    "paper",
+    "dark",
+    "experimental",
+    "sequential",
+    "iterative"
+  ],
+  "faberge": [
+    "light",
+    "blog",
+    "luxury",
+    "jeweled",
+    "ornate"
+  ],
+  "faq": [
+    "light",
+    "docs",
+    "faq"
+  ],
+  "fascicle": [
+    "book",
+    "light",
+    "serial",
+    "unbound",
+    "installment"
+  ],
+  "fault-siren": [
+    "event",
+    "dark",
+    "warning",
+    "preparedness",
+    "civil-defense"
+  ],
+  "fauvist-wild": [
+    "dark",
+    "blog",
+    "fauvist",
+    "colorful"
+  ],
+  "ferrofluid": [
+    "dark",
+    "blog",
+    "ferrofluid",
+    "magnetic"
+  ],
+  "festival": [
+    "dark",
+    "event",
+    "elegant",
+    "glow",
+    "bold"
+  ],
+  "festival-ground": [
+    "event",
+    "festival",
+    "outdoor",
+    "grounds",
+    "map"
+  ],
+  "field-report": [
+    "paper",
+    "dark",
+    "field",
+    "expedition",
+    "rugged"
+  ],
+  "fiesta": [
+    "light",
+    "blog",
+    "colorful",
+    "celebration"
+  ],
+  "filigree": [
+    "dark",
+    "blog",
+    "filigree",
+    "metalwork"
+  ],
+  "fintech-pulse": [
+    "landing",
+    "dark",
+    "fintech",
+    "data-viz"
+  ],
+  "fireside": [
+    "dark",
+    "blog",
+    "book-review"
+  ],
+  "fireworks": [
+    "dark",
+    "elegant",
+    "animation",
+    "glow"
+  ],
+  "firing-range": [
+    "event",
+    "dark",
+    "precision",
+    "target",
+    "competitive"
+  ],
+  "fjord": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "flamingo": [
+    "light",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "flowsync": [
+    "dark",
+    "landing"
+  ],
+  "fluorescent": [
+    "dark",
+    "blog",
+    "neon",
+    "pop-art"
+  ],
+  "folio": [
+    "light",
+    "portfolio"
+  ],
+  "folio-docs": [
+    "light",
+    "docs",
+    "design-system"
+  ],
+  "folio-gigante": [
+    "book",
+    "dark",
+    "oversized",
+    "monumental",
+    "maximal"
+  ],
+  "forge": [
+    "light",
+    "docs",
+    "opensource"
+  ],
+  "formulary": [
+    "light",
+    "docs",
+    "math"
+  ],
+  "forty": [
+    "dark",
+    "portfolio",
+    "gallery"
+  ],
+  "foundry": [
+    "dark",
+    "blog",
+    "maker"
+  ],
+  "foxhole": [
+    "dark",
+    "blog",
+    "security"
+  ],
+  "fractal": [
+    "dark",
+    "gallery",
+    "generative",
+    "mathematical"
+  ],
+  "frequency": [
+    "dark",
+    "blog",
+    "radio"
+  ],
+  "frottage": [
+    "light",
+    "minimal",
+    "art",
+    "clean"
+  ],
+  "frutiger-aero": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "furnace": [
+    "dark",
+    "docs",
+    "performance"
+  ],
+  "gala": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "garden": [
+    "light",
+    "blog",
+    "garden"
+  ],
+  "garnet": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "garrison": [
+    "dark",
+    "docs",
+    "firewall"
+  ],
+  "gateway": [
+    "dark",
+    "docs",
+    "auth"
+  ],
+  "gauntlet-run": [
+    "event",
+    "dark",
+    "endurance",
+    "challenge",
+    "sequential"
+  ],
+  "gazebo": [
+    "light",
+    "blog",
+    "event"
+  ],
+  "gazette": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "generative-art": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "glamorous"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
+  ],
+  "geodesic": [
+    "light",
+    "landing",
+    "geometric"
+  ],
+  "gilded": [
+    "dark",
+    "blog",
+    "luxury",
+    "gold"
+  ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
+  ],
+  "glacial-blog": [
+    "blog",
+    "light",
+    "cool",
+    "minimal"
+  ],
+  "glacial-ice": [
+    "dark",
+    "blog",
+    "ice",
+    "frost"
+  ],
+  "glacier": [
+    "light",
+    "blog",
+    "tech"
+  ],
+  "glam-rock": [
+    "dark",
+    "blog",
+    "rock",
+    "glam",
+    "metallic"
+  ],
+  "glassmorphism": [
+    "dark",
+    "blog",
+    "glassmorphism"
+  ],
+  "glitch": [
+    "dark",
+    "blog",
+    "experimental",
+    "glitch-art"
+  ],
+  "glitch-elegance": [
+    "dark",
+    "blog",
+    "glitch",
+    "elegant"
+  ],
+  "glow-reef": [
+    "dark",
+    "blog",
+    "elegant",
+    "neon"
+  ],
+  "glyphic": [
+    "dark",
+    "blog",
+    "glyph",
+    "carved"
+  ],
+  "gong-show": [
+    "event",
+    "dark",
+    "competition",
+    "judgment",
+    "dramatic"
+  ],
+  "gossamer": [
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "gothic": [
+    "dark",
+    "blog",
+    "gothic",
+    "medieval"
+  ],
+  "gradient-mesh": [
+    "dark",
+    "blog",
+    "gradient"
+  ],
+  "graffiti": [
+    "dark",
+    "blog",
+    "street-art",
+    "urban"
+  ],
+  "grand-finale": [
+    "event",
+    "festival",
+    "finale",
+    "closing",
+    "spectacular"
+  ],
+  "grant-proposal": [
+    "paper",
+    "light",
+    "proposal",
+    "funding",
+    "persuasive"
+  ],
+  "graphite-docs": [
+    "docs",
+    "dark",
+    "technical"
+  ],
+  "greenhouse": [
+    "light",
+    "blog",
+    "plant"
+  ],
+  "grisaille": [
+    "dark",
+    "blog",
+    "minimal",
+    "monochrome"
+  ],
+  "ground-zero": [
+    "event",
+    "dark",
+    "origin",
+    "impact",
+    "transformative"
+  ],
+  "guidebook": [
+    "light",
+    "docs",
+    "guide"
+  ],
+  "gunmetal": [
+    "dark",
+    "elegant",
+    "industrial",
+    "metallic"
+  ],
+  "gyroscope": [
+    "dark",
+    "dashboard",
+    "motion-sensor",
+    "3d-rotation"
+  ],
+  "habitat": [
+    "light",
+    "landing",
+    "listing"
+  ],
+  "hacker": [
+    "dark",
+    "blog"
+  ],
+  "hall-of-voices": [
+    "event",
+    "poetry",
+    "spoken-word",
+    "slam",
+    "voices"
+  ],
+  "hammer-drop": [
+    "event",
+    "light",
+    "auction",
+    "bidding",
+    "final"
+  ],
+  "hammock": [
+    "light",
+    "blog",
+    "slowlife"
+  ],
+  "handbook": [
+    "light",
+    "docs",
+    "corporate"
+  ],
+  "hangar": [
+    "dark",
+    "blog",
+    "aviation"
+  ],
+  "hardcore-pit": [
+    "event",
+    "punk",
+    "hardcore",
+    "show",
+    "chaotic"
+  ],
+  "haute-couture": [
+    "elegant",
+    "fashion",
+    "magazine"
+  ],
+  "headliner-bold": [
+    "event",
+    "festival",
+    "lineup",
+    "headliner",
+    "hierarchy"
+  ],
+  "hearth": [
+    "light",
+    "blog",
+    "traditional",
+    "elegant"
+  ],
+  "heavy-curtain": [
+    "event",
+    "theater",
+    "drama",
+    "production",
+    "heavy"
+  ],
+  "heliograph": [
+    "dark",
+    "blog",
+    "heliograph",
+    "sun-print"
+  ],
+  "helix": [
+    "light",
+    "landing",
+    "biotech",
+    "3d"
+  ],
+  "helix-docs": [
+    "docs",
+    "light",
+    "science"
+  ],
+  "herald": [
+    "light",
+    "magazine",
+    "editorial",
+    "news"
+  ],
+  "hermit": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "hibiscus": [
+    "dark",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "hologram": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "holographic": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "horizon-ai": [
+    "landing",
+    "dark",
+    "ai",
+    "futuristic"
+  ],
+  "house-lights": [
+    "event",
+    "venue",
+    "concert",
+    "lighting",
+    "technical"
+  ],
+  "hwaro.386": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "hwaronight": [
+    "dark",
+    "blog"
+  ],
+  "hypercube": [
+    "dark",
+    "docs",
+    "3d",
+    "wireframe"
+  ],
+  "hyperpop": [
+    "dark",
+    "glamorous",
+    "neon",
+    "trendy",
+    "elegant"
+  ],
+  "igloo": [
+    "light",
+    "blog",
+    "nordic"
+  ],
+  "ignite": [
+    "landing",
+    "dark",
+    "startup"
+  ],
+  "ignition-sequence": [
+    "event",
+    "dark",
+    "phased",
+    "launch",
+    "sequential"
+  ],
+  "impasto": [
+    "light",
+    "blog",
+    "bold",
+    "artistic"
+  ],
+  "incunabula-noir": [
+    "book",
+    "dark",
+    "incunabulum",
+    "early-print",
+    "revolutionary"
+  ],
+  "inferno": [
+    "dark",
+    "community",
+    "fire",
+    "gaming"
+  ],
+  "infographic": [
+    "light",
+    "landing",
+    "infographic",
+    "data-viz"
+  ],
+  "ink-seoul": [
+    "light",
+    "blog",
+    "monochrome",
+    "seoul",
+    "minimal"
+  ],
+  "inkdrop-docs": [
+    "docs",
+    "dark",
+    "elegant",
+    "animation"
+  ],
+  "inkwell": [
+    "light",
+    "blog",
+    "poetry"
+  ],
+  "intaglio": [
+    "dark",
+    "portfolio",
+    "engraving",
+    "minimal"
+  ],
+  "intarsia": [
+    "light",
+    "portfolio",
+    "bold",
+    "clean",
+    "geometric"
+  ],
+  "interferogram": [
+    "dark",
+    "blog",
+    "interference",
+    "optical"
+  ],
+  "inventory": [
+    "light",
+    "dashboard",
+    "management"
+  ],
+  "iridescent-oil": [
+    "dark",
+    "blog",
+    "iridescent",
+    "oil"
+  ],
+  "iron-stage": [
+    "event",
+    "festival",
+    "metal",
+    "industrial",
+    "heavy"
+  ],
+  "ironclad": [
+    "dark",
+    "landing",
+    "metallic",
+    "security"
+  ],
+  "ironworks": [
+    "dark",
+    "blog",
+    "history"
+  ],
+  "isometric": [
+    "light",
+    "3d",
+    "dashboard",
+    "ui"
+  ],
+  "isthmus": [
+    "light",
+    "hub",
+    "bridge",
+    "horizontal-scroll"
+  ],
+  "jade-palace": [
+    "dark",
+    "blog",
+    "luxury",
+    "eastern"
+  ],
+  "japanese-industrial": [
+    "dark",
+    "blog",
+    "japanese",
+    "industrial"
+  ],
+  "jewel-tone": [
+    "dark",
+    "glamorous",
+    "jewel",
+    "elegant"
+  ],
+  "jugendstil": [
+    "light",
+    "blog",
+    "art-nouveau",
+    "organic",
+    "nature"
+  ],
+  "kaleidoscope": [
+    "light",
+    "event",
+    "psychedelic",
+    "pattern"
+  ],
+  "ketubah": [
+    "book",
+    "light",
+    "ceremonial",
+    "decorated",
+    "formal"
+  ],
+  "keynote-blast": [
+    "event",
+    "dark",
+    "conference",
+    "keynote",
+    "explosive"
+  ],
+  "keystone": [
+    "light",
+    "docs",
+    "architecture"
+  ],
+  "kiln": [
+    "light",
+    "portfolio",
+    "craft"
+  ],
+  "kinetic": [
+    "dark",
+    "agency",
+    "physics",
+    "interactive"
+  ],
+  "kinetic-mobile": [
+    "dark",
+    "blog",
+    "kinetic",
+    "mobile"
+  ],
+  "kinetic-typography": [
+    "dark",
+    "blog",
+    "kinetic",
+    "typography"
+  ],
+  "kintsugi": [
+    "dark",
+    "blog",
+    "kintsugi",
+    "gold-repair"
+  ],
+  "lab": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
+  ],
+  "labyrinth": [
+    "dark",
+    "portfolio",
+    "maze",
+    "gamification"
+  ],
+  "lagoon": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "laser-show": [
+    "dark",
+    "blog",
+    "landing",
+    "concert",
+    "glamorous"
+  ],
+  "last-call": [
+    "event",
+    "dark",
+    "closing",
+    "final",
+    "urgent"
+  ],
+  "lattice": [
+    "light",
+    "docs",
+    "graph-db"
+  ],
+  "launchpad": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "launchpad-event": [
+    "event",
+    "dark",
+    "launch",
+    "space",
+    "countdown"
+  ],
+  "lava-flow": [
+    "dark",
+    "blog",
+    "lava",
+    "volcanic"
+  ],
+  "layered-docs": [
+    "light",
+    "docs",
+    "enterprise"
+  ],
+  "ledger": [
+    "light",
+    "docs",
+    "finance"
+  ],
+  "letter-to-editor": [
+    "paper",
+    "light",
+    "correspondence",
+    "urgent",
+    "brief"
+  ],
+  "letterbox": [
+    "light",
+    "blog",
+    "newsletter"
+  ],
+  "lexicon": [
+    "light",
+    "docs",
+    "glossary"
+  ],
+  "lichen-moss": [
+    "dark",
+    "blog",
+    "lichen",
+    "organic"
+  ],
+  "lighthouse": [
+    "light",
+    "docs",
+    "directory"
+  ],
+  "linktree": [
+    "dark",
+    "landing",
+    "links"
+  ],
+  "linocut": [
+    "light",
+    "printmaking",
+    "bold",
+    "creative"
+  ],
+  "liquid": [
+    "dark",
+    "interactive",
+    "gooey",
+    "svg"
+  ],
+  "liquid-chrome": [
+    "dark",
+    "blog",
+    "metallic",
+    "glamorous"
+  ],
+  "lithium": [
+    "dark",
+    "landing",
+    "electric",
+    "tech"
+  ],
+  "lithograph": [
+    "dark",
+    "blog",
+    "lithograph",
+    "printmaking"
+  ],
+  "logbook": [
+    "light",
+    "docs",
+    "compliance"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
+  ],
+  "lookbook": [
+    "dark",
+    "portfolio",
+    "lookbook",
+    "fashion"
+  ],
+  "loom": [
+    "light",
+    "portfolio",
+    "fashion"
+  ],
+  "lumiere": [
+    "dark",
+    "elegant",
+    "minimal",
+    "luminescent"
+  ],
+  "lumina": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "luminary": [
+    "light",
+    "elegant",
+    "portfolio"
+  ],
+  "luminescent-mesh": [
+    "dark",
+    "blog",
+    "luminescent",
+    "mesh"
+  ],
+  "lumos": [
+    "blog",
+    "elegant",
+    "light",
+    "minimal"
+  ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
+  "lunar-breeze": [
+    "dark",
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "luxe-noir": [
+    "dark",
+    "glamorous",
+    "luxury",
+    "elegant"
+  ],
+  "luxury-horology": [
+    "dark",
+    "portfolio",
+    "horology",
+    "luxury"
+  ],
+  "macro-snowflake": [
+    "dark",
+    "blog",
+    "snowflake",
+    "crystalline"
+  ],
+  "madhubani": [
+    "light",
+    "blog",
+    "indian",
+    "folk-art",
+    "geometric"
+  ],
+  "magenta-sunset": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "magma": [
+    "dark",
+    "dashboard",
+    "volcanic",
+    "animation"
+  ],
+  "magnetar": [
+    "dark",
+    "blog",
+    "magnetar",
+    "cosmic"
+  ],
+  "main-act": [
+    "event",
+    "concert",
+    "headline",
+    "performer",
+    "dramatic"
+  ],
+  "mainstage": [
+    "event",
+    "dark",
+    "performance",
+    "stage",
+    "dramatic"
+  ],
+  "manifesto": [
+    "dark",
+    "blog",
+    "opinion"
+  ],
+  "manifesto-press": [
+    "book",
+    "dark",
+    "revolutionary",
+    "bold",
+    "political"
+  ],
+  "manifold": [
+    "light",
+    "docs",
+    "saas"
+  ],
+  "marble": [
+    "light",
+    "gallery",
+    "luxury",
+    "marble-texture"
+  ],
+  "marbled-paper": [
+    "dark",
+    "blog",
+    "marbled",
+    "paper"
+  ],
+  "mardi-gras": [
+    "glamorous",
+    "trendy",
+    "bold",
+    "purple",
+    "gold",
+    "green"
+  ],
+  "marketplace": [
+    "light",
+    "store",
+    "marketplace"
+  ],
+  "marquetry": [
+    "light",
+    "portfolio",
+    "geometric",
+    "minimal"
+  ],
+  "masquerade": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "luxury",
+    "mystery"
+  ],
+  "matcha": [
+    "blog",
+    "light",
+    "minimal",
+    "zen"
+  ],
+  "matrix": [
+    "light",
+    "docs",
+    "compatibility"
+  ],
+  "maximal-bloom": [
+    "elegant",
+    "floral",
+    "bold",
+    "glamorous"
+  ],
+  "maximalist": [
+    "dark",
+    "blog",
+    "bold",
+    "glamorous"
+  ],
+  "mayan-geometry": [
+    "dark",
+    "blog",
+    "mayan",
+    "geometric"
+  ],
+  "meadow": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "medieval-manuscript": [
+    "dark",
+    "blog",
+    "medieval",
+    "manuscript"
+  ],
+  "memoir": [
+    "light",
+    "blog",
+    "longform"
+  ],
+  "memphis": [
+    "light",
+    "retro",
+    "colorful",
+    "bold",
+    "portfolio"
+  ],
+  "mercury": [
+    "dark",
+    "blog",
+    "minimal",
+    "metallic",
+    "elegant"
+  ],
+  "meridian": [
+    "dark",
+    "landing",
+    "timezone"
+  ],
+  "meridian-docs": [
+    "light",
+    "docs",
+    "scheduling"
+  ],
+  "meridiem": [
+    "dual",
+    "dashboard",
+    "time-based",
+    "auto-theme"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
+  ],
+  "meteor": [
+    "dark",
+    "interactive",
+    "meteor-shower",
+    "cosmic"
+  ],
+  "methods-paper": [
+    "paper",
+    "light",
+    "methods",
+    "protocol",
+    "technical"
+  ],
+  "metronome": [
+    "dark",
+    "blog",
+    "music-production",
+    "rhythm"
+  ],
+  "mezzotint": [
+    "light",
+    "blog",
+    "bold",
+    "clean",
+    "monochrome"
+  ],
+  "micro": [
+    "light",
+    "blog",
+    "microblog"
+  ],
+  "midnight-blog": [
+    "dark",
+    "blog",
+    "reading"
+  ],
+  "midnight-launch": [
+    "landing",
+    "dark",
+    "animation",
+    "product"
+  ],
+  "migration": [
+    "light",
+    "docs",
+    "database"
+  ],
+  "minifolio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "minimalzen": [
+    "light",
+    "blog",
+    "minimal",
+    "zen"
+  ],
+  "mint-fresh": [
+    "landing",
+    "light",
+    "saas"
+  ],
+  "mirage": [
+    "light",
+    "gallery",
+    "desert",
+    "distortion"
+  ],
+  "misprint": [
+    "book",
+    "dark",
+    "error",
+    "accidental",
+    "artistic"
+  ],
+  "mixed-methods": [
+    "paper",
+    "light",
+    "mixed-methods",
+    "convergent",
+    "dual"
+  ],
+  "modern-blog": [
+    "dark",
+    "blog",
+    "modern"
+  ],
+  "molten": [
+    "dark",
+    "blog",
+    "metalwork",
+    "melting"
+  ],
+  "molten-gold": [
+    "elegant",
+    "gold",
+    "trendy"
+  ],
+  "monochrome": [
+    "light",
+    "photo-essay",
+    "monochrome",
+    "grayscale"
+  ],
+  "monograph": [
+    "book",
+    "light",
+    "academic",
+    "thorough",
+    "reference"
+  ],
+  "monolith": [
+    "dark",
+    "landing",
+    "onepage"
+  ],
+  "monolithic-dark": [
+    "dark",
+    "blog",
+    "monolithic",
+    "bold"
+  ],
+  "monoprint": [
+    "light",
+    "monoprint",
+    "bold",
+    "creative"
+  ],
+  "monorepo-docs": [
+    "docs",
+    "dark",
+    "developer",
+    "monorepo"
+  ],
+  "moonrise": [
+    "dark",
+    "blog",
+    "essay"
+  ],
+  "moonstone": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "moroccan-zellige": [
+    "light",
+    "blog",
+    "moroccan",
+    "mosaic",
+    "geometric"
+  ],
+  "morphogenesis": [
+    "dark",
+    "blog",
+    "generative",
+    "biology",
+    "patterns"
+  ],
+  "mortar": [
+    "dark",
+    "docs",
+    "build-system"
+  ],
+  "mosaic": [
+    "light",
+    "blog",
+    "magazine"
+  ],
+  "mosh-pit": [
+    "event",
+    "dark",
+    "punk",
+    "chaotic",
+    "raw"
+  ],
+  "mosstown": [
+    "light",
+    "blog",
+    "cozy"
+  ],
+  "mughal": [
+    "light",
+    "blog",
+    "mughal",
+    "ornate",
+    "gold"
+  ],
+  "murano-glass": [
+    "light",
+    "blog",
+    "glass",
+    "translucent",
+    "venetian"
+  ],
+  "mycelium": [
+    "dark",
+    "blog",
+    "mycelium",
+    "fungal"
+  ],
+  "nadir": [
+    "dark",
+    "blog",
+    "minimal",
+    "oled-black"
+  ],
+  "nautical": [
+    "dark",
+    "blog",
+    "nautical"
+  ],
+  "nebula": [
+    "dark",
+    "gallery",
+    "space",
+    "ethereal"
+  ],
+  "neo-deco": [
+    "dark",
+    "portfolio",
+    "artdeco",
+    "elegant"
+  ],
+  "neo-memphis-dark": [
+    "dark",
+    "blog",
+    "memphis",
+    "neo-memphis"
+  ],
+  "neobrutal": [
+    "light",
+    "landing",
+    "neo-brutalism",
+    "bold"
+  ],
+  "neoclassical": [
+    "light",
+    "gallery",
+    "marble-texture",
+    "elegant"
+  ],
+  "neon": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "neon-jungle": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "neon"
+  ],
+  "neon-marquee": [
+    "event",
+    "theater",
+    "marquee",
+    "vintage",
+    "retro"
+  ],
+  "neon-tokyo": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "tokyo",
+    "glamorous"
+  ],
+  "network-meta": [
+    "paper",
+    "dark",
+    "network",
+    "meta-analysis",
+    "comparative"
+  ],
+  "neumorphism": [
+    "light",
+    "ui",
+    "soft",
+    "shadow"
+  ],
+  "neural-bloom": [
+    "dark",
+    "blog",
+    "neural",
+    "ai",
+    "synaptic"
+  ],
+  "newspaper": [
+    "light",
+    "blog",
+    "editorial",
+    "newspaper"
+  ],
+  "nexus": [
+    "dark",
+    "docs",
+    "microservice"
+  ],
+  "nexus-docs": [
+    "docs",
+    "dark",
+    "developer"
+  ],
+  "niello": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "no-style-please": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "noctis": [
+    "landing",
+    "dark",
+    "glassmorphism",
+    "neon"
+  ],
+  "nocturne": [
+    "dark",
+    "blog",
+    "classical-music",
+    "piano"
+  ],
+  "noir": [
+    "dark",
+    "blog",
+    "noir"
+  ],
+  "northern-lights": [
+    "dark",
+    "blog",
+    "aurora",
+    "arctic",
+    "atmospheric"
+  ],
+  "notebook": [
+    "light",
+    "blog",
+    "journal"
+  ],
+  "null-result": [
+    "paper",
+    "light",
+    "null",
+    "negative",
+    "honest"
+  ],
+  "oasis": [
+    "light",
+    "blog",
+    "relaxation"
+  ],
+  "obelisk": [
+    "light",
+    "one-page",
+    "monumental",
+    "vertical"
+  ],
+  "oblique": [
+    "light",
+    "blog",
+    "bold",
+    "angular"
+  ],
+  "oblong-quarto": [
+    "book",
+    "light",
+    "landscape",
+    "panoramic",
+    "unusual"
+  ],
+  "observatory": [
+    "dark",
+    "blog",
+    "space"
+  ],
+  "obsidian": [
+    "dark",
+    "wiki",
+    "glass",
+    "oled"
+  ],
+  "obsidian-docs": [
+    "docs",
+    "dark",
+    "wiki",
+    "knowledge"
+  ],
+  "obsidian-mirror": [
+    "dark",
+    "blog",
+    "obsidian",
+    "reflective"
+  ],
+  "old-map-cartography": [
+    "dark",
+    "blog",
+    "cartography",
+    "vintage"
+  ],
+  "onyx": [
+    "landing",
+    "dark",
+    "minimal",
+    "luxury"
+  ],
+  "op-art": [
+    "dark",
+    "blog",
+    "geometric",
+    "optical-illusion"
+  ],
+  "opalescent": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "opening-act": [
+    "event",
+    "opening",
+    "season",
+    "premiere",
+    "fresh"
+  ],
+  "opening-night": [
+    "event",
+    "dark",
+    "premiere",
+    "formal",
+    "electric"
+  ],
+  "opulent": [
+    "light",
+    "elegant",
+    "luxury",
+    "portfolio",
+    "bold"
+  ],
+  "orchard": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "orchid": [
+    "dark",
+    "blog",
+    "glamorous",
+    "botanical"
+  ],
+  "origami": [
+    "light",
+    "blog",
+    "material"
+  ],
+  "oscilloscope": [
+    "dark",
+    "blog",
+    "oscilloscope",
+    "retro"
+  ],
+  "overture": [
+    "event",
+    "dark",
+    "opening",
+    "orchestral",
+    "grand"
+  ],
+  "oxidation": [
+    "dark",
+    "blog",
+    "oxidation",
+    "rust"
+  ],
+  "oxide": [
+    "dark",
+    "gallery",
+    "industrial",
+    "rust-texture"
+  ],
+  "pagoda": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "palette": [
+    "light",
+    "docs",
+    "design"
+  ],
+  "palimpsest-noir": [
+    "book",
+    "dark",
+    "layered",
+    "erased",
+    "ghostly"
+  ],
+  "panopticon": [
+    "dark",
+    "brutalist",
+    "radial",
+    "experimental"
+  ],
+  "pantry": [
+    "light",
+    "docs",
+    "package-manager"
+  ],
+  "paper": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "paper-art": [
+    "light",
+    "blog",
+    "paper",
+    "collage"
+  ],
+  "papermod": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "parallax": [
+    "light",
+    "storytelling",
+    "parallax",
+    "cinematic"
+  ],
+  "parallax-heavy": [
+    "dark",
+    "landing",
+    "gallery",
+    "parallax"
+  ],
+  "parchment": [
+    "light",
+    "docs",
+    "fantasy"
+  ],
+  "parquetry": [
+    "dark",
+    "blog",
+    "parquetry",
+    "woodwork"
+  ],
+  "particle-storm": [
+    "dark",
+    "blog",
+    "neon",
+    "particles",
+    "energy"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
+  ],
+  "patina": [
+    "dark",
+    "blog",
+    "minimal",
+    "craft"
+  ],
+  "peacock": [
+    "elegant",
+    "glamorous",
+    "portfolio"
+  ],
+  "pearlescent": [
+    "light",
+    "blog",
+    "iridescent",
+    "luxury",
+    "soft"
+  ],
+  "peer-review": [
+    "paper",
+    "light",
+    "academic",
+    "review",
+    "transparent"
+  ],
+  "pendulum": [
+    "dark",
+    "blog",
+    "productivity"
+  ],
+  "pentimento": [
+    "light",
+    "portfolio",
+    "elegant",
+    "bold",
+    "clean"
+  ],
+  "permafrost": [
+    "light",
+    "archive",
+    "ice",
+    "frozen"
+  ],
+  "persian-carpet": [
+    "light",
+    "blog",
+    "persian",
+    "carpet",
+    "ornate"
+  ],
+  "perspective-piece": [
+    "paper",
+    "dark",
+    "opinion",
+    "viewpoint",
+    "argumentative"
+  ],
+  "petrified-wood": [
+    "dark",
+    "blog",
+    "fossil",
+    "wood"
+  ],
+  "phantom": [
+    "dark",
+    "blog",
+    "ghost",
+    "translucent"
+  ],
+  "phosphor": [
+    "dark",
+    "gallery",
+    "bioluminescence",
+    "glow"
+  ],
+  "photoblog": [
+    "dark",
+    "blog",
+    "photography",
+    "gallery"
+  ],
+  "photon": [
+    "dark",
+    "elegant",
+    "luminescent",
+    "portfolio"
+  ],
+  "pietra-dura": [
+    "dark",
+    "creative",
+    "bold",
+    "stone"
+  ],
+  "pinecone": [
+    "dark",
+    "blog",
+    "nature"
+  ],
+  "pipeline": [
+    "light",
+    "docs",
+    "cicd"
+  ],
+  "pit-stop": [
+    "event",
+    "dark",
+    "motorsport",
+    "speed",
+    "frantic"
+  ],
+  "pixel": [
+    "dark",
+    "blog",
+    "gaming"
+  ],
+  "plasma": [
+    "dark",
+    "science",
+    "plasma",
+    "visualization"
+  ],
+  "platinum": [
+    "light",
+    "minimal",
+    "luxury",
+    "portfolio"
+  ],
+  "playlist": [
+    "dark",
+    "blog",
+    "music"
+  ],
+  "podcast-fm": [
+    "dark",
+    "media",
+    "podcast"
+  ],
+  "podium-rush": [
+    "event",
+    "competition",
+    "awards",
+    "victory",
+    "podium"
+  ],
+  "pointillism": [
+    "dark",
+    "blog",
+    "pointillism",
+    "dots"
+  ],
+  "poison": [
+    "dark",
+    "blog",
+    "sidebar"
+  ],
+  "polaris": [
+    "dark",
+    "guide",
+    "astronomy",
+    "constellation"
+  ],
+  "polaroid": [
+    "light",
+    "blog",
+    "gallery"
+  ],
+  "pop-surreal": [
+    "dark",
+    "glamorous",
+    "elegant",
+    "surreal",
+    "trendy"
+  ],
+  "pop-up-page": [
+    "book",
+    "light",
+    "dimensional",
+    "paper-engineering",
+    "interactive"
+  ],
+  "portfolio-blog": [
+    "dark",
+    "blog",
+    "portfolio"
+  ],
+  "portico": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
+  ],
+  "postcard": [
+    "light",
+    "blog",
+    "postcard"
+  ],
+  "powder-burn": [
+    "event",
+    "dark",
+    "rapid-fire",
+    "flash",
+    "quick"
+  ],
+  "prairie": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "preprint-rush": [
+    "paper",
+    "light",
+    "preprint",
+    "urgent",
+    "draft"
+  ],
+  "pressure-cooker": [
+    "event",
+    "dark",
+    "hackathon",
+    "pressure",
+    "deadline"
+  ],
+  "pricetable": [
+    "light",
+    "landing",
+    "saas",
+    "pricing"
+  ],
+  "primer": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "printer-devil": [
+    "book",
+    "dark",
+    "error",
+    "playful",
+    "craft"
+  ],
+  "prism": [
+    "dark",
+    "docs",
+    "data"
+  ],
+  "prism-docs": [
+    "docs",
+    "light",
+    "colorful"
+  ],
+  "prism-refraction": [
+    "dark",
+    "blog",
+    "prism",
+    "refraction"
+  ],
+  "prismify": [
+    "glassmorphism",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "proof-sheet": [
+    "book",
+    "light",
+    "proof",
+    "unfinished",
+    "editorial"
+  ],
+  "protocol": [
+    "dark",
+    "docs",
+    "networking"
+  ],
+  "protocol-paper": [
+    "paper",
+    "light",
+    "protocol",
+    "pre-registration",
+    "rigorous"
+  ],
+  "psychedelic": [
+    "dark",
+    "minimal",
+    "elegant",
+    "glamorous"
+  ],
+  "pulp-fiction": [
+    "book",
+    "dark",
+    "pulp",
+    "lurid",
+    "cheap"
+  ],
+  "pulsar": [
+    "dark",
+    "blog",
+    "cosmic",
+    "pulse-animation"
+  ],
+  "pulse-api": [
+    "dark",
+    "docs"
+  ],
+  "pyrite": [
+    "dark",
+    "showcase",
+    "metallic",
+    "luxury"
+  ],
+  "pyrotechnic": [
+    "event",
+    "show",
+    "pyrotechnics",
+    "fireworks",
+    "explosive"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
+  ],
+  "quantum": [
+    "dark",
+    "blog",
+    "quantum",
+    "science"
+  ],
+  "quarry": [
+    "dark",
+    "docs",
+    "data-warehouse"
+  ],
+  "quasar": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
+  "radiolaria": [
+    "dark",
+    "blog",
+    "radiolaria",
+    "skeletal"
+  ],
+  "rainbow-cascade": [
+    "elegant",
+    "glowing",
+    "box-shadow"
+  ],
+  "ramble": [
+    "light",
+    "blog",
+    "hiking"
+  ],
+  "randomized-trial": [
+    "paper",
+    "light",
+    "rct",
+    "clinical-trial",
+    "rigorous"
+  ],
+  "rave": [
+    "dark",
+    "blog",
+    "acid",
+    "rave",
+    "neon"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
+  ],
+  "reactor": [
+    "dark",
+    "docs",
+    "reactive"
+  ],
+  "realty": [
+    "light",
+    "realestate",
+    "luxury",
+    "elegant"
+  ],
+  "recipe": [
+    "light",
+    "blog",
+    "recipe"
+  ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
+  ],
+  "red-carpet": [
+    "event",
+    "premiere",
+    "celebrity",
+    "glamour",
+    "fashion"
+  ],
+  "reef": [
+    "dark",
+    "blog",
+    "diving"
+  ],
+  "relay": [
+    "light",
+    "docs",
+    "integration"
+  ],
+  "remainder-bin": [
+    "book",
+    "light",
+    "secondhand",
+    "discount",
+    "worn"
+  ],
+  "remedy": [
+    "light",
+    "docs",
+    "troubleshooting"
+  ],
+  "renaissance": [
+    "light",
+    "art",
+    "classic",
+    "serif",
+    "elegant"
+  ],
+  "repousse": [
+    "dark",
+    "blog",
+    "repousse",
+    "metalwork"
+  ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
+  ],
+  "resume": [
+    "light",
+    "resume"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
+  ],
+  "retro-radar": [
+    "dark",
+    "blog",
+    "radar",
+    "retro"
+  ],
+  "retromac": [
+    "light",
+    "mac",
+    "os9",
+    "retro",
+    "system"
+  ],
+  "retrowave": [
+    "dark",
+    "blog",
+    "retro",
+    "synthwave"
+  ],
+  "reveille": [
+    "event",
+    "dark",
+    "military",
+    "assembly",
+    "urgent"
+  ],
+  "review-article": [
+    "paper",
+    "light",
+    "review",
+    "literature",
+    "synthesis"
+  ],
+  "ridgeline": [
+    "dark",
+    "blog",
+    "outdoor"
+  ],
+  "riftzone": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "dimensional"
+  ],
+  "ring-bell": [
+    "event",
+    "dark",
+    "boxing",
+    "fight",
+    "intense"
+  ],
+  "riverbank": [
+    "light",
+    "blog",
+    "nature-journal"
+  ],
+  "rococo": [
+    "light",
+    "blog",
+    "pastel",
+    "elegant"
+  ],
+  "roll-call": [
+    "event",
+    "light",
+    "assembly",
+    "formal",
+    "attendance"
+  ],
+  "roll-scroll": [
+    "book",
+    "light",
+    "scroll",
+    "continuous",
+    "ancient"
+  ],
+  "rooftop": [
+    "dark",
+    "blog",
+    "urban"
+  ],
+  "rose-gold": [
+    "elegant",
+    "luxury",
+    "minimal"
+  ],
+  "rosemary": [
+    "light",
+    "blog",
+    "cooking"
+  ],
+  "rosetta": [
+    "light",
+    "docs",
+    "i18n"
+  ],
+  "rosewood": [
+    "blog",
+    "dark",
+    "warm",
+    "classic"
+  ],
+  "rubric": [
+    "book",
+    "light",
+    "rubricated",
+    "two-color",
+    "traditional"
+  ],
+  "ruby-fire": [
+    "dark",
+    "blog",
+    "bold"
+  ],
+  "runbook": [
+    "light",
+    "docs",
+    "operations"
+  ],
+  "rune": [
+    "dark",
+    "archive",
+    "viking",
+    "mystic"
+  ],
+  "saffron": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "sage-guide": [
+    "docs",
+    "light",
+    "tutorial",
+    "guide"
+  ],
+  "sakura-storm": [
+    "dark",
+    "blog",
+    "glamorous",
+    "sakura"
+  ],
+  "sandcastle": [
+    "light",
+    "blog",
+    "sand",
+    "beach"
+  ],
+  "sandstone": [
+    "light",
+    "blog",
+    "architecture"
+  ],
+  "sandstorm": [
+    "dark",
+    "blog",
+    "desert",
+    "particles"
+  ],
+  "sapphire": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "savanna": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "sawmill": [
+    "light",
+    "blog",
+    "woodworking"
+  ],
+  "scaffold": [
+    "dark",
+    "landing",
+    "comingsoon"
+  ],
+  "scaffold-docs": [
+    "dark",
+    "docs",
+    "scaffolding"
+  ],
+  "schematic": [
+    "light",
+    "docs",
+    "hardware"
+  ],
+  "scientific-journal": [
+    "dark",
+    "docs",
+    "scientific",
+    "academic"
+  ],
+  "scoping-review": [
+    "paper",
+    "light",
+    "scoping",
+    "mapping",
+    "landscape"
+  ],
+  "scrimshaw": [
+    "bold",
+    "elegant",
+    "clean",
+    "blog"
+  ],
+  "sentinel": [
+    "dark",
+    "docs",
+    "monitoring"
+  ],
+  "seraph": [
+    "minimal",
+    "elegant",
+    "portfolio"
+  ],
+  "serenity": [
+    "light",
+    "blog",
+    "elegant"
+  ],
+  "sextant": [
+    "light",
+    "docs",
+    "metrics"
+  ],
+  "sfumato": [
+    "dark",
+    "blog",
+    "atmospheric",
+    "minimal"
+  ],
+  "sgraffito": [
+    "dark",
+    "blog",
+    "sgraffito",
+    "scratched"
+  ],
+  "shutout": [
+    "event",
+    "dark",
+    "competition",
+    "dominant",
+    "perfect"
+  ],
+  "silhouette": [
+    "dark",
+    "landing",
+    "silhouette",
+    "dramatic"
+  ],
+  "silk-road": [
+    "elegant",
+    "glamorous",
+    "silk",
+    "cultural"
+  ],
+  "simulation-paper": [
+    "paper",
+    "dark",
+    "computational",
+    "simulation",
+    "model"
+  ],
+  "sketch": [
+    "light",
+    "blog",
+    "handdrawn"
+  ],
+  "skeuomorphic": [
+    "light",
+    "blog",
+    "skeuomorphic",
+    "realistic"
+  ],
+  "slide": [
+    "dark",
+    "docs",
+    "presentation"
+  ],
+  "snowfall": [
+    "light",
+    "blog",
+    "winter"
+  ],
+  "solar-punk": [
+    "light",
+    "blog",
+    "solarpunk",
+    "sustainable"
+  ],
+  "solarflare": [
+    "dark",
+    "landing",
+    "solar",
+    "energy"
+  ],
+  "solaris": [
+    "dark",
+    "dashboard",
+    "solar-system",
+    "space-mission"
+  ],
+  "solarium": [
+    "blog",
+    "light",
+    "warm"
+  ],
+  "solstice": [
+    "dual",
+    "blog",
+    "seasonal",
+    "time-based"
+  ],
+  "sonar": [
+    "dark",
+    "hub",
+    "radar",
+    "discovery"
+  ],
+  "spectra": [
+    "dark",
+    "data-science",
+    "spectrum",
+    "rainbow"
+  ],
+  "spectrum": [
+    "light",
+    "blog",
+    "a11y"
+  ],
+  "spectrum-docs": [
+    "light",
+    "docs",
+    "accessibility"
+  ],
+  "spire": [
+    "dark",
+    "blog",
+    "architecture"
+  ],
+  "split-tone": [
+    "light",
+    "blog",
+    "photography",
+    "cinematic",
+    "toning"
+  ],
+  "stained-glass": [
+    "light",
+    "blog",
+    "cathedral",
+    "colorful",
+    "gothic"
+  ],
+  "standing-ovation": [
+    "event",
+    "light",
+    "awards",
+    "acclaim",
+    "celebration"
+  ],
+  "starlight": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "minimal"
+  ],
+  "starting-gun": [
+    "event",
+    "dark",
+    "race",
+    "competition",
+    "explosive"
+  ],
+  "statuspage": [
+    "light",
+    "landing",
+    "status"
+  ],
+  "stellar-launch": [
+    "landing",
+    "dark",
+    "parallax",
+    "animation"
+  ],
+  "stipple": [
+    "light",
+    "artistic",
+    "dot-art",
+    "gallery"
+  ],
+  "storefront": [
+    "light",
+    "landing",
+    "shop"
+  ],
+  "stratum": [
+    "dark",
+    "timeline",
+    "geological",
+    "layered"
+  ],
+  "strobe": [
+    "dark",
+    "event",
+    "club",
+    "strobe"
+  ],
+  "studio": [
+    "dark",
+    "landing",
+    "portfolio"
+  ],
+  "subzero": [
+    "dark",
+    "research",
+    "cryogenic",
+    "frozen"
+  ],
+  "summit": [
+    "dark",
+    "landing",
+    "conference"
+  ],
+  "summit-event": [
+    "conference",
+    "dark",
+    "event",
+    "landing"
+  ],
+  "summit-strike": [
+    "event",
+    "dark",
+    "conference",
+    "summit",
+    "ascending"
+  ],
+  "sunburst": [
+    "light",
+    "blog",
+    "warm",
+    "golden",
+    "radiant"
+  ],
+  "sundew": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "supernova": [
+    "dark",
+    "landing",
+    "cosmic",
+    "particles"
+  ],
+  "supplementary": [
+    "paper",
+    "light",
+    "supplementary",
+    "data-heavy",
+    "exhaustive"
+  ],
+  "supreme-sun": [
+    "light",
+    "blog",
+    "community"
+  ],
+  "survey-instrument": [
+    "paper",
+    "light",
+    "survey",
+    "instrument",
+    "psychometric"
+  ],
+  "synthwave": [
+    "dark",
+    "retro",
+    "glamorous",
+    "trendy"
+  ],
+  "systematic-review": [
+    "paper",
+    "light",
+    "systematic",
+    "evidence",
+    "methodology"
+  ],
+  "tactile-fabric": [
+    "light",
+    "blog",
+    "fabric",
+    "textile"
+  ],
+  "talavera": [
+    "light",
+    "blog",
+    "mexican",
+    "pottery",
+    "colorful"
+  ],
+  "tale": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "tangram": [
+    "light",
+    "portfolio",
+    "puzzle",
+    "geometric"
+  ],
+  "tapestry": [
+    "light",
+    "blog",
+    "timeline"
+  ],
+  "taskboard": [
+    "light",
+    "dashboard",
+    "kanban"
+  ],
+  "tavern": [
+    "dark",
+    "blog",
+    "rpg"
+  ],
+  "techbyte": [
+    "light",
+    "blog",
+    "tech",
+    "card"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
+  ],
+  "tectonic": [
+    "dark",
+    "hub",
+    "geological",
+    "interactive"
+  ],
+  "telegraph": [
+    "light",
+    "blog",
+    "news"
+  ],
+  "tempera": [
+    "dark",
+    "blog",
+    "tempera",
+    "painting"
+  ],
+  "tempest": [
+    "dark",
+    "magazine",
+    "storm",
+    "dramatic"
+  ],
+  "tenebrism": [
+    "dark",
+    "creative",
+    "bold",
+    "clean"
+  ],
+  "terminal": [
+    "dark",
+    "blog"
+  ],
+  "terrace": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "terracotta-studio": [
+    "landing",
+    "light",
+    "creative",
+    "artisan"
+  ],
+  "terracotta-tiles": [
+    "dark",
+    "blog",
+    "terracotta",
+    "tile"
+  ],
+  "terraform": [
+    "dark",
+    "dashboard",
+    "sci-fi",
+    "terraforming"
+  ],
+  "terraform-docs": [
+    "docs",
+    "dark",
+    "infra",
+    "devops"
+  ],
+  "terrarium": [
+    "light",
+    "portfolio",
+    "miniature"
+  ],
+  "terrazzo": [
+    "light",
+    "portfolio",
+    "terrazzo",
+    "speckled"
+  ],
+  "terrazzo-blog": [
+    "blog",
+    "light",
+    "colorful",
+    "memphis"
+  ],
+  "tessellation": [
+    "light",
+    "gallery",
+    "escher",
+    "pattern-art"
+  ],
+  "tesseract": [
+    "dark",
+    "education",
+    "4d",
+    "mathematical"
+  ],
+  "thermal": [
+    "dark",
+    "dashboard",
+    "thermal",
+    "heatmap"
+  ],
+  "thesis": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "thesis-defense": [
+    "paper",
+    "dark",
+    "thesis",
+    "formal",
+    "institutional"
+  ],
+  "thunderdome": [
+    "event",
+    "dark",
+    "arena",
+    "competition",
+    "ultimate"
+  ],
+  "ticker-board": [
+    "event",
+    "dark",
+    "transit",
+    "departure",
+    "mechanical"
+  ],
+  "ticker-tape": [
+    "event",
+    "light",
+    "celebration",
+    "parade",
+    "festive"
+  ],
+  "tidal": [
+    "light",
+    "blog",
+    "ocean",
+    "wellness"
+  ],
+  "timber": [
+    "light",
+    "blog",
+    "craft"
+  ],
+  "titanium": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ],
+  "topaz": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "topographic-gradient": [
+    "dark",
+    "blog",
+    "topographic",
+    "contour"
+  ],
+  "topographic-sand": [
+    "dark",
+    "blog",
+    "topographic",
+    "sand"
+  ],
+  "topography": [
+    "light",
+    "blog",
+    "topographic",
+    "outdoor"
+  ],
+  "torchlight": [
+    "dark",
+    "blog",
+    "adventure"
+  ],
+  "totem": [
+    "dark",
+    "portfolio",
+    "tribal",
+    "vertical-stack"
+  ],
+  "tremor": [
+    "dark",
+    "dashboard",
+    "seismic",
+    "data-viz"
+  ],
+  "trompe-loeil": [
+    "light",
+    "portfolio",
+    "creative",
+    "bold",
+    "illusion"
+  ],
+  "tropical-paradise": [
+    "elegant",
+    "vivid",
+    "botanical"
+  ],
+  "tundra": [
+    "dark",
+    "blog",
+    "expedition"
+  ],
+  "turbine": [
+    "light",
+    "corporate",
+    "energy",
+    "rotation"
+  ],
+  "turret": [
+    "dark",
+    "docs",
+    "waf"
+  ],
+  "twilight": [
+    "dark",
+    "blog",
+    "photo-essay"
+  ],
+  "typeface": [
+    "blog",
+    "light",
+    "typography",
+    "minimal"
+  ],
+  "typewriter": [
+    "light",
+    "blog",
+    "vintage"
+  ],
+  "typhoon": [
+    "dark",
+    "magazine",
+    "storm",
+    "spiral"
+  ],
+  "ukiyo-e": [
+    "light",
+    "blog",
+    "japanese",
+    "woodblock",
+    "traditional"
+  ],
+  "ultraviolet": [
+    "dark",
+    "blog",
+    "ultraviolet",
+    "neon"
+  ],
+  "umbra": [
+    "dark",
+    "portfolio",
+    "monochrome",
+    "shadow"
+  ],
+  "vapor": [
+    "light",
+    "blog",
+    "vaporwave",
+    "surreal"
+  ],
+  "vault": [
+    "dark",
+    "docs",
+    "security"
+  ],
+  "vellum": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "velocity": [
+    "landing",
+    "dark",
+    "saas"
+  ],
+  "velvet": [
+    "dark",
+    "landing",
+    "luxury"
+  ],
+  "velvet-rope": [
+    "event",
+    "gala",
+    "exclusive",
+    "luxury",
+    "velvet"
+  ],
+  "venetian": [
+    "light",
+    "blog",
+    "renaissance",
+    "venetian",
+    "ornate"
+  ],
+  "verdigris": [
+    "dark",
+    "blog",
+    "editorial"
+  ],
+  "versailles": [
+    "dark",
+    "elegant",
+    "classic",
+    "luxury"
+  ],
+  "vertigo": [
+    "dark",
+    "one-page",
+    "experimental",
+    "perspective"
+  ],
+  "vibrant-brutalism": [
+    "dark",
+    "blog",
+    "brutalist",
+    "vibrant"
+  ],
+  "victorian": [
+    "dark",
+    "blog",
+    "gothic",
+    "classic"
+  ],
+  "vineyard": [
+    "dark",
+    "blog",
+    "wine"
+  ],
+  "vintage": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "vintagetv": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "vinyl": [
+    "dark",
+    "blog",
+    "vinyl"
+  ],
+  "voltage": [
+    "dark",
+    "blog",
+    "electric",
+    "sparks"
+  ],
+  "volumetric": [
+    "dark",
+    "blog",
+    "3d",
+    "glow",
+    "atmospheric"
+  ],
+  "vortex": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "animation"
+  ],
+  "wanderlust": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "war-room": [
+    "event",
+    "dark",
+    "strategy",
+    "military",
+    "command"
+  ],
+  "warpzone": [
+    "dark",
+    "portfolio",
+    "warp",
+    "gaming"
+  ],
+  "washi-bound": [
+    "book",
+    "light",
+    "japanese",
+    "stab-binding",
+    "paper"
+  ],
+  "wavelength": [
+    "audio",
+    "dark",
+    "landing",
+    "music"
+  ],
+  "weathervane": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "wedding": [
+    "light",
+    "wedding",
+    "elegant",
+    "event"
+  ],
+  "white-paper-noir": [
+    "paper",
+    "dark",
+    "industry",
+    "executive",
+    "authoritative"
+  ],
+  "wiki": [
+    "light",
+    "docs",
+    "wiki"
+  ],
+  "willow": [
+    "light",
+    "blog",
+    "literature"
+  ],
+  "windmill": [
+    "light",
+    "blog",
+    "european"
+  ],
+  "windows95": [
+    "light",
+    "retro",
+    "os",
+    "nostalgia"
+  ],
+  "woodblock": [
+    "dark",
+    "blog",
+    "woodblock",
+    "printmaking"
+  ],
+  "working-paper": [
+    "paper",
+    "light",
+    "working",
+    "in-progress",
+    "honest"
+  ],
+  "woven-tapestry": [
+    "dark",
+    "blog",
+    "tapestry",
+    "textile"
+  ],
+  "x-ray": [
+    "dark",
+    "blog",
+    "x-ray",
+    "transparent"
+  ],
+  "xerograph": [
+    "dark",
+    "blog",
+    "minimal",
+    "photocopy"
+  ],
+  "y2k": [
+    "dark",
+    "cyber",
+    "metallic",
+    "retro"
+  ],
+  "zen": [
+    "light",
+    "blog",
+    "zen"
+  ],
+  "zenith": [
+    "light",
+    "landing",
+    "minimal",
+    "altitude"
+  ],
+  "zenithpoint": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ]
 }


### PR DESCRIPTION
Closes #1539

## Summary
- Add manifesto-press (revolutionary tract publication) example site
- Dark theme with bold red accents and near-black ground
- SVG raised fist illustrations for revolutionary chapter openers
- SVG banner and flag patterns for section headers
- Typography: Bebas Neue / Oswald Black for demands; Archivo SemiBold / Work Sans Medium for body
- 5 demands covering broadside, pamphlet, manifesto, press, and the word
- Tags: book, dark, revolutionary, bold, political

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of revolutionary theme and raised fist SVGs
- [ ] Check responsive behavior on narrow viewports