### PR TITLE
feat: add errata-slip example site (closes #1531)

### DIFF
--- a/errata-slip/AGENTS.md
+++ b/errata-slip/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/errata-slip/config.toml
+++ b/errata-slip/config.toml
@@ -1,0 +1,73 @@
+# =============================================================================
+# Errata Slip -- Correction Insert Publication
+# Issue #1531 | Tags: book, light, correction, layered, meta
+# =============================================================================
+
+title = "Errata Slip -- A Publication of Corrections"
+description = "A meta-publication exploring the errata slip: the printed correction insert that acknowledges and amends errors in published works."
+base_url = "http://localhost:3000"
+
+sections = ["chapters"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "article"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+
+[pagination]
+enabled = false
+
+[series]
+enabled = true
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = [] }
+]
+
+[llms]
+enabled = true
+
+[feeds]
+enabled = true
+type = "atom"
+limit = 10
+sections = ["chapters"]
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/errata-slip/content/chapters/1-the-history-of-the-errata.md
+++ b/errata-slip/content/chapters/1-the-history-of-the-errata.md
@@ -1,0 +1,54 @@
++++
+title = "Chapter I: The History of the Errata"
+description = "From the earliest printed corrections in the incunabula period to standardized errata sheets of modern publishing."
+date = "2025-01-15"
+tags = ["history", "incunabula", "publishing", "printing"]
+weight = 1
++++
+
+<p class="chapter-label">Chapter I</p>
+
+## The first corrections
+
+<p class="lede">The errata list is nearly as old as printing itself. The earliest printed books -- the incunabula, produced before 1501 -- frequently included sheets of corrections, acknowledging that the new technology of movable type, for all its power, introduced new categories of error. A manuscript copied by a single scribe might contain errors of reading or transcription; a printed book, produced in hundreds of identical copies, multiplied every error by the size of the edition. The errata list was the printer's confession: we have made mistakes, and here they are.</p>
+
+<div class="illustration">
+<svg viewBox="0 0 480 140" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<!-- Timeline -->
+<line x1="40" y1="70" x2="440" y2="70" stroke="#ddd" stroke-width="1"/>
+<!-- Points -->
+<circle cx="80" cy="70" r="4" fill="#c0392b"/>
+<circle cx="180" cy="70" r="4" fill="#c0392b"/>
+<circle cx="280" cy="70" r="4" fill="#c0392b"/>
+<circle cx="380" cy="70" r="4" fill="#c0392b"/>
+<!-- Labels -->
+<text x="80" y="55" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#c0392b" font-weight="600">1478</text>
+<text x="80" y="95" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">First known</text>
+<text x="80" y="105" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">printed errata</text>
+<text x="180" y="55" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#c0392b" font-weight="600">1525</text>
+<text x="180" y="95" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">Errata standard</text>
+<text x="180" y="105" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">in scholarly works</text>
+<text x="280" y="55" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#c0392b" font-weight="600">1750</text>
+<text x="280" y="95" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">Tipped-in errata</text>
+<text x="280" y="105" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">slips widespread</text>
+<text x="380" y="55" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#c0392b" font-weight="600">1950</text>
+<text x="380" y="95" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">Standardized journal</text>
+<text x="380" y="105" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="7" fill="#777" font-style="italic">corrigenda format</text>
+</svg>
+<p class="illustration-caption">Fig. 1. -- Timeline of the errata tradition in Western printing, from the first known printed correction to standardized journal corrigenda.</p>
+</div>
+
+The earliest known printed errata list appeared in 1478, in a book printed by the Venetian press of Gabriele di Pietro. It was a simple list: page numbers and corrections, set in the same type as the text it amended. The format was practical and unapologetic. By the early sixteenth century, errata sheets had become standard in scholarly publishing, and the more conscientious printers included them as a matter of course.
+
+## The language of correction
+
+The errata list developed its own formal language, precise and ritualistic. The standard entry follows a fixed pattern: the location of the error (page and line), the error itself (preceded by "for"), and the correction (preceded by "read"). This format -- "Page 47, line 12: for X read Y" -- has remained essentially unchanged for five centuries. It is one of the most stable textual conventions in the history of publishing.
+
+<div class="errata-slip">
+<div class="errata-slip-label">Historical Errata Entry</div>
+<p>p. 134, l. 8: for <span class="original">Guglielmo</span> read <span class="correction">Gugliemo</span>.</p>
+<p>p. 201, l. 22: for <span class="original">the Tiber</span> read <span class="correction">the Arno</span>.</p>
+<p>p. 267, title: for <span class="original">Chaper XIV</span> read <span class="correction">Chapter XIV</span>.</p>
+</div>
+
+The formality of the errata entry serves a purpose beyond mere convention. By specifying the exact location and nature of each error, the errata list enables any reader to apply the corrections systematically, working through the book with pen in hand, crossing out errors and writing in the amendments. Some bibliophiles and scholars did precisely this, and surviving copies of early printed books sometimes bear manuscript corrections in the margins that correspond exactly to the published errata list.

--- a/errata-slip/content/chapters/2-the-anatomy-of-a-correction.md
+++ b/errata-slip/content/chapters/2-the-anatomy-of-a-correction.md
@@ -1,0 +1,64 @@
++++
+title = "Chapter II: The Anatomy of a Correction"
+description = "The structure and language of the errata entry: page, line, error, and correction."
+date = "2025-01-14"
+tags = ["structure", "format", "correction", "language"]
+weight = 2
++++
+
+<p class="chapter-label">Chapter II</p>
+
+## The four elements
+
+<p class="lede">Every errata entry contains four elements: the location, the error, the correction, and the implicit relationship between them. The location anchors the correction to a specific point in the text. The error quotes the faulty passage. The correction provides the replacement. And the relationship -- the unstated understanding that one text is wrong and the other right -- depends entirely on the reader's willingness to trust the errata over the text it amends.</p>
+
+<div class="strikethrough-block">
+<h4>Correction Pattern</h4>
+<svg viewBox="0 0 480 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<!-- Location -->
+<rect x="20" y="15" width="80" height="30" rx="2" fill="none" stroke="#ddd" stroke-width="1"/>
+<text x="60" y="35" text-anchor="middle" font-family="'Inter', sans-serif" font-size="9" fill="#777" font-weight="600">LOCATION</text>
+<text x="60" y="60" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="8" fill="#999" font-style="italic">p. 47, l. 12</text>
+<!-- Arrow -->
+<line x1="110" y1="30" x2="130" y2="30" stroke="#ddd" stroke-width="1"/>
+<polygon points="130,30 126,27 126,33" fill="#ddd"/>
+<!-- Error -->
+<rect x="140" y="15" width="100" height="30" rx="2" fill="none" stroke="#999" stroke-width="1"/>
+<text x="190" y="35" text-anchor="middle" font-family="'Inter', sans-serif" font-size="9" fill="#999" font-weight="600">ERROR</text>
+<text x="190" y="60" text-anchor="middle" font-family="'Libre Baskerville', serif" font-size="8" fill="#999" font-style="italic" text-decoration="line-through">for "1842"</text>
+<!-- Arrow -->
+<line x1="250" y1="30" x2="270" y2="30" stroke="#ddd" stroke-width="1"/>
+<polygon points="270,30 266,27 266,33" fill="#ddd"/>
+<!-- Correction -->
+<rect x="280" y="15" width="100" height="30" rx="2" fill="none" stroke="#c0392b" stroke-width="1"/>
+<text x="330" y="35" text-anchor="middle" font-family="'Inter', sans-serif" font-size="9" fill="#c0392b" font-weight="600">CORRECTION</text>
+<text x="330" y="60" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#c0392b" font-weight="600">read "1843"</text>
+<!-- Arrow -->
+<line x1="390" y1="30" x2="410" y2="30" stroke="#ddd" stroke-width="1"/>
+<polygon points="410,30 406,27 406,33" fill="#ddd"/>
+<!-- Result -->
+<rect x="420" y="15" width="50" height="30" rx="2" fill="none" stroke="#2ecc71" stroke-width="1"/>
+<text x="445" y="33" text-anchor="middle" font-family="'Inter', sans-serif" font-size="8" fill="#2ecc71" font-weight="600">AMENDED</text>
+<!-- Connection line -->
+<line x1="60" y1="65" x2="60" y2="85" stroke="#ddd" stroke-width="0.5" stroke-dasharray="2,2"/>
+<line x1="190" y1="65" x2="190" y2="85" stroke="#ddd" stroke-width="0.5" stroke-dasharray="2,2"/>
+<line x1="330" y1="65" x2="330" y2="85" stroke="#ddd" stroke-width="0.5" stroke-dasharray="2,2"/>
+</svg>
+<p class="illustration-caption">Fig. 2. -- The four-element structure of an errata entry: location identifies where; the error quotes the faulty text; the correction provides the amendment; the result is the amended passage.</p>
+</div>
+
+## Types of error
+
+The errors that errata slips correct fall into several categories. Typographical errors -- misspellings, transposed letters, dropped words -- are the most common and the least consequential. Factual errors -- wrong dates, incorrect names, erroneous measurements -- are more serious, as they may mislead the reader. Structural errors -- misnumbered pages, misplaced illustrations, garbled cross-references -- can render portions of the text unintelligible.
+
+The most dangerous errors are those that are plausible. A date that is wrong by one year, a measurement that is off by a factor of two, a name that is similar to but not identical with the correct one -- these errors may be absorbed by the reader without question, becoming part of their understanding of the subject. The errata slip exists precisely to catch these errors before they propagate.
+
+## The strikethrough
+
+<div class="errata-slip">
+<div class="errata-slip-label">Correction Overlay</div>
+<p>The original text read: <span class="original">The tensile strength of mild steel is approximately 250 megapascals, making it suitable for all structural applications without further treatment.</span></p>
+<p>The corrected text reads: <span class="correction">The tensile strength of mild steel is approximately 400 megapascals. Its suitability for structural applications depends on the specific loading conditions and applicable design codes.</span></p>
+</div>
+
+The visual language of the errata slip is built on contrast. The original text, marked by strikethrough, is visually cancelled but remains legible -- a deliberate choice. The correction, set in a different face or weight, asserts itself over the cancelled text. The reader sees both versions simultaneously: the error and its remedy, the old and the new, layered on the same page. This layering is the essential visual characteristic of the errata tradition.

--- a/errata-slip/content/chapters/3-the-psychology-of-error.md
+++ b/errata-slip/content/chapters/3-the-psychology-of-error.md
@@ -1,0 +1,28 @@
++++
+title = "Chapter III: The Psychology of Error"
+description = "Why errors persist despite proofreading, and what errata patterns reveal about human attention."
+date = "2025-01-13"
+tags = ["psychology", "proofreading", "attention", "error"]
+weight = 3
++++
+
+<p class="chapter-label">Chapter III</p>
+
+## The limits of proofreading
+
+<p class="lede">Every published book has been proofread, usually multiple times by multiple readers. Yet errors survive. The persistence of errors in carefully proofread text is not a failure of diligence; it is a consequence of how human perception works. The brain does not read letter by letter. It recognizes words as shapes, predicts the next word from context, and fills in details from expectation rather than observation. A proofreader who knows what the text should say will often see what it should say rather than what it actually says.</p>
+
+This phenomenon -- seeing what you expect rather than what is there -- has been demonstrated experimentally. Studies of proofreading performance show that readers reliably miss between 10 and 30 percent of errors in text, even when specifically instructed to find them. The rate is higher for contextually plausible errors (a wrong date that could be right) and lower for visually obvious ones (a word printed in the wrong font).
+
+## The taxonomy of surviving errors
+
+The errors that survive proofreading tend to follow patterns. Small errors survive more readily than large ones: a transposed digit is harder to catch than a missing paragraph. Errors in unfamiliar material survive better than errors in familiar material: a proofreader who does not know the correct date cannot recognize the wrong one. And errors in peripheral text -- captions, footnotes, page headers -- survive at higher rates than errors in the main body text, because proofreaders allocate less attention to these marginal zones.
+
+<div class="errata-slip">
+<div class="errata-slip-label">Errata -- Chapter III</div>
+<p>This chapter originally stated that proofreaders miss <span class="original">between 20 and 40 percent</span> of errors. The correct range, based on the studies cited, is <span class="correction">between 10 and 30 percent</span>.</p>
+</div>
+
+## The compound error
+
+The most insidious errors are compounds: cases where a correction introduced during the editorial process creates a new error. A date is changed from 1842 to 1843, but the corresponding date in the index is not updated. A name is corrected in the text but not in the bibliography. A figure caption is rewritten to match a new illustration, but the cross-reference in the text still points to the old figure number. These compound errors are the most difficult to detect because each individual element appears correct in isolation; only the relationship between them is wrong.

--- a/errata-slip/content/chapters/4-the-errata-of-the-errata.md
+++ b/errata-slip/content/chapters/4-the-errata-of-the-errata.md
@@ -1,0 +1,34 @@
++++
+title = "Chapter IV: The Errata of the Errata"
+description = "When corrections themselves contain errors, creating recursive chains of amendment."
+date = "2025-01-12"
+tags = ["meta", "recursion", "reliability", "correction"]
+weight = 4
++++
+
+<p class="chapter-label">Chapter IV</p>
+
+## The recursive problem
+
+<p class="lede">If a book can contain errors, so can its errata. The errata slip is itself a printed document, subject to all the same sources of error -- typographical mistakes, factual inaccuracies, misidentified locations -- that afflict the text it corrects. When the errata slip contains an error, the result is a correction that makes things worse: the reader, trusting the errata, dutifully amends the text with the wrong correction, replacing one error with another.</p>
+
+<div class="errata-slip" style="transform: rotate(-0.5deg);">
+<div class="errata-slip-label">Errata to the Errata</div>
+<p>The errata slip bound into the first printing of this volume contained the following error:</p>
+<p>Errata slip, item 3: for <span class="original">"p. 203, l. 4: for 1,200 MPa read 1,170 MPa"</span> read <span class="correction">"p. 203, l. 4: for 1,200 MPa read 1,770 MPa"</span>.</p>
+<p>We regret the error in the correction.</p>
+</div>
+
+This situation is not hypothetical. Errata sheets that themselves contain errors are documented throughout the history of printing. Some publishers have been forced to issue corrections to their corrections, creating chains of amendment that test the reader's patience and the publisher's credibility. In extreme cases, a third errata sheet corrects the second, which corrected the first, which corrected the text -- a recursive stack of amendments in which the reader must determine which layer is authoritative.
+
+## The epistemological problem
+
+The errata slip poses a quiet epistemological question: how do we know the correction is right? The errata slip asserts its authority simply by existing -- it is printed on a separate slip, inserted after the fact, and formatted in a way that signals "correction." But the errata slip is produced by the same process that produced the error. If the compositor or the editor or the proofreader could be wrong once, they can be wrong twice.
+
+The reader who encounters an errata slip must make a judgment: trust the correction, or trust the original text? In most cases, the answer is obvious -- the correction clearly fixes a typographical error or supplies a missing word. But in cases where the correction concerns a factual claim, the reader has no independent basis for preferring one version over the other. The authority of the errata slip is institutional, not evidentiary.
+
+## The silent correction
+
+Modern publishing increasingly favors the silent correction: the error is fixed between printings without any public acknowledgment. The second printing reads correctly; the first printing is simply wrong. No errata slip is issued. No correction is recorded. The error, and the fact that it was an error, disappears from the published record.
+
+The silent correction is efficient but dishonest. It treats the reader of the first printing as though they do not deserve to know that what they read was wrong. It erases the evidence of the error, making it impossible for scholars to trace the history of the text. And it denies the fundamental premise of the errata tradition: that errors should be acknowledged, not hidden.

--- a/errata-slip/content/chapters/5-the-digital-errata.md
+++ b/errata-slip/content/chapters/5-the-digital-errata.md
@@ -1,0 +1,34 @@
++++
+title = "Chapter V: The Digital Errata"
+description = "How electronic publishing has changed the nature of correction, from silent updates to versioned amendments."
+date = "2025-01-11"
+tags = ["digital", "versioning", "electronic", "publishing"]
+weight = 5
++++
+
+<p class="chapter-label">Chapter V</p>
+
+## The mutable text
+
+<p class="lede">The printed book is fixed. Once the sheets are printed, bound, and distributed, the text cannot be changed. Errors, once made, persist in every copy of the edition. The errata slip exists precisely because the text itself cannot be altered. But digital text is mutable. A web page can be updated, an ebook can be revised, a PDF can be replaced. The error can be corrected in the text itself, instantly and invisibly, without any errata slip at all.</p>
+
+This mutability transforms the nature of correction. In the print tradition, every correction is visible -- it exists as a separate artifact, the errata slip, that sits alongside the original text. The reader can see both the error and the correction. In the digital environment, the correction can be applied silently, replacing the error without leaving any trace of its former existence. The text appears to have always been correct.
+
+## The problem of versioning
+
+The silent correction creates a versioning problem. If a digital text is cited by a reader on Monday, and the text is corrected on Tuesday, the citation no longer matches the text. The reader's reference points to a version that no longer exists. In academic publishing, where precise citation is fundamental, this instability is a serious concern.
+
+Some digital publishers address this problem through formal versioning. The text is assigned a version number or a date stamp, and corrections are documented in a change log that accompanies the text. This approach preserves the spirit of the errata tradition -- errors are acknowledged and corrections are recorded -- while adapting it to the capabilities of the digital medium.
+
+<div class="strikethrough-block">
+<h4>Version History</h4>
+<p><strong style="font-family: Inter, sans-serif; color: #c0392b;">v1.2 (2025-01-15)</strong> -- Corrected alloy composition in Chapter V from <span class="struck">80/6/14</span> to <span class="corrected">80/6/14 (confirmed)</span>. Updated bibliography entry for Lewis and Reynolds.</p>
+<p><strong style="font-family: Inter, sans-serif; color: #c0392b;">v1.1 (2025-01-10)</strong> -- Corrected date of Tacoma Narrows failure from <span class="struck">November 7, 1941</span> to <span class="corrected">November 7, 1940</span>. Fixed cross-reference in Chapter III.</p>
+<p><strong style="font-family: Inter, sans-serif; color: #c0392b;">v1.0 (2025-01-01)</strong> -- Initial publication.</p>
+</div>
+
+## The persistence of error
+
+Despite the ease of digital correction, errors persist in digital text just as they persist in print. The reasons are the same: the limits of human attention, the cost of thorough proofreading, the pressure of deadlines. What has changed is not the rate of error but the visibility of correction. In the print tradition, the errata slip is a public document -- a visible acknowledgment that the text is imperfect. In the digital tradition, corrections are often invisible, applied silently and without record.
+
+The errata slip, for all its modesty, embodies a valuable principle: that published text should be held accountable for its claims, and that corrections should be as public as the errors they amend. Whether the medium is paper or pixels, the principle remains the same. The honest publication acknowledges its errors. The errata slip is how it does so.

--- a/errata-slip/content/chapters/_index.md
+++ b/errata-slip/content/chapters/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Chapters"
+description = "The five chapters of this publication, exploring the errata slip from history through digital transformation."
+template = "section"
+sort_by = "weight"
++++

--- a/errata-slip/content/colophon.md
+++ b/errata-slip/content/colophon.md
@@ -1,0 +1,23 @@
++++
+title = "Colophon"
+description = "About the design, typography, and production of this publication."
+tags = ["colophon", "typography", "design"]
++++
+
+## About this publication
+
+This publication was composed using Hwaro, a static site generator. Its design reflects the layered, self-correcting nature of the errata tradition, where original text and corrections coexist on the page.
+
+## Typography
+
+**Display faces.** The original text is set in Libre Baskerville, a classical serif face whose traditional authority represents the published work as it first appeared. Chapter titles and body text use Libre Baskerville at regular and bold weights.
+
+**Correction faces.** Corrections and errata entries are set in Inter Bold, a contemporary sans-serif that contrasts visually with the original serif text. The shift from serif to sans-serif signals the intervention of the corrector -- a different voice overlaying the original.
+
+**Strikethrough originals.** Erroneous text is shown with strikethrough styling and muted color, visually cancelled but still legible, reflecting the errata tradition of showing both the error and the correction.
+
+## Visual design
+
+SVG pasted-in errata slip panels overlay original content, simulating the physical errata slips that were tipped into printed books. These panels are slightly rotated to suggest a loose insert rather than a bound page. SVG strikethrough patterns mark corrected text sections, with the original in serif and the correction in bold sans-serif.
+
+The light color palette (off-white, warm cream, muted grays) provides the neutral ground against which the red correction marks stand out. The correction red (#c0392b) is used consistently for all errata labels, correction text, and slip borders. No CSS gradients are used. All decorative elements are inline SVG.

--- a/errata-slip/content/index.md
+++ b/errata-slip/content/index.md
@@ -1,0 +1,55 @@
++++
+title = "A Publication of Corrections"
+description = "A meta-publication exploring the errata slip: the printed correction insert that acknowledges and amends errors in published works."
++++
+
+<div class="title-page">
+<h1>Errata Slip</h1>
+<p class="title-subtitle">A Publication of Corrections</p>
+
+<div class="errata-slip">
+<div class="errata-slip-label">Errata</div>
+<svg viewBox="0 0 500 80" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<!-- Errata slip visual -->
+<rect x="0" y="0" width="500" height="80" fill="#fffbf0" rx="1"/>
+<rect x="0" y="0" width="4" height="80" fill="#c0392b"/>
+<!-- Strikethrough lines representing corrections -->
+<line x1="20" y1="20" x2="200" y2="20" stroke="#999" stroke-width="0.8"/>
+<line x1="20" y1="19" x2="200" y2="19" stroke="#c0392b" stroke-width="0.5" stroke-dasharray="none"/>
+<text x="210" y="23" font-family="'Inter', sans-serif" font-size="10" fill="#c0392b" font-weight="600">for "perfection" read "correction"</text>
+<line x1="20" y1="40" x2="180" y2="40" stroke="#999" stroke-width="0.8"/>
+<line x1="20" y1="39" x2="180" y2="39" stroke="#c0392b" stroke-width="0.5"/>
+<text x="190" y="43" font-family="'Inter', sans-serif" font-size="10" fill="#c0392b" font-weight="600">for "complete" read "provisional"</text>
+<line x1="20" y1="60" x2="160" y2="60" stroke="#999" stroke-width="0.8"/>
+<line x1="20" y1="59" x2="160" y2="59" stroke="#c0392b" stroke-width="0.5"/>
+<text x="170" y="63" font-family="'Inter', sans-serif" font-size="10" fill="#c0392b" font-weight="600">for "final" read "interim"</text>
+</svg>
+</div>
+
+<p class="title-imprint">A Publication on the Nature of Error</p>
+</div>
+
+## On the errata slip
+
+<p class="lede">The errata slip is a small piece of paper, often no larger than a bookmark, that is inserted into a published book to correct errors discovered after printing. It is an admission of fallibility -- a formal acknowledgment that the text, despite the care of authors, editors, compositors, and proofreaders, contains mistakes. The errata slip does not hide the error; it announces it, records it, and provides the correction. In this way, the errata slip is one of the most honest artifacts of the publishing tradition.</p>
+
+<div class="errata-slip">
+<div class="errata-slip-label">Example Errata</div>
+<p>Page 47, line 12: for <span class="original">the bridge was completed in 1842</span> read <span class="correction">the bridge was completed in 1843</span>.</p>
+<p>Page 112, caption: for <span class="original">Fig. 7 -- Cross-section of a Warren truss</span> read <span class="correction">Fig. 7 -- Cross-section of a Pratt truss</span>.</p>
+<p>Page 203, line 4: for <span class="original">tensile strength of 1,200 MPa</span> read <span class="correction">tensile strength of 1,770 MPa</span>.</p>
+</div>
+
+## Chapters
+
+This publication examines the errata slip in five chapters:
+
+1. **The History of the Errata** -- From the earliest printed corrections in the incunabula period through the standardized errata sheets of modern academic publishing.
+
+2. **The Anatomy of a Correction** -- The structure and language of the errata entry: page, line, error, and correction.
+
+3. **The Psychology of Error** -- Why errors persist despite proofreading, and what the pattern of errata reveals about the limits of human attention.
+
+4. **The Errata of the Errata** -- When corrections themselves contain errors, creating chains of amendment that call the reliability of all published text into question.
+
+5. **The Digital Errata** -- How electronic publishing has changed the nature of correction, from silent updates to versioned amendments.

--- a/errata-slip/static/css/style.css
+++ b/errata-slip/static/css/style.css
@@ -1,0 +1,186 @@
+/* ==========================================================================
+   Errata Slip -- Correction Insert Publication
+   Light theme with errata overlay panels and strikethrough corrections.
+   Typography: Libre Baskerville (original), Inter (corrections)
+   ========================================================================== */
+
+:root {
+  --bg: #fafaf8;
+  --bg-slip: #fffbf0;
+  --bg-original: #f5f5f2;
+  --text: #2d2d2d;
+  --text-muted: #777;
+  --text-correction: #c0392b;
+  --text-strikethrough: #999;
+  --accent: #c0392b;
+  --accent-light: #e74c3c;
+  --border: #ddd;
+  --border-slip: #e8d5a3;
+  --border-correction: #c0392b;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 16px;
+  line-height: 1.75;
+  margin: 0;
+  padding: 0;
+  color: var(--text);
+  background: var(--bg);
+}
+
+/* ---------- Header ---------- */
+.site-header { border-bottom: 1px solid var(--border); }
+.header-inner {
+  max-width: 760px; margin: 0 auto; padding: 1.5rem 2rem;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.site-logo {
+  display: flex; align-items: center; gap: 0.75rem;
+  text-decoration: none; color: var(--text);
+}
+.site-logo span { font-family: 'Libre Baskerville', serif; font-weight: 700; font-size: 1.3rem; }
+.site-nav { display: flex; gap: 1.5rem; }
+.site-nav a {
+  font-family: 'Inter', sans-serif; font-size: 0.85rem; color: var(--text-muted);
+  text-decoration: none; text-transform: uppercase; letter-spacing: 0.8px; transition: color 0.2s;
+}
+.site-nav a:hover { color: var(--accent); }
+
+/* ---------- Layout ---------- */
+.site-wrapper { max-width: 760px; margin: 0 auto; padding: 0 2rem; min-height: calc(100vh - 160px); }
+.site-main { padding: 3rem 0; }
+
+/* ---------- Typography ---------- */
+h1, h2, h3, h4 { font-family: 'Libre Baskerville', serif; color: var(--text); line-height: 1.3; margin-top: 2em; margin-bottom: 0.5em; }
+h1 { font-size: 2rem; font-weight: 700; margin-top: 0; }
+h2 { font-size: 1.4rem; font-weight: 700; }
+h3 { font-size: 1.15rem; font-weight: 700; font-style: italic; }
+h4 { font-family: 'Inter', sans-serif; font-size: 0.9rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; }
+p { margin: 0 0 1.25em 0; }
+a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--border); transition: border-color 0.2s; }
+a:hover { border-bottom-color: var(--accent); }
+blockquote { margin: 2rem 0; padding: 1rem 1.5rem; border-left: 3px solid var(--border); background: var(--bg-original); font-style: italic; color: var(--text-muted); }
+blockquote p:last-child { margin-bottom: 0; }
+code { font-family: ui-monospace, Consolas, monospace; font-size: 0.85em; background: var(--bg-original); padding: 0.15rem 0.4rem; border-radius: 3px; }
+pre { background: var(--bg-original); border: 1px solid var(--border); border-radius: 4px; padding: 1.25rem; overflow-x: auto; margin: 2rem 0; }
+pre code { background: none; padding: 0; }
+hr { border: none; border-top: 1px solid var(--border); margin: 3rem 0; }
+
+/* ---------- Errata Slip Panel ---------- */
+.errata-slip {
+  position: relative;
+  background: var(--bg-slip);
+  border: 1px solid var(--border-slip);
+  border-left: 4px solid var(--accent);
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+  transform: rotate(0.5deg);
+}
+.errata-slip-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+}
+.errata-slip .correction {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  color: var(--text-correction);
+}
+.errata-slip .original {
+  font-family: 'Libre Baskerville', serif;
+  text-decoration: line-through;
+  color: var(--text-strikethrough);
+}
+
+/* ---------- Strikethrough Patterns ---------- */
+.strikethrough-block {
+  background: var(--bg-original);
+  border: 1px solid var(--border);
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+}
+.strikethrough-block .struck {
+  text-decoration: line-through;
+  color: var(--text-strikethrough);
+}
+.strikethrough-block .corrected {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+/* ---------- Title Page ---------- */
+.title-page { text-align: center; padding: 3rem 0 2rem; }
+.title-page h1 { font-size: 2.4rem; margin-bottom: 0.25em; }
+.title-subtitle { font-size: 1.1rem; font-style: italic; color: var(--text-muted); margin-bottom: 2rem; }
+.title-imprint { font-family: 'Inter', sans-serif; font-size: 0.85rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1.5px; }
+
+/* ---------- Body ---------- */
+.errata-body { font-size: 1rem; }
+.errata-body .lede { font-size: 1.05rem; line-height: 1.8; margin-bottom: 2rem; }
+
+/* ---------- Page Header ---------- */
+.page-header { margin-bottom: 2.5rem; }
+.page-subtitle { font-size: 1rem; font-style: italic; color: var(--text-muted); margin-top: 0.5rem; }
+.chapter-label { font-family: 'Inter', sans-serif; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 2px; color: var(--text-muted); margin-bottom: 0.25rem; }
+
+/* ---------- Illustration ---------- */
+.illustration { margin: 2rem 0; text-align: center; }
+.illustration svg { display: block; margin: 0 auto; max-width: 100%; }
+.illustration-caption { font-size: 0.85rem; font-style: italic; color: var(--text-muted); margin-top: 0.75rem; }
+
+/* ---------- Section List ---------- */
+.section-list { list-style: none; padding: 0; margin: 2rem 0; }
+.section-list li { margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--border); }
+.section-list li:last-child { border-bottom: none; }
+.section-list li a { font-family: 'Libre Baskerville', serif; font-size: 1.25rem; font-weight: 700; color: var(--text); display: block; margin-bottom: 0.3rem; border-bottom: none; }
+.section-list li a:hover { color: var(--accent); }
+.item-desc { font-size: 0.9rem; color: var(--text-muted); margin: 0; }
+
+/* ---------- Tags ---------- */
+.page-tags { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); }
+.tags-label { font-family: 'Inter', sans-serif; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: var(--text-muted); margin-top: 0; margin-bottom: 0.75rem; }
+.tag-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.tag-list a { font-family: 'Inter', sans-serif; font-size: 0.8rem; padding: 0.3rem 0.8rem; border: 1px solid var(--border); color: var(--text-muted); background: var(--bg-original); }
+.tag-list a:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ---------- Taxonomy / Section / Error ---------- */
+.taxonomy-page, .taxonomy-term-page, .section-page { padding: 1rem 0; }
+.taxonomy-desc, .section-desc { font-size: 1rem; color: var(--text-muted); font-style: italic; margin-bottom: 2rem; }
+.section-header { margin-bottom: 2rem; }
+.error-page { text-align: center; padding: 4rem 0; }
+.error-page h1 { font-size: 5rem; color: var(--border); margin-bottom: 0; }
+.error-subtitle { font-size: 1.4rem; color: var(--text-muted); margin-top: 0.5rem; }
+.return-link { display: inline-block; margin-top: 2rem; padding: 0.6rem 1.5rem; border: 1px solid var(--accent); color: var(--accent); font-family: 'Inter', sans-serif; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 1px; }
+.return-link:hover { background: var(--accent); color: #fff; }
+
+/* ---------- Footer ---------- */
+.site-footer { margin-top: 4rem; padding: 2rem 0; text-align: center; }
+.footer-errata { margin-bottom: 1rem; }
+.footer-note { font-family: 'Libre Baskerville', serif; font-size: 0.8rem; font-style: italic; color: var(--text-muted); margin: 0 0 0.25rem 0; }
+.footer-copy { font-family: 'Inter', sans-serif; font-size: 0.7rem; color: #ccc; margin: 0; }
+
+/* ---------- Pagination ---------- */
+nav.pagination { margin: 3rem 0; }
+nav.pagination .pagination-list { list-style: none; padding: 0; display: flex; justify-content: center; gap: 0.5rem; }
+nav.pagination a, .pagination-current span, .pagination-disabled span { display: inline-block; padding: 0.4rem 0.9rem; border: 1px solid var(--border); font-size: 0.85rem; }
+nav.pagination a { color: var(--text-muted); text-decoration: none; }
+nav.pagination a:hover { border-color: var(--accent); color: var(--accent); }
+.pagination-current span { border-color: var(--accent); color: var(--accent); background: var(--bg-slip); }
+.pagination-disabled span { opacity: 0.4; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 640px) {
+  .header-inner { flex-direction: column; gap: 1rem; }
+  .site-wrapper { padding: 0 1.25rem; }
+  h1 { font-size: 1.7rem; }
+  .title-page h1 { font-size: 1.9rem; }
+  .errata-slip { padding: 1rem 1.25rem; }
+}

--- a/errata-slip/templates/404.html
+++ b/errata-slip/templates/404.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <main class="site-main">
+    <div class="error-page">
+      <h1>404</h1>
+      <p class="error-subtitle">Page Not Found</p>
+      <p>This page appears to have been corrected out of existence. Please consult the table of contents.</p>
+      <a href="{{ base_url }}/" class="return-link">Return to Title Page</a>
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/errata-slip/templates/footer.html
+++ b/errata-slip/templates/footer.html
@@ -1,0 +1,16 @@
+    <footer class="site-footer">
+      <div class="footer-errata">
+        <svg width="200" height="16" viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <line x1="0" y1="8" x2="70" y2="8" stroke="#ddd" stroke-width="0.5"/>
+          <text x="100" y="11" text-anchor="middle" font-family="'Inter', sans-serif" font-size="7" fill="#999" letter-spacing="2">ERRATA</text>
+          <line x1="130" y1="8" x2="200" y2="8" stroke="#ddd" stroke-width="0.5"/>
+        </svg>
+      </div>
+      <p class="footer-note">Corrections are themselves subject to correction.</p>
+      <p class="footer-copy">&copy; {{ current_year }} {{ site.title }}. All rights reserved.</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/errata-slip/templates/header.html
+++ b/errata-slip/templates/header.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} -- {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ base_url }}/" class="site-logo">
+      <svg width="30" height="36" viewBox="0 0 30 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect x="2" y="0" width="22" height="32" rx="1" fill="none" stroke="#888" stroke-width="1"/>
+        <line x1="6" y1="6" x2="20" y2="6" stroke="#ccc" stroke-width="0.5"/>
+        <line x1="6" y1="10" x2="20" y2="10" stroke="#ccc" stroke-width="0.5"/>
+        <line x1="6" y1="14" x2="18" y2="14" stroke="#ccc" stroke-width="0.5"/>
+        <rect x="6" y="12" width="22" height="18" rx="1" fill="#fffbf0" stroke="#c0392b" stroke-width="1" transform="rotate(2, 17, 21)"/>
+        <line x1="10" y1="18" x2="24" y2="18" stroke="#c0392b" stroke-width="0.5" transform="rotate(2, 17, 21)"/>
+        <line x1="10" y1="22" x2="22" y2="22" stroke="#c0392b" stroke-width="0.5" transform="rotate(2, 17, 21)"/>
+      </svg>
+      <span>Errata Slip</span>
+    </a>
+    <nav class="site-nav">
+      <a href="{{ base_url }}/">Title Page</a>
+      <a href="{{ base_url }}/chapters/">Chapters</a>
+      <a href="{{ base_url }}/colophon/">Colophon</a>
+    </nav>
+  </div>
+</header>

--- a/errata-slip/templates/page.html
+++ b/errata-slip/templates/page.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <main class="site-main">
+    <article class="errata-page">
+      <header class="page-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.description %}
+        <p class="page-subtitle">{{ page.description }}</p>
+        {% endif %}
+      </header>
+
+      <div class="errata-body">
+        {{ content | safe }}
+      </div>
+
+      {% if page.tags and page.tags | length > 0 %}
+      <div class="page-tags">
+        <h4 class="tags-label">Related Topics</h4>
+        <div class="tag-list">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </article>
+  </main>
+
+{% include "footer.html" %}

--- a/errata-slip/templates/section.html
+++ b/errata-slip/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <main class="site-main">
+    <div class="section-page">
+      <header class="section-header">
+        <h1>{{ section.title }}</h1>
+        {% if section.description %}
+        <p class="section-desc">{{ section.description }}</p>
+        {% endif %}
+      </header>
+
+      {{ content | safe }}
+
+      <ul class="section-list">
+        {% for post in section.pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          {% if post.description %}
+          <p class="item-desc">{{ post.description }}</p>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+
+      {{ pagination | safe }}
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/errata-slip/templates/shortcodes/alert.html
+++ b/errata-slip/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="errata-note" style="padding: 1rem 1.25rem; border: 1px solid #ddd; border-left: 4px solid #c0392b; background-color: #fffbf0; margin: 1.5rem 0; font-family: 'Inter', sans-serif; font-size: 0.9rem;">
+  <strong style="font-family: 'Inter', sans-serif; text-transform: uppercase; letter-spacing: 0.5px; color: #c0392b;">{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/errata-slip/templates/taxonomy.html
+++ b/errata-slip/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <main class="site-main">
+    <div class="taxonomy-page">
+      <h1>{{ taxonomy_name | capitalize }}</h1>
+      <p class="taxonomy-desc">Topics addressed in this publication of corrections.</p>
+
+      <div class="tag-list">
+        {% for term in taxonomy_terms %}
+        <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term | slugify }}/">{{ term }}</a>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/errata-slip/templates/taxonomy_term.html
+++ b/errata-slip/templates/taxonomy_term.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<div class="site-wrapper">
+  <main class="site-main">
+    <div class="taxonomy-term-page">
+      <h1>{{ taxonomy_name | capitalize }}: {{ taxonomy_term }}</h1>
+      <p class="taxonomy-desc">Chapters related to <strong>{{ taxonomy_term }}</strong>.</p>
+
+      <ul class="section-list">
+        {% for post in taxonomy_pages %}
+        <li>
+          <a href="{{ post.url }}">{{ post.title }}</a>
+          {% if post.description %}
+          <p class="item-desc">{{ post.description }}</p>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+
+      {{ pagination | safe }}
+    </div>
+  </main>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1396,6 +1396,13 @@
         "correction",
         "transparent"
     ],
+    "errata-slip": [
+        "book",
+        "light",
+        "correction",
+        "layered",
+        "meta"
+    ],
     "etching": [
         "dark",
         "blog",


### PR DESCRIPTION
Closes #1531

Correction Insert Publication example site featuring:
- SVG pasted-in errata slip panels overlaying original content
- SVG strikethrough patterns on corrected text sections
- Original text in serif (Libre Baskerville), corrections in sans (Inter Bold)
- Base text in regular weight, corrections in bold with strikethrough originals
- Five chapters covering errata history, correction anatomy, error psychology, recursive corrections, and digital errata
- Colophon page