### PR TITLE
feat: add thumb-bible example site (closes #1538)

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -1,4647 +1,4654 @@
 {
-    "abstract-noir": [
-        "paper",
-        "dark",
-        "abstract",
-        "bold",
-        "typography"
-    ],
-    "abyss": [
-        "dark",
-        "blog",
-        "deep-sea",
-        "immersive"
-    ],
-    "acid-graphics": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "acme-docs": [
-        "light",
-        "docs"
-    ],
-    "acoustic-soundwaves": [
-        "dark",
-        "blog",
-        "sound",
-        "waveform"
-    ],
-    "adminpanel": [
-        "dark",
-        "dashboard",
-        "admin",
-        "sidebar"
-    ],
-    "aether": [
-        "dark",
-        "blog",
-        "elegant"
-    ],
-    "aetheria": [
-        "dark-mode",
-        "elegant",
-        "portfolio"
-    ],
-    "after-dark": [
-        "blog",
-        "dark",
-        "reading"
-    ],
-    "afterparty": [
-        "event",
-        "party",
-        "nightlife",
-        "club",
-        "late-night"
-    ],
-    "aftershock": [
-        "event",
-        "dark",
-        "post-event",
-        "retrospective",
-        "impact"
-    ],
-    "airwave": [
-        "dark",
-        "blog",
-        "podcast"
-    ],
-    "alexandrite": [
-        "dark",
-        "blog",
-        "glamorous",
-        "gemstone"
-    ],
-    "almanac": [
-        "light",
-        "blog",
-        "calendar"
-    ],
-    "almanac-docs": [
-        "light",
-        "docs",
-        "roadmap"
-    ],
-    "amber-preservation": [
-        "dark",
-        "blog",
-        "amber",
-        "fossil"
-    ],
-    "amethyst": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "anaglyph": [
-        "dark",
-        "blog",
-        "3d",
-        "stereoscopic"
-    ],
-    "analytics": [
-        "light",
-        "dashboard",
-        "analytics"
-    ],
-    "anamorphic": [
-        "dark",
-        "portfolio",
-        "anamorphic",
-        "optical"
-    ],
-    "anatomy-atlas": [
-        "dark",
-        "docs",
-        "medical",
-        "vintage"
-    ],
-    "annotation-layer": [
-        "book",
-        "light",
-        "scholarly",
-        "annotated",
-        "dense"
-    ],
-    "anthology": [
-        "light",
-        "docs",
-        "sdk-reference"
-    ],
-    "antimatter": [
-        "dark",
-        "blog",
-        "experimental",
-        "inverted"
-    ],
-    "anubis": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "anvil": [
-        "dark",
-        "blog",
-        "workshop"
-    ],
-    "apiary": [
-        "light",
-        "docs",
-        "api",
-        "two-column"
-    ],
-    "apolo": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "apothecary": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "appsite": [
-        "light",
-        "landing",
-        "app"
-    ],
-    "aquarium": [
-        "dark",
-        "blog",
-        "marine"
-    ],
-    "aquatint": [
-        "light",
-        "portfolio",
-        "creative",
-        "elegant",
-        "bold"
-    ],
-    "aqueduct": [
-        "light",
-        "blog",
-        "engineering"
-    ],
-    "arbor": [
-        "light",
-        "docs",
-        "git-workflow"
-    ],
-    "archipelago": [
-        "dark",
-        "landing",
-        "hub"
-    ],
-    "archive": [
-        "light",
-        "docs",
-        "archive"
-    ],
-    "archway-docs": [
-        "docs",
-        "light",
-        "architecture"
-    ],
-    "arctic-saas": [
-        "landing",
-        "light",
-        "saas",
-        "minimal"
-    ],
-    "arena": [
-        "dark",
-        "blog",
-        "sports"
-    ],
-    "artdeco": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "artnouveau": [
-        "light",
-        "portfolio",
-        "art-nouveau",
-        "botanical"
-    ],
-    "arxiv-preprint": [
-        "paper",
-        "light",
-        "preprint",
-        "self-published",
-        "raw"
-    ],
-    "ascii": [
-        "dark",
-        "terminal",
-        "ascii"
-    ],
-    "asymmetric": [
-        "light",
-        "portfolio",
-        "grid",
-        "asymmetric"
-    ],
-    "atelier": [
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "athena": [
-        "elegant",
-        "portfolio",
-        "light"
-    ],
-    "atlas": [
-        "light",
-        "blog",
-        "geography"
-    ],
-    "atlas-docs": [
-        "docs",
-        "light",
-        "navigation"
-    ],
-    "aurelia": [
-        "elegant",
-        "minimalist",
-        "blog"
-    ],
-    "aurora": [
-        "dark",
-        "blog",
-        "aurora"
-    ],
-    "aurora-glimmer": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "aurora-launch": [
-        "landing",
-        "dark",
-        "animation"
-    ],
-    "aurum": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "avalanche-event": [
-        "event",
-        "dark",
-        "momentum",
-        "cascading",
-        "overwhelming"
-    ],
-    "axiom": [
-        "light",
-        "design-system",
-        "geometric",
-        "mathematical"
-    ],
-    "bamboo": [
-        "light",
-        "blog",
-        "eco"
-    ],
-    "baroque": [
-        "dark",
-        "blog",
-        "ornamental",
-        "glamorous"
-    ],
-    "bas-relief": [
-        "light",
-        "artistic",
-        "minimal"
-    ],
-    "bastard-title": [
-        "book",
-        "light",
-        "preliminary",
-        "ceremonial",
-        "typography"
-    ],
-    "bastion": [
-        "dark",
-        "docs",
-        "zero-trust"
-    ],
-    "batik": [
-        "light",
-        "blog",
-        "elegant",
-        "batik"
-    ],
-    "bauhaus": [
-        "light",
-        "portfolio",
-        "design",
-        "geometric"
-    ],
-    "bayesian-prior": [
-        "paper",
-        "dark",
-        "bayesian",
-        "probabilistic",
-        "visualization"
-    ],
-    "bazaar": [
-        "light",
-        "landing",
-        "marketplace"
-    ],
-    "beacon": [
-        "dark",
-        "blog",
-        "alert"
-    ],
-    "beacon-docs": [
-        "light",
-        "docs",
-        "feature-flag"
-    ],
-    "beautiful-hwaro": [
-        "light",
-        "blog"
-    ],
-    "bejeweled": [
-        "elegant",
-        "glamorous",
-        "luxury"
-    ],
-    "bell-tower": [
-        "event",
-        "light",
-        "scheduled",
-        "clock",
-        "traditional"
-    ],
-    "bench-report": [
-        "paper",
-        "light",
-        "laboratory",
-        "bench",
-        "experimental"
-    ],
-    "bijou": [
-        "dark",
-        "elegant",
-        "jewelry",
-        "glamorous"
-    ],
-    "bioluminescence": [
-        "dark",
-        "blog",
-        "bioluminescence",
-        "minimal"
-    ],
-    "bismuth": [
-        "dark",
-        "collection",
-        "mineral",
-        "rainbow-metallic"
-    ],
-    "black-box": [
-        "event",
-        "dark",
-        "theater",
-        "intimate",
-        "minimal"
-    ],
-    "black-letter-bible": [
-        "book",
-        "dark",
-        "sacred",
-        "blackletter",
-        "dense"
-    ],
-    "blacklight": [
-        "dark",
-        "fluorescent",
-        "elegant"
-    ],
-    "blast-furnace": [
-        "event",
-        "dark",
-        "workshop",
-        "intense",
-        "industrial"
-    ],
-    "blockade-run": [
-        "event",
-        "dark",
-        "breakthrough",
-        "barriers",
-        "overcome"
-    ],
-    "blueprint": [
-        "dark",
-        "docs",
-        "spec"
-    ],
-    "blueprint-pro": [
-        "landing",
-        "dark",
-        "devtool"
-    ],
-    "bonfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "bonsai": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "book": [
-        "light",
-        "docs"
-    ],
-    "borealis": [
-        "dark",
-        "blog",
-        "aurora",
-        "nordic"
-    ],
-    "botanical-press": [
-        "blog",
-        "light",
-        "botanical",
-        "vintage"
-    ],
-    "boutique": [
-        "light",
-        "store",
-        "fashion",
-        "elegant"
-    ],
-    "box-office": [
-        "event",
-        "tickets",
-        "sales",
-        "urgency",
-        "countdown"
-    ],
-    "bramble": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "breeze": [
-        "landing",
-        "light",
-        "minimal",
-        "one-page"
-    ],
-    "brocade": [
-        "dark",
-        "blog",
-        "glamorous",
-        "luxury"
-    ],
-    "brutalist": [
-        "light",
-        "blog",
-        "brutalist"
-    ],
-    "brutopia": [
-        "dark",
-        "blog",
-        "brutalist",
-        "monospace"
-    ],
-    "bulwark": [
-        "dark",
-        "docs",
-        "disaster-recovery"
-    ],
-    "bureau": [
-        "light",
-        "docs",
-        "governance"
-    ],
-    "burlesque": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "burnt-charcoal": [
-        "dark",
-        "blog",
-        "charcoal",
-        "texture"
-    ],
-    "butterfly-wing": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "trendy",
-        "blog"
-    ],
-    "byzantine": [
-        "light",
-        "blog",
-        "byzantine",
-        "mosaic",
-        "imperial"
-    ],
-    "cabaret": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "cabin": [
-        "dark",
-        "blog",
-        "lifestyle"
-    ],
-    "cactus": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cafe": [
-        "light",
-        "landing",
-        "menu"
-    ],
-    "cage-match": [
-        "event",
-        "dark",
-        "competition",
-        "fight",
-        "enclosed"
-    ],
-    "call-to-stage": [
-        "event",
-        "talent",
-        "open-call",
-        "audition",
-        "stage"
-    ],
-    "calligraphy": [
-        "dark",
-        "blog",
-        "calligraphy",
-        "ink"
-    ],
-    "cameo": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "campfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "cancel-leaf": [
-        "book",
-        "light",
-        "correction",
-        "repair",
-        "visible"
-    ],
-    "canopy": [
-        "light",
-        "blog",
-        "outdoor"
-    ],
-    "canvas-studio": [
-        "landing",
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "carbon-fiber": [
-        "dark",
-        "blog",
-        "tech"
-    ],
-    "carnival": [
-        "dark",
-        "blog",
-        "glamorous",
-        "event"
-    ],
-    "cartograph": [
-        "dark",
-        "docs",
-        "infrastructure"
-    ],
-    "cascade": [
-        "light",
-        "longform",
-        "waterfall",
-        "scroll-driven"
-    ],
-    "case-report": [
-        "paper",
-        "light",
-        "clinical",
-        "case-study",
-        "medical"
-    ],
-    "cassette": [
-        "dark",
-        "blog",
-        "retro",
-        "audio"
-    ],
-    "catacombs": [
-        "dark",
-        "blog",
-        "underground",
-        "adventure"
-    ],
-    "catalyst": [
-        "light",
-        "landing",
-        "science",
-        "chemistry"
-    ],
-    "cathedral": [
-        "light",
-        "portfolio",
-        "architecture"
-    ],
-    "cauldron": [
-        "dark",
-        "wiki",
-        "fantasy",
-        "potion"
-    ],
-    "celebrate": [
-        "light",
-        "landing",
-        "event"
-    ],
-    "celestial-burst": [
-        "dark",
-        "glamorous",
-        "celestial",
-        "trendy"
-    ],
-    "center-stage": [
-        "event",
-        "solo",
-        "show",
-        "spotlight",
-        "centered"
-    ],
-    "chain-reaction": [
-        "event",
-        "dark",
-        "sequential",
-        "cascade",
-        "connected"
-    ],
-    "chalkboard": [
-        "dark",
-        "blog",
-        "education"
-    ],
-    "champagne": [
-        "light",
-        "luxury",
-        "elegant",
-        "champagne"
-    ],
-    "chandelier": [
-        "light",
-        "blog",
-        "crystal",
-        "elegant",
-        "prismatic"
-    ],
-    "changelog": [
-        "dark",
-        "docs",
-        "changelog"
-    ],
-    "chase-frame": [
-        "book",
-        "dark",
-        "letterpress",
-        "mechanical",
-        "craft"
-    ],
-    "chiaroscuro": [
-        "dark",
-        "portfolio",
-        "chiaroscuro",
-        "contrast"
-    ],
-    "chinoiserie": [
-        "light",
-        "blog",
-        "chinese",
-        "porcelain",
-        "elegant"
-    ],
-    "chromatic": [
-        "dark",
-        "photoblog",
-        "chromatic",
-        "lens"
-    ],
-    "chromatic-wave": [
-        "dark",
-        "portfolio",
-        "glamorous",
-        "animation"
-    ],
-    "chromatophore": [
-        "dark",
-        "bold",
-        "minimal",
-        "creative"
-    ],
-    "chrome-pulse": [
-        "minimal",
-        "dark",
-        "landing"
-    ],
-    "chromolithograph": [
-        "book",
-        "light",
-        "color-plate",
-        "print",
-        "illustration"
-    ],
-    "chronicle": [
-        "light",
-        "blog",
-        "traditional",
-        "serif"
-    ],
-    "chronosphere": [
-        "dark",
-        "space",
-        "time"
-    ],
-    "chrysanthemum": [
-        "dark",
-        "blog",
-        "floral",
-        "glamorous"
-    ],
-    "cinder": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cinema": [
-        "dark",
-        "blog",
-        "review"
-    ],
-    "cinema-silent": [
-        "dark",
-        "blog",
-        "retro",
-        "editorial"
-    ],
-    "cipher": [
-        "dark",
-        "docs",
-        "cryptography"
-    ],
-    "citation-graph": [
-        "paper",
-        "dark",
-        "network",
-        "citations",
-        "visualization"
-    ],
-    "clarity-docs": [
-        "docs",
-        "light",
-        "minimal",
-        "typography"
-    ],
-    "clocktower": [
-        "dark",
-        "landing",
-        "countdown"
-    ],
-    "cloisonne": [
-        "dark",
-        "portfolio",
-        "enamel",
-        "ornate"
-    ],
-    "cloister": [
-        "light",
-        "blog",
-        "meditation"
-    ],
-    "closed": [
-        "light",
-        "error",
-        "499",
-        "minimal"
-    ],
-    "cloudnest": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "cobblestone": [
-        "light",
-        "blog",
-        "culture"
-    ],
-    "cockpit": [
-        "dark",
-        "landing",
-        "telemetry"
-    ],
-    "codebook": [
-        "light",
-        "docs",
-        "styleguide"
-    ],
-    "codecraft": [
-        "api",
-        "dark",
-        "developer",
-        "docs"
-    ],
-    "codex": [
-        "light",
-        "blog",
-        "medieval"
-    ],
-    "codex-rotundus": [
-        "book",
-        "dark",
-        "circular",
-        "unusual",
-        "experimental"
-    ],
-    "cohort-study": [
-        "paper",
-        "light",
-        "cohort",
-        "survival",
-        "epidemiological"
-    ],
-    "cold-case": [
-        "paper",
-        "dark",
-        "forensic",
-        "investigation",
-        "reopened"
-    ],
-    "colosseum": [
-        "light",
-        "event",
-        "classical",
-        "grand"
-    ],
-    "comic": [
-        "light",
-        "blog",
-        "comic"
-    ],
-    "command-center": [
-        "docs",
-        "dark",
-        "cli",
-        "developer"
-    ],
-    "compass": [
-        "light",
-        "landing",
-        "career"
-    ],
-    "compass-docs": [
-        "light",
-        "docs",
-        "onboarding"
-    ],
-    "conduit": [
-        "light",
-        "docs",
-        "data-pipeline"
-    ],
-    "conference-poster": [
-        "paper",
-        "dark",
-        "poster",
-        "conference",
-        "visual"
-    ],
-    "confetti": [
-        "celebration",
-        "elegant",
-        "festive"
-    ],
-    "console": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "constellation": [
-        "dark",
-        "blog",
-        "astronomy"
-    ],
-    "controlroom": [
-        "dark",
-        "dashboard",
-        "monitoring"
-    ],
-    "copper-patina": [
-        "dark",
-        "blog",
-        "patina",
-        "industrial"
-    ],
-    "copper-wire": [
-        "blog",
-        "dark",
-        "industrial"
-    ],
-    "copperplate": [
-        "dark",
-        "blog",
-        "copperplate",
-        "engraving"
-    ],
-    "coral": [
-        "light",
-        "documentary",
-        "organic",
-        "ocean"
-    ],
-    "coral-bloom": [
-        "dark",
-        "blog",
-        "elegant",
-        "marine",
-        "glamorous"
-    ],
-    "corrigendum": [
-        "paper",
-        "light",
-        "correction",
-        "errata",
-        "formal"
-    ],
-    "cosmos": [
-        "dark",
-        "magazine",
-        "space",
-        "planetary"
-    ],
-    "cost-effectiveness": [
-        "paper",
-        "light",
-        "economics",
-        "cost-effectiveness",
-        "health"
-    ],
-    "countdown-zero": [
-        "event",
-        "dark",
-        "countdown",
-        "convergence",
-        "climactic"
-    ],
-    "creative-agency": [
-        "dark",
-        "portfolio",
-        "agency",
-        "bold"
-    ],
-    "cross-sectional": [
-        "paper",
-        "light",
-        "cross-sectional",
-        "snapshot",
-        "population"
-    ],
-    "crucible": [
-        "light",
-        "docs",
-        "testing"
-    ],
-    "cruciform": [
-        "light",
-        "design-system",
-        "grid",
-        "swiss"
-    ],
-    "crystalline": [
-        "light",
-        "portfolio",
-        "crystal",
-        "faceted"
-    ],
-    "cuneiform-tablet": [
-        "book",
-        "dark",
-        "ancient",
-        "impressed",
-        "archaeological"
-    ],
-    "curator": [
-        "light",
-        "portfolio",
-        "exhibition"
-    ],
-    "curtain-call": [
-        "event",
-        "dark",
-        "closing",
-        "ceremony",
-        "theatrical"
-    ],
-    "cyanotype": [
-        "light",
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "cyberpunk": [
-        "dark",
-        "magazine",
-        "cyberpunk",
-        "neon"
-    ],
-    "daguerreotype": [
-        "dark",
-        "blog",
-        "photography",
-        "vintage"
-    ],
-    "damask": [
-        "dark",
-        "blog",
-        "luxury",
-        "glamorous"
-    ],
-    "dark-manual": [
-        "docs",
-        "dark",
-        "technical",
-        "manual"
-    ],
-    "darkfolio": [
-        "dark",
-        "portfolio",
-        "developer",
-        "minimal"
-    ],
-    "darkmarket": [
-        "dark",
-        "marketplace",
-        "bold"
-    ],
-    "darkroom": [
-        "dark",
-        "portfolio",
-        "photography"
-    ],
-    "darkwave": [
-        "dark",
-        "blog",
-        "synthwave"
-    ],
-    "dashboard": [
-        "dark",
-        "landing",
-        "dashboard"
-    ],
-    "data-paper": [
-        "paper",
-        "light",
-        "dataset",
-        "schema",
-        "minimal-text"
-    ],
-    "deckle-edge": [
-        "book",
-        "light",
-        "craft",
-        "handmade",
-        "texture"
-    ],
-    "deconstructed": [
-        "light",
-        "agency",
-        "deconstructivism",
-        "architecture"
-    ],
-    "deconstructivist": [
-        "dark",
-        "portfolio",
-        "deconstructivist",
-        "architecture"
-    ],
-    "demolition-derby": [
-        "event",
-        "dark",
-        "competition",
-        "destruction",
-        "chaotic"
-    ],
-    "depot": [
-        "light",
-        "landing",
-        "tracker"
-    ],
-    "devconf": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "devlog": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "devtool": [
-        "dark",
-        "landing",
-        "developer"
-    ],
-    "dewdrop": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "diamond-facet": [
-        "dark",
-        "blog",
-        "glamorous",
-        "prismatic"
-    ],
-    "diary": [
-        "light",
-        "blog",
-        "personal",
-        "journal"
-    ],
-    "diorama": [
-        "dark",
-        "landing",
-        "product"
-    ],
-    "disco-fever": [
-        "dark",
-        "blog",
-        "retro",
-        "disco",
-        "neon"
-    ],
-    "dispatch": [
-        "light",
-        "docs",
-        "event-driven"
-    ],
-    "dockhub": [
-        "dark",
-        "docs",
-        "devops"
-    ],
-    "dojo": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "dose-response": [
-        "paper",
-        "light",
-        "pharmacological",
-        "dose-response",
-        "clinical"
-    ],
-    "double-header": [
-        "event",
-        "dark",
-        "double",
-        "dual",
-        "packed"
-    ],
-    "driftwood": [
-        "light",
-        "blog",
-        "photo"
-    ],
-    "dropzone": [
-        "cloud",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "dune": [
-        "light",
-        "journal",
-        "desert",
-        "travel"
-    ],
-    "duodecimo": [
-        "book",
-        "light",
-        "compact",
-        "portable",
-        "efficient"
-    ],
-    "dusk": [
-        "dark",
-        "blog",
-        "sunset"
-    ],
-    "dynamo": [
-        "dark",
-        "docs",
-        "serverless"
-    ],
-    "easel": [
-        "light",
-        "docs",
-        "art"
-    ],
-    "eclipse": [
-        "dark",
-        "blog",
-        "celestial",
-        "dramatic"
-    ],
-    "editorial-letter": [
-        "paper",
-        "light",
-        "editorial",
-        "authority",
-        "statement"
-    ],
-    "electric-bloom": [
-        "dark",
-        "blog",
-        "glamorous",
-        "neon",
-        "botanical"
-    ],
-    "electroplate": [
-        "dark",
-        "blog",
-        "metallic",
-        "plating"
-    ],
-    "elevate": [
-        "landing",
-        "light",
-        "saas",
-        "enterprise"
-    ],
-    "elysian": [
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "elysium": [
-        "portfolio",
-        "minimal",
-        "dark"
-    ],
-    "elysium-portfolio": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "embargo-lift": [
-        "event",
-        "dark",
-        "embargo",
-        "release",
-        "timed"
-    ],
-    "ember": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "embroidery": [
-        "dark",
-        "blog",
-        "glamorous",
-        "trendy"
-    ],
-    "emerald": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "empyrean": [
-        "light",
-        "landing",
-        "divine",
-        "ethereal"
-    ],
-    "encaustic": [
-        "light",
-        "blog",
-        "art",
-        "painting"
-    ],
-    "encore": [
-        "event",
-        "dark",
-        "repeat",
-        "popular",
-        "demanded"
-    ],
-    "encore-night": [
-        "event",
-        "concert",
-        "farewell",
-        "encore",
-        "emotional"
-    ],
-    "endpaper": [
-        "book",
-        "dark",
-        "decorative",
-        "pattern",
-        "hidden"
-    ],
-    "enigma": [
-        "dark",
-        "puzzle",
-        "cryptography",
-        "mechanical"
-    ],
-    "entropy": [
-        "dual",
-        "magazine",
-        "experimental",
-        "asymmetric"
-    ],
-    "errata-sheet": [
-        "paper",
-        "light",
-        "errata",
-        "correction",
-        "transparent"
-    ],
-    "errata-slip": [
-        "book",
-        "light",
-        "correction",
-        "layered",
-        "meta"
-    ],
-    "etching": [
-        "dark",
-        "blog",
-        "etching",
-        "printmaking"
-    ],
-    "ethereal-canvas": [
-        "blog",
-        "dark",
-        "elegant",
-        "minimal",
-        "portfolio"
-    ],
-    "ethereal-vapor": [
-        "light",
-        "blog",
-        "ethereal",
-        "translucent"
-    ],
-    "ethos": [
-        "light",
-        "docs",
-        "culture"
-    ],
-    "even": [
-        "light",
-        "blog"
-    ],
-    "evergreen-docs": [
-        "docs",
-        "light",
-        "enterprise",
-        "classic"
-    ],
-    "experiment-log": [
-        "paper",
-        "dark",
-        "experimental",
-        "sequential",
-        "iterative"
-    ],
-    "faberge": [
-        "light",
-        "blog",
-        "luxury",
-        "jeweled",
-        "ornate"
-    ],
-    "faq": [
-        "light",
-        "docs",
-        "faq"
-    ],
-    "fascicle": [
-        "book",
-        "light",
-        "serial",
-        "unbound",
-        "installment"
-    ],
-    "fault-siren": [
-        "event",
-        "dark",
-        "warning",
-        "preparedness",
-        "civil-defense"
-    ],
-    "fauvist-wild": [
-        "dark",
-        "blog",
-        "fauvist",
-        "colorful"
-    ],
-    "ferrofluid": [
-        "dark",
-        "blog",
-        "ferrofluid",
-        "magnetic"
-    ],
-    "festival": [
-        "dark",
-        "event",
-        "elegant",
-        "glow",
-        "bold"
-    ],
-    "festival-ground": [
-        "event",
-        "festival",
-        "outdoor",
-        "grounds",
-        "map"
-    ],
-    "field-report": [
-        "paper",
-        "dark",
-        "field",
-        "expedition",
-        "rugged"
-    ],
-    "fiesta": [
-        "light",
-        "blog",
-        "colorful",
-        "celebration"
-    ],
-    "filigree": [
-        "dark",
-        "blog",
-        "filigree",
-        "metalwork"
-    ],
-    "fintech-pulse": [
-        "landing",
-        "dark",
-        "fintech",
-        "data-viz"
-    ],
-    "fireside": [
-        "dark",
-        "blog",
-        "book-review"
-    ],
-    "fireworks": [
-        "dark",
-        "elegant",
-        "animation",
-        "glow"
-    ],
-    "firing-range": [
-        "event",
-        "dark",
-        "precision",
-        "target",
-        "competitive"
-    ],
-    "fjord": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "flamingo": [
-        "light",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "flong-press": [
-        "book",
-        "dark",
-        "industrial",
-        "reversed",
-        "typography"
-    ],
-    "flowsync": [
-        "dark",
-        "landing"
-    ],
-    "fluorescent": [
-        "dark",
-        "blog",
-        "neon",
-        "pop-art"
-    ],
-    "folio": [
-        "light",
-        "portfolio"
-    ],
-    "folio-docs": [
-        "light",
-        "docs",
-        "design-system"
-    ],
-    "folio-gigante": [
-        "book",
-        "dark",
-        "oversized",
-        "monumental",
-        "maximal"
-    ],
-    "forge": [
-        "light",
-        "docs",
-        "opensource"
-    ],
-    "formulary": [
-        "light",
-        "docs",
-        "math"
-    ],
-    "forty": [
-        "dark",
-        "portfolio",
-        "gallery"
-    ],
-    "foundry": [
-        "dark",
-        "blog",
-        "maker"
-    ],
-    "foxhole": [
-        "dark",
-        "blog",
-        "security"
-    ],
-    "fractal": [
-        "dark",
-        "gallery",
-        "generative",
-        "mathematical"
-    ],
-    "frequency": [
-        "dark",
-        "blog",
-        "radio"
-    ],
-    "frottage": [
-        "light",
-        "minimal",
-        "art",
-        "clean"
-    ],
-    "frutiger-aero": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "furnace": [
-        "dark",
-        "docs",
-        "performance"
-    ],
-    "gala": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "garden": [
-        "light",
-        "blog",
-        "garden"
-    ],
-    "garnet": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "garrison": [
-        "dark",
-        "docs",
-        "firewall"
-    ],
-    "gateway": [
-        "dark",
-        "docs",
-        "auth"
-    ],
-    "gauntlet-run": [
-        "event",
-        "dark",
-        "endurance",
-        "challenge",
-        "sequential"
-    ],
-    "gazebo": [
-        "light",
-        "blog",
-        "event"
-    ],
-    "gazette": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "generative-art": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "glamorous"
-    ],
-    "genome-paper": [
-        "paper",
-        "dark",
-        "genomics",
-        "bioinformatics",
-        "data-intensive"
-    ],
-    "geodesic": [
-        "light",
-        "landing",
-        "geometric"
-    ],
-    "gilded": [
-        "dark",
-        "blog",
-        "luxury",
-        "gold"
-    ],
-    "gilt-edge": [
-        "book",
-        "dark",
-        "luxury",
-        "gilded",
-        "opulent"
-    ],
-    "glacial-blog": [
-        "blog",
-        "light",
-        "cool",
-        "minimal"
-    ],
-    "glacial-ice": [
-        "dark",
-        "blog",
-        "ice",
-        "frost"
-    ],
-    "glacier": [
-        "light",
-        "blog",
-        "tech"
-    ],
-    "glam-rock": [
-        "dark",
-        "blog",
-        "rock",
-        "glam",
-        "metallic"
-    ],
-    "glassmorphism": [
-        "dark",
-        "blog",
-        "glassmorphism"
-    ],
-    "glitch": [
-        "dark",
-        "blog",
-        "experimental",
-        "glitch-art"
-    ],
-    "glitch-elegance": [
-        "dark",
-        "blog",
-        "glitch",
-        "elegant"
-    ],
-    "glow-reef": [
-        "dark",
-        "blog",
-        "elegant",
-        "neon"
-    ],
-    "glyphic": [
-        "dark",
-        "blog",
-        "glyph",
-        "carved"
-    ],
-    "gong-show": [
-        "event",
-        "dark",
-        "competition",
-        "judgment",
-        "dramatic"
-    ],
-    "gossamer": [
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "gothic": [
-        "dark",
-        "blog",
-        "gothic",
-        "medieval"
-    ],
-    "gradient-mesh": [
-        "dark",
-        "blog",
-        "gradient"
-    ],
-    "graffiti": [
-        "dark",
-        "blog",
-        "street-art",
-        "urban"
-    ],
-    "grand-finale": [
-        "event",
-        "festival",
-        "finale",
-        "closing",
-        "spectacular"
-    ],
-    "grant-proposal": [
-        "paper",
-        "light",
-        "proposal",
-        "funding",
-        "persuasive"
-    ],
-    "graphite-docs": [
-        "docs",
-        "dark",
-        "technical"
-    ],
-    "greenhouse": [
-        "light",
-        "blog",
-        "plant"
-    ],
-    "grisaille": [
-        "dark",
-        "blog",
-        "minimal",
-        "monochrome"
-    ],
-    "ground-zero": [
-        "event",
-        "dark",
-        "origin",
-        "impact",
-        "transformative"
-    ],
-    "guidebook": [
-        "light",
-        "docs",
-        "guide"
-    ],
-    "gunmetal": [
-        "dark",
-        "elegant",
-        "industrial",
-        "metallic"
-    ],
-    "gyroscope": [
-        "dark",
-        "dashboard",
-        "motion-sensor",
-        "3d-rotation"
-    ],
-    "habitat": [
-        "light",
-        "landing",
-        "listing"
-    ],
-    "hacker": [
-        "dark",
-        "blog"
-    ],
-    "hall-of-voices": [
-        "event",
-        "poetry",
-        "spoken-word",
-        "slam",
-        "voices"
-    ],
-    "hammer-drop": [
-        "event",
-        "light",
-        "auction",
-        "bidding",
-        "final"
-    ],
-    "hammock": [
-        "light",
-        "blog",
-        "slowlife"
-    ],
-    "handbook": [
-        "light",
-        "docs",
-        "corporate"
-    ],
-    "hangar": [
-        "dark",
-        "blog",
-        "aviation"
-    ],
-    "hardcore-pit": [
-        "event",
-        "punk",
-        "hardcore",
-        "show",
-        "chaotic"
-    ],
-    "haute-couture": [
-        "elegant",
-        "fashion",
-        "magazine"
-    ],
-    "headliner-bold": [
-        "event",
-        "festival",
-        "lineup",
-        "headliner",
-        "hierarchy"
-    ],
-    "hearth": [
-        "light",
-        "blog",
-        "traditional",
-        "elegant"
-    ],
-    "heavy-curtain": [
-        "event",
-        "theater",
-        "drama",
-        "production",
-        "heavy"
-    ],
-    "heliograph": [
-        "dark",
-        "blog",
-        "heliograph",
-        "sun-print"
-    ],
-    "helix": [
-        "light",
-        "landing",
-        "biotech",
-        "3d"
-    ],
-    "helix-docs": [
-        "docs",
-        "light",
-        "science"
-    ],
-    "herald": [
-        "light",
-        "magazine",
-        "editorial",
-        "news"
-    ],
-    "hermit": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "hibiscus": [
-        "dark",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "hologram": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "holographic": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "horizon-ai": [
-        "landing",
-        "dark",
-        "ai",
-        "futuristic"
-    ],
-    "house-lights": [
-        "event",
-        "venue",
-        "concert",
-        "lighting",
-        "technical"
-    ],
-    "hwaro.386": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "hwaronight": [
-        "dark",
-        "blog"
-    ],
-    "hypercube": [
-        "dark",
-        "docs",
-        "3d",
-        "wireframe"
-    ],
-    "hyperpop": [
-        "dark",
-        "glamorous",
-        "neon",
-        "trendy",
-        "elegant"
-    ],
-    "igloo": [
-        "light",
-        "blog",
-        "nordic"
-    ],
-    "ignite": [
-        "landing",
-        "dark",
-        "startup"
-    ],
-    "ignition-sequence": [
-        "event",
-        "dark",
-        "phased",
-        "launch",
-        "sequential"
-    ],
-    "impasto": [
-        "light",
-        "blog",
-        "bold",
-        "artistic"
-    ],
-    "incunabula-noir": [
-        "book",
-        "dark",
-        "incunabulum",
-        "early-print",
-        "revolutionary"
-    ],
-    "inferno": [
-        "dark",
-        "community",
-        "fire",
-        "gaming"
-    ],
-    "infographic": [
-        "light",
-        "landing",
-        "infographic",
-        "data-viz"
-    ],
-    "ink-seoul": [
-        "light",
-        "blog",
-        "monochrome",
-        "seoul",
-        "minimal"
-    ],
-    "inkdrop-docs": [
-        "docs",
-        "dark",
-        "elegant",
-        "animation"
-    ],
-    "inkwell": [
-        "light",
-        "blog",
-        "poetry"
-    ],
-    "intaglio": [
-        "dark",
-        "portfolio",
-        "engraving",
-        "minimal"
-    ],
-    "intarsia": [
-        "light",
-        "portfolio",
-        "bold",
-        "clean",
-        "geometric"
-    ],
-    "interferogram": [
-        "dark",
-        "blog",
-        "interference",
-        "optical"
-    ],
-    "inventory": [
-        "light",
-        "dashboard",
-        "management"
-    ],
-    "iridescent-oil": [
-        "dark",
-        "blog",
-        "iridescent",
-        "oil"
-    ],
-    "iron-stage": [
-        "event",
-        "festival",
-        "metal",
-        "industrial",
-        "heavy"
-    ],
-    "ironclad": [
-        "dark",
-        "landing",
-        "metallic",
-        "security"
-    ],
-    "ironworks": [
-        "dark",
-        "blog",
-        "history"
-    ],
-    "isometric": [
-        "light",
-        "3d",
-        "dashboard",
-        "ui"
-    ],
-    "isthmus": [
-        "light",
-        "hub",
-        "bridge",
-        "horizontal-scroll"
-    ],
-    "jade-palace": [
-        "dark",
-        "blog",
-        "luxury",
-        "eastern"
-    ],
-    "japanese-industrial": [
-        "dark",
-        "blog",
-        "japanese",
-        "industrial"
-    ],
-    "jewel-tone": [
-        "dark",
-        "glamorous",
-        "jewel",
-        "elegant"
-    ],
-    "jugendstil": [
-        "light",
-        "blog",
-        "art-nouveau",
-        "organic",
-        "nature"
-    ],
-    "kaleidoscope": [
-        "light",
-        "event",
-        "psychedelic",
-        "pattern"
-    ],
-    "ketubah": [
-        "book",
-        "light",
-        "ceremonial",
-        "decorated",
-        "formal"
-    ],
-    "keynote-blast": [
-        "event",
-        "dark",
-        "conference",
-        "keynote",
-        "explosive"
-    ],
-    "keystone": [
-        "light",
-        "docs",
-        "architecture"
-    ],
-    "kiln": [
-        "light",
-        "portfolio",
-        "craft"
-    ],
-    "kinetic": [
-        "dark",
-        "agency",
-        "physics",
-        "interactive"
-    ],
-    "kinetic-mobile": [
-        "dark",
-        "blog",
-        "kinetic",
-        "mobile"
-    ],
-    "kinetic-typography": [
-        "dark",
-        "blog",
-        "kinetic",
-        "typography"
-    ],
-    "kintsugi": [
-        "dark",
-        "blog",
-        "kintsugi",
-        "gold-repair"
-    ],
-    "lab": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "lab-notebook": [
-        "paper",
-        "light",
-        "laboratory",
-        "raw",
-        "observational"
-    ],
-    "labyrinth": [
-        "dark",
-        "portfolio",
-        "maze",
-        "gamification"
-    ],
-    "lagoon": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "laser-show": [
-        "dark",
-        "blog",
-        "landing",
-        "concert",
-        "glamorous"
-    ],
-    "last-call": [
-        "event",
-        "dark",
-        "closing",
-        "final",
-        "urgent"
-    ],
-    "lattice": [
-        "light",
-        "docs",
-        "graph-db"
-    ],
-    "launchpad": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "launchpad-event": [
-        "event",
-        "dark",
-        "launch",
-        "space",
-        "countdown"
-    ],
-    "lava-flow": [
-        "dark",
-        "blog",
-        "lava",
-        "volcanic"
-    ],
-    "layered-docs": [
-        "light",
-        "docs",
-        "enterprise"
-    ],
-    "ledger": [
-        "light",
-        "docs",
-        "finance"
-    ],
-    "letter-to-editor": [
-        "paper",
-        "light",
-        "correspondence",
-        "urgent",
-        "brief"
-    ],
-    "letterbox": [
-        "light",
-        "blog",
-        "newsletter"
-    ],
-    "lexicon": [
-        "light",
-        "docs",
-        "glossary"
-    ],
-    "lichen-moss": [
-        "dark",
-        "blog",
-        "lichen",
-        "organic"
-    ],
-    "lighthouse": [
-        "light",
-        "docs",
-        "directory"
-    ],
-    "linktree": [
-        "dark",
-        "landing",
-        "links"
-    ],
-    "linocut": [
-        "light",
-        "printmaking",
-        "bold",
-        "creative"
-    ],
-    "liquid": [
-        "dark",
-        "interactive",
-        "gooey",
-        "svg"
-    ],
-    "liquid-chrome": [
-        "dark",
-        "blog",
-        "metallic",
-        "glamorous"
-    ],
-    "lithium": [
-        "dark",
-        "landing",
-        "electric",
-        "tech"
-    ],
-    "lithograph": [
-        "dark",
-        "blog",
-        "lithograph",
-        "printmaking"
-    ],
-    "logbook": [
-        "light",
-        "docs",
-        "compliance"
-    ],
-    "longitudinal": [
-        "paper",
-        "dark",
-        "longitudinal",
-        "temporal",
-        "tracking"
-    ],
-    "lookbook": [
-        "dark",
-        "portfolio",
-        "lookbook",
-        "fashion"
-    ],
-    "loom": [
-        "light",
-        "portfolio",
-        "fashion"
-    ],
-    "lumiere": [
-        "dark",
-        "elegant",
-        "minimal",
-        "luminescent"
-    ],
-    "lumina": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "luminary": [
-        "light",
-        "elegant",
-        "portfolio"
-    ],
-    "luminescent-mesh": [
-        "dark",
-        "blog",
-        "luminescent",
-        "mesh"
-    ],
-    "lumos": [
-        "blog",
-        "elegant",
-        "light",
-        "minimal"
-    ],
-    "lunar-base": [
-        "elegant",
-        "portfolio",
-        "dark"
-    ],
-    "lunar-breeze": [
-        "dark",
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "luxe-noir": [
-        "dark",
-        "glamorous",
-        "luxury",
-        "elegant"
-    ],
-    "luxury-horology": [
-        "dark",
-        "portfolio",
-        "horology",
-        "luxury"
-    ],
-    "macro-snowflake": [
-        "dark",
-        "blog",
-        "snowflake",
-        "crystalline"
-    ],
-    "madhubani": [
-        "light",
-        "blog",
-        "indian",
-        "folk-art",
-        "geometric"
-    ],
-    "magenta-sunset": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "magma": [
-        "dark",
-        "dashboard",
-        "volcanic",
-        "animation"
-    ],
-    "magnetar": [
-        "dark",
-        "blog",
-        "magnetar",
-        "cosmic"
-    ],
-    "main-act": [
-        "event",
-        "concert",
-        "headline",
-        "performer",
-        "dramatic"
-    ],
-    "mainstage": [
-        "event",
-        "dark",
-        "performance",
-        "stage",
-        "dramatic"
-    ],
-    "manifesto": [
-        "dark",
-        "blog",
-        "opinion"
-    ],
-    "manifesto-press": [
-        "book",
-        "dark",
-        "revolutionary",
-        "bold",
-        "political"
-    ],
-    "manifold": [
-        "light",
-        "docs",
-        "saas"
-    ],
-    "marble": [
-        "light",
-        "gallery",
-        "luxury",
-        "marble-texture"
-    ],
-    "marbled-paper": [
-        "dark",
-        "blog",
-        "marbled",
-        "paper"
-    ],
-    "mardi-gras": [
-        "glamorous",
-        "trendy",
-        "bold",
-        "purple",
-        "gold",
-        "green"
-    ],
-    "marketplace": [
-        "light",
-        "store",
-        "marketplace"
-    ],
-    "marquetry": [
-        "light",
-        "portfolio",
-        "geometric",
-        "minimal"
-    ],
-    "masquerade": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "luxury",
-        "mystery"
-    ],
-    "matcha": [
-        "blog",
-        "light",
-        "minimal",
-        "zen"
-    ],
-    "matrix": [
-        "light",
-        "docs",
-        "compatibility"
-    ],
-    "maximal-bloom": [
-        "elegant",
-        "floral",
-        "bold",
-        "glamorous"
-    ],
-    "maximalist": [
-        "dark",
-        "blog",
-        "bold",
-        "glamorous"
-    ],
-    "mayan-geometry": [
-        "dark",
-        "blog",
-        "mayan",
-        "geometric"
-    ],
-    "meadow": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "medieval-manuscript": [
-        "dark",
-        "blog",
-        "medieval",
-        "manuscript"
-    ],
-    "memoir": [
-        "light",
-        "blog",
-        "longform"
-    ],
-    "memphis": [
-        "light",
-        "retro",
-        "colorful",
-        "bold",
-        "portfolio"
-    ],
-    "mercury": [
-        "dark",
-        "blog",
-        "minimal",
-        "metallic",
-        "elegant"
-    ],
-    "meridian": [
-        "dark",
-        "landing",
-        "timezone"
-    ],
-    "meridian-docs": [
-        "light",
-        "docs",
-        "scheduling"
-    ],
-    "meridiem": [
-        "dual",
-        "dashboard",
-        "time-based",
-        "auto-theme"
-    ],
-    "meta-analysis": [
-        "paper",
-        "light",
-        "statistical",
-        "synthesis",
-        "evidence"
-    ],
-    "meteor": [
-        "dark",
-        "interactive",
-        "meteor-shower",
-        "cosmic"
-    ],
-    "methods-paper": [
-        "paper",
-        "light",
-        "methods",
-        "protocol",
-        "technical"
-    ],
-    "metronome": [
-        "dark",
-        "blog",
-        "music-production",
-        "rhythm"
-    ],
-    "mezzotint": [
-        "light",
-        "blog",
-        "bold",
-        "clean",
-        "monochrome"
-    ],
-    "micro": [
-        "light",
-        "blog",
-        "microblog"
-    ],
-    "midnight-blog": [
-        "dark",
-        "blog",
-        "reading"
-    ],
-    "midnight-launch": [
-        "landing",
-        "dark",
-        "animation",
-        "product"
-    ],
-    "migration": [
-        "light",
-        "docs",
-        "database"
-    ],
-    "minifolio": [
-        "light",
-        "portfolio",
-        "minimal"
-    ],
-    "minimalzen": [
-        "light",
-        "blog",
-        "minimal",
-        "zen"
-    ],
-    "mint-fresh": [
-        "landing",
-        "light",
-        "saas"
-    ],
-    "mirage": [
-        "light",
-        "gallery",
-        "desert",
-        "distortion"
-    ],
-    "misprint": [
-        "book",
-        "dark",
-        "error",
-        "accidental",
-        "artistic"
-    ],
-    "mixed-methods": [
-        "paper",
-        "light",
-        "mixed-methods",
-        "convergent",
-        "dual"
-    ],
-    "modern-blog": [
-        "dark",
-        "blog",
-        "modern"
-    ],
-    "molten": [
-        "dark",
-        "blog",
-        "metalwork",
-        "melting"
-    ],
-    "molten-gold": [
-        "elegant",
-        "gold",
-        "trendy"
-    ],
-    "monochrome": [
-        "light",
-        "photo-essay",
-        "monochrome",
-        "grayscale"
-    ],
-    "monograph": [
-        "book",
-        "light",
-        "academic",
-        "thorough",
-        "reference"
-    ],
-    "monolith": [
-        "dark",
-        "landing",
-        "onepage"
-    ],
-    "monolithic-dark": [
-        "dark",
-        "blog",
-        "monolithic",
-        "bold"
-    ],
-    "monoprint": [
-        "light",
-        "monoprint",
-        "bold",
-        "creative"
-    ],
-    "monorepo-docs": [
-        "docs",
-        "dark",
-        "developer",
-        "monorepo"
-    ],
-    "moonrise": [
-        "dark",
-        "blog",
-        "essay"
-    ],
-    "moonstone": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "moroccan-zellige": [
-        "light",
-        "blog",
-        "moroccan",
-        "mosaic",
-        "geometric"
-    ],
-    "morphogenesis": [
-        "dark",
-        "blog",
-        "generative",
-        "biology",
-        "patterns"
-    ],
-    "mortar": [
-        "dark",
-        "docs",
-        "build-system"
-    ],
-    "mosaic": [
-        "light",
-        "blog",
-        "magazine"
-    ],
-    "mosh-pit": [
-        "event",
-        "dark",
-        "punk",
-        "chaotic",
-        "raw"
-    ],
-    "mosstown": [
-        "light",
-        "blog",
-        "cozy"
-    ],
-    "mughal": [
-        "light",
-        "blog",
-        "mughal",
-        "ornate",
-        "gold"
-    ],
-    "murano-glass": [
-        "light",
-        "blog",
-        "glass",
-        "translucent",
-        "venetian"
-    ],
-    "mycelium": [
-        "dark",
-        "blog",
-        "mycelium",
-        "fungal"
-    ],
-    "nadir": [
-        "dark",
-        "blog",
-        "minimal",
-        "oled-black"
-    ],
-    "nautical": [
-        "dark",
-        "blog",
-        "nautical"
-    ],
-    "nebula": [
-        "dark",
-        "gallery",
-        "space",
-        "ethereal"
-    ],
-    "neo-deco": [
-        "dark",
-        "portfolio",
-        "artdeco",
-        "elegant"
-    ],
-    "neo-memphis-dark": [
-        "dark",
-        "blog",
-        "memphis",
-        "neo-memphis"
-    ],
-    "neobrutal": [
-        "light",
-        "landing",
-        "neo-brutalism",
-        "bold"
-    ],
-    "neoclassical": [
-        "light",
-        "gallery",
-        "marble-texture",
-        "elegant"
-    ],
-    "neon": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "neon-jungle": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "neon"
-    ],
-    "neon-marquee": [
-        "event",
-        "theater",
-        "marquee",
-        "vintage",
-        "retro"
-    ],
-    "neon-tokyo": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "tokyo",
-        "glamorous"
-    ],
-    "network-meta": [
-        "paper",
-        "dark",
-        "network",
-        "meta-analysis",
-        "comparative"
-    ],
-    "neumorphism": [
-        "light",
-        "ui",
-        "soft",
-        "shadow"
-    ],
-    "neural-bloom": [
-        "dark",
-        "blog",
-        "neural",
-        "ai",
-        "synaptic"
-    ],
-    "newspaper": [
-        "light",
-        "blog",
-        "editorial",
-        "newspaper"
-    ],
-    "nexus": [
-        "dark",
-        "docs",
-        "microservice"
-    ],
-    "nexus-docs": [
-        "docs",
-        "dark",
-        "developer"
-    ],
-    "niello": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "no-style-please": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "noctis": [
-        "landing",
-        "dark",
-        "glassmorphism",
-        "neon"
-    ],
-    "nocturne": [
-        "dark",
-        "blog",
-        "classical-music",
-        "piano"
-    ],
-    "noir": [
-        "dark",
-        "blog",
-        "noir"
-    ],
-    "northern-lights": [
-        "dark",
-        "blog",
-        "aurora",
-        "arctic",
-        "atmospheric"
-    ],
-    "notebook": [
-        "light",
-        "blog",
-        "journal"
-    ],
-    "null-result": [
-        "paper",
-        "light",
-        "null",
-        "negative",
-        "honest"
-    ],
-    "oasis": [
-        "light",
-        "blog",
-        "relaxation"
-    ],
-    "obelisk": [
-        "light",
-        "one-page",
-        "monumental",
-        "vertical"
-    ],
-    "oblique": [
-        "light",
-        "blog",
-        "bold",
-        "angular"
-    ],
-    "oblong-quarto": [
-        "book",
-        "light",
-        "landscape",
-        "panoramic",
-        "unusual"
-    ],
-    "observatory": [
-        "dark",
-        "blog",
-        "space"
-    ],
-    "obsidian": [
-        "dark",
-        "wiki",
-        "glass",
-        "oled"
-    ],
-    "obsidian-docs": [
-        "docs",
-        "dark",
-        "wiki",
-        "knowledge"
-    ],
-    "obsidian-mirror": [
-        "dark",
-        "blog",
-        "obsidian",
-        "reflective"
-    ],
-    "old-map-cartography": [
-        "dark",
-        "blog",
-        "cartography",
-        "vintage"
-    ],
-    "onyx": [
-        "landing",
-        "dark",
-        "minimal",
-        "luxury"
-    ],
-    "op-art": [
-        "dark",
-        "blog",
-        "geometric",
-        "optical-illusion"
-    ],
-    "opalescent": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "opening-act": [
-        "event",
-        "opening",
-        "season",
-        "premiere",
-        "fresh"
-    ],
-    "opening-night": [
-        "event",
-        "dark",
-        "premiere",
-        "formal",
-        "electric"
-    ],
-    "opulent": [
-        "light",
-        "elegant",
-        "luxury",
-        "portfolio",
-        "bold"
-    ],
-    "orchard": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "orchid": [
-        "dark",
-        "blog",
-        "glamorous",
-        "botanical"
-    ],
-    "origami": [
-        "light",
-        "blog",
-        "material"
-    ],
-    "oscilloscope": [
-        "dark",
-        "blog",
-        "oscilloscope",
-        "retro"
-    ],
-    "overture": [
-        "event",
-        "dark",
-        "opening",
-        "orchestral",
-        "grand"
-    ],
-    "oxidation": [
-        "dark",
-        "blog",
-        "oxidation",
-        "rust"
-    ],
-    "oxide": [
-        "dark",
-        "gallery",
-        "industrial",
-        "rust-texture"
-    ],
-    "pagoda": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "palette": [
-        "light",
-        "docs",
-        "design"
-    ],
-    "palimpsest-noir": [
-        "book",
-        "dark",
-        "layered",
-        "erased",
-        "ghostly"
-    ],
-    "panopticon": [
-        "dark",
-        "brutalist",
-        "radial",
-        "experimental"
-    ],
-    "pantry": [
-        "light",
-        "docs",
-        "package-manager"
-    ],
-    "paper": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "paper-art": [
-        "light",
-        "blog",
-        "paper",
-        "collage"
-    ],
-    "papermod": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "parallax": [
-        "light",
-        "storytelling",
-        "parallax",
-        "cinematic"
-    ],
-    "parallax-heavy": [
-        "dark",
-        "landing",
-        "gallery",
-        "parallax"
-    ],
-    "parchment": [
-        "light",
-        "docs",
-        "fantasy"
-    ],
-    "parquetry": [
-        "dark",
-        "blog",
-        "parquetry",
-        "woodwork"
-    ],
-    "particle-storm": [
-        "dark",
-        "blog",
-        "neon",
-        "particles",
-        "energy"
-    ],
-    "pastel-docs": [
-        "docs",
-        "light",
-        "friendly"
-    ],
-    "patina": [
-        "dark",
-        "blog",
-        "minimal",
-        "craft"
-    ],
-    "peacock": [
-        "elegant",
-        "glamorous",
-        "portfolio"
-    ],
-    "pearlescent": [
-        "light",
-        "blog",
-        "iridescent",
-        "luxury",
-        "soft"
-    ],
-    "peer-review": [
-        "paper",
-        "light",
-        "academic",
-        "review",
-        "transparent"
-    ],
-    "pendulum": [
-        "dark",
-        "blog",
-        "productivity"
-    ],
-    "pentimento": [
-        "light",
-        "portfolio",
-        "elegant",
-        "bold",
-        "clean"
-    ],
-    "permafrost": [
-        "light",
-        "archive",
-        "ice",
-        "frozen"
-    ],
-    "persian-carpet": [
-        "light",
-        "blog",
-        "persian",
-        "carpet",
-        "ornate"
-    ],
-    "perspective-piece": [
-        "paper",
-        "dark",
-        "opinion",
-        "viewpoint",
-        "argumentative"
-    ],
-    "petrified-wood": [
-        "dark",
-        "blog",
-        "fossil",
-        "wood"
-    ],
-    "phantom": [
-        "dark",
-        "blog",
-        "ghost",
-        "translucent"
-    ],
-    "phosphor": [
-        "dark",
-        "gallery",
-        "bioluminescence",
-        "glow"
-    ],
-    "photoblog": [
-        "dark",
-        "blog",
-        "photography",
-        "gallery"
-    ],
-    "photon": [
-        "dark",
-        "elegant",
-        "luminescent",
-        "portfolio"
-    ],
-    "pietra-dura": [
-        "dark",
-        "creative",
-        "bold",
-        "stone"
-    ],
-    "pinecone": [
-        "dark",
-        "blog",
-        "nature"
-    ],
-    "pipeline": [
-        "light",
-        "docs",
-        "cicd"
-    ],
-    "pit-stop": [
-        "event",
-        "dark",
-        "motorsport",
-        "speed",
-        "frantic"
-    ],
-    "pixel": [
-        "dark",
-        "blog",
-        "gaming"
-    ],
-    "plasma": [
-        "dark",
-        "science",
-        "plasma",
-        "visualization"
-    ],
-    "platinum": [
-        "light",
-        "minimal",
-        "luxury",
-        "portfolio"
-    ],
-    "playlist": [
-        "dark",
-        "blog",
-        "music"
-    ],
-    "podcast-fm": [
-        "dark",
-        "media",
-        "podcast"
-    ],
-    "podium-rush": [
-        "event",
-        "competition",
-        "awards",
-        "victory",
-        "podium"
-    ],
-    "pointillism": [
-        "dark",
-        "blog",
-        "pointillism",
-        "dots"
-    ],
-    "poison": [
-        "dark",
-        "blog",
-        "sidebar"
-    ],
-    "polaris": [
-        "dark",
-        "guide",
-        "astronomy",
-        "constellation"
-    ],
-    "polaroid": [
-        "light",
-        "blog",
-        "gallery"
-    ],
-    "pop-surreal": [
-        "dark",
-        "glamorous",
-        "elegant",
-        "surreal",
-        "trendy"
-    ],
-    "pop-up-page": [
-        "book",
-        "light",
-        "dimensional",
-        "paper-engineering",
-        "interactive"
-    ],
-    "portfolio-blog": [
-        "dark",
-        "blog",
-        "portfolio"
-    ],
-    "portico": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "position-paper": [
-        "paper",
-        "dark",
-        "position",
-        "argumentative",
-        "bold"
-    ],
-    "postcard": [
-        "light",
-        "blog",
-        "postcard"
-    ],
-    "powder-burn": [
-        "event",
-        "dark",
-        "rapid-fire",
-        "flash",
-        "quick"
-    ],
-    "prairie": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "preprint-rush": [
-        "paper",
-        "light",
-        "preprint",
-        "urgent",
-        "draft"
-    ],
-    "pressure-cooker": [
-        "event",
-        "dark",
-        "hackathon",
-        "pressure",
-        "deadline"
-    ],
-    "pricetable": [
-        "light",
-        "landing",
-        "saas",
-        "pricing"
-    ],
-    "primer": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "printer-devil": [
-        "book",
-        "dark",
-        "error",
-        "playful",
-        "craft"
-    ],
-    "prism": [
-        "dark",
-        "docs",
-        "data"
-    ],
-    "prism-docs": [
-        "docs",
-        "light",
-        "colorful"
-    ],
-    "prism-refraction": [
-        "dark",
-        "blog",
-        "prism",
-        "refraction"
-    ],
-    "prismify": [
-        "glassmorphism",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "proof-sheet": [
-        "book",
-        "light",
-        "proof",
-        "unfinished",
-        "editorial"
-    ],
-    "protocol": [
-        "dark",
-        "docs",
-        "networking"
-    ],
-    "protocol-paper": [
-        "paper",
-        "light",
-        "protocol",
-        "pre-registration",
-        "rigorous"
-    ],
-    "psychedelic": [
-        "dark",
-        "minimal",
-        "elegant",
-        "glamorous"
-    ],
-    "pulp-fiction": [
-        "book",
-        "dark",
-        "pulp",
-        "lurid",
-        "cheap"
-    ],
-    "pulsar": [
-        "dark",
-        "blog",
-        "cosmic",
-        "pulse-animation"
-    ],
-    "pulse-api": [
-        "dark",
-        "docs"
-    ],
-    "pyrite": [
-        "dark",
-        "showcase",
-        "metallic",
-        "luxury"
-    ],
-    "pyrotechnic": [
-        "event",
-        "show",
-        "pyrotechnics",
-        "fireworks",
-        "explosive"
-    ],
-    "qualitative-study": [
-        "paper",
-        "light",
-        "qualitative",
-        "thematic",
-        "interpretive"
-    ],
-    "quantum": [
-        "dark",
-        "blog",
-        "quantum",
-        "science"
-    ],
-    "quarry": [
-        "dark",
-        "docs",
-        "data-warehouse"
-    ],
-    "quasar": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "quill": [
-        "light",
-        "blog",
-        "fiction"
-    ],
-    "radiolaria": [
-        "dark",
-        "blog",
-        "radiolaria",
-        "skeletal"
-    ],
-    "rainbow-cascade": [
-        "elegant",
-        "glowing",
-        "box-shadow"
-    ],
-    "ramble": [
-        "light",
-        "blog",
-        "hiking"
-    ],
-    "randomized-trial": [
-        "paper",
-        "light",
-        "rct",
-        "clinical-trial",
-        "rigorous"
-    ],
-    "rave": [
-        "dark",
-        "blog",
-        "acid",
-        "rave",
-        "neon"
-    ],
-    "raw-data": [
-        "paper",
-        "light",
-        "raw",
-        "data",
-        "tables"
-    ],
-    "reactor": [
-        "dark",
-        "docs",
-        "reactive"
-    ],
-    "realty": [
-        "light",
-        "realestate",
-        "luxury",
-        "elegant"
-    ],
-    "recipe": [
-        "light",
-        "blog",
-        "recipe"
-    ],
-    "red-alert": [
-        "event",
-        "dark",
-        "emergency",
-        "crisis",
-        "urgent"
-    ],
-    "red-carpet": [
-        "event",
-        "premiere",
-        "celebrity",
-        "glamour",
-        "fashion"
-    ],
-    "reef": [
-        "dark",
-        "blog",
-        "diving"
-    ],
-    "relay": [
-        "light",
-        "docs",
-        "integration"
-    ],
-    "remainder-bin": [
-        "book",
-        "light",
-        "secondhand",
-        "discount",
-        "worn"
-    ],
-    "remedy": [
-        "light",
-        "docs",
-        "troubleshooting"
-    ],
-    "renaissance": [
-        "light",
-        "art",
-        "classic",
-        "serif",
-        "elegant"
-    ],
-    "repousse": [
-        "dark",
-        "blog",
-        "repousse",
-        "metalwork"
-    ],
-    "reproducibility": [
-        "paper",
-        "light",
-        "replication",
-        "comparison",
-        "verdict"
-    ],
-    "resume": [
-        "light",
-        "resume"
-    ],
-    "retraction-notice": [
-        "paper",
-        "light",
-        "retracted",
-        "warning",
-        "editorial"
-    ],
-    "retro-radar": [
-        "dark",
-        "blog",
-        "radar",
-        "retro"
-    ],
-    "retromac": [
-        "light",
-        "mac",
-        "os9",
-        "retro",
-        "system"
-    ],
-    "retrowave": [
-        "dark",
-        "blog",
-        "retro",
-        "synthwave"
-    ],
-    "reveille": [
-        "event",
-        "dark",
-        "military",
-        "assembly",
-        "urgent"
-    ],
-    "review-article": [
-        "paper",
-        "light",
-        "review",
-        "literature",
-        "synthesis"
-    ],
-    "ridgeline": [
-        "dark",
-        "blog",
-        "outdoor"
-    ],
-    "riftzone": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "dimensional"
-    ],
-    "ring-bell": [
-        "event",
-        "dark",
-        "boxing",
-        "fight",
-        "intense"
-    ],
-    "riverbank": [
-        "light",
-        "blog",
-        "nature-journal"
-    ],
-    "rococo": [
-        "light",
-        "blog",
-        "pastel",
-        "elegant"
-    ],
-    "roll-call": [
-        "event",
-        "light",
-        "assembly",
-        "formal",
-        "attendance"
-    ],
-    "roll-scroll": [
-        "book",
-        "light",
-        "scroll",
-        "continuous",
-        "ancient"
-    ],
-    "rooftop": [
-        "dark",
-        "blog",
-        "urban"
-    ],
-    "rose-gold": [
-        "elegant",
-        "luxury",
-        "minimal"
-    ],
-    "rosemary": [
-        "light",
-        "blog",
-        "cooking"
-    ],
-    "rosetta": [
-        "light",
-        "docs",
-        "i18n"
-    ],
-    "rosewood": [
-        "blog",
-        "dark",
-        "warm",
-        "classic"
-    ],
-    "rubric": [
-        "book",
-        "light",
-        "rubricated",
-        "two-color",
-        "traditional"
-    ],
-    "ruby-fire": [
-        "dark",
-        "blog",
-        "bold"
-    ],
-    "runbook": [
-        "light",
-        "docs",
-        "operations"
-    ],
-    "rune": [
-        "dark",
-        "archive",
-        "viking",
-        "mystic"
-    ],
-    "saffron": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "sage-guide": [
-        "docs",
-        "light",
-        "tutorial",
-        "guide"
-    ],
-    "sakura-storm": [
-        "dark",
-        "blog",
-        "glamorous",
-        "sakura"
-    ],
-    "sandcastle": [
-        "light",
-        "blog",
-        "sand",
-        "beach"
-    ],
-    "sandstone": [
-        "light",
-        "blog",
-        "architecture"
-    ],
-    "sandstorm": [
-        "dark",
-        "blog",
-        "desert",
-        "particles"
-    ],
-    "sapphire": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "savanna": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "sawmill": [
-        "light",
-        "blog",
-        "woodworking"
-    ],
-    "scaffold": [
-        "dark",
-        "landing",
-        "comingsoon"
-    ],
-    "scaffold-docs": [
-        "dark",
-        "docs",
-        "scaffolding"
-    ],
-    "schematic": [
-        "light",
-        "docs",
-        "hardware"
-    ],
-    "scientific-journal": [
-        "dark",
-        "docs",
-        "scientific",
-        "academic"
-    ],
-    "scoping-review": [
-        "paper",
-        "light",
-        "scoping",
-        "mapping",
-        "landscape"
-    ],
-    "scrimshaw": [
-        "bold",
-        "elegant",
-        "clean",
-        "blog"
-    ],
-    "sentinel": [
-        "dark",
-        "docs",
-        "monitoring"
-    ],
-    "seraph": [
-        "minimal",
-        "elegant",
-        "portfolio"
-    ],
-    "serenity": [
-        "light",
-        "blog",
-        "elegant"
-    ],
-    "sextant": [
-        "light",
-        "docs",
-        "metrics"
-    ],
-    "sfumato": [
-        "dark",
-        "blog",
-        "atmospheric",
-        "minimal"
-    ],
-    "sgraffito": [
-        "dark",
-        "blog",
-        "sgraffito",
-        "scratched"
-    ],
-    "shutout": [
-        "event",
-        "dark",
-        "competition",
-        "dominant",
-        "perfect"
-    ],
-    "silhouette": [
-        "dark",
-        "landing",
-        "silhouette",
-        "dramatic"
-    ],
-    "silk-road": [
-        "elegant",
-        "glamorous",
-        "silk",
-        "cultural"
-    ],
-    "simulation-paper": [
-        "paper",
-        "dark",
-        "computational",
-        "simulation",
-        "model"
-    ],
-    "sketch": [
-        "light",
-        "blog",
-        "handdrawn"
-    ],
-    "skeuomorphic": [
-        "light",
-        "blog",
-        "skeuomorphic",
-        "realistic"
-    ],
-    "slide": [
-        "dark",
-        "docs",
-        "presentation"
-    ],
-    "snowfall": [
-        "light",
-        "blog",
-        "winter"
-    ],
-    "solar-punk": [
-        "light",
-        "blog",
-        "solarpunk",
-        "sustainable"
-    ],
-    "solarflare": [
-        "dark",
-        "landing",
-        "solar",
-        "energy"
-    ],
-    "solaris": [
-        "dark",
-        "dashboard",
-        "solar-system",
-        "space-mission"
-    ],
-    "solarium": [
-        "blog",
-        "light",
-        "warm"
-    ],
-    "solstice": [
-        "dual",
-        "blog",
-        "seasonal",
-        "time-based"
-    ],
-    "sonar": [
-        "dark",
-        "hub",
-        "radar",
-        "discovery"
-    ],
-    "spectra": [
-        "dark",
-        "data-science",
-        "spectrum",
-        "rainbow"
-    ],
-    "spectrum": [
-        "light",
-        "blog",
-        "a11y"
-    ],
-    "spectrum-docs": [
-        "light",
-        "docs",
-        "accessibility"
-    ],
-    "spire": [
-        "dark",
-        "blog",
-        "architecture"
-    ],
-    "split-tone": [
-        "light",
-        "blog",
-        "photography",
-        "cinematic",
-        "toning"
-    ],
-    "stained-glass": [
-        "light",
-        "blog",
-        "cathedral",
-        "colorful",
-        "gothic"
-    ],
-    "standing-ovation": [
-        "event",
-        "light",
-        "awards",
-        "acclaim",
-        "celebration"
-    ],
-    "starlight": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "minimal"
-    ],
-    "starting-gun": [
-        "event",
-        "dark",
-        "race",
-        "competition",
-        "explosive"
-    ],
-    "statuspage": [
-        "light",
-        "landing",
-        "status"
-    ],
-    "stellar-launch": [
-        "landing",
-        "dark",
-        "parallax",
-        "animation"
-    ],
-    "stipple": [
-        "light",
-        "artistic",
-        "dot-art",
-        "gallery"
-    ],
-    "storefront": [
-        "light",
-        "landing",
-        "shop"
-    ],
-    "stratum": [
-        "dark",
-        "timeline",
-        "geological",
-        "layered"
-    ],
-    "strobe": [
-        "dark",
-        "event",
-        "club",
-        "strobe"
-    ],
-    "studio": [
-        "dark",
-        "landing",
-        "portfolio"
-    ],
-    "subzero": [
-        "dark",
-        "research",
-        "cryogenic",
-        "frozen"
-    ],
-    "summit": [
-        "dark",
-        "landing",
-        "conference"
-    ],
-    "summit-event": [
-        "conference",
-        "dark",
-        "event",
-        "landing"
-    ],
-    "summit-strike": [
-        "event",
-        "dark",
-        "conference",
-        "summit",
-        "ascending"
-    ],
-    "sunburst": [
-        "light",
-        "blog",
-        "warm",
-        "golden",
-        "radiant"
-    ],
-    "sundew": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "supernova": [
-        "dark",
-        "landing",
-        "cosmic",
-        "particles"
-    ],
-    "supplementary": [
-        "paper",
-        "light",
-        "supplementary",
-        "data-heavy",
-        "exhaustive"
-    ],
-    "supreme-sun": [
-        "light",
-        "blog",
-        "community"
-    ],
-    "survey-instrument": [
-        "paper",
-        "light",
-        "survey",
-        "instrument",
-        "psychometric"
-    ],
-    "synthwave": [
-        "dark",
-        "retro",
-        "glamorous",
-        "trendy"
-    ],
-    "systematic-review": [
-        "paper",
-        "light",
-        "systematic",
-        "evidence",
-        "methodology"
-    ],
-    "tactile-fabric": [
-        "light",
-        "blog",
-        "fabric",
-        "textile"
-    ],
-    "talavera": [
-        "light",
-        "blog",
-        "mexican",
-        "pottery",
-        "colorful"
-    ],
-    "tale": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "tangram": [
-        "light",
-        "portfolio",
-        "puzzle",
-        "geometric"
-    ],
-    "tapestry": [
-        "light",
-        "blog",
-        "timeline"
-    ],
-    "taskboard": [
-        "light",
-        "dashboard",
-        "kanban"
-    ],
-    "tavern": [
-        "dark",
-        "blog",
-        "rpg"
-    ],
-    "techbyte": [
-        "light",
-        "blog",
-        "tech",
-        "card"
-    ],
-    "technical-report": [
-        "paper",
-        "light",
-        "institutional",
-        "technical-report",
-        "formal"
-    ],
-    "tectonic": [
-        "dark",
-        "hub",
-        "geological",
-        "interactive"
-    ],
-    "telegraph": [
-        "light",
-        "blog",
-        "news"
-    ],
-    "tempera": [
-        "dark",
-        "blog",
-        "tempera",
-        "painting"
-    ],
-    "tempest": [
-        "dark",
-        "magazine",
-        "storm",
-        "dramatic"
-    ],
-    "tenebrism": [
-        "dark",
-        "creative",
-        "bold",
-        "clean"
-    ],
-    "terminal": [
-        "dark",
-        "blog"
-    ],
-    "terrace": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "terracotta-studio": [
-        "landing",
-        "light",
-        "creative",
-        "artisan"
-    ],
-    "terracotta-tiles": [
-        "dark",
-        "blog",
-        "terracotta",
-        "tile"
-    ],
-    "terraform": [
-        "dark",
-        "dashboard",
-        "sci-fi",
-        "terraforming"
-    ],
-    "terraform-docs": [
-        "docs",
-        "dark",
-        "infra",
-        "devops"
-    ],
-    "terrarium": [
-        "light",
-        "portfolio",
-        "miniature"
-    ],
-    "terrazzo": [
-        "light",
-        "portfolio",
-        "terrazzo",
-        "speckled"
-    ],
-    "terrazzo-blog": [
-        "blog",
-        "light",
-        "colorful",
-        "memphis"
-    ],
-    "tessellation": [
-        "light",
-        "gallery",
-        "escher",
-        "pattern-art"
-    ],
-    "tesseract": [
-        "dark",
-        "education",
-        "4d",
-        "mathematical"
-    ],
-    "thermal": [
-        "dark",
-        "dashboard",
-        "thermal",
-        "heatmap"
-    ],
-    "thesis": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "thesis-defense": [
-        "paper",
-        "dark",
-        "thesis",
-        "formal",
-        "institutional"
-    ],
-    "thunderdome": [
-        "event",
-        "dark",
-        "arena",
-        "competition",
-        "ultimate"
-    ],
-    "ticker-board": [
-        "event",
-        "dark",
-        "transit",
-        "departure",
-        "mechanical"
-    ],
-    "ticker-tape": [
-        "event",
-        "light",
-        "celebration",
-        "parade",
-        "festive"
-    ],
-    "tidal": [
-        "light",
-        "blog",
-        "ocean",
-        "wellness"
-    ],
-    "timber": [
-        "light",
-        "blog",
-        "craft"
-    ],
-    "titanium": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ],
-    "topaz": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "topographic-gradient": [
-        "dark",
-        "blog",
-        "topographic",
-        "contour"
-    ],
-    "topographic-sand": [
-        "dark",
-        "blog",
-        "topographic",
-        "sand"
-    ],
-    "topography": [
-        "light",
-        "blog",
-        "topographic",
-        "outdoor"
-    ],
-    "torchlight": [
-        "dark",
-        "blog",
-        "adventure"
-    ],
-    "totem": [
-        "dark",
-        "portfolio",
-        "tribal",
-        "vertical-stack"
-    ],
-    "tremor": [
-        "dark",
-        "dashboard",
-        "seismic",
-        "data-viz"
-    ],
-    "trompe-loeil": [
-        "light",
-        "portfolio",
-        "creative",
-        "bold",
-        "illusion"
-    ],
-    "tropical-paradise": [
-        "elegant",
-        "vivid",
-        "botanical"
-    ],
-    "tundra": [
-        "dark",
-        "blog",
-        "expedition"
-    ],
-    "turbine": [
-        "light",
-        "corporate",
-        "energy",
-        "rotation"
-    ],
-    "turret": [
-        "dark",
-        "docs",
-        "waf"
-    ],
-    "twilight": [
-        "dark",
-        "blog",
-        "photo-essay"
-    ],
-    "typeface": [
-        "blog",
-        "light",
-        "typography",
-        "minimal"
-    ],
-    "typewriter": [
-        "light",
-        "blog",
-        "vintage"
-    ],
-    "typhoon": [
-        "dark",
-        "magazine",
-        "storm",
-        "spiral"
-    ],
-    "ukiyo-e": [
-        "light",
-        "blog",
-        "japanese",
-        "woodblock",
-        "traditional"
-    ],
-    "ultraviolet": [
-        "dark",
-        "blog",
-        "ultraviolet",
-        "neon"
-    ],
-    "umbra": [
-        "dark",
-        "portfolio",
-        "monochrome",
-        "shadow"
-    ],
-    "vapor": [
-        "light",
-        "blog",
-        "vaporwave",
-        "surreal"
-    ],
-    "vault": [
-        "dark",
-        "docs",
-        "security"
-    ],
-    "vellum": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "velocity": [
-        "landing",
-        "dark",
-        "saas"
-    ],
-    "velvet": [
-        "dark",
-        "landing",
-        "luxury"
-    ],
-    "velvet-rope": [
-        "event",
-        "gala",
-        "exclusive",
-        "luxury",
-        "velvet"
-    ],
-    "venetian": [
-        "light",
-        "blog",
-        "renaissance",
-        "venetian",
-        "ornate"
-    ],
-    "verdigris": [
-        "dark",
-        "blog",
-        "editorial"
-    ],
-    "versailles": [
-        "dark",
-        "elegant",
-        "classic",
-        "luxury"
-    ],
-    "vertigo": [
-        "dark",
-        "one-page",
-        "experimental",
-        "perspective"
-    ],
-    "vibrant-brutalism": [
-        "dark",
-        "blog",
-        "brutalist",
-        "vibrant"
-    ],
-    "victorian": [
-        "dark",
-        "blog",
-        "gothic",
-        "classic"
-    ],
-    "vineyard": [
-        "dark",
-        "blog",
-        "wine"
-    ],
-    "vintage": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "vintagetv": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "vinyl": [
-        "dark",
-        "blog",
-        "vinyl"
-    ],
-    "voltage": [
-        "dark",
-        "blog",
-        "electric",
-        "sparks"
-    ],
-    "volumetric": [
-        "dark",
-        "blog",
-        "3d",
-        "glow",
-        "atmospheric"
-    ],
-    "vortex": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "animation"
-    ],
-    "wanderlust": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "war-room": [
-        "event",
-        "dark",
-        "strategy",
-        "military",
-        "command"
-    ],
-    "warpzone": [
-        "dark",
-        "portfolio",
-        "warp",
-        "gaming"
-    ],
-    "washi-bound": [
-        "book",
-        "light",
-        "japanese",
-        "stab-binding",
-        "paper"
-    ],
-    "wavelength": [
-        "audio",
-        "dark",
-        "landing",
-        "music"
-    ],
-    "weathervane": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "wedding": [
-        "light",
-        "wedding",
-        "elegant",
-        "event"
-    ],
-    "white-paper-noir": [
-        "paper",
-        "dark",
-        "industry",
-        "executive",
-        "authoritative"
-    ],
-    "wiki": [
-        "light",
-        "docs",
-        "wiki"
-    ],
-    "willow": [
-        "light",
-        "blog",
-        "literature"
-    ],
-    "windmill": [
-        "light",
-        "blog",
-        "european"
-    ],
-    "windows95": [
-        "light",
-        "retro",
-        "os",
-        "nostalgia"
-    ],
-    "woodblock": [
-        "dark",
-        "blog",
-        "woodblock",
-        "printmaking"
-    ],
-    "working-paper": [
-        "paper",
-        "light",
-        "working",
-        "in-progress",
-        "honest"
-    ],
-    "woven-tapestry": [
-        "dark",
-        "blog",
-        "tapestry",
-        "textile"
-    ],
-    "x-ray": [
-        "dark",
-        "blog",
-        "x-ray",
-        "transparent"
-    ],
-    "xerograph": [
-        "dark",
-        "blog",
-        "minimal",
-        "photocopy"
-    ],
-    "y2k": [
-        "dark",
-        "cyber",
-        "metallic",
-        "retro"
-    ],
-    "zen": [
-        "light",
-        "blog",
-        "zen"
-    ],
-    "zenith": [
-        "light",
-        "landing",
-        "minimal",
-        "altitude"
-    ],
-    "zenithpoint": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ]
+  "abstract-noir": [
+    "paper",
+    "dark",
+    "abstract",
+    "bold",
+    "typography"
+  ],
+  "abyss": [
+    "dark",
+    "blog",
+    "deep-sea",
+    "immersive"
+  ],
+  "acid-graphics": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "acme-docs": [
+    "light",
+    "docs"
+  ],
+  "acoustic-soundwaves": [
+    "dark",
+    "blog",
+    "sound",
+    "waveform"
+  ],
+  "adminpanel": [
+    "dark",
+    "dashboard",
+    "admin",
+    "sidebar"
+  ],
+  "aether": [
+    "dark",
+    "blog",
+    "elegant"
+  ],
+  "aetheria": [
+    "dark-mode",
+    "elegant",
+    "portfolio"
+  ],
+  "after-dark": [
+    "blog",
+    "dark",
+    "reading"
+  ],
+  "afterparty": [
+    "event",
+    "party",
+    "nightlife",
+    "club",
+    "late-night"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
+  ],
+  "airwave": [
+    "dark",
+    "blog",
+    "podcast"
+  ],
+  "alexandrite": [
+    "dark",
+    "blog",
+    "glamorous",
+    "gemstone"
+  ],
+  "almanac": [
+    "light",
+    "blog",
+    "calendar"
+  ],
+  "almanac-docs": [
+    "light",
+    "docs",
+    "roadmap"
+  ],
+  "amber-preservation": [
+    "dark",
+    "blog",
+    "amber",
+    "fossil"
+  ],
+  "amethyst": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "anaglyph": [
+    "dark",
+    "blog",
+    "3d",
+    "stereoscopic"
+  ],
+  "analytics": [
+    "light",
+    "dashboard",
+    "analytics"
+  ],
+  "anamorphic": [
+    "dark",
+    "portfolio",
+    "anamorphic",
+    "optical"
+  ],
+  "anatomy-atlas": [
+    "dark",
+    "docs",
+    "medical",
+    "vintage"
+  ],
+  "annotation-layer": [
+    "book",
+    "light",
+    "scholarly",
+    "annotated",
+    "dense"
+  ],
+  "anthology": [
+    "light",
+    "docs",
+    "sdk-reference"
+  ],
+  "antimatter": [
+    "dark",
+    "blog",
+    "experimental",
+    "inverted"
+  ],
+  "anubis": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "anvil": [
+    "dark",
+    "blog",
+    "workshop"
+  ],
+  "apiary": [
+    "light",
+    "docs",
+    "api",
+    "two-column"
+  ],
+  "apolo": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "apothecary": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "appsite": [
+    "light",
+    "landing",
+    "app"
+  ],
+  "aquarium": [
+    "dark",
+    "blog",
+    "marine"
+  ],
+  "aquatint": [
+    "light",
+    "portfolio",
+    "creative",
+    "elegant",
+    "bold"
+  ],
+  "aqueduct": [
+    "light",
+    "blog",
+    "engineering"
+  ],
+  "arbor": [
+    "light",
+    "docs",
+    "git-workflow"
+  ],
+  "archipelago": [
+    "dark",
+    "landing",
+    "hub"
+  ],
+  "archive": [
+    "light",
+    "docs",
+    "archive"
+  ],
+  "archway-docs": [
+    "docs",
+    "light",
+    "architecture"
+  ],
+  "arctic-saas": [
+    "landing",
+    "light",
+    "saas",
+    "minimal"
+  ],
+  "arena": [
+    "dark",
+    "blog",
+    "sports"
+  ],
+  "artdeco": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "artnouveau": [
+    "light",
+    "portfolio",
+    "art-nouveau",
+    "botanical"
+  ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
+  ],
+  "ascii": [
+    "dark",
+    "terminal",
+    "ascii"
+  ],
+  "asymmetric": [
+    "light",
+    "portfolio",
+    "grid",
+    "asymmetric"
+  ],
+  "atelier": [
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "athena": [
+    "elegant",
+    "portfolio",
+    "light"
+  ],
+  "atlas": [
+    "light",
+    "blog",
+    "geography"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
+  ],
+  "aurelia": [
+    "elegant",
+    "minimalist",
+    "blog"
+  ],
+  "aurora": [
+    "dark",
+    "blog",
+    "aurora"
+  ],
+  "aurora-glimmer": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "aurora-launch": [
+    "landing",
+    "dark",
+    "animation"
+  ],
+  "aurum": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "avalanche-event": [
+    "event",
+    "dark",
+    "momentum",
+    "cascading",
+    "overwhelming"
+  ],
+  "axiom": [
+    "light",
+    "design-system",
+    "geometric",
+    "mathematical"
+  ],
+  "bamboo": [
+    "light",
+    "blog",
+    "eco"
+  ],
+  "baroque": [
+    "dark",
+    "blog",
+    "ornamental",
+    "glamorous"
+  ],
+  "bas-relief": [
+    "light",
+    "artistic",
+    "minimal"
+  ],
+  "bastard-title": [
+    "book",
+    "light",
+    "preliminary",
+    "ceremonial",
+    "typography"
+  ],
+  "bastion": [
+    "dark",
+    "docs",
+    "zero-trust"
+  ],
+  "batik": [
+    "light",
+    "blog",
+    "elegant",
+    "batik"
+  ],
+  "bauhaus": [
+    "light",
+    "portfolio",
+    "design",
+    "geometric"
+  ],
+  "bayesian-prior": [
+    "paper",
+    "dark",
+    "bayesian",
+    "probabilistic",
+    "visualization"
+  ],
+  "bazaar": [
+    "light",
+    "landing",
+    "marketplace"
+  ],
+  "beacon": [
+    "dark",
+    "blog",
+    "alert"
+  ],
+  "beacon-docs": [
+    "light",
+    "docs",
+    "feature-flag"
+  ],
+  "beautiful-hwaro": [
+    "light",
+    "blog"
+  ],
+  "bejeweled": [
+    "elegant",
+    "glamorous",
+    "luxury"
+  ],
+  "bell-tower": [
+    "event",
+    "light",
+    "scheduled",
+    "clock",
+    "traditional"
+  ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
+  ],
+  "bijou": [
+    "dark",
+    "elegant",
+    "jewelry",
+    "glamorous"
+  ],
+  "bioluminescence": [
+    "dark",
+    "blog",
+    "bioluminescence",
+    "minimal"
+  ],
+  "bismuth": [
+    "dark",
+    "collection",
+    "mineral",
+    "rainbow-metallic"
+  ],
+  "black-box": [
+    "event",
+    "dark",
+    "theater",
+    "intimate",
+    "minimal"
+  ],
+  "black-letter-bible": [
+    "book",
+    "dark",
+    "sacred",
+    "blackletter",
+    "dense"
+  ],
+  "blacklight": [
+    "dark",
+    "fluorescent",
+    "elegant"
+  ],
+  "blast-furnace": [
+    "event",
+    "dark",
+    "workshop",
+    "intense",
+    "industrial"
+  ],
+  "blockade-run": [
+    "event",
+    "dark",
+    "breakthrough",
+    "barriers",
+    "overcome"
+  ],
+  "blueprint": [
+    "dark",
+    "docs",
+    "spec"
+  ],
+  "blueprint-pro": [
+    "landing",
+    "dark",
+    "devtool"
+  ],
+  "bonfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "bonsai": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "book": [
+    "light",
+    "docs"
+  ],
+  "borealis": [
+    "dark",
+    "blog",
+    "aurora",
+    "nordic"
+  ],
+  "botanical-press": [
+    "blog",
+    "light",
+    "botanical",
+    "vintage"
+  ],
+  "boutique": [
+    "light",
+    "store",
+    "fashion",
+    "elegant"
+  ],
+  "box-office": [
+    "event",
+    "tickets",
+    "sales",
+    "urgency",
+    "countdown"
+  ],
+  "bramble": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "breeze": [
+    "landing",
+    "light",
+    "minimal",
+    "one-page"
+  ],
+  "brocade": [
+    "dark",
+    "blog",
+    "glamorous",
+    "luxury"
+  ],
+  "brutalist": [
+    "light",
+    "blog",
+    "brutalist"
+  ],
+  "brutopia": [
+    "dark",
+    "blog",
+    "brutalist",
+    "monospace"
+  ],
+  "bulwark": [
+    "dark",
+    "docs",
+    "disaster-recovery"
+  ],
+  "bureau": [
+    "light",
+    "docs",
+    "governance"
+  ],
+  "burlesque": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "burnt-charcoal": [
+    "dark",
+    "blog",
+    "charcoal",
+    "texture"
+  ],
+  "butterfly-wing": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "trendy",
+    "blog"
+  ],
+  "byzantine": [
+    "light",
+    "blog",
+    "byzantine",
+    "mosaic",
+    "imperial"
+  ],
+  "cabaret": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "cabin": [
+    "dark",
+    "blog",
+    "lifestyle"
+  ],
+  "cactus": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cafe": [
+    "light",
+    "landing",
+    "menu"
+  ],
+  "cage-match": [
+    "event",
+    "dark",
+    "competition",
+    "fight",
+    "enclosed"
+  ],
+  "call-to-stage": [
+    "event",
+    "talent",
+    "open-call",
+    "audition",
+    "stage"
+  ],
+  "calligraphy": [
+    "dark",
+    "blog",
+    "calligraphy",
+    "ink"
+  ],
+  "cameo": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "campfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "cancel-leaf": [
+    "book",
+    "light",
+    "correction",
+    "repair",
+    "visible"
+  ],
+  "canopy": [
+    "light",
+    "blog",
+    "outdoor"
+  ],
+  "canvas-studio": [
+    "landing",
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "carbon-fiber": [
+    "dark",
+    "blog",
+    "tech"
+  ],
+  "carnival": [
+    "dark",
+    "blog",
+    "glamorous",
+    "event"
+  ],
+  "cartograph": [
+    "dark",
+    "docs",
+    "infrastructure"
+  ],
+  "cascade": [
+    "light",
+    "longform",
+    "waterfall",
+    "scroll-driven"
+  ],
+  "case-report": [
+    "paper",
+    "light",
+    "clinical",
+    "case-study",
+    "medical"
+  ],
+  "cassette": [
+    "dark",
+    "blog",
+    "retro",
+    "audio"
+  ],
+  "catacombs": [
+    "dark",
+    "blog",
+    "underground",
+    "adventure"
+  ],
+  "catalyst": [
+    "light",
+    "landing",
+    "science",
+    "chemistry"
+  ],
+  "cathedral": [
+    "light",
+    "portfolio",
+    "architecture"
+  ],
+  "cauldron": [
+    "dark",
+    "wiki",
+    "fantasy",
+    "potion"
+  ],
+  "celebrate": [
+    "light",
+    "landing",
+    "event"
+  ],
+  "celestial-burst": [
+    "dark",
+    "glamorous",
+    "celestial",
+    "trendy"
+  ],
+  "center-stage": [
+    "event",
+    "solo",
+    "show",
+    "spotlight",
+    "centered"
+  ],
+  "chain-reaction": [
+    "event",
+    "dark",
+    "sequential",
+    "cascade",
+    "connected"
+  ],
+  "chalkboard": [
+    "dark",
+    "blog",
+    "education"
+  ],
+  "champagne": [
+    "light",
+    "luxury",
+    "elegant",
+    "champagne"
+  ],
+  "chandelier": [
+    "light",
+    "blog",
+    "crystal",
+    "elegant",
+    "prismatic"
+  ],
+  "changelog": [
+    "dark",
+    "docs",
+    "changelog"
+  ],
+  "chase-frame": [
+    "book",
+    "dark",
+    "letterpress",
+    "mechanical",
+    "craft"
+  ],
+  "chiaroscuro": [
+    "dark",
+    "portfolio",
+    "chiaroscuro",
+    "contrast"
+  ],
+  "chinoiserie": [
+    "light",
+    "blog",
+    "chinese",
+    "porcelain",
+    "elegant"
+  ],
+  "chromatic": [
+    "dark",
+    "photoblog",
+    "chromatic",
+    "lens"
+  ],
+  "chromatic-wave": [
+    "dark",
+    "portfolio",
+    "glamorous",
+    "animation"
+  ],
+  "chromatophore": [
+    "dark",
+    "bold",
+    "minimal",
+    "creative"
+  ],
+  "chrome-pulse": [
+    "minimal",
+    "dark",
+    "landing"
+  ],
+  "chromolithograph": [
+    "book",
+    "light",
+    "color-plate",
+    "print",
+    "illustration"
+  ],
+  "chronicle": [
+    "light",
+    "blog",
+    "traditional",
+    "serif"
+  ],
+  "chronosphere": [
+    "dark",
+    "space",
+    "time"
+  ],
+  "chrysanthemum": [
+    "dark",
+    "blog",
+    "floral",
+    "glamorous"
+  ],
+  "cinder": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cinema": [
+    "dark",
+    "blog",
+    "review"
+  ],
+  "cinema-silent": [
+    "dark",
+    "blog",
+    "retro",
+    "editorial"
+  ],
+  "cipher": [
+    "dark",
+    "docs",
+    "cryptography"
+  ],
+  "citation-graph": [
+    "paper",
+    "dark",
+    "network",
+    "citations",
+    "visualization"
+  ],
+  "clarity-docs": [
+    "docs",
+    "light",
+    "minimal",
+    "typography"
+  ],
+  "clocktower": [
+    "dark",
+    "landing",
+    "countdown"
+  ],
+  "cloisonne": [
+    "dark",
+    "portfolio",
+    "enamel",
+    "ornate"
+  ],
+  "cloister": [
+    "light",
+    "blog",
+    "meditation"
+  ],
+  "closed": [
+    "light",
+    "error",
+    "499",
+    "minimal"
+  ],
+  "cloudnest": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "cobblestone": [
+    "light",
+    "blog",
+    "culture"
+  ],
+  "cockpit": [
+    "dark",
+    "landing",
+    "telemetry"
+  ],
+  "codebook": [
+    "light",
+    "docs",
+    "styleguide"
+  ],
+  "codecraft": [
+    "api",
+    "dark",
+    "developer",
+    "docs"
+  ],
+  "codex": [
+    "light",
+    "blog",
+    "medieval"
+  ],
+  "codex-rotundus": [
+    "book",
+    "dark",
+    "circular",
+    "unusual",
+    "experimental"
+  ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
+  ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
+  ],
+  "colosseum": [
+    "light",
+    "event",
+    "classical",
+    "grand"
+  ],
+  "comic": [
+    "light",
+    "blog",
+    "comic"
+  ],
+  "command-center": [
+    "docs",
+    "dark",
+    "cli",
+    "developer"
+  ],
+  "compass": [
+    "light",
+    "landing",
+    "career"
+  ],
+  "compass-docs": [
+    "light",
+    "docs",
+    "onboarding"
+  ],
+  "conduit": [
+    "light",
+    "docs",
+    "data-pipeline"
+  ],
+  "conference-poster": [
+    "paper",
+    "dark",
+    "poster",
+    "conference",
+    "visual"
+  ],
+  "confetti": [
+    "celebration",
+    "elegant",
+    "festive"
+  ],
+  "console": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "constellation": [
+    "dark",
+    "blog",
+    "astronomy"
+  ],
+  "controlroom": [
+    "dark",
+    "dashboard",
+    "monitoring"
+  ],
+  "copper-patina": [
+    "dark",
+    "blog",
+    "patina",
+    "industrial"
+  ],
+  "copper-wire": [
+    "blog",
+    "dark",
+    "industrial"
+  ],
+  "copperplate": [
+    "dark",
+    "blog",
+    "copperplate",
+    "engraving"
+  ],
+  "coral": [
+    "light",
+    "documentary",
+    "organic",
+    "ocean"
+  ],
+  "coral-bloom": [
+    "dark",
+    "blog",
+    "elegant",
+    "marine",
+    "glamorous"
+  ],
+  "corrigendum": [
+    "paper",
+    "light",
+    "correction",
+    "errata",
+    "formal"
+  ],
+  "cosmos": [
+    "dark",
+    "magazine",
+    "space",
+    "planetary"
+  ],
+  "cost-effectiveness": [
+    "paper",
+    "light",
+    "economics",
+    "cost-effectiveness",
+    "health"
+  ],
+  "countdown-zero": [
+    "event",
+    "dark",
+    "countdown",
+    "convergence",
+    "climactic"
+  ],
+  "creative-agency": [
+    "dark",
+    "portfolio",
+    "agency",
+    "bold"
+  ],
+  "cross-sectional": [
+    "paper",
+    "light",
+    "cross-sectional",
+    "snapshot",
+    "population"
+  ],
+  "crucible": [
+    "light",
+    "docs",
+    "testing"
+  ],
+  "cruciform": [
+    "light",
+    "design-system",
+    "grid",
+    "swiss"
+  ],
+  "crystalline": [
+    "light",
+    "portfolio",
+    "crystal",
+    "faceted"
+  ],
+  "cuneiform-tablet": [
+    "book",
+    "dark",
+    "ancient",
+    "impressed",
+    "archaeological"
+  ],
+  "curator": [
+    "light",
+    "portfolio",
+    "exhibition"
+  ],
+  "curtain-call": [
+    "event",
+    "dark",
+    "closing",
+    "ceremony",
+    "theatrical"
+  ],
+  "cyanotype": [
+    "light",
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "cyberpunk": [
+    "dark",
+    "magazine",
+    "cyberpunk",
+    "neon"
+  ],
+  "daguerreotype": [
+    "dark",
+    "blog",
+    "photography",
+    "vintage"
+  ],
+  "damask": [
+    "dark",
+    "blog",
+    "luxury",
+    "glamorous"
+  ],
+  "dark-manual": [
+    "docs",
+    "dark",
+    "technical",
+    "manual"
+  ],
+  "darkfolio": [
+    "dark",
+    "portfolio",
+    "developer",
+    "minimal"
+  ],
+  "darkmarket": [
+    "dark",
+    "marketplace",
+    "bold"
+  ],
+  "darkroom": [
+    "dark",
+    "portfolio",
+    "photography"
+  ],
+  "darkwave": [
+    "dark",
+    "blog",
+    "synthwave"
+  ],
+  "dashboard": [
+    "dark",
+    "landing",
+    "dashboard"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
+  ],
+  "deckle-edge": [
+    "book",
+    "light",
+    "craft",
+    "handmade",
+    "texture"
+  ],
+  "deconstructed": [
+    "light",
+    "agency",
+    "deconstructivism",
+    "architecture"
+  ],
+  "deconstructivist": [
+    "dark",
+    "portfolio",
+    "deconstructivist",
+    "architecture"
+  ],
+  "demolition-derby": [
+    "event",
+    "dark",
+    "competition",
+    "destruction",
+    "chaotic"
+  ],
+  "depot": [
+    "light",
+    "landing",
+    "tracker"
+  ],
+  "devconf": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "devlog": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "devtool": [
+    "dark",
+    "landing",
+    "developer"
+  ],
+  "dewdrop": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "diamond-facet": [
+    "dark",
+    "blog",
+    "glamorous",
+    "prismatic"
+  ],
+  "diary": [
+    "light",
+    "blog",
+    "personal",
+    "journal"
+  ],
+  "diorama": [
+    "dark",
+    "landing",
+    "product"
+  ],
+  "disco-fever": [
+    "dark",
+    "blog",
+    "retro",
+    "disco",
+    "neon"
+  ],
+  "dispatch": [
+    "light",
+    "docs",
+    "event-driven"
+  ],
+  "dockhub": [
+    "dark",
+    "docs",
+    "devops"
+  ],
+  "dojo": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "dose-response": [
+    "paper",
+    "light",
+    "pharmacological",
+    "dose-response",
+    "clinical"
+  ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
+  ],
+  "driftwood": [
+    "light",
+    "blog",
+    "photo"
+  ],
+  "dropzone": [
+    "cloud",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "dune": [
+    "light",
+    "journal",
+    "desert",
+    "travel"
+  ],
+  "duodecimo": [
+    "book",
+    "light",
+    "compact",
+    "portable",
+    "efficient"
+  ],
+  "dusk": [
+    "dark",
+    "blog",
+    "sunset"
+  ],
+  "dynamo": [
+    "dark",
+    "docs",
+    "serverless"
+  ],
+  "easel": [
+    "light",
+    "docs",
+    "art"
+  ],
+  "eclipse": [
+    "dark",
+    "blog",
+    "celestial",
+    "dramatic"
+  ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
+  ],
+  "electric-bloom": [
+    "dark",
+    "blog",
+    "glamorous",
+    "neon",
+    "botanical"
+  ],
+  "electroplate": [
+    "dark",
+    "blog",
+    "metallic",
+    "plating"
+  ],
+  "elevate": [
+    "landing",
+    "light",
+    "saas",
+    "enterprise"
+  ],
+  "elysian": [
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "elysium": [
+    "portfolio",
+    "minimal",
+    "dark"
+  ],
+  "elysium-portfolio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "embargo-lift": [
+    "event",
+    "dark",
+    "embargo",
+    "release",
+    "timed"
+  ],
+  "ember": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "embroidery": [
+    "dark",
+    "blog",
+    "glamorous",
+    "trendy"
+  ],
+  "emerald": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "empyrean": [
+    "light",
+    "landing",
+    "divine",
+    "ethereal"
+  ],
+  "encaustic": [
+    "light",
+    "blog",
+    "art",
+    "painting"
+  ],
+  "encore": [
+    "event",
+    "dark",
+    "repeat",
+    "popular",
+    "demanded"
+  ],
+  "encore-night": [
+    "event",
+    "concert",
+    "farewell",
+    "encore",
+    "emotional"
+  ],
+  "endpaper": [
+    "book",
+    "dark",
+    "decorative",
+    "pattern",
+    "hidden"
+  ],
+  "enigma": [
+    "dark",
+    "puzzle",
+    "cryptography",
+    "mechanical"
+  ],
+  "entropy": [
+    "dual",
+    "magazine",
+    "experimental",
+    "asymmetric"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
+  ],
+  "errata-slip": [
+    "book",
+    "light",
+    "correction",
+    "layered",
+    "meta"
+  ],
+  "etching": [
+    "dark",
+    "blog",
+    "etching",
+    "printmaking"
+  ],
+  "ethereal-canvas": [
+    "blog",
+    "dark",
+    "elegant",
+    "minimal",
+    "portfolio"
+  ],
+  "ethereal-vapor": [
+    "light",
+    "blog",
+    "ethereal",
+    "translucent"
+  ],
+  "ethos": [
+    "light",
+    "docs",
+    "culture"
+  ],
+  "even": [
+    "light",
+    "blog"
+  ],
+  "evergreen-docs": [
+    "docs",
+    "light",
+    "enterprise",
+    "classic"
+  ],
+  "experiment-log": [
+    "paper",
+    "dark",
+    "experimental",
+    "sequential",
+    "iterative"
+  ],
+  "faberge": [
+    "light",
+    "blog",
+    "luxury",
+    "jeweled",
+    "ornate"
+  ],
+  "faq": [
+    "light",
+    "docs",
+    "faq"
+  ],
+  "fascicle": [
+    "book",
+    "light",
+    "serial",
+    "unbound",
+    "installment"
+  ],
+  "fault-siren": [
+    "event",
+    "dark",
+    "warning",
+    "preparedness",
+    "civil-defense"
+  ],
+  "fauvist-wild": [
+    "dark",
+    "blog",
+    "fauvist",
+    "colorful"
+  ],
+  "ferrofluid": [
+    "dark",
+    "blog",
+    "ferrofluid",
+    "magnetic"
+  ],
+  "festival": [
+    "dark",
+    "event",
+    "elegant",
+    "glow",
+    "bold"
+  ],
+  "festival-ground": [
+    "event",
+    "festival",
+    "outdoor",
+    "grounds",
+    "map"
+  ],
+  "field-report": [
+    "paper",
+    "dark",
+    "field",
+    "expedition",
+    "rugged"
+  ],
+  "fiesta": [
+    "light",
+    "blog",
+    "colorful",
+    "celebration"
+  ],
+  "filigree": [
+    "dark",
+    "blog",
+    "filigree",
+    "metalwork"
+  ],
+  "fintech-pulse": [
+    "landing",
+    "dark",
+    "fintech",
+    "data-viz"
+  ],
+  "fireside": [
+    "dark",
+    "blog",
+    "book-review"
+  ],
+  "fireworks": [
+    "dark",
+    "elegant",
+    "animation",
+    "glow"
+  ],
+  "firing-range": [
+    "event",
+    "dark",
+    "precision",
+    "target",
+    "competitive"
+  ],
+  "fjord": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "flamingo": [
+    "light",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "flong-press": [
+    "book",
+    "dark",
+    "industrial",
+    "reversed",
+    "typography"
+  ],
+  "flowsync": [
+    "dark",
+    "landing"
+  ],
+  "fluorescent": [
+    "dark",
+    "blog",
+    "neon",
+    "pop-art"
+  ],
+  "folio": [
+    "light",
+    "portfolio"
+  ],
+  "folio-docs": [
+    "light",
+    "docs",
+    "design-system"
+  ],
+  "folio-gigante": [
+    "book",
+    "dark",
+    "oversized",
+    "monumental",
+    "maximal"
+  ],
+  "forge": [
+    "light",
+    "docs",
+    "opensource"
+  ],
+  "formulary": [
+    "light",
+    "docs",
+    "math"
+  ],
+  "forty": [
+    "dark",
+    "portfolio",
+    "gallery"
+  ],
+  "foundry": [
+    "dark",
+    "blog",
+    "maker"
+  ],
+  "foxhole": [
+    "dark",
+    "blog",
+    "security"
+  ],
+  "fractal": [
+    "dark",
+    "gallery",
+    "generative",
+    "mathematical"
+  ],
+  "frequency": [
+    "dark",
+    "blog",
+    "radio"
+  ],
+  "frottage": [
+    "light",
+    "minimal",
+    "art",
+    "clean"
+  ],
+  "frutiger-aero": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "furnace": [
+    "dark",
+    "docs",
+    "performance"
+  ],
+  "gala": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "garden": [
+    "light",
+    "blog",
+    "garden"
+  ],
+  "garnet": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "garrison": [
+    "dark",
+    "docs",
+    "firewall"
+  ],
+  "gateway": [
+    "dark",
+    "docs",
+    "auth"
+  ],
+  "gauntlet-run": [
+    "event",
+    "dark",
+    "endurance",
+    "challenge",
+    "sequential"
+  ],
+  "gazebo": [
+    "light",
+    "blog",
+    "event"
+  ],
+  "gazette": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "generative-art": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "glamorous"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
+  ],
+  "geodesic": [
+    "light",
+    "landing",
+    "geometric"
+  ],
+  "gilded": [
+    "dark",
+    "blog",
+    "luxury",
+    "gold"
+  ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
+  ],
+  "glacial-blog": [
+    "blog",
+    "light",
+    "cool",
+    "minimal"
+  ],
+  "glacial-ice": [
+    "dark",
+    "blog",
+    "ice",
+    "frost"
+  ],
+  "glacier": [
+    "light",
+    "blog",
+    "tech"
+  ],
+  "glam-rock": [
+    "dark",
+    "blog",
+    "rock",
+    "glam",
+    "metallic"
+  ],
+  "glassmorphism": [
+    "dark",
+    "blog",
+    "glassmorphism"
+  ],
+  "glitch": [
+    "dark",
+    "blog",
+    "experimental",
+    "glitch-art"
+  ],
+  "glitch-elegance": [
+    "dark",
+    "blog",
+    "glitch",
+    "elegant"
+  ],
+  "glow-reef": [
+    "dark",
+    "blog",
+    "elegant",
+    "neon"
+  ],
+  "glyphic": [
+    "dark",
+    "blog",
+    "glyph",
+    "carved"
+  ],
+  "gong-show": [
+    "event",
+    "dark",
+    "competition",
+    "judgment",
+    "dramatic"
+  ],
+  "gossamer": [
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "gothic": [
+    "dark",
+    "blog",
+    "gothic",
+    "medieval"
+  ],
+  "gradient-mesh": [
+    "dark",
+    "blog",
+    "gradient"
+  ],
+  "graffiti": [
+    "dark",
+    "blog",
+    "street-art",
+    "urban"
+  ],
+  "grand-finale": [
+    "event",
+    "festival",
+    "finale",
+    "closing",
+    "spectacular"
+  ],
+  "grant-proposal": [
+    "paper",
+    "light",
+    "proposal",
+    "funding",
+    "persuasive"
+  ],
+  "graphite-docs": [
+    "docs",
+    "dark",
+    "technical"
+  ],
+  "greenhouse": [
+    "light",
+    "blog",
+    "plant"
+  ],
+  "grisaille": [
+    "dark",
+    "blog",
+    "minimal",
+    "monochrome"
+  ],
+  "ground-zero": [
+    "event",
+    "dark",
+    "origin",
+    "impact",
+    "transformative"
+  ],
+  "guidebook": [
+    "light",
+    "docs",
+    "guide"
+  ],
+  "gunmetal": [
+    "dark",
+    "elegant",
+    "industrial",
+    "metallic"
+  ],
+  "gyroscope": [
+    "dark",
+    "dashboard",
+    "motion-sensor",
+    "3d-rotation"
+  ],
+  "habitat": [
+    "light",
+    "landing",
+    "listing"
+  ],
+  "hacker": [
+    "dark",
+    "blog"
+  ],
+  "hall-of-voices": [
+    "event",
+    "poetry",
+    "spoken-word",
+    "slam",
+    "voices"
+  ],
+  "hammer-drop": [
+    "event",
+    "light",
+    "auction",
+    "bidding",
+    "final"
+  ],
+  "hammock": [
+    "light",
+    "blog",
+    "slowlife"
+  ],
+  "handbook": [
+    "light",
+    "docs",
+    "corporate"
+  ],
+  "hangar": [
+    "dark",
+    "blog",
+    "aviation"
+  ],
+  "hardcore-pit": [
+    "event",
+    "punk",
+    "hardcore",
+    "show",
+    "chaotic"
+  ],
+  "haute-couture": [
+    "elegant",
+    "fashion",
+    "magazine"
+  ],
+  "headliner-bold": [
+    "event",
+    "festival",
+    "lineup",
+    "headliner",
+    "hierarchy"
+  ],
+  "hearth": [
+    "light",
+    "blog",
+    "traditional",
+    "elegant"
+  ],
+  "heavy-curtain": [
+    "event",
+    "theater",
+    "drama",
+    "production",
+    "heavy"
+  ],
+  "heliograph": [
+    "dark",
+    "blog",
+    "heliograph",
+    "sun-print"
+  ],
+  "helix": [
+    "light",
+    "landing",
+    "biotech",
+    "3d"
+  ],
+  "helix-docs": [
+    "docs",
+    "light",
+    "science"
+  ],
+  "herald": [
+    "light",
+    "magazine",
+    "editorial",
+    "news"
+  ],
+  "hermit": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "hibiscus": [
+    "dark",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "hologram": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "holographic": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "horizon-ai": [
+    "landing",
+    "dark",
+    "ai",
+    "futuristic"
+  ],
+  "house-lights": [
+    "event",
+    "venue",
+    "concert",
+    "lighting",
+    "technical"
+  ],
+  "hwaro.386": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "hwaronight": [
+    "dark",
+    "blog"
+  ],
+  "hypercube": [
+    "dark",
+    "docs",
+    "3d",
+    "wireframe"
+  ],
+  "hyperpop": [
+    "dark",
+    "glamorous",
+    "neon",
+    "trendy",
+    "elegant"
+  ],
+  "igloo": [
+    "light",
+    "blog",
+    "nordic"
+  ],
+  "ignite": [
+    "landing",
+    "dark",
+    "startup"
+  ],
+  "ignition-sequence": [
+    "event",
+    "dark",
+    "phased",
+    "launch",
+    "sequential"
+  ],
+  "impasto": [
+    "light",
+    "blog",
+    "bold",
+    "artistic"
+  ],
+  "incunabula-noir": [
+    "book",
+    "dark",
+    "incunabulum",
+    "early-print",
+    "revolutionary"
+  ],
+  "inferno": [
+    "dark",
+    "community",
+    "fire",
+    "gaming"
+  ],
+  "infographic": [
+    "light",
+    "landing",
+    "infographic",
+    "data-viz"
+  ],
+  "ink-seoul": [
+    "light",
+    "blog",
+    "monochrome",
+    "seoul",
+    "minimal"
+  ],
+  "inkdrop-docs": [
+    "docs",
+    "dark",
+    "elegant",
+    "animation"
+  ],
+  "inkwell": [
+    "light",
+    "blog",
+    "poetry"
+  ],
+  "intaglio": [
+    "dark",
+    "portfolio",
+    "engraving",
+    "minimal"
+  ],
+  "intarsia": [
+    "light",
+    "portfolio",
+    "bold",
+    "clean",
+    "geometric"
+  ],
+  "interferogram": [
+    "dark",
+    "blog",
+    "interference",
+    "optical"
+  ],
+  "inventory": [
+    "light",
+    "dashboard",
+    "management"
+  ],
+  "iridescent-oil": [
+    "dark",
+    "blog",
+    "iridescent",
+    "oil"
+  ],
+  "iron-stage": [
+    "event",
+    "festival",
+    "metal",
+    "industrial",
+    "heavy"
+  ],
+  "ironclad": [
+    "dark",
+    "landing",
+    "metallic",
+    "security"
+  ],
+  "ironworks": [
+    "dark",
+    "blog",
+    "history"
+  ],
+  "isometric": [
+    "light",
+    "3d",
+    "dashboard",
+    "ui"
+  ],
+  "isthmus": [
+    "light",
+    "hub",
+    "bridge",
+    "horizontal-scroll"
+  ],
+  "jade-palace": [
+    "dark",
+    "blog",
+    "luxury",
+    "eastern"
+  ],
+  "japanese-industrial": [
+    "dark",
+    "blog",
+    "japanese",
+    "industrial"
+  ],
+  "jewel-tone": [
+    "dark",
+    "glamorous",
+    "jewel",
+    "elegant"
+  ],
+  "jugendstil": [
+    "light",
+    "blog",
+    "art-nouveau",
+    "organic",
+    "nature"
+  ],
+  "kaleidoscope": [
+    "light",
+    "event",
+    "psychedelic",
+    "pattern"
+  ],
+  "ketubah": [
+    "book",
+    "light",
+    "ceremonial",
+    "decorated",
+    "formal"
+  ],
+  "keynote-blast": [
+    "event",
+    "dark",
+    "conference",
+    "keynote",
+    "explosive"
+  ],
+  "keystone": [
+    "light",
+    "docs",
+    "architecture"
+  ],
+  "kiln": [
+    "light",
+    "portfolio",
+    "craft"
+  ],
+  "kinetic": [
+    "dark",
+    "agency",
+    "physics",
+    "interactive"
+  ],
+  "kinetic-mobile": [
+    "dark",
+    "blog",
+    "kinetic",
+    "mobile"
+  ],
+  "kinetic-typography": [
+    "dark",
+    "blog",
+    "kinetic",
+    "typography"
+  ],
+  "kintsugi": [
+    "dark",
+    "blog",
+    "kintsugi",
+    "gold-repair"
+  ],
+  "lab": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
+  ],
+  "labyrinth": [
+    "dark",
+    "portfolio",
+    "maze",
+    "gamification"
+  ],
+  "lagoon": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "laser-show": [
+    "dark",
+    "blog",
+    "landing",
+    "concert",
+    "glamorous"
+  ],
+  "last-call": [
+    "event",
+    "dark",
+    "closing",
+    "final",
+    "urgent"
+  ],
+  "lattice": [
+    "light",
+    "docs",
+    "graph-db"
+  ],
+  "launchpad": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "launchpad-event": [
+    "event",
+    "dark",
+    "launch",
+    "space",
+    "countdown"
+  ],
+  "lava-flow": [
+    "dark",
+    "blog",
+    "lava",
+    "volcanic"
+  ],
+  "layered-docs": [
+    "light",
+    "docs",
+    "enterprise"
+  ],
+  "ledger": [
+    "light",
+    "docs",
+    "finance"
+  ],
+  "letter-to-editor": [
+    "paper",
+    "light",
+    "correspondence",
+    "urgent",
+    "brief"
+  ],
+  "letterbox": [
+    "light",
+    "blog",
+    "newsletter"
+  ],
+  "lexicon": [
+    "light",
+    "docs",
+    "glossary"
+  ],
+  "lichen-moss": [
+    "dark",
+    "blog",
+    "lichen",
+    "organic"
+  ],
+  "lighthouse": [
+    "light",
+    "docs",
+    "directory"
+  ],
+  "linktree": [
+    "dark",
+    "landing",
+    "links"
+  ],
+  "linocut": [
+    "light",
+    "printmaking",
+    "bold",
+    "creative"
+  ],
+  "liquid": [
+    "dark",
+    "interactive",
+    "gooey",
+    "svg"
+  ],
+  "liquid-chrome": [
+    "dark",
+    "blog",
+    "metallic",
+    "glamorous"
+  ],
+  "lithium": [
+    "dark",
+    "landing",
+    "electric",
+    "tech"
+  ],
+  "lithograph": [
+    "dark",
+    "blog",
+    "lithograph",
+    "printmaking"
+  ],
+  "logbook": [
+    "light",
+    "docs",
+    "compliance"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
+  ],
+  "lookbook": [
+    "dark",
+    "portfolio",
+    "lookbook",
+    "fashion"
+  ],
+  "loom": [
+    "light",
+    "portfolio",
+    "fashion"
+  ],
+  "lumiere": [
+    "dark",
+    "elegant",
+    "minimal",
+    "luminescent"
+  ],
+  "lumina": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "luminary": [
+    "light",
+    "elegant",
+    "portfolio"
+  ],
+  "luminescent-mesh": [
+    "dark",
+    "blog",
+    "luminescent",
+    "mesh"
+  ],
+  "lumos": [
+    "blog",
+    "elegant",
+    "light",
+    "minimal"
+  ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
+  "lunar-breeze": [
+    "dark",
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "luxe-noir": [
+    "dark",
+    "glamorous",
+    "luxury",
+    "elegant"
+  ],
+  "luxury-horology": [
+    "dark",
+    "portfolio",
+    "horology",
+    "luxury"
+  ],
+  "macro-snowflake": [
+    "dark",
+    "blog",
+    "snowflake",
+    "crystalline"
+  ],
+  "madhubani": [
+    "light",
+    "blog",
+    "indian",
+    "folk-art",
+    "geometric"
+  ],
+  "magenta-sunset": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "magma": [
+    "dark",
+    "dashboard",
+    "volcanic",
+    "animation"
+  ],
+  "magnetar": [
+    "dark",
+    "blog",
+    "magnetar",
+    "cosmic"
+  ],
+  "main-act": [
+    "event",
+    "concert",
+    "headline",
+    "performer",
+    "dramatic"
+  ],
+  "mainstage": [
+    "event",
+    "dark",
+    "performance",
+    "stage",
+    "dramatic"
+  ],
+  "manifesto": [
+    "dark",
+    "blog",
+    "opinion"
+  ],
+  "manifesto-press": [
+    "book",
+    "dark",
+    "revolutionary",
+    "bold",
+    "political"
+  ],
+  "manifold": [
+    "light",
+    "docs",
+    "saas"
+  ],
+  "marble": [
+    "light",
+    "gallery",
+    "luxury",
+    "marble-texture"
+  ],
+  "marbled-paper": [
+    "dark",
+    "blog",
+    "marbled",
+    "paper"
+  ],
+  "mardi-gras": [
+    "glamorous",
+    "trendy",
+    "bold",
+    "purple",
+    "gold",
+    "green"
+  ],
+  "marketplace": [
+    "light",
+    "store",
+    "marketplace"
+  ],
+  "marquetry": [
+    "light",
+    "portfolio",
+    "geometric",
+    "minimal"
+  ],
+  "masquerade": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "luxury",
+    "mystery"
+  ],
+  "matcha": [
+    "blog",
+    "light",
+    "minimal",
+    "zen"
+  ],
+  "matrix": [
+    "light",
+    "docs",
+    "compatibility"
+  ],
+  "maximal-bloom": [
+    "elegant",
+    "floral",
+    "bold",
+    "glamorous"
+  ],
+  "maximalist": [
+    "dark",
+    "blog",
+    "bold",
+    "glamorous"
+  ],
+  "mayan-geometry": [
+    "dark",
+    "blog",
+    "mayan",
+    "geometric"
+  ],
+  "meadow": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "medieval-manuscript": [
+    "dark",
+    "blog",
+    "medieval",
+    "manuscript"
+  ],
+  "memoir": [
+    "light",
+    "blog",
+    "longform"
+  ],
+  "memphis": [
+    "light",
+    "retro",
+    "colorful",
+    "bold",
+    "portfolio"
+  ],
+  "mercury": [
+    "dark",
+    "blog",
+    "minimal",
+    "metallic",
+    "elegant"
+  ],
+  "meridian": [
+    "dark",
+    "landing",
+    "timezone"
+  ],
+  "meridian-docs": [
+    "light",
+    "docs",
+    "scheduling"
+  ],
+  "meridiem": [
+    "dual",
+    "dashboard",
+    "time-based",
+    "auto-theme"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
+  ],
+  "meteor": [
+    "dark",
+    "interactive",
+    "meteor-shower",
+    "cosmic"
+  ],
+  "methods-paper": [
+    "paper",
+    "light",
+    "methods",
+    "protocol",
+    "technical"
+  ],
+  "metronome": [
+    "dark",
+    "blog",
+    "music-production",
+    "rhythm"
+  ],
+  "mezzotint": [
+    "light",
+    "blog",
+    "bold",
+    "clean",
+    "monochrome"
+  ],
+  "micro": [
+    "light",
+    "blog",
+    "microblog"
+  ],
+  "midnight-blog": [
+    "dark",
+    "blog",
+    "reading"
+  ],
+  "midnight-launch": [
+    "landing",
+    "dark",
+    "animation",
+    "product"
+  ],
+  "migration": [
+    "light",
+    "docs",
+    "database"
+  ],
+  "minifolio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "minimalzen": [
+    "light",
+    "blog",
+    "minimal",
+    "zen"
+  ],
+  "mint-fresh": [
+    "landing",
+    "light",
+    "saas"
+  ],
+  "mirage": [
+    "light",
+    "gallery",
+    "desert",
+    "distortion"
+  ],
+  "misprint": [
+    "book",
+    "dark",
+    "error",
+    "accidental",
+    "artistic"
+  ],
+  "mixed-methods": [
+    "paper",
+    "light",
+    "mixed-methods",
+    "convergent",
+    "dual"
+  ],
+  "modern-blog": [
+    "dark",
+    "blog",
+    "modern"
+  ],
+  "molten": [
+    "dark",
+    "blog",
+    "metalwork",
+    "melting"
+  ],
+  "molten-gold": [
+    "elegant",
+    "gold",
+    "trendy"
+  ],
+  "monochrome": [
+    "light",
+    "photo-essay",
+    "monochrome",
+    "grayscale"
+  ],
+  "monograph": [
+    "book",
+    "light",
+    "academic",
+    "thorough",
+    "reference"
+  ],
+  "monolith": [
+    "dark",
+    "landing",
+    "onepage"
+  ],
+  "monolithic-dark": [
+    "dark",
+    "blog",
+    "monolithic",
+    "bold"
+  ],
+  "monoprint": [
+    "light",
+    "monoprint",
+    "bold",
+    "creative"
+  ],
+  "monorepo-docs": [
+    "docs",
+    "dark",
+    "developer",
+    "monorepo"
+  ],
+  "moonrise": [
+    "dark",
+    "blog",
+    "essay"
+  ],
+  "moonstone": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "moroccan-zellige": [
+    "light",
+    "blog",
+    "moroccan",
+    "mosaic",
+    "geometric"
+  ],
+  "morphogenesis": [
+    "dark",
+    "blog",
+    "generative",
+    "biology",
+    "patterns"
+  ],
+  "mortar": [
+    "dark",
+    "docs",
+    "build-system"
+  ],
+  "mosaic": [
+    "light",
+    "blog",
+    "magazine"
+  ],
+  "mosh-pit": [
+    "event",
+    "dark",
+    "punk",
+    "chaotic",
+    "raw"
+  ],
+  "mosstown": [
+    "light",
+    "blog",
+    "cozy"
+  ],
+  "mughal": [
+    "light",
+    "blog",
+    "mughal",
+    "ornate",
+    "gold"
+  ],
+  "murano-glass": [
+    "light",
+    "blog",
+    "glass",
+    "translucent",
+    "venetian"
+  ],
+  "mycelium": [
+    "dark",
+    "blog",
+    "mycelium",
+    "fungal"
+  ],
+  "nadir": [
+    "dark",
+    "blog",
+    "minimal",
+    "oled-black"
+  ],
+  "nautical": [
+    "dark",
+    "blog",
+    "nautical"
+  ],
+  "nebula": [
+    "dark",
+    "gallery",
+    "space",
+    "ethereal"
+  ],
+  "neo-deco": [
+    "dark",
+    "portfolio",
+    "artdeco",
+    "elegant"
+  ],
+  "neo-memphis-dark": [
+    "dark",
+    "blog",
+    "memphis",
+    "neo-memphis"
+  ],
+  "neobrutal": [
+    "light",
+    "landing",
+    "neo-brutalism",
+    "bold"
+  ],
+  "neoclassical": [
+    "light",
+    "gallery",
+    "marble-texture",
+    "elegant"
+  ],
+  "neon": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "neon-jungle": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "neon"
+  ],
+  "neon-marquee": [
+    "event",
+    "theater",
+    "marquee",
+    "vintage",
+    "retro"
+  ],
+  "neon-tokyo": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "tokyo",
+    "glamorous"
+  ],
+  "network-meta": [
+    "paper",
+    "dark",
+    "network",
+    "meta-analysis",
+    "comparative"
+  ],
+  "neumorphism": [
+    "light",
+    "ui",
+    "soft",
+    "shadow"
+  ],
+  "neural-bloom": [
+    "dark",
+    "blog",
+    "neural",
+    "ai",
+    "synaptic"
+  ],
+  "newspaper": [
+    "light",
+    "blog",
+    "editorial",
+    "newspaper"
+  ],
+  "nexus": [
+    "dark",
+    "docs",
+    "microservice"
+  ],
+  "nexus-docs": [
+    "docs",
+    "dark",
+    "developer"
+  ],
+  "niello": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "no-style-please": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "noctis": [
+    "landing",
+    "dark",
+    "glassmorphism",
+    "neon"
+  ],
+  "nocturne": [
+    "dark",
+    "blog",
+    "classical-music",
+    "piano"
+  ],
+  "noir": [
+    "dark",
+    "blog",
+    "noir"
+  ],
+  "northern-lights": [
+    "dark",
+    "blog",
+    "aurora",
+    "arctic",
+    "atmospheric"
+  ],
+  "notebook": [
+    "light",
+    "blog",
+    "journal"
+  ],
+  "null-result": [
+    "paper",
+    "light",
+    "null",
+    "negative",
+    "honest"
+  ],
+  "oasis": [
+    "light",
+    "blog",
+    "relaxation"
+  ],
+  "obelisk": [
+    "light",
+    "one-page",
+    "monumental",
+    "vertical"
+  ],
+  "oblique": [
+    "light",
+    "blog",
+    "bold",
+    "angular"
+  ],
+  "oblong-quarto": [
+    "book",
+    "light",
+    "landscape",
+    "panoramic",
+    "unusual"
+  ],
+  "observatory": [
+    "dark",
+    "blog",
+    "space"
+  ],
+  "obsidian": [
+    "dark",
+    "wiki",
+    "glass",
+    "oled"
+  ],
+  "obsidian-docs": [
+    "docs",
+    "dark",
+    "wiki",
+    "knowledge"
+  ],
+  "obsidian-mirror": [
+    "dark",
+    "blog",
+    "obsidian",
+    "reflective"
+  ],
+  "old-map-cartography": [
+    "dark",
+    "blog",
+    "cartography",
+    "vintage"
+  ],
+  "onyx": [
+    "landing",
+    "dark",
+    "minimal",
+    "luxury"
+  ],
+  "op-art": [
+    "dark",
+    "blog",
+    "geometric",
+    "optical-illusion"
+  ],
+  "opalescent": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "opening-act": [
+    "event",
+    "opening",
+    "season",
+    "premiere",
+    "fresh"
+  ],
+  "opening-night": [
+    "event",
+    "dark",
+    "premiere",
+    "formal",
+    "electric"
+  ],
+  "opulent": [
+    "light",
+    "elegant",
+    "luxury",
+    "portfolio",
+    "bold"
+  ],
+  "orchard": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "orchid": [
+    "dark",
+    "blog",
+    "glamorous",
+    "botanical"
+  ],
+  "origami": [
+    "light",
+    "blog",
+    "material"
+  ],
+  "oscilloscope": [
+    "dark",
+    "blog",
+    "oscilloscope",
+    "retro"
+  ],
+  "overture": [
+    "event",
+    "dark",
+    "opening",
+    "orchestral",
+    "grand"
+  ],
+  "oxidation": [
+    "dark",
+    "blog",
+    "oxidation",
+    "rust"
+  ],
+  "oxide": [
+    "dark",
+    "gallery",
+    "industrial",
+    "rust-texture"
+  ],
+  "pagoda": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "palette": [
+    "light",
+    "docs",
+    "design"
+  ],
+  "palimpsest-noir": [
+    "book",
+    "dark",
+    "layered",
+    "erased",
+    "ghostly"
+  ],
+  "panopticon": [
+    "dark",
+    "brutalist",
+    "radial",
+    "experimental"
+  ],
+  "pantry": [
+    "light",
+    "docs",
+    "package-manager"
+  ],
+  "paper": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "paper-art": [
+    "light",
+    "blog",
+    "paper",
+    "collage"
+  ],
+  "papermod": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "parallax": [
+    "light",
+    "storytelling",
+    "parallax",
+    "cinematic"
+  ],
+  "parallax-heavy": [
+    "dark",
+    "landing",
+    "gallery",
+    "parallax"
+  ],
+  "parchment": [
+    "light",
+    "docs",
+    "fantasy"
+  ],
+  "parquetry": [
+    "dark",
+    "blog",
+    "parquetry",
+    "woodwork"
+  ],
+  "particle-storm": [
+    "dark",
+    "blog",
+    "neon",
+    "particles",
+    "energy"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
+  ],
+  "patina": [
+    "dark",
+    "blog",
+    "minimal",
+    "craft"
+  ],
+  "peacock": [
+    "elegant",
+    "glamorous",
+    "portfolio"
+  ],
+  "pearlescent": [
+    "light",
+    "blog",
+    "iridescent",
+    "luxury",
+    "soft"
+  ],
+  "peer-review": [
+    "paper",
+    "light",
+    "academic",
+    "review",
+    "transparent"
+  ],
+  "pendulum": [
+    "dark",
+    "blog",
+    "productivity"
+  ],
+  "pentimento": [
+    "light",
+    "portfolio",
+    "elegant",
+    "bold",
+    "clean"
+  ],
+  "permafrost": [
+    "light",
+    "archive",
+    "ice",
+    "frozen"
+  ],
+  "persian-carpet": [
+    "light",
+    "blog",
+    "persian",
+    "carpet",
+    "ornate"
+  ],
+  "perspective-piece": [
+    "paper",
+    "dark",
+    "opinion",
+    "viewpoint",
+    "argumentative"
+  ],
+  "petrified-wood": [
+    "dark",
+    "blog",
+    "fossil",
+    "wood"
+  ],
+  "phantom": [
+    "dark",
+    "blog",
+    "ghost",
+    "translucent"
+  ],
+  "phosphor": [
+    "dark",
+    "gallery",
+    "bioluminescence",
+    "glow"
+  ],
+  "photoblog": [
+    "dark",
+    "blog",
+    "photography",
+    "gallery"
+  ],
+  "photon": [
+    "dark",
+    "elegant",
+    "luminescent",
+    "portfolio"
+  ],
+  "pietra-dura": [
+    "dark",
+    "creative",
+    "bold",
+    "stone"
+  ],
+  "pinecone": [
+    "dark",
+    "blog",
+    "nature"
+  ],
+  "pipeline": [
+    "light",
+    "docs",
+    "cicd"
+  ],
+  "pit-stop": [
+    "event",
+    "dark",
+    "motorsport",
+    "speed",
+    "frantic"
+  ],
+  "pixel": [
+    "dark",
+    "blog",
+    "gaming"
+  ],
+  "plasma": [
+    "dark",
+    "science",
+    "plasma",
+    "visualization"
+  ],
+  "platinum": [
+    "light",
+    "minimal",
+    "luxury",
+    "portfolio"
+  ],
+  "playlist": [
+    "dark",
+    "blog",
+    "music"
+  ],
+  "podcast-fm": [
+    "dark",
+    "media",
+    "podcast"
+  ],
+  "podium-rush": [
+    "event",
+    "competition",
+    "awards",
+    "victory",
+    "podium"
+  ],
+  "pointillism": [
+    "dark",
+    "blog",
+    "pointillism",
+    "dots"
+  ],
+  "poison": [
+    "dark",
+    "blog",
+    "sidebar"
+  ],
+  "polaris": [
+    "dark",
+    "guide",
+    "astronomy",
+    "constellation"
+  ],
+  "polaroid": [
+    "light",
+    "blog",
+    "gallery"
+  ],
+  "pop-surreal": [
+    "dark",
+    "glamorous",
+    "elegant",
+    "surreal",
+    "trendy"
+  ],
+  "pop-up-page": [
+    "book",
+    "light",
+    "dimensional",
+    "paper-engineering",
+    "interactive"
+  ],
+  "portfolio-blog": [
+    "dark",
+    "blog",
+    "portfolio"
+  ],
+  "portico": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
+  ],
+  "postcard": [
+    "light",
+    "blog",
+    "postcard"
+  ],
+  "powder-burn": [
+    "event",
+    "dark",
+    "rapid-fire",
+    "flash",
+    "quick"
+  ],
+  "prairie": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "preprint-rush": [
+    "paper",
+    "light",
+    "preprint",
+    "urgent",
+    "draft"
+  ],
+  "pressure-cooker": [
+    "event",
+    "dark",
+    "hackathon",
+    "pressure",
+    "deadline"
+  ],
+  "pricetable": [
+    "light",
+    "landing",
+    "saas",
+    "pricing"
+  ],
+  "primer": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "printer-devil": [
+    "book",
+    "dark",
+    "error",
+    "playful",
+    "craft"
+  ],
+  "prism": [
+    "dark",
+    "docs",
+    "data"
+  ],
+  "prism-docs": [
+    "docs",
+    "light",
+    "colorful"
+  ],
+  "prism-refraction": [
+    "dark",
+    "blog",
+    "prism",
+    "refraction"
+  ],
+  "prismify": [
+    "glassmorphism",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "proof-sheet": [
+    "book",
+    "light",
+    "proof",
+    "unfinished",
+    "editorial"
+  ],
+  "protocol": [
+    "dark",
+    "docs",
+    "networking"
+  ],
+  "protocol-paper": [
+    "paper",
+    "light",
+    "protocol",
+    "pre-registration",
+    "rigorous"
+  ],
+  "psychedelic": [
+    "dark",
+    "minimal",
+    "elegant",
+    "glamorous"
+  ],
+  "pulp-fiction": [
+    "book",
+    "dark",
+    "pulp",
+    "lurid",
+    "cheap"
+  ],
+  "pulsar": [
+    "dark",
+    "blog",
+    "cosmic",
+    "pulse-animation"
+  ],
+  "pulse-api": [
+    "dark",
+    "docs"
+  ],
+  "pyrite": [
+    "dark",
+    "showcase",
+    "metallic",
+    "luxury"
+  ],
+  "pyrotechnic": [
+    "event",
+    "show",
+    "pyrotechnics",
+    "fireworks",
+    "explosive"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
+  ],
+  "quantum": [
+    "dark",
+    "blog",
+    "quantum",
+    "science"
+  ],
+  "quarry": [
+    "dark",
+    "docs",
+    "data-warehouse"
+  ],
+  "quasar": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
+  "radiolaria": [
+    "dark",
+    "blog",
+    "radiolaria",
+    "skeletal"
+  ],
+  "rainbow-cascade": [
+    "elegant",
+    "glowing",
+    "box-shadow"
+  ],
+  "ramble": [
+    "light",
+    "blog",
+    "hiking"
+  ],
+  "randomized-trial": [
+    "paper",
+    "light",
+    "rct",
+    "clinical-trial",
+    "rigorous"
+  ],
+  "rave": [
+    "dark",
+    "blog",
+    "acid",
+    "rave",
+    "neon"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
+  ],
+  "reactor": [
+    "dark",
+    "docs",
+    "reactive"
+  ],
+  "realty": [
+    "light",
+    "realestate",
+    "luxury",
+    "elegant"
+  ],
+  "recipe": [
+    "light",
+    "blog",
+    "recipe"
+  ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
+  ],
+  "red-carpet": [
+    "event",
+    "premiere",
+    "celebrity",
+    "glamour",
+    "fashion"
+  ],
+  "reef": [
+    "dark",
+    "blog",
+    "diving"
+  ],
+  "relay": [
+    "light",
+    "docs",
+    "integration"
+  ],
+  "remainder-bin": [
+    "book",
+    "light",
+    "secondhand",
+    "discount",
+    "worn"
+  ],
+  "remedy": [
+    "light",
+    "docs",
+    "troubleshooting"
+  ],
+  "renaissance": [
+    "light",
+    "art",
+    "classic",
+    "serif",
+    "elegant"
+  ],
+  "repousse": [
+    "dark",
+    "blog",
+    "repousse",
+    "metalwork"
+  ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
+  ],
+  "resume": [
+    "light",
+    "resume"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
+  ],
+  "retro-radar": [
+    "dark",
+    "blog",
+    "radar",
+    "retro"
+  ],
+  "retromac": [
+    "light",
+    "mac",
+    "os9",
+    "retro",
+    "system"
+  ],
+  "retrowave": [
+    "dark",
+    "blog",
+    "retro",
+    "synthwave"
+  ],
+  "reveille": [
+    "event",
+    "dark",
+    "military",
+    "assembly",
+    "urgent"
+  ],
+  "review-article": [
+    "paper",
+    "light",
+    "review",
+    "literature",
+    "synthesis"
+  ],
+  "ridgeline": [
+    "dark",
+    "blog",
+    "outdoor"
+  ],
+  "riftzone": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "dimensional"
+  ],
+  "ring-bell": [
+    "event",
+    "dark",
+    "boxing",
+    "fight",
+    "intense"
+  ],
+  "riverbank": [
+    "light",
+    "blog",
+    "nature-journal"
+  ],
+  "rococo": [
+    "light",
+    "blog",
+    "pastel",
+    "elegant"
+  ],
+  "roll-call": [
+    "event",
+    "light",
+    "assembly",
+    "formal",
+    "attendance"
+  ],
+  "roll-scroll": [
+    "book",
+    "light",
+    "scroll",
+    "continuous",
+    "ancient"
+  ],
+  "rooftop": [
+    "dark",
+    "blog",
+    "urban"
+  ],
+  "rose-gold": [
+    "elegant",
+    "luxury",
+    "minimal"
+  ],
+  "rosemary": [
+    "light",
+    "blog",
+    "cooking"
+  ],
+  "rosetta": [
+    "light",
+    "docs",
+    "i18n"
+  ],
+  "rosewood": [
+    "blog",
+    "dark",
+    "warm",
+    "classic"
+  ],
+  "rubric": [
+    "book",
+    "light",
+    "rubricated",
+    "two-color",
+    "traditional"
+  ],
+  "ruby-fire": [
+    "dark",
+    "blog",
+    "bold"
+  ],
+  "runbook": [
+    "light",
+    "docs",
+    "operations"
+  ],
+  "rune": [
+    "dark",
+    "archive",
+    "viking",
+    "mystic"
+  ],
+  "saffron": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "sage-guide": [
+    "docs",
+    "light",
+    "tutorial",
+    "guide"
+  ],
+  "sakura-storm": [
+    "dark",
+    "blog",
+    "glamorous",
+    "sakura"
+  ],
+  "sandcastle": [
+    "light",
+    "blog",
+    "sand",
+    "beach"
+  ],
+  "sandstone": [
+    "light",
+    "blog",
+    "architecture"
+  ],
+  "sandstorm": [
+    "dark",
+    "blog",
+    "desert",
+    "particles"
+  ],
+  "sapphire": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "savanna": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "sawmill": [
+    "light",
+    "blog",
+    "woodworking"
+  ],
+  "scaffold": [
+    "dark",
+    "landing",
+    "comingsoon"
+  ],
+  "scaffold-docs": [
+    "dark",
+    "docs",
+    "scaffolding"
+  ],
+  "schematic": [
+    "light",
+    "docs",
+    "hardware"
+  ],
+  "scientific-journal": [
+    "dark",
+    "docs",
+    "scientific",
+    "academic"
+  ],
+  "scoping-review": [
+    "paper",
+    "light",
+    "scoping",
+    "mapping",
+    "landscape"
+  ],
+  "scrimshaw": [
+    "bold",
+    "elegant",
+    "clean",
+    "blog"
+  ],
+  "sentinel": [
+    "dark",
+    "docs",
+    "monitoring"
+  ],
+  "seraph": [
+    "minimal",
+    "elegant",
+    "portfolio"
+  ],
+  "serenity": [
+    "light",
+    "blog",
+    "elegant"
+  ],
+  "sextant": [
+    "light",
+    "docs",
+    "metrics"
+  ],
+  "sfumato": [
+    "dark",
+    "blog",
+    "atmospheric",
+    "minimal"
+  ],
+  "sgraffito": [
+    "dark",
+    "blog",
+    "sgraffito",
+    "scratched"
+  ],
+  "shutout": [
+    "event",
+    "dark",
+    "competition",
+    "dominant",
+    "perfect"
+  ],
+  "silhouette": [
+    "dark",
+    "landing",
+    "silhouette",
+    "dramatic"
+  ],
+  "silk-road": [
+    "elegant",
+    "glamorous",
+    "silk",
+    "cultural"
+  ],
+  "simulation-paper": [
+    "paper",
+    "dark",
+    "computational",
+    "simulation",
+    "model"
+  ],
+  "sketch": [
+    "light",
+    "blog",
+    "handdrawn"
+  ],
+  "skeuomorphic": [
+    "light",
+    "blog",
+    "skeuomorphic",
+    "realistic"
+  ],
+  "slide": [
+    "dark",
+    "docs",
+    "presentation"
+  ],
+  "snowfall": [
+    "light",
+    "blog",
+    "winter"
+  ],
+  "solar-punk": [
+    "light",
+    "blog",
+    "solarpunk",
+    "sustainable"
+  ],
+  "solarflare": [
+    "dark",
+    "landing",
+    "solar",
+    "energy"
+  ],
+  "solaris": [
+    "dark",
+    "dashboard",
+    "solar-system",
+    "space-mission"
+  ],
+  "solarium": [
+    "blog",
+    "light",
+    "warm"
+  ],
+  "solstice": [
+    "dual",
+    "blog",
+    "seasonal",
+    "time-based"
+  ],
+  "sonar": [
+    "dark",
+    "hub",
+    "radar",
+    "discovery"
+  ],
+  "spectra": [
+    "dark",
+    "data-science",
+    "spectrum",
+    "rainbow"
+  ],
+  "spectrum": [
+    "light",
+    "blog",
+    "a11y"
+  ],
+  "spectrum-docs": [
+    "light",
+    "docs",
+    "accessibility"
+  ],
+  "spire": [
+    "dark",
+    "blog",
+    "architecture"
+  ],
+  "split-tone": [
+    "light",
+    "blog",
+    "photography",
+    "cinematic",
+    "toning"
+  ],
+  "stained-glass": [
+    "light",
+    "blog",
+    "cathedral",
+    "colorful",
+    "gothic"
+  ],
+  "standing-ovation": [
+    "event",
+    "light",
+    "awards",
+    "acclaim",
+    "celebration"
+  ],
+  "starlight": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "minimal"
+  ],
+  "starting-gun": [
+    "event",
+    "dark",
+    "race",
+    "competition",
+    "explosive"
+  ],
+  "statuspage": [
+    "light",
+    "landing",
+    "status"
+  ],
+  "stellar-launch": [
+    "landing",
+    "dark",
+    "parallax",
+    "animation"
+  ],
+  "stipple": [
+    "light",
+    "artistic",
+    "dot-art",
+    "gallery"
+  ],
+  "storefront": [
+    "light",
+    "landing",
+    "shop"
+  ],
+  "stratum": [
+    "dark",
+    "timeline",
+    "geological",
+    "layered"
+  ],
+  "strobe": [
+    "dark",
+    "event",
+    "club",
+    "strobe"
+  ],
+  "studio": [
+    "dark",
+    "landing",
+    "portfolio"
+  ],
+  "subzero": [
+    "dark",
+    "research",
+    "cryogenic",
+    "frozen"
+  ],
+  "summit": [
+    "dark",
+    "landing",
+    "conference"
+  ],
+  "summit-event": [
+    "conference",
+    "dark",
+    "event",
+    "landing"
+  ],
+  "summit-strike": [
+    "event",
+    "dark",
+    "conference",
+    "summit",
+    "ascending"
+  ],
+  "sunburst": [
+    "light",
+    "blog",
+    "warm",
+    "golden",
+    "radiant"
+  ],
+  "sundew": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "supernova": [
+    "dark",
+    "landing",
+    "cosmic",
+    "particles"
+  ],
+  "supplementary": [
+    "paper",
+    "light",
+    "supplementary",
+    "data-heavy",
+    "exhaustive"
+  ],
+  "supreme-sun": [
+    "light",
+    "blog",
+    "community"
+  ],
+  "survey-instrument": [
+    "paper",
+    "light",
+    "survey",
+    "instrument",
+    "psychometric"
+  ],
+  "synthwave": [
+    "dark",
+    "retro",
+    "glamorous",
+    "trendy"
+  ],
+  "systematic-review": [
+    "paper",
+    "light",
+    "systematic",
+    "evidence",
+    "methodology"
+  ],
+  "tactile-fabric": [
+    "light",
+    "blog",
+    "fabric",
+    "textile"
+  ],
+  "talavera": [
+    "light",
+    "blog",
+    "mexican",
+    "pottery",
+    "colorful"
+  ],
+  "tale": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "tangram": [
+    "light",
+    "portfolio",
+    "puzzle",
+    "geometric"
+  ],
+  "tapestry": [
+    "light",
+    "blog",
+    "timeline"
+  ],
+  "taskboard": [
+    "light",
+    "dashboard",
+    "kanban"
+  ],
+  "tavern": [
+    "dark",
+    "blog",
+    "rpg"
+  ],
+  "techbyte": [
+    "light",
+    "blog",
+    "tech",
+    "card"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
+  ],
+  "tectonic": [
+    "dark",
+    "hub",
+    "geological",
+    "interactive"
+  ],
+  "telegraph": [
+    "light",
+    "blog",
+    "news"
+  ],
+  "tempera": [
+    "dark",
+    "blog",
+    "tempera",
+    "painting"
+  ],
+  "tempest": [
+    "dark",
+    "magazine",
+    "storm",
+    "dramatic"
+  ],
+  "tenebrism": [
+    "dark",
+    "creative",
+    "bold",
+    "clean"
+  ],
+  "terminal": [
+    "dark",
+    "blog"
+  ],
+  "terrace": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "terracotta-studio": [
+    "landing",
+    "light",
+    "creative",
+    "artisan"
+  ],
+  "terracotta-tiles": [
+    "dark",
+    "blog",
+    "terracotta",
+    "tile"
+  ],
+  "terraform": [
+    "dark",
+    "dashboard",
+    "sci-fi",
+    "terraforming"
+  ],
+  "terraform-docs": [
+    "docs",
+    "dark",
+    "infra",
+    "devops"
+  ],
+  "terrarium": [
+    "light",
+    "portfolio",
+    "miniature"
+  ],
+  "terrazzo": [
+    "light",
+    "portfolio",
+    "terrazzo",
+    "speckled"
+  ],
+  "terrazzo-blog": [
+    "blog",
+    "light",
+    "colorful",
+    "memphis"
+  ],
+  "tessellation": [
+    "light",
+    "gallery",
+    "escher",
+    "pattern-art"
+  ],
+  "tesseract": [
+    "dark",
+    "education",
+    "4d",
+    "mathematical"
+  ],
+  "thermal": [
+    "dark",
+    "dashboard",
+    "thermal",
+    "heatmap"
+  ],
+  "thesis": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "thesis-defense": [
+    "paper",
+    "dark",
+    "thesis",
+    "formal",
+    "institutional"
+  ],
+  "thumb-bible": [
+    "book",
+    "light",
+    "miniature",
+    "dense",
+    "craft"
+  ],
+  "thunderdome": [
+    "event",
+    "dark",
+    "arena",
+    "competition",
+    "ultimate"
+  ],
+  "ticker-board": [
+    "event",
+    "dark",
+    "transit",
+    "departure",
+    "mechanical"
+  ],
+  "ticker-tape": [
+    "event",
+    "light",
+    "celebration",
+    "parade",
+    "festive"
+  ],
+  "tidal": [
+    "light",
+    "blog",
+    "ocean",
+    "wellness"
+  ],
+  "timber": [
+    "light",
+    "blog",
+    "craft"
+  ],
+  "titanium": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ],
+  "topaz": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "topographic-gradient": [
+    "dark",
+    "blog",
+    "topographic",
+    "contour"
+  ],
+  "topographic-sand": [
+    "dark",
+    "blog",
+    "topographic",
+    "sand"
+  ],
+  "topography": [
+    "light",
+    "blog",
+    "topographic",
+    "outdoor"
+  ],
+  "torchlight": [
+    "dark",
+    "blog",
+    "adventure"
+  ],
+  "totem": [
+    "dark",
+    "portfolio",
+    "tribal",
+    "vertical-stack"
+  ],
+  "tremor": [
+    "dark",
+    "dashboard",
+    "seismic",
+    "data-viz"
+  ],
+  "trompe-loeil": [
+    "light",
+    "portfolio",
+    "creative",
+    "bold",
+    "illusion"
+  ],
+  "tropical-paradise": [
+    "elegant",
+    "vivid",
+    "botanical"
+  ],
+  "tundra": [
+    "dark",
+    "blog",
+    "expedition"
+  ],
+  "turbine": [
+    "light",
+    "corporate",
+    "energy",
+    "rotation"
+  ],
+  "turret": [
+    "dark",
+    "docs",
+    "waf"
+  ],
+  "twilight": [
+    "dark",
+    "blog",
+    "photo-essay"
+  ],
+  "typeface": [
+    "blog",
+    "light",
+    "typography",
+    "minimal"
+  ],
+  "typewriter": [
+    "light",
+    "blog",
+    "vintage"
+  ],
+  "typhoon": [
+    "dark",
+    "magazine",
+    "storm",
+    "spiral"
+  ],
+  "ukiyo-e": [
+    "light",
+    "blog",
+    "japanese",
+    "woodblock",
+    "traditional"
+  ],
+  "ultraviolet": [
+    "dark",
+    "blog",
+    "ultraviolet",
+    "neon"
+  ],
+  "umbra": [
+    "dark",
+    "portfolio",
+    "monochrome",
+    "shadow"
+  ],
+  "vapor": [
+    "light",
+    "blog",
+    "vaporwave",
+    "surreal"
+  ],
+  "vault": [
+    "dark",
+    "docs",
+    "security"
+  ],
+  "vellum": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "velocity": [
+    "landing",
+    "dark",
+    "saas"
+  ],
+  "velvet": [
+    "dark",
+    "landing",
+    "luxury"
+  ],
+  "velvet-rope": [
+    "event",
+    "gala",
+    "exclusive",
+    "luxury",
+    "velvet"
+  ],
+  "venetian": [
+    "light",
+    "blog",
+    "renaissance",
+    "venetian",
+    "ornate"
+  ],
+  "verdigris": [
+    "dark",
+    "blog",
+    "editorial"
+  ],
+  "versailles": [
+    "dark",
+    "elegant",
+    "classic",
+    "luxury"
+  ],
+  "vertigo": [
+    "dark",
+    "one-page",
+    "experimental",
+    "perspective"
+  ],
+  "vibrant-brutalism": [
+    "dark",
+    "blog",
+    "brutalist",
+    "vibrant"
+  ],
+  "victorian": [
+    "dark",
+    "blog",
+    "gothic",
+    "classic"
+  ],
+  "vineyard": [
+    "dark",
+    "blog",
+    "wine"
+  ],
+  "vintage": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "vintagetv": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "vinyl": [
+    "dark",
+    "blog",
+    "vinyl"
+  ],
+  "voltage": [
+    "dark",
+    "blog",
+    "electric",
+    "sparks"
+  ],
+  "volumetric": [
+    "dark",
+    "blog",
+    "3d",
+    "glow",
+    "atmospheric"
+  ],
+  "vortex": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "animation"
+  ],
+  "wanderlust": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "war-room": [
+    "event",
+    "dark",
+    "strategy",
+    "military",
+    "command"
+  ],
+  "warpzone": [
+    "dark",
+    "portfolio",
+    "warp",
+    "gaming"
+  ],
+  "washi-bound": [
+    "book",
+    "light",
+    "japanese",
+    "stab-binding",
+    "paper"
+  ],
+  "wavelength": [
+    "audio",
+    "dark",
+    "landing",
+    "music"
+  ],
+  "weathervane": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "wedding": [
+    "light",
+    "wedding",
+    "elegant",
+    "event"
+  ],
+  "white-paper-noir": [
+    "paper",
+    "dark",
+    "industry",
+    "executive",
+    "authoritative"
+  ],
+  "wiki": [
+    "light",
+    "docs",
+    "wiki"
+  ],
+  "willow": [
+    "light",
+    "blog",
+    "literature"
+  ],
+  "windmill": [
+    "light",
+    "blog",
+    "european"
+  ],
+  "windows95": [
+    "light",
+    "retro",
+    "os",
+    "nostalgia"
+  ],
+  "woodblock": [
+    "dark",
+    "blog",
+    "woodblock",
+    "printmaking"
+  ],
+  "working-paper": [
+    "paper",
+    "light",
+    "working",
+    "in-progress",
+    "honest"
+  ],
+  "woven-tapestry": [
+    "dark",
+    "blog",
+    "tapestry",
+    "textile"
+  ],
+  "x-ray": [
+    "dark",
+    "blog",
+    "x-ray",
+    "transparent"
+  ],
+  "xerograph": [
+    "dark",
+    "blog",
+    "minimal",
+    "photocopy"
+  ],
+  "y2k": [
+    "dark",
+    "cyber",
+    "metallic",
+    "retro"
+  ],
+  "zen": [
+    "light",
+    "blog",
+    "zen"
+  ],
+  "zenith": [
+    "light",
+    "landing",
+    "minimal",
+    "altitude"
+  ],
+  "zenithpoint": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ]
 }

--- a/thumb-bible/AGENTS.md
+++ b/thumb-bible/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/thumb-bible/config.toml
+++ b/thumb-bible/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Thumb Bible - Miniature Publication
+# Issue #1538 | Tags: book, light, miniature, dense, craft
+# =============================================================================
+
+title = "Thumb Bible"
+description = "A miniature publication inspired by the thumb bible tradition: tiny books small enough to be hidden under a thumb. Compact serif typography, magnifying loupe SVG illustrations, and page-frame borders at miniature book proportions."
+base_url = "http://localhost:3000"
+
+sections = ["specimens"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/thumb-bible/content/about.md
+++ b/thumb-bible/content/about.md
@@ -1,0 +1,62 @@
++++
+title = "About"
+description = "About the Thumb Bible miniature publication project."
++++
+
+<p class="specimen-label">Reference</p>
+
+# About This Publication
+
+<p class="lede">Thumb Bible is a study of miniature book design. Every element of this publication -- its compact layout, its tight margins, its small type -- is shaped by the constraints and traditions of the miniature book.</p>
+
+## The miniature book tradition
+
+<p>Miniature books have been produced since the invention of printing. They served as portable devotionals, children's primers, almanacs, and curiosities. The challenge of setting type at the smallest possible scale while maintaining legibility pushed printers to refine their craft to extraordinary precision.</p>
+
+<p>This publication takes the thumb bible as its organizing metaphor. The content explores the history, technique, and aesthetics of miniature book production. The design itself is compressed to a narrow measure, with dense type and tight spacing that evoke the miniature format while remaining readable on screen.</p>
+
+## Design principles
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Compact measure</h3>
+<p>The page width is constrained to approximately 480 pixels, narrower than most web publications. This mirrors the narrow page of a miniature book and forces the text into a dense, columnar arrangement.</p>
+</div>
+<div class="specimen-card">
+<h3>Small but readable type</h3>
+<p>The body type is set in IBM Plex Serif and Noto Serif at sizes that feel small and dense while remaining comfortable for sustained reading. Display type uses Crimson Text and Lora, compact serif faces with excellent readability at small sizes.</p>
+</div>
+<div class="specimen-card">
+<h3>Page-frame borders</h3>
+<p>Each page is enclosed in a decorative border drawn as inline SVG, evoking the ruled frames that printers placed around the text block of miniature books to define the page area and add a sense of preciousness.</p>
+</div>
+</div>
+
+## The loupe motif
+
+<p>Throughout this publication, magnifying loupe circles appear as decorative elements. These reference the hand loupe or watchmaker's glass used to read the smallest miniature books. The loupe is the essential tool of the miniature book reader: it transforms illegible micro-text into a readable page, and the act of looking through the lens becomes part of the reading experience.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="120" fill="#f5f0e6"/>
+  <circle cx="100" cy="55" r="40" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="100" cy="55" r="37" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="129" y1="84" x2="155" y2="110" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="129" y1="84" x2="155" y2="110" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="65" y1="42" x2="135" y2="42" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="65" y1="47" x2="132" y2="47" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="68" y1="52" x2="134" y2="52" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="66" y1="57" x2="130" y2="57" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="67" y1="62" x2="135" y2="62" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="65" y1="67" x2="131" y2="67" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="200" y1="30" x2="340" y2="30" stroke="#c4b396" stroke-width="0.4"/>
+  <line x1="200" y1="38" x2="335" y2="38" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="46" x2="338" y2="46" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="54" x2="330" y2="54" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="62" x2="340" y2="62" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="70" x2="332" y2="70" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="78" x2="337" y2="78" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="86" x2="328" y2="86" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="200" y1="94" x2="340" y2="94" stroke="#c4b396" stroke-width="0.3"/>
+</svg>
+</div>

--- a/thumb-bible/content/colophon.md
+++ b/thumb-bible/content/colophon.md
@@ -1,0 +1,37 @@
++++
+title = "Colophon"
+description = "The colophon of this publication: type, design, and construction."
++++
+
+<div class="colophon-page">
+<p class="specimen-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="rule-ornament" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<line x1="20" y1="8" x2="180" y2="8" stroke="#c4b396" stroke-width="0.5"/>
+<rect x="90" y="4" width="20" height="8" fill="none" stroke="#8a7560" stroke-width="0.5"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of miniature book typography and design. Every element reflects the constraints of the thumb bible tradition: compact measure, dense setting, and the intimate scale of the smallest books.</p>
+
+<p class="colophon-detail"><strong>Display type</strong> is set in Crimson Text and Lora, compact serif faces chosen for their sharp letterforms and excellent readability at small sizes. These are typefaces designed for dense setting -- the kind of faces a printer would choose when every point of space matters.</p>
+
+<p class="colophon-detail"><strong>Body type</strong> is set in IBM Plex Serif and Noto Serif, optimized for sustained reading at the small sizes characteristic of miniature publications. The body size is deliberately compact, evoking the feel of micro-text while remaining comfortable on screen.</p>
+
+<p class="colophon-detail"><strong>Illustrations</strong> are drawn as inline SVG in a style inspired by miniature book decoration. Magnifying loupe circles appear over areas of dense micro-text, referencing the hand loupe used to read the smallest thumb bibles. Page-frame borders at miniature book proportions enclose each page. All decorative elements use only stroke and fill -- no gradients, no photographic effects.</p>
+
+<p class="colophon-detail"><strong>The page frame</strong> is a double-ruled border that appears at the top and bottom of each page, in the tradition of the printer's ruled frame around the text block of a miniature book. The center ornament marks the spine.</p>
+
+<div class="rule-ornament" aria-hidden="true">
+<svg viewBox="0 0 200 16" xmlns="http://www.w3.org/2000/svg">
+<rect x="88" y="5" width="6" height="6" fill="#8a7560"/>
+<rect x="98" y="5" width="6" height="6" fill="#8a7560"/>
+<rect x="108" y="5" width="6" height="6" fill="#8a7560"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First digital edition, 2026. Set in small type, read with attention.</p>
+</div>

--- a/thumb-bible/content/index.md
+++ b/thumb-bible/content/index.md
@@ -1,0 +1,90 @@
++++
+title = "Thumb Bible"
+description = "A miniature publication inspired by the thumb bible tradition."
++++
+
+<p class="specimen-label">Miniature</p>
+
+# Thumb Bible
+
+<p class="lede">A publication so small it can be concealed beneath a thumb. The thumb bible is the extreme expression of the printer's art: every element of book design compressed to the smallest possible scale, yet still legible, still readable, still a book in the fullest sense of the word.</p>
+
+<div class="miniature-cover" aria-hidden="true">
+<svg viewBox="0 0 400 280" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="400" height="280" fill="#f5f0e6"/>
+  <rect x="120" y="30" width="160" height="220" fill="#faf6ef" stroke="#3e2e1e" stroke-width="1.2" rx="2"/>
+  <rect x="126" y="36" width="148" height="208" fill="none" stroke="#3e2e1e" stroke-width="0.4" rx="1"/>
+  <rect x="130" y="40" width="140" height="200" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <rect x="150" y="55" width="100" height="12" fill="none" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="145" y1="80" x2="255" y2="80" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="145" y1="85" x2="252" y2="85" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="90" x2="254" y2="90" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="95" x2="248" y2="95" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="100" x2="255" y2="100" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="105" x2="250" y2="105" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="110" x2="253" y2="110" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="115" x2="249" y2="115" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="120" x2="255" y2="120" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="125" x2="251" y2="125" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="130" x2="254" y2="130" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="135" x2="247" y2="135" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="140" x2="255" y2="140" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="145" x2="250" y2="145" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="150" x2="253" y2="150" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="155" x2="248" y2="155" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="160" x2="255" y2="160" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="165" x2="251" y2="165" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="170" x2="254" y2="170" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="175" x2="249" y2="175" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="180" x2="255" y2="180" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="185" x2="252" y2="185" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="190" x2="248" y2="190" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="195" x2="255" y2="195" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="200" x2="250" y2="200" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="205" x2="253" y2="205" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="210" x2="249" y2="210" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="215" x2="255" y2="215" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="220" x2="251" y2="220" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="145" y1="225" x2="254" y2="225" stroke="#8a7560" stroke-width="0.3"/>
+  <circle cx="310" cy="180" r="55" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="310" cy="180" r="52" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="349" y1="219" x2="380" y2="250" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="349" y1="219" x2="380" y2="250" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="265" y1="165" x2="355" y2="165" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="265" y1="170" x2="350" y2="170" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="265" y1="175" x2="353" y2="175" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="265" y1="180" x2="348" y2="180" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="265" y1="185" x2="355" y2="185" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="265" y1="190" x2="351" y2="190" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="265" y1="195" x2="347" y2="195" stroke="#3e2e1e" stroke-width="0.5"/>
+</svg>
+</div>
+
+## The tradition of the miniature book
+
+<p>The thumb bible takes its name from a real genre of miniature publishing. Beginning in the seventeenth century, printers produced tiny books -- often abridgements of the Bible -- small enough to be held between the thumb and forefinger. These were not novelties. They were devotional objects, portable texts meant to be carried in a pocket, consulted in private, and read with the aid of a magnifying glass. The tradition persisted for centuries, and miniature book collecting remains a dedicated field today.</p>
+
+## What makes a book miniature
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>The three-inch rule</h3>
+<p>By convention, a miniature book measures no more than three inches (76mm) in any dimension. Below one inch, the book enters the realm of the micro-miniature. Below a quarter inch, it is an ultra-miniature.</p>
+</div>
+<div class="specimen-card">
+<h3>Dense composition</h3>
+<p>Every element must be compressed. Margins shrink, leading tightens, type size drops to the smallest legible point. The printer must balance density against readability at every decision.</p>
+</div>
+<div class="specimen-card">
+<h3>The loupe</h3>
+<p>Many miniature books require magnification to read. A hand loupe or magnifying glass becomes part of the reading apparatus, and the act of reading transforms into a concentrated, intimate encounter.</p>
+</div>
+<div class="specimen-card">
+<h3>Craft binding</h3>
+<p>Binding a miniature book demands exceptional craft. Every fold, stitch, and trim must be precise at the smallest scale. A millimeter of error that would be invisible in a full-size book becomes a catastrophic flaw in a miniature.</p>
+</div>
+</div>
+
+## Reading this collection
+
+<p>Each specimen in this publication examines one aspect of the miniature book tradition. Navigate to the <a href="/specimens/">specimens catalogue</a> to browse the full collection, or use the navigation above.</p>

--- a/thumb-bible/content/specimens/1-the-miniature.md
+++ b/thumb-bible/content/specimens/1-the-miniature.md
@@ -1,0 +1,87 @@
++++
+title = "The Miniature"
+description = "A history of miniature books and the thumb bible tradition."
+tags = ["history", "miniature"]
++++
+
+<p class="specimen-label">Specimen I</p>
+
+# The Miniature
+
+<p class="lede">The miniature book is older than printing. Manuscript miniatures existed in the medieval period, and with the arrival of moveable type, printers immediately began experimenting with how small a book could be produced. The thumb bible represents the extreme of this ambition.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 140" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="140" fill="#f5f0e6"/>
+  <rect x="20" y="20" width="80" height="100" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.8" rx="1"/>
+  <rect x="24" y="24" width="72" height="92" fill="none" stroke="#3e2e1e" stroke-width="0.3"/>
+  <line x1="30" y1="40" x2="86" y2="40" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="44" x2="84" y2="44" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="48" x2="85" y2="48" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="52" x2="82" y2="52" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="56" x2="86" y2="56" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="60" x2="83" y2="60" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="64" x2="85" y2="64" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="68" x2="81" y2="68" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="72" x2="86" y2="72" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="76" x2="84" y2="76" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="80" x2="85" y2="80" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="84" x2="82" y2="84" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="88" x2="86" y2="88" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="92" x2="83" y2="92" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="96" x2="85" y2="96" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="100" x2="81" y2="100" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="30" y1="104" x2="86" y2="104" stroke="#8a7560" stroke-width="0.2"/>
+  <rect x="30" y="28" width="40" height="6" fill="none" stroke="#3e2e1e" stroke-width="0.3"/>
+  <circle cx="155" cy="75" r="45" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="155" cy="75" r="42" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="187" y1="107" x2="210" y2="130" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="187" y1="107" x2="210" y2="130" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="118" y1="58" x2="192" y2="58" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="118" y1="64" x2="188" y2="64" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="118" y1="70" x2="190" y2="70" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="118" y1="76" x2="186" y2="76" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="118" y1="82" x2="192" y2="82" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="118" y1="88" x2="187" y2="88" stroke="#3e2e1e" stroke-width="0.6"/>
+  <rect x="240" y="30" width="100" height="80" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.6" rx="1"/>
+  <rect x="244" y="34" width="92" height="72" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="250" y1="45" x2="330" y2="45" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="250" y1="50" x2="326" y2="50" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="55" x2="329" y2="55" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="60" x2="324" y2="60" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="65" x2="330" y2="65" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="70" x2="327" y2="70" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="75" x2="325" y2="75" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="80" x2="330" y2="80" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="85" x2="326" y2="85" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="90" x2="329" y2="90" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="250" y1="95" x2="324" y2="95" stroke="#8a7560" stroke-width="0.2"/>
+</svg>
+</div>
+
+## Origins
+
+<p>The earliest printed miniature books appeared in the late fifteenth century, not long after Gutenberg. By the sixteenth century, printers in the Low Countries and Italy were producing tiny editions of devotional texts, almanacs, and classical literature. The term "thumb bible" emerged in the seventeenth century, when John Taylor published his "Verbum Sempiternum" in 1614 -- a verse summary of the Bible printed in a volume measuring roughly one and a half inches tall.</p>
+
+## The devotional miniature
+
+<p>Many early miniature books were religious in nature. Their small size made them genuinely portable -- they could be slipped into a pocket or a purse and consulted during the day. For devout readers who wished to keep scripture close at hand, the thumb bible was a practical solution. The small format also gave these books a private, intimate quality. Reading a miniature book is a solitary act that requires concentration and close attention.</p>
+
+## Beyond the Bible
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Almanacs</h3>
+<p>Pocket almanacs were among the most popular miniature publications. A year's calendar, astronomical tables, and useful reference information compressed into a volume that could be carried daily.</p>
+</div>
+<div class="specimen-card">
+<h3>Literary classics</h3>
+<p>Miniature editions of Shakespeare, Dante, and other literary works were produced as collector's items and curiosities. Some were fully readable; others were demonstrations of the printer's skill.</p>
+</div>
+<div class="specimen-card">
+<h3>Children's books</h3>
+<p>Small books for small hands. Miniature primers, alphabets, and storybooks were popular gifts for children in the eighteenth and nineteenth centuries. The small scale suited the small reader.</p>
+</div>
+</div>
+
+<blockquote>The miniature book is not a reduction. It is a compression. Every element of the full-size book is present, but each has been refined to its smallest possible expression.</blockquote>

--- a/thumb-bible/content/specimens/2-the-loupe.md
+++ b/thumb-bible/content/specimens/2-the-loupe.md
@@ -1,0 +1,75 @@
++++
+title = "The Loupe"
+description = "Reading miniature books with magnification."
+tags = ["loupe", "optics"]
++++
+
+<p class="specimen-label">Specimen II</p>
+
+# The Loupe
+
+<p class="lede">The magnifying loupe is the miniature book reader's essential tool. When type is set at four or five points -- or smaller -- the unaided eye cannot resolve individual letterforms. The loupe bridges the gap between the printer's ambition and the reader's vision.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 160" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="160" fill="#f5f0e6"/>
+  <circle cx="120" cy="75" r="55" fill="none" stroke="#8a7560" stroke-width="2"/>
+  <circle cx="120" cy="75" r="52" fill="none" stroke="#8a7560" stroke-width="0.5"/>
+  <circle cx="120" cy="75" r="48" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="159" y1="114" x2="195" y2="150" stroke="#8a7560" stroke-width="4" stroke-linecap="round"/>
+  <line x1="159" y1="114" x2="195" y2="150" stroke="#c4b396" stroke-width="2" stroke-linecap="round"/>
+  <line x1="80" y1="50" x2="160" y2="50" stroke="#3e2e1e" stroke-width="0.8"/>
+  <line x1="78" y1="57" x2="158" y2="57" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="80" y1="64" x2="162" y2="64" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="76" y1="71" x2="156" y2="71" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="78" y1="78" x2="160" y2="78" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="80" y1="85" x2="158" y2="85" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="82" y1="92" x2="162" y2="92" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="86" y1="99" x2="156" y2="99" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="230" y1="30" x2="340" y2="30" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="230" y1="36" x2="335" y2="36" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="42" x2="338" y2="42" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="48" x2="332" y2="48" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="54" x2="340" y2="54" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="60" x2="334" y2="60" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="66" x2="337" y2="66" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="72" x2="330" y2="72" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="78" x2="340" y2="78" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="84" x2="336" y2="84" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="90" x2="338" y2="90" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="96" x2="333" y2="96" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="102" x2="340" y2="102" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="108" x2="335" y2="108" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="114" x2="337" y2="114" stroke="#c4b396" stroke-width="0.2"/>
+  <line x1="230" y1="120" x2="331" y2="120" stroke="#c4b396" stroke-width="0.2"/>
+</svg>
+</div>
+
+## Optics of the miniature
+
+<p>The human eye has a minimum angular resolution of roughly one arc-minute. At a comfortable reading distance of 30 centimeters, this means the smallest resolvable detail is about 0.09 millimeters. A four-point type character has a body height of approximately 1.4 millimeters, with stroke widths that can drop below 0.1 millimeters in the thinnest hairlines. For type smaller than four points, magnification is not a luxury -- it is a necessity.</p>
+
+## Types of loupes
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Hand loupe</h3>
+<p>The classic hand-held magnifying glass, typically 2x to 5x magnification. Sufficient for reading most miniature books down to about 4-point type. The most common tool of the miniature book collector.</p>
+</div>
+<div class="specimen-card">
+<h3>Watchmaker's loupe</h3>
+<p>A higher-power loupe (8x to 15x) originally designed for examining watch mechanisms. Used for the smallest micro-miniatures where individual letterforms are barely visible to the naked eye.</p>
+</div>
+<div class="specimen-card">
+<h3>Linen tester</h3>
+<p>A folding loupe with a built-in stand that sets the correct focal distance. Originally used by weavers to count threads, it became a favorite of printers and book collectors for examining fine detail.</p>
+</div>
+</div>
+
+## The act of magnified reading
+
+<p>Reading through a loupe changes the nature of the reading experience. The field of view is narrow -- perhaps only a few words at a time. The reader must move the loupe across the page in a slow, deliberate scan, or move the book beneath a stationary loupe. Either way, the reading pace slows dramatically. Each word receives more attention than it would in normal reading. The reader becomes aware of individual letterforms, of the spacing between words, of the ink impression on the paper. Magnified reading is close reading in the most literal sense.</p>
+
+<p>There is an intimacy to this kind of reading that no other format provides. The miniature book demands that the reader come close, look carefully, and give the text sustained attention. The loupe creates a private window into the page -- a circle of clarity surrounded by blur -- that focuses the mind as much as the eye.</p>
+
+<blockquote>Through the loupe, the miniature page becomes a landscape. What seemed like a speck of ink resolves into a word, a sentence, a complete thought. The magnifying glass does not merely enlarge; it reveals.</blockquote>

--- a/thumb-bible/content/specimens/3-the-type.md
+++ b/thumb-bible/content/specimens/3-the-type.md
@@ -1,0 +1,79 @@
++++
+title = "The Type"
+description = "Setting type at micro scale for miniature books."
+tags = ["typography", "micro-type"]
++++
+
+<p class="specimen-label">Specimen III</p>
+
+# The Type
+
+<p class="lede">Setting type for a miniature book is among the most demanding tasks in typography. Every decision that is forgiving at normal sizes becomes critical at micro scale. Letterform selection, spacing, ink density, and paper surface must all be reconsidered from first principles.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="120" fill="#f5f0e6"/>
+  <rect x="20" y="15" width="140" height="90" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.6"/>
+  <rect x="24" y="19" width="132" height="82" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="30" y1="30" x2="148" y2="30" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="30" y1="34" x2="145" y2="34" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="38" x2="147" y2="38" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="42" x2="142" y2="42" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="46" x2="148" y2="46" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="52" x2="148" y2="52" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="30" y1="56" x2="144" y2="56" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="60" x2="147" y2="60" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="64" x2="140" y2="64" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="68" x2="148" y2="68" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="74" x2="148" y2="74" stroke="#3e2e1e" stroke-width="0.5"/>
+  <line x1="30" y1="78" x2="146" y2="78" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="82" x2="143" y2="82" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="86" x2="148" y2="86" stroke="#8a7560" stroke-width="0.3"/>
+  <line x1="30" y1="90" x2="141" y2="90" stroke="#8a7560" stroke-width="0.3"/>
+  <circle cx="250" cy="60" r="42" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="250" cy="60" r="39" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="280" y1="90" x2="305" y2="115" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="280" y1="90" x2="305" y2="115" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="218" y1="42" x2="282" y2="42" stroke="#3e2e1e" stroke-width="0.9"/>
+  <line x1="216" y1="49" x2="280" y2="49" stroke="#3e2e1e" stroke-width="0.8"/>
+  <line x1="218" y1="56" x2="284" y2="56" stroke="#3e2e1e" stroke-width="0.8"/>
+  <line x1="214" y1="63" x2="278" y2="63" stroke="#3e2e1e" stroke-width="0.8"/>
+  <line x1="216" y1="70" x2="282" y2="70" stroke="#3e2e1e" stroke-width="0.8"/>
+  <line x1="220" y1="77" x2="280" y2="77" stroke="#3e2e1e" stroke-width="0.8"/>
+</svg>
+</div>
+
+## Type size at the limit
+
+<p>The standard unit of type measurement is the point, approximately 0.353 millimeters. Ordinary book text is set between 9 and 12 points. Miniature books typically use type between 4 and 6 points. The most extreme micro-miniatures have been printed with type as small as 1 point -- characters whose body height is a third of a millimeter. At this scale, the type is not readable by the naked eye. It exists at the boundary between text and texture.</p>
+
+## Typeface selection
+
+<p>Not all typefaces survive reduction equally. The critical factors at micro scale are:</p>
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Open counters</h3>
+<p>Typefaces with large, open counter spaces (the enclosed areas in letters like 'e', 'a', and 'o') remain legible at small sizes because ink spread does not fill these spaces. Faces with small counters collapse into unreadable blobs.</p>
+</div>
+<div class="specimen-card">
+<h3>Moderate contrast</h3>
+<p>High-contrast faces (with very thin hairlines and thick stems) lose their thin strokes at small sizes. The hairlines disappear, and the character becomes an irregular mass. Low-to-moderate contrast faces maintain legibility.</p>
+</div>
+<div class="specimen-card">
+<h3>Generous x-height</h3>
+<p>A large x-height (the height of lowercase letters relative to uppercase) maximizes the legible area of the character. Faces with tall x-heights make better use of the limited vertical space.</p>
+</div>
+<div class="specimen-card">
+<h3>Clear differentiation</h3>
+<p>At small sizes, similar letterforms (I, l, 1; O, 0; rn, m) must be clearly distinguished. Typefaces designed for small-size use build in exaggerated differentiating features.</p>
+</div>
+</div>
+
+## Spacing and leading
+
+<p>Letterspacing at micro scale must be slightly more generous than at text sizes. Characters that touch or nearly touch will merge under magnification. Word spacing must be clearly defined so that individual words remain distinct. Line spacing (leading) must provide enough vertical separation that descenders from one line do not collide with ascenders from the next.</p>
+
+<p>The compositor of a miniature book works in a paradox: every element must be compressed to fit the tiny page, but the compression must stop short of the point where legibility fails. The art lies in finding the exact threshold -- the smallest size, the tightest spacing, the narrowest margins -- at which the text remains readable.</p>
+
+<blockquote>At four points, typography becomes jewelry. Each letter is a tiny artifact, precision-cut and carefully placed. The compositor is no longer a typesetter but a craftsman working at the scale of a watchmaker.</blockquote>

--- a/thumb-bible/content/specimens/4-the-binding.md
+++ b/thumb-bible/content/specimens/4-the-binding.md
@@ -1,0 +1,80 @@
++++
+title = "The Binding"
+description = "Binding miniature books at the smallest scale."
+tags = ["binding", "craft"]
++++
+
+<p class="specimen-label">Specimen IV</p>
+
+# The Binding
+
+<p class="lede">Binding a miniature book requires a different order of skill than binding a full-size volume. The same operations -- folding, sewing, trimming, covering -- must be performed at a scale where the margin for error approaches zero. A millimeter of misalignment that would be invisible in a quarto is a disaster in a thumb bible.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 130" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="130" fill="#f5f0e6"/>
+  <rect x="30" y="20" width="60" height="90" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.8" rx="1"/>
+  <rect x="33" y="23" width="54" height="84" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="30" y1="35" x2="30" y2="95" stroke="#3e2e1e" stroke-width="1.5"/>
+  <line x1="38" y1="35" x2="82" y2="35" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="40" x2="80" y2="40" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="45" x2="82" y2="45" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="50" x2="79" y2="50" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="55" x2="82" y2="55" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="60" x2="80" y2="60" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="65" x2="81" y2="65" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="70" x2="82" y2="70" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="75" x2="79" y2="75" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="80" x2="82" y2="80" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="85" x2="80" y2="85" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="90" x2="81" y2="90" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="38" y1="95" x2="82" y2="95" stroke="#8a7560" stroke-width="0.2"/>
+  <rect x="120" y="20" width="60" height="90" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.8" rx="1"/>
+  <rect x="123" y="23" width="54" height="84" fill="none" stroke="#c4b396" stroke-width="0.3"/>
+  <line x1="120" y1="35" x2="120" y2="95" stroke="#3e2e1e" stroke-width="1.5"/>
+  <line x1="126" y1="35" x2="172" y2="35" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="40" x2="170" y2="40" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="45" x2="172" y2="45" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="50" x2="168" y2="50" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="55" x2="172" y2="55" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="60" x2="170" y2="60" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="126" y1="65" x2="171" y2="65" stroke="#8a7560" stroke-width="0.2"/>
+  <circle cx="270" cy="65" r="45" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="270" cy="65" r="42" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="302" y1="97" x2="325" y2="120" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="302" y1="97" x2="325" y2="120" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="240" y1="48" x2="300" y2="48" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="238" y1="55" x2="298" y2="55" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="240" y1="62" x2="302" y2="62" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="236" y1="69" x2="296" y2="69" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="238" y1="76" x2="300" y2="76" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="242" y1="83" x2="298" y2="83" stroke="#3e2e1e" stroke-width="0.6"/>
+</svg>
+</div>
+
+## Folding
+
+<p>The sheets for a miniature book must be folded with absolute precision. In a full-size book, a fold that is off by a millimeter is corrected when the edges are trimmed. In a miniature book, that millimeter may represent a significant fraction of the page margin. Some miniature books have margins of only two or three millimeters; a fold error of one millimeter means the text block shifts visibly off-center.</p>
+
+## Sewing
+
+<p>Miniature books are typically sewn through the fold of each section (signature) just as full-size books are, but the sewing thread must be much finer. Standard bookbinding thread is too thick for a miniature binding -- it would create a spine so bulky that the book would not close flat. Miniature binders use silk thread, or fine linen thread, and sew with needles designed for embroidery or beading. The sewing stations (the holes through which the thread passes) must be positioned with extreme care, as a misplaced hole can tear through the narrow fold margin.</p>
+
+## Covering and finishing
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Leather covers</h3>
+<p>Full leather binding is traditional for fine miniature books. The leather must be pared (thinned) to a fraction of a millimeter so that it does not add excessive bulk. Turning in the leather at the board edges requires particular dexterity at this scale.</p>
+</div>
+<div class="specimen-card">
+<h3>Gold tooling</h3>
+<p>Some miniature books are finished with gold-stamped decoration on the covers. The tools must be tiny -- often custom-made -- and the impression must be perfectly positioned. A stamp that wanders by half a millimeter ruins the design at this scale.</p>
+</div>
+<div class="specimen-card">
+<h3>Slip cases and boxes</h3>
+<p>Miniature books are often housed in protective slip cases or boxes, both for protection and for display. The case must fit precisely: too loose and the book slides around; too tight and it is difficult to extract without damage.</p>
+</div>
+</div>
+
+<blockquote>The binder of miniature books works at the boundary between bookbinding and watchmaking. The same patience, the same precision tools, the same intolerance of error. A thumb bible in fine binding is as much a feat of engineering as it is of craft.</blockquote>

--- a/thumb-bible/content/specimens/5-the-collection.md
+++ b/thumb-bible/content/specimens/5-the-collection.md
@@ -1,0 +1,96 @@
++++
+title = "The Collection"
+description = "Collecting miniature books and the community of miniature book enthusiasts."
+tags = ["collecting", "community"]
++++
+
+<p class="specimen-label">Specimen V</p>
+
+# The Collection
+
+<p class="lede">Miniature book collecting is a dedicated field with its own societies, exhibitions, dealers, and standards. Unlike most bibliophilic pursuits, miniature book collecting is uniquely practical: an entire library of hundreds of volumes can fit on a single shelf, and even the rarest specimens occupy almost no physical space.</p>
+
+<div class="loupe-illustration" aria-hidden="true">
+<svg viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="360" height="120" fill="#f5f0e6"/>
+  <rect x="20" y="20" width="40" height="60" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.6" rx="1"/>
+  <line x1="26" y1="30" x2="54" y2="30" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="34" x2="52" y2="34" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="38" x2="54" y2="38" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="42" x2="50" y2="42" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="46" x2="54" y2="46" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="50" x2="52" y2="50" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="54" x2="53" y2="54" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="58" x2="50" y2="58" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="62" x2="54" y2="62" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="66" x2="52" y2="66" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="26" y1="70" x2="54" y2="70" stroke="#8a7560" stroke-width="0.2"/>
+  <rect x="70" y="15" width="45" height="65" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.6" rx="1"/>
+  <line x1="76" y1="25" x2="109" y2="25" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="29" x2="107" y2="29" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="33" x2="109" y2="33" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="37" x2="105" y2="37" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="41" x2="109" y2="41" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="45" x2="107" y2="45" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="49" x2="108" y2="49" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="53" x2="105" y2="53" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="57" x2="109" y2="57" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="61" x2="107" y2="61" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="65" x2="109" y2="65" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="76" y1="69" x2="106" y2="69" stroke="#8a7560" stroke-width="0.2"/>
+  <rect x="125" y="22" width="35" height="58" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.6" rx="1"/>
+  <line x1="130" y1="32" x2="155" y2="32" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="36" x2="153" y2="36" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="40" x2="155" y2="40" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="44" x2="152" y2="44" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="48" x2="155" y2="48" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="52" x2="153" y2="52" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="56" x2="154" y2="56" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="60" x2="151" y2="60" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="64" x2="155" y2="64" stroke="#8a7560" stroke-width="0.2"/>
+  <line x1="130" y1="68" x2="153" y2="68" stroke="#8a7560" stroke-width="0.2"/>
+  <circle cx="260" cy="55" r="45" fill="none" stroke="#8a7560" stroke-width="1.5"/>
+  <circle cx="260" cy="55" r="42" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+  <line x1="292" y1="87" x2="318" y2="113" stroke="#8a7560" stroke-width="3" stroke-linecap="round"/>
+  <line x1="292" y1="87" x2="318" y2="113" stroke="#c4b396" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="228" y1="38" x2="292" y2="38" stroke="#3e2e1e" stroke-width="0.7"/>
+  <line x1="226" y1="45" x2="290" y2="45" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="228" y1="52" x2="294" y2="52" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="224" y1="59" x2="288" y2="59" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="226" y1="66" x2="292" y2="66" stroke="#3e2e1e" stroke-width="0.6"/>
+  <line x1="230" y1="73" x2="290" y2="73" stroke="#3e2e1e" stroke-width="0.6"/>
+</svg>
+</div>
+
+## The Miniature Book Society
+
+<p>The Miniature Book Society, founded in 1983, is the principal organization for collectors and publishers of miniature books. The society maintains the standard definition: a miniature book measures no more than three inches in height, width, or depth. The society publishes a newsletter, holds annual conclaves, and maintains a network of dealers and publishers who specialize in the format.</p>
+
+## What collectors look for
+
+<div class="specimen-grid">
+<div class="specimen-card">
+<h3>Printing quality</h3>
+<p>The finest miniature books are letterpress printed from handset type or photopolymer plates. The sharpness of the impression, the evenness of the inking, and the registration of the pages are all critical quality markers.</p>
+</div>
+<div class="specimen-card">
+<h3>Binding quality</h3>
+<p>A miniature book in full leather binding with gold tooling, sewn on tapes with silk endbands, represents the highest level of the binder's craft. Collectors prize fine binding as a sign of serious craftsmanship.</p>
+</div>
+<div class="specimen-card">
+<h3>Legibility</h3>
+<p>The best miniature books are genuinely readable, not merely miniature objects. A book that can be read -- even with a loupe -- is more valued than one that is merely small but illegible.</p>
+</div>
+<div class="specimen-card">
+<h3>Limited editions</h3>
+<p>Most fine miniature books are produced in editions of 100 to 300 copies. The combination of small edition size and specialized collector interest means that desirable miniature books can command prices out of proportion to their physical size.</p>
+</div>
+</div>
+
+## The appeal of the miniature
+
+<p>Why collect books that are almost too small to read? The appeal is partly aesthetic -- a well-made miniature book is a beautiful object, a perfect thing in a small space. It is partly intellectual -- the challenge of producing and reading text at the extreme limit of legibility. And it is partly the collector's ancient impulse toward completeness: the desire to hold an entire book, an entire world of text, in the palm of one's hand.</p>
+
+<p>A miniature book collection is also, in a practical sense, the most efficient library imaginable. Where a collector of folios needs a room, a collector of miniatures needs a drawer. A thousand miniature books occupy less space than a single shelf of novels. The entire history of miniature publishing -- five centuries of printers pushing against the limits of their craft -- can fit in a modest cabinet.</p>
+
+<blockquote>The miniature book collector holds the paradox in hand: the smaller the book, the greater the craft required to make it. A thumb bible is not a lesser book. It is a book in which every element has been refined to its essential form.</blockquote>

--- a/thumb-bible/content/specimens/_index.md
+++ b/thumb-bible/content/specimens/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Specimens"
+description = "The specimen catalogue of this miniature publication."
++++
+
+<p class="lede">Five specimens, each examining one aspect of the miniature book tradition. From the history of the thumb bible to the craft of binding at the smallest scale, these pages explore a world measured in millimeters.</p>
+
+<p>The specimens are arranged as a progression from the broadest context to the finest detail: history, optics, typography, binding, and collecting.</p>

--- a/thumb-bible/static/css/style.css
+++ b/thumb-bible/static/css/style.css
@@ -1,0 +1,393 @@
+/* =============================================================================
+   Thumb Bible - Miniature Publication
+   Issue #1538 | book, light, miniature, dense, craft
+   Palette: cream/ivory background, dark brown ink, warm accents
+   No gradients. Magnifying loupe circles + page-frame borders as inline SVG.
+   ============================================================================= */
+
+:root {
+  --ivory: #faf6ef;
+  --ivory-soft: #f5f0e6;
+  --ivory-deep: #ede7da;
+  --ivory-edge: #c4b396;
+  --ink: #3e2e1e;
+  --ink-soft: #5c4a38;
+  --ink-dim: #8a7560;
+  --brown: #6b4e32;         /* warm brown accent */
+  --brown-soft: #8a6a4a;
+  --gold: #b8943e;          /* warm gold accent */
+  --gold-soft: #a88535;
+  --bg: #f2ece2;            /* outer background */
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "IBM Plex Serif", "Noto Serif", Georgia, serif;
+  font-size: 13.5px;
+  line-height: 1.68;
+  min-height: 100vh;
+}
+
+.miniature-shell {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 1.2rem 0 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--ivory-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 28px; height: 38px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Crimson Text", "Lora", serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Lora", "Crimson Text", serif;
+  font-weight: 500;
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Lora", serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+}
+.site-nav a:hover { color: var(--brown); border-bottom-color: var(--brown); }
+
+/* --- Page frame ---------------------------------------------------------- */
+.site-main {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 1.2rem 1rem 2rem;
+}
+
+.page-frame {
+  position: relative;
+  background-color: var(--ivory);
+  border-left: 1px solid var(--ivory-edge);
+  border-right: 1px solid var(--ivory-edge);
+  min-height: 320px;
+  box-shadow: 0 1px 0 var(--ivory-deep);
+  overflow: hidden;
+}
+
+.page-frame-narrow {
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.frame-border { width: 100%; }
+.frame-border svg { width: 100%; display: block; }
+
+.page-body {
+  padding: clamp(1rem, 3vw, 1.8rem) clamp(1rem, 3vw, 1.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.page-body h1,
+.page-body h2,
+.page-body h3 {
+  font-family: "Crimson Text", "Lora", serif;
+  color: var(--ink);
+  line-height: 1.25;
+  font-weight: 700;
+}
+.page-body h1 {
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  margin: 0 0 0.15em;
+  letter-spacing: 0.01em;
+}
+.page-body h2 {
+  font-size: 1.05rem;
+  margin: 1.8em 0 0.25em;
+  padding-top: 0.5em;
+  border-top: 1px solid var(--ivory-edge);
+  font-weight: 600;
+}
+.page-body h3 {
+  font-size: 0.88rem;
+  margin: 1.4em 0 0.15em;
+  color: var(--brown);
+  font-weight: 600;
+}
+
+.page-body p {
+  margin: 0.7em 0;
+  color: var(--ink);
+  font-family: "IBM Plex Serif", "Noto Serif", serif;
+  font-size: 0.92rem;
+  max-width: 50ch;
+}
+.page-body p.lede {
+  font-family: "Noto Serif", "IBM Plex Serif", serif;
+  font-size: 0.96rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  font-style: italic;
+  max-width: 48ch;
+}
+
+.specimen-label {
+  display: inline-block;
+  font-family: "Crimson Text", serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brown);
+  margin: 0 0 0.3em;
+  padding: 0.15em 0.5em;
+  background-color: var(--ivory-soft);
+  border: 1px solid var(--ivory-edge);
+}
+
+.page-head { margin-bottom: 1.2rem; }
+.page-title {
+  font-family: "Crimson Text", "Lora", serif;
+  font-weight: 700;
+  font-size: clamp(1.3rem, 3.5vw, 1.7rem);
+  margin: 0;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+
+.page-body a {
+  color: var(--brown);
+  text-decoration: none;
+  border-bottom: 1px solid var(--brown-soft);
+}
+.page-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+blockquote {
+  margin: 1.2rem 0;
+  padding: 0.4rem 0.9rem;
+  border-left: 2px solid var(--brown);
+  background-color: var(--ivory-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Noto Serif", "IBM Plex Serif", serif;
+  font-size: 0.9rem;
+  max-width: 48ch;
+}
+
+.page-body ul,
+.page-body ol {
+  margin: 0.8em 0 0.8em 1.2em;
+  padding: 0;
+}
+.page-body ul { list-style: disc; }
+.page-body ol { list-style: decimal; }
+.page-body li { padding: 0.15em 0; max-width: 50ch; font-size: 0.92rem; }
+
+/* --- Loupe & miniature illustrations ------------------------------------- */
+.loupe-illustration {
+  margin: 1rem 0;
+  border: 1px solid var(--ivory-edge);
+}
+.loupe-illustration svg {
+  width: 100%;
+  display: block;
+}
+
+.miniature-cover {
+  margin: 1rem 0;
+  border: 1px solid var(--ivory-edge);
+}
+.miniature-cover svg {
+  width: 100%;
+  display: block;
+}
+
+/* --- Specimen card grid -------------------------------------------------- */
+.specimen-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+  margin: 1rem 0;
+}
+.specimen-card {
+  background-color: var(--ivory-soft);
+  border: 1px solid var(--ivory-edge);
+  padding: 0.6rem 0.8rem;
+  position: relative;
+}
+.specimen-card h3 {
+  margin: 0 0 0.2em;
+  color: var(--brown);
+  font-size: 0.82rem;
+  font-family: "Crimson Text", serif;
+  font-weight: 600;
+}
+.specimen-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.2rem 0 0;
+  border-top: 1px solid var(--ivory-edge);
+}
+.section-list li {
+  padding: 0.5rem 0.15rem;
+  border-bottom: 1px solid var(--ivory-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: "Lora", serif;
+  font-size: 0.88rem;
+}
+.section-list li::before {
+  content: "\00b7";               /* middle dot - compact marker */
+  color: var(--brown);
+  flex-shrink: 0;
+  font-weight: 700;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--ink);
+  border: none;
+  font-size: 0.88rem;
+  letter-spacing: 0.01em;
+}
+.section-list li a:hover { color: var(--brown); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 0.8rem;
+  font-size: 0.88rem;
+}
+
+nav.pagination { margin-top: 1.2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.2em 0.45em;
+  border: 1px solid var(--ivory-edge);
+  font-family: "Lora", serif;
+  font-size: 0.75rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--ivory-soft);
+}
+nav.pagination a:hover { color: var(--brown); border-color: var(--brown); }
+.pagination-current span { color: var(--brown); border-color: var(--brown); }
+
+/* --- Colophon ------------------------------------------------------------ */
+.colophon-page .colophon-detail {
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+.colophon-imprint {
+  font-family: "Crimson Text", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.82rem;
+  text-align: center;
+  margin-top: 1.5rem;
+}
+.rule-ornament {
+  text-align: center;
+  margin: 1rem 0;
+}
+.rule-ornament svg {
+  width: 160px;
+  display: inline-block;
+}
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+  border-top: 1px solid var(--ivory-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1rem; }
+.footer-mark {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+.footer-mark svg { width: 20px; height: 28px; display: block; margin: 0 auto; }
+.footer-line {
+  font-family: "Crimson Text", serif;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0.15em 0;
+  font-size: 0.88rem;
+  letter-spacing: 0.02em;
+}
+.footer-line-small {
+  font-family: "IBM Plex Serif", serif;
+  font-style: italic;
+  color: var(--ink-dim);
+  font-size: 0.75rem;
+  margin: 0.15em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 520px) {
+  .page-body { padding: 0.8rem 0.9rem 1.2rem; }
+  .site-header { padding: 1rem 0 0.6rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 0.7rem; }
+  .page-title, .page-body h1 { font-size: 1.25rem; }
+  .page-body h2 { font-size: 0.95rem; }
+  .page-body p, .page-body li { max-width: none; }
+  .miniature-shell { max-width: 100%; }
+}

--- a/thumb-bible/templates/404.html
+++ b/thumb-bible/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="page-frame page-frame-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="specimen-label">404</p>
+          <h1 class="page-title">Page not found</h1>
+        </header>
+        <p>This page has been lost somewhere among the miniatures. The text is too small to find. Return to the collection and try another specimen.</p>
+        <p><a href="{{ base_url }}/">Back to the collection</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/thumb-bible/templates/footer.html
+++ b/thumb-bible/templates/footer.html
@@ -1,0 +1,20 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-mark" aria-hidden="true">
+        <svg viewBox="0 0 24 32" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="3" width="18" height="26" fill="none" stroke="#8a7560" stroke-width="0.6" rx="1"/>
+          <line x1="7" y1="10" x2="17" y2="10" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="13" x2="16" y2="13" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="16" x2="17" y2="16" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="19" x2="15" y2="19" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="22" x2="17" y2="22" stroke="#8a7560" stroke-width="0.3"/>
+        </svg>
+      </div>
+      <p class="footer-line">Thumb Bible</p>
+      <p class="footer-line-small">A miniature publication, small enough to hide under a thumb.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; set in small type, read with a loupe</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/thumb-bible/templates/header.html
+++ b/thumb-bible/templates/header.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;1,400&family=Noto+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="miniature-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Thumb Bible home">
+        <svg viewBox="0 0 32 44" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="2" width="28" height="40" fill="#faf6ef" stroke="#3e2e1e" stroke-width="0.8" rx="1"/>
+          <rect x="4" y="4" width="24" height="36" fill="none" stroke="#3e2e1e" stroke-width="0.3" rx="0.5"/>
+          <line x1="7" y1="12" x2="25" y2="12" stroke="#8a7560" stroke-width="0.4"/>
+          <line x1="7" y1="15" x2="23" y2="15" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="18" x2="24" y2="18" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="21" x2="22" y2="21" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="24" x2="25" y2="24" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="27" x2="21" y2="27" stroke="#8a7560" stroke-width="0.3"/>
+          <line x1="7" y1="30" x2="24" y2="30" stroke="#8a7560" stroke-width="0.3"/>
+          <rect x="9" y="6" width="14" height="3" fill="none" stroke="#3e2e1e" stroke-width="0.4"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Thumb Bible</span>
+          <span class="logo-sub">Miniature Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/specimens/">Specimens</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/thumb-bible/templates/page.html
+++ b/thumb-bible/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="page-frame">
+      <div class="frame-border" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="400" height="8" fill="#faf6ef"/>
+          <line x1="8" y1="3" x2="392" y2="3" stroke="#c4b396" stroke-width="0.4"/>
+          <line x1="8" y1="5" x2="392" y2="5" stroke="#c4b396" stroke-width="0.4"/>
+          <rect x="185" y="1" width="30" height="6" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+        </svg>
+      </div>
+      <div class="page-body">
+        {{ content }}
+      </div>
+      <div class="frame-border frame-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="400" height="8" fill="#faf6ef"/>
+          <line x1="8" y1="3" x2="392" y2="3" stroke="#c4b396" stroke-width="0.4"/>
+          <line x1="8" y1="5" x2="392" y2="5" stroke="#c4b396" stroke-width="0.4"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/thumb-bible/templates/section.html
+++ b/thumb-bible/templates/section.html
@@ -1,0 +1,32 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="page-frame">
+      <div class="frame-border" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="400" height="8" fill="#faf6ef"/>
+          <line x1="8" y1="3" x2="392" y2="3" stroke="#c4b396" stroke-width="0.4"/>
+          <line x1="8" y1="5" x2="392" y2="5" stroke="#c4b396" stroke-width="0.4"/>
+          <rect x="185" y="1" width="30" height="6" fill="none" stroke="#8a7560" stroke-width="0.4"/>
+        </svg>
+      </div>
+      <div class="page-body">
+        <header class="page-head">
+          <p class="specimen-label">Catalogue</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+      <div class="frame-border frame-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 400 8" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="400" height="8" fill="#faf6ef"/>
+          <line x1="8" y1="3" x2="392" y2="3" stroke="#c4b396" stroke-width="0.4"/>
+          <line x1="8" y1="5" x2="392" y2="5" stroke="#c4b396" stroke-width="0.4"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/thumb-bible/templates/shortcodes/alert.html
+++ b/thumb-bible/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 0.6rem 0.8rem; border: 1px solid #c4b396; background-color: #faf6ef; border-left: 4px solid #8a7560; margin: 0.8rem 0; font-size: 0.85rem;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/thumb-bible/templates/taxonomy.html
+++ b/thumb-bible/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="page-frame page-frame-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="specimen-label">Index</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this miniature collection:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/thumb-bible/templates/taxonomy_term.html
+++ b/thumb-bible/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="page-frame page-frame-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="specimen-label">Subject</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Specimens filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Closes #1538

## Summary
- Add thumb-bible (miniature publication) example site
- Light cream/ivory theme with max-width 480px for miniature feel
- SVG magnifying loupe circles over micro-text detail areas
- SVG page-frame borders at miniature book proportions
- Typography: Crimson Text / Lora for display; IBM Plex Serif / Noto Serif for compact body
- 5 specimens covering the miniature, the loupe, the type, the binding, and the collection
- Tags: book, light, miniature, dense, craft

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of miniature format and loupe SVGs
- [ ] Check responsive behavior on narrow viewports