### PR TITLE
feat: add marginalia-noir example site (closes #1537)

### DIFF
--- a/marginalia-noir/AGENTS.md
+++ b/marginalia-noir/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/marginalia-noir/config.toml
+++ b/marginalia-noir/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Marginalia Noir - Dark Annotation Publication
+# Issue #1537 | Tags: book, dark, annotated, consumed, experimental
+# =============================================================================
+
+title = "Marginalia Noir"
+description = "A dark annotation publication where margin notes have grown to consume the main text. Ink bleed patterns, bracket marks, and increasingly heavy annotation weight overtake the dissolving original."
+base_url = "http://localhost:3000"
+
+sections = ["annotations"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/marginalia-noir/content/about.md
+++ b/marginalia-noir/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "About this dark annotation publication and the tradition of marginalia."
++++
+
+<p class="codex-label">Reference</p>
+
+# About This Publication
+
+<p class="lede">This publication is a study of marginalia: the margin annotations that grow to consume the text they were meant to serve, until the reader's voice overwhelms the author's entirely.</p>
+
+## The dark annotation
+
+<p>The design of this site uses a near-black background to evoke the darkened page of a heavily annotated book, where layers of ink from successive readers have stained the paper itself. The annotation red that marks the margin notes is drawn from the tradition of rubrication -- the use of red ink for headings and emphasis in medieval manuscripts. Here, that red has escaped the headings and colonized the margins.</p>
+
+## Design principles
+
+<p>Every page carries inline SVG patterns that suggest ink bleed and bracket marks: the visual evidence of annotation spreading beyond its boundaries. The typography uses two contrasting voices. The original text is set in Cormorant and EB Garamond, classical serifs that fade and dissolve as the annotations overtake them. The annotations themselves are set in Inter, growing progressively heavier from Bold to Black weight, representing the increasing authority of the marginal voice.</p>
+
+<blockquote>The margin is not a space of subordination. It is a space of power. The annotator who fills the margin rewrites the text from the outside in, until the outside becomes the inside and the original author is merely a guest in their own work.</blockquote>

--- a/marginalia-noir/content/annotations/1-the-gloss.md
+++ b/marginalia-noir/content/annotations/1-the-gloss.md
@@ -1,0 +1,58 @@
++++
+title = "The Gloss"
+description = "The medieval glossing tradition and the origins of marginal annotation."
+tags = ["gloss", "medieval", "origins"]
++++
+
+<p class="codex-label">Annotation I</p>
+
+# The Gloss
+
+<p class="lede">The gloss began as the humblest form of annotation: a single word written above another word, offering a synonym or translation. It was a servant of the text, a guide for the struggling reader. But the gloss had ambitions of its own.</p>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 4 L10 4 L10 26 L20 26" stroke="#c44" stroke-width="1.2" fill="none"/>
+<path d="M380 4 L390 4 L390 26 L380 26" stroke="#c44" stroke-width="1.2" fill="none"/>
+<text x="200" y="17" font-family="'Cormorant', serif" font-size="9" fill="#555" font-style="italic" text-anchor="middle" opacity="0.4">glossae marginales et interlineares</text>
+</svg>
+</div>
+
+## The interlinear gloss
+
+<p>In the early medieval period, when Latin literacy was unevenly distributed across the monasteries of Europe, scribes began adding small explanatory notes between the lines of difficult texts. A rare Latin word might receive a more common synonym written above it in tiny script. A Greek term might be translated. A grammatical construction might be parsed. These interlinear glosses were functional and modest: they existed only to help the reader through the text, and they were always smaller and lighter than the words they served.</p>
+
+<div class="margin-note">
+<p class="annotation-text">Note: The interlinear gloss is the first assertion of the reader's authority. By writing above the author's word, the glossator claims the right to mediate between text and reader.</p>
+</div>
+
+## The marginal gloss
+
+<p>As glossing became more sophisticated, it migrated from the space between lines to the wider space of the margins. The marginal gloss could be longer, more discursive, more opinionated. A marginal note might explain the historical context of a passage, cross-reference another text, or offer an interpretation that went beyond simple translation. The margin became a space for scholarly conversation: later readers would add their own glosses beside the earlier ones, creating layers of commentary around a single passage.</p>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<text x="20" y="12" font-family="'EB Garamond', serif" font-size="9" fill="#444" font-style="italic" opacity="0.3">the original line of text proceeds in its measured way</text>
+<ellipse cx="60" cy="12" rx="18" ry="5" fill="#c44" opacity="0.05"/>
+<ellipse cx="200" cy="12" rx="25" ry="6" fill="#c44" opacity="0.04"/>
+</svg>
+</div>
+
+## The Glossa Ordinaria
+
+<p>By the twelfth century, the marginal gloss had become an institution. The Glossa Ordinaria -- the "standard gloss" -- was a massive apparatus of commentary surrounding the text of the Bible. On a typical page, the biblical text occupied a narrow column at the center, while glosses filled the margins on all four sides and even squeezed between the lines. The glosses were drawn from centuries of patristic commentary: Augustine, Jerome, Gregory the Great, Bede. The standard gloss was so authoritative that it was often more studied than the biblical text it surrounded.</p>
+
+<div class="annotation-grid">
+<div class="annotation-card">
+<h3>The text</h3>
+<p class="original-text" aria-hidden="true">narrow column at center</p>
+<p>The biblical text was copied in a small, narrow column, leaving vast margins on every side. The text was physically diminished to make room for its commentary.</p>
+</div>
+<div class="annotation-card">
+<h3>The apparatus</h3>
+<p class="original-text" aria-hidden="true">glosses surrounding text</p>
+<p>The marginal glosses were written in a smaller hand but occupied far more space than the text they served. A single biblical verse might generate a full page of commentary.</p>
+</div>
+</div>
+
+<blockquote>The gloss is the first step in the consumption of a text. It begins as a service and ends as a conquest. The glossator who adds a single word above a line has set in motion a process that will, over centuries, reduce the original text to a pretext for commentary.</blockquote>

--- a/marginalia-noir/content/annotations/2-the-bracket.md
+++ b/marginalia-noir/content/annotations/2-the-bracket.md
@@ -1,0 +1,68 @@
++++
+title = "The Bracket"
+description = "Bracket and brace annotation marks in progressively thicker weights."
+tags = ["bracket", "marks", "attention"]
++++
+
+<p class="codex-label">Annotation II</p>
+
+# The Bracket
+
+<p class="lede">The bracket is the annotator's pointing finger. A vertical line drawn in the margin beside a passage, it says nothing about the text except this: look here. But the bracket is never satisfied with marking a single passage. It multiplies, thickens, and proliferates until the entire page is enclosed.</p>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 36" xmlns="http://www.w3.org/2000/svg">
+<path d="M30 4 L18 4 L18 32 L30 32" stroke="#c44" stroke-width="1" fill="none" opacity="0.4"/>
+<path d="M50 6 L40 6 L40 30 L50 30" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.5"/>
+<path d="M70 8 L62 8 L62 28 L70 28" stroke="#c44" stroke-width="2" fill="none" opacity="0.6"/>
+<path d="M90 10 L84 10 L84 26 L90 26" stroke="#c44" stroke-width="2.5" fill="none" opacity="0.8"/>
+<path d="M110 12 L106 12 L106 24 L110 24" stroke="#c44" stroke-width="3" fill="none"/>
+<text x="250" y="20" font-family="'Cormorant', serif" font-size="9" fill="#555" font-style="italic" text-anchor="middle" opacity="0.35">thickening brackets in the margin</text>
+</svg>
+</div>
+
+## The simple bracket
+
+<p>The simplest form of marginal annotation is the vertical line: a straight stroke drawn beside a passage to mark it for attention. In early printed books, readers would draw these lines with pen or pencil, sometimes extending the length of an entire paragraph. The simple bracket makes no claim about the meaning of the text. It only says that this passage is important -- to this reader, at this moment, for reasons that may or may not be recorded elsewhere.</p>
+
+<div class="margin-note">
+<p class="annotation-text">Note: The bracket is pure deixis. It points without explaining. This makes it both the most economical and the most mysterious of annotation marks.</p>
+</div>
+
+## The double bracket
+
+<p>When a single bracket is insufficient, the reader adds a second. The double bracket -- two vertical lines side by side -- indicates a passage of special importance. Some readers developed elaborate systems: single brackets for interesting passages, double brackets for essential ones, triple brackets for passages they intended to memorize or cite. The escalation of bracket weight is an escalation of attention, a visual record of the reader's growing engagement with the text.</p>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
+<path d="M40 4 L30 4 L30 26 L40 26" stroke="#c44" stroke-width="1" fill="none"/>
+<path d="M48 4 L38 4 L38 26 L48 26" stroke="#c44" stroke-width="1" fill="none"/>
+<path d="M180 6 L172 6 L172 24 L180 24" stroke="#c44" stroke-width="1.5" fill="none"/>
+<path d="M188 6 L180 6 L180 24 L188 24" stroke="#c44" stroke-width="1.5" fill="none"/>
+<path d="M196 6 L188 6 L188 24 L196 24" stroke="#c44" stroke-width="1.5" fill="none"/>
+<path d="M330 4 Q 320 15 330 26" stroke="#c44" stroke-width="2" fill="none"/>
+<path d="M360 4 Q 370 15 360 26" stroke="#c44" stroke-width="2" fill="none"/>
+</svg>
+</div>
+
+## The curly brace
+
+<p>The curly brace is the bracket's more expressive cousin. Where the square bracket is austere and functional, the curly brace is calligraphic and emphatic. In mathematical notation, braces group and contain. In marginal annotation, they serve a similar function: a curly brace drawn beside a passage gathers multiple lines into a single unit, declaring that these words belong together and must be read as a whole. The brace is the annotator's embrace of the text.</p>
+
+<div class="margin-note-heavy">
+<p class="annotation-text-heavy">The curly brace is also a territorial mark. It claims a region of the page for the annotator's attention, enclosing text within its arms and asserting ownership over the passage.</p>
+</div>
+
+## The bracket as colonization
+
+<p>In heavily annotated books, brackets cover every margin. The reader has marked so many passages that the marks have lost their discriminating function: when everything is bracketed, nothing is specially marked. But the brackets persist as a visual record of total engagement. They are the evidence that this reader consumed the text entirely, that no passage escaped their attention. The page becomes a field of vertical lines, the original text imprisoned within a cage of the reader's making.</p>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 24" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 4 L4 4 L4 20 L10 20" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.3"/>
+<path d="M390 4 L396 4 L396 20 L390 20" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.3"/>
+<text x="200" y="14" font-family="'EB Garamond', serif" font-size="8" fill="#444" font-style="italic" text-anchor="middle" opacity="0.25">the entire page enclosed in brackets now</text>
+</svg>
+</div>
+
+<blockquote>The bracket does not annotate the text. It annotates the reader. Each bracket mark is a record of attention, a fossil of the moment when a reader's eye paused and a hand moved to the margin. A fully bracketed page is a portrait of a reader who could not stop paying attention.</blockquote>

--- a/marginalia-noir/content/annotations/3-the-bleed.md
+++ b/marginalia-noir/content/annotations/3-the-bleed.md
@@ -1,0 +1,74 @@
++++
+title = "The Bleed"
+description = "When annotations bleed into the main text and boundaries dissolve."
+tags = ["bleed", "boundaries", "dissolution"]
++++
+
+<p class="codex-label">Annotation III</p>
+
+# The Bleed
+
+<p class="lede">Ink is a liquid. It does not respect the boundaries drawn for it. When a reader writes in the margin of a page, the ink seeps into the paper fibers and spreads beyond the letters that were intended. Over time, this bleed becomes visible: a halo of color around each annotation, a stain that reaches toward the main text. The bleed is the physical evidence of annotation's ambition to consume.</p>
+
+<div class="ink-bleed ink-bleed-large" aria-hidden="true">
+<svg viewBox="0 0 400 50" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="40" cy="25" rx="30" ry="18" fill="#c44" opacity="0.04"/>
+<ellipse cx="50" cy="25" rx="45" ry="15" fill="#c44" opacity="0.03"/>
+<ellipse cx="60" cy="25" rx="60" ry="12" fill="#c44" opacity="0.025"/>
+<ellipse cx="70" cy="25" rx="80" ry="10" fill="#c44" opacity="0.02"/>
+<ellipse cx="350" cy="25" rx="35" ry="16" fill="#c44" opacity="0.04"/>
+<ellipse cx="340" cy="25" rx="50" ry="14" fill="#c44" opacity="0.03"/>
+<ellipse cx="330" cy="25" rx="70" ry="11" fill="#c44" opacity="0.02"/>
+<text x="200" y="20" font-family="'Cormorant', serif" font-size="9" fill="#555" font-style="italic" text-anchor="middle" opacity="0.3">the text that once lived in the center of the page</text>
+<text x="200" y="35" font-family="'Inter', sans-serif" font-size="8" fill="#c44" font-weight="700" text-anchor="middle" opacity="0.4">annotation ink spreading inward from both margins</text>
+</svg>
+</div>
+
+## The chemistry of bleed
+
+<p>Iron gall ink, the standard writing medium from the medieval period through the nineteenth century, is made from tannic acid, iron sulfate, and gum arabic. When applied to paper or parchment, the iron reacts with the cellulose fibers, creating a permanent chemical bond. But the reaction does not stop at the boundary of the letter. Iron ions migrate through the paper matrix, carried by moisture and capillary action, creating a brown halo around each stroke. This is the chemistry of bleed: the ink goes where it was not invited.</p>
+
+<div class="margin-note-heavy">
+<p class="annotation-text-heavy">The bleed is not a flaw. It is the annotation's true expression. The reader's intention may have been confined to the margin, but the ink's intention is always to spread, to reach, to colonize the paper it touches.</p>
+</div>
+
+## The foxing of annotation
+
+<p>Over centuries, the iron in annotation ink oxidizes, producing the reddish-brown spots called "foxing." These spots appear not just at the site of the original writing but throughout the surrounding paper, as migrating iron ions reach areas far from any visible text. The foxing of an annotation is its ghost: a stain that persists long after the ink itself has faded, marking the territory that the annotation once claimed.</p>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="15" r="6" fill="#c44" opacity="0.06"/>
+<circle cx="55" cy="10" r="4" fill="#c44" opacity="0.05"/>
+<circle cx="70" cy="18" r="3" fill="#c44" opacity="0.04"/>
+<circle cx="120" cy="12" r="5" fill="#c44" opacity="0.05"/>
+<circle cx="180" cy="16" r="7" fill="#c44" opacity="0.04"/>
+<circle cx="250" cy="14" r="4" fill="#c44" opacity="0.06"/>
+<circle cx="300" cy="11" r="5" fill="#c44" opacity="0.05"/>
+<circle cx="350" cy="17" r="6" fill="#c44" opacity="0.04"/>
+<circle cx="380" cy="13" r="3" fill="#c44" opacity="0.06"/>
+</svg>
+</div>
+
+## When margins meet
+
+<p>In a book that has been annotated on both sides of the page, the bleed from the left margin and the bleed from the right margin eventually meet in the center. The main text is caught between two advancing fronts of annotation ink, its letters gradually obscured by the spreading stain. This is the moment of dissolution: the boundary between text and annotation, between author and reader, between center and margin, ceases to exist. The page becomes a single field of ink in which all voices are merged.</p>
+
+<div class="margin-note-consumed">
+<p class="annotation-text-black">The bleed is the physical manifestation of a conceptual truth: no text exists in isolation. Every reading leaves a mark. Every mark spreads. Given enough time and enough readers, the original text will be entirely subsumed by the accumulated marks of its readers.</p>
+</div>
+
+<div class="annotation-grid">
+<div class="annotation-card">
+<h3>The halo</h3>
+<p class="original-text-fading" aria-hidden="true">visible ring around each mark</p>
+<p>Each annotation carries a halo of migrated ink that extends beyond the visible letters. The halo marks the annotation's true extent: wider, deeper, and more permanent than the words themselves.</p>
+</div>
+<div class="annotation-card">
+<h3>The convergence</h3>
+<p class="original-text-fading" aria-hidden="true">margins meeting at center</p>
+<p>When left-margin and right-margin annotations bleed toward the center, the main text is caught between them. The convergence marks the end of the text as an independent entity.</p>
+</div>
+</div>
+
+<blockquote>Ink bleed is the annotation's unconscious. The reader may choose to write in the margin, but the ink chooses to spread. The bleed reveals what the reader truly wanted: not to annotate the text, but to become it.</blockquote>

--- a/marginalia-noir/content/annotations/4-the-consumption.md
+++ b/marginalia-noir/content/annotations/4-the-consumption.md
@@ -1,0 +1,62 @@
++++
+title = "The Consumption"
+description = "When annotations overtake the original text entirely."
+tags = ["consumption", "overtaking", "authority"]
++++
+
+<p class="codex-label">Annotation IV</p>
+
+# The Consumption
+
+<p class="lede">There comes a point in the life of an annotated book when the annotations can no longer be called marginal. They have moved from the edges to the center. They have grown from whispers to shouts. The original text, once the reason for the book's existence, has become a thin thread running through a vast apparatus of commentary, correction, and reinterpretation. The annotations have consumed the text.</p>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 36" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 2 L6 2 L6 34 L20 34" stroke="#c44" stroke-width="3" fill="none"/>
+<path d="M380 2 L394 2 L394 34 L380 34" stroke="#c44" stroke-width="3" fill="none"/>
+<path d="M40 6 L30 6 L30 30 L40 30" stroke="#c44" stroke-width="2" fill="none" opacity="0.6"/>
+<path d="M360 6 L370 6 L370 30 L360 30" stroke="#c44" stroke-width="2" fill="none" opacity="0.6"/>
+<text x="200" y="16" font-family="'EB Garamond', serif" font-size="8" fill="#333" font-style="italic" text-anchor="middle" opacity="0.2">barely visible original</text>
+<text x="200" y="28" font-family="'Inter', sans-serif" font-size="9" fill="#c44" font-weight="800" text-anchor="middle" opacity="0.7">the annotation is all that remains</text>
+</svg>
+</div>
+
+## The Talmudic model
+
+<p>The Talmud is perhaps the greatest example of textual consumption in the history of the book. At the center of each page sits the Mishnah, the core text of rabbinic law. Surrounding it is the Gemara, centuries of rabbinic discussion and interpretation. Surrounding the Gemara are the commentaries of Rashi and the Tosafists, medieval scholars whose notes have become as authoritative as the text they annotate. On a typical page, the Mishnah occupies perhaps ten percent of the available space. The rest is annotation, commentary upon commentary, a vast architecture of reading that dwarfs its foundation.</p>
+
+<div class="margin-note-consumed">
+<p class="annotation-text-black">The Talmud does not treat this consumption as a problem. It treats it as the natural condition of a living text. A text that is not annotated is a text that is not being read. A text that is heavily annotated is a text that is deeply alive.</p>
+</div>
+
+## The variorum edition
+
+<p>In the scholarly tradition, the variorum edition is a text published with the accumulated annotations of all its major commentators. The variorum Shakespeare, for example, presents each play with footnotes that may run to hundreds of pages, recording every textual variant, every editorial decision, every scholarly disagreement about a word or a comma. The play itself becomes a small island in an ocean of apparatus. The reader who opens a variorum edition does not read Shakespeare. They read the history of reading Shakespeare.</p>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
+<rect x="160" y="4" width="80" height="22" fill="none" stroke="#444" stroke-width="0.4" opacity="0.3"/>
+<text x="200" y="17" font-family="'EB Garamond', serif" font-size="7" fill="#333" font-style="italic" text-anchor="middle" opacity="0.2">text</text>
+<ellipse cx="100" cy="15" rx="70" ry="12" fill="#c44" opacity="0.03"/>
+<ellipse cx="300" cy="15" rx="70" ry="12" fill="#c44" opacity="0.03"/>
+<ellipse cx="200" cy="15" rx="160" ry="10" fill="#c44" opacity="0.02"/>
+</svg>
+</div>
+
+## The annotator as author
+
+<p>When annotations consume the text, a transformation occurs: the annotator becomes the author. The original writer's words serve only as a framework for the annotator's commentary, a set of provocations to which the annotator responds. This is not parasitism but metamorphosis. The text has changed form. What was once a work of literature or law or philosophy has become a work of reading, a record of how one mind engaged with another's words. The consumed text is not destroyed. It is transformed into something its original author could never have imagined.</p>
+
+<div class="annotation-grid">
+<div class="annotation-card">
+<h3>The original</h3>
+<p class="original-text-dissolved" aria-hidden="true">almost invisible now</p>
+<p>The original text has been reduced to a vestige, a thin thread of fading serif type that the reader must strain to follow beneath the weight of accumulated commentary.</p>
+</div>
+<div class="annotation-card">
+<h3>The apparatus</h3>
+<p class="annotation-text">The annotation apparatus has grown to fill the page. Its voice is clear, bold, and authoritative. The margin has become the center.</p>
+</div>
+</div>
+
+<blockquote>To consume a text is not to destroy it. It is to love it so thoroughly that it disappears into the reader's response. The consumed text lives on in its annotations, transformed but not lost, like a melody that persists in its variations.</blockquote>

--- a/marginalia-noir/content/annotations/5-the-palimpsest-of-reading.md
+++ b/marginalia-noir/content/annotations/5-the-palimpsest-of-reading.md
@@ -1,0 +1,74 @@
++++
+title = "The Palimpsest of Reading"
+description = "The annotated book as a palimpsest of successive readers."
+tags = ["palimpsest", "readers", "layers"]
++++
+
+<p class="codex-label">Annotation V</p>
+
+# The Palimpsest of Reading
+
+<p class="lede">A book that has been annotated by many hands over many years becomes a palimpsest of reading. Each reader's marks overlay the previous reader's marks. Each generation's understanding obscures, revises, and transforms the understanding that came before. The book is no longer a single text. It is a geological record of attention.</p>
+
+<div class="ink-bleed ink-bleed-large" aria-hidden="true">
+<svg viewBox="0 0 400 60" xmlns="http://www.w3.org/2000/svg">
+<text x="200" y="12" font-family="'Cormorant', serif" font-size="9" fill="#333" font-style="italic" text-anchor="middle" opacity="0.15">the first reader wrote here in brown ink, centuries ago</text>
+<text x="200" y="24" font-family="'EB Garamond', serif" font-size="9" fill="#444" font-style="italic" text-anchor="middle" opacity="0.25">a second reader added notes beside the first</text>
+<text x="200" y="36" font-family="'Inter', sans-serif" font-size="9" fill="#822" font-weight="600" text-anchor="middle" opacity="0.4">a third reader underlined and bracketed</text>
+<text x="200" y="48" font-family="'Inter', sans-serif" font-size="10" fill="#c44" font-weight="800" text-anchor="middle" opacity="0.7">the latest reader's marks are the most visible</text>
+<path d="M30 4 L20 4 L20 56 L30 56" stroke="#c44" stroke-width="1" fill="none" opacity="0.3"/>
+<path d="M36 8 L28 8 L28 52 L36 52" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.4"/>
+<path d="M42 12 L36 12 L36 48 L42 48" stroke="#c44" stroke-width="2" fill="none" opacity="0.5"/>
+<path d="M370 4 L380 4 L380 56 L370 56" stroke="#c44" stroke-width="1" fill="none" opacity="0.3"/>
+<path d="M364 8 L372 8 L372 52 L364 52" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.4"/>
+<path d="M358 12 L364 12 L364 48 L358 48" stroke="#c44" stroke-width="2" fill="none" opacity="0.5"/>
+</svg>
+</div>
+
+## Layers of ink
+
+<p>In a book annotated over centuries, each reader's ink can often be distinguished by color and chemistry. The earliest annotations may be in brown iron gall ink that has faded to near-invisibility. Later readers wrote in blacker carbon inks. Modern readers have added pencil marks, ballpoint annotations, and highlighter streaks. The page becomes a stratigraphy of reading, with each layer of ink representing a different era, a different reader, a different understanding of the same words.</p>
+
+<div class="margin-note">
+<p class="annotation-text">Note: Bibliographers call this "provenance of reading." The accumulated marginalia in a book are evidence not just of what the text says, but of how it has been read, by whom, and in what spirit, across the centuries.</p>
+</div>
+
+## The conversation across time
+
+<p>Sometimes later readers respond directly to earlier annotations. A sixteenth-century reader might correct a fifteenth-century gloss. An eighteenth-century scholar might add "sic" beside a passage that a seventeenth-century reader had praised. These cross-temporal conversations are among the most remarkable features of heavily annotated books. They transform the margin into a forum that spans centuries, a space where readers separated by hundreds of years can disagree, agree, or elaborate on each other's responses to a shared text.</p>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 4 L12 4 L12 26 L20 26" stroke="#555" stroke-width="0.8" fill="none" opacity="0.3"/>
+<path d="M25 6 L18 6 L18 24 L25 24" stroke="#822" stroke-width="1.2" fill="none" opacity="0.5"/>
+<path d="M30 8 L24 8 L24 22 L30 22" stroke="#c44" stroke-width="1.8" fill="none" opacity="0.7"/>
+<path d="M380 4 L388 4 L388 26 L380 26" stroke="#555" stroke-width="0.8" fill="none" opacity="0.3"/>
+<path d="M375 6 L382 6 L382 24 L375 24" stroke="#822" stroke-width="1.2" fill="none" opacity="0.5"/>
+<path d="M370 8 L376 8 L376 22 L370 22" stroke="#c44" stroke-width="1.8" fill="none" opacity="0.7"/>
+<text x="200" y="18" font-family="'Cormorant', serif" font-size="8" fill="#555" font-style="italic" text-anchor="middle" opacity="0.3">three centuries of readers, layered in the margin</text>
+</svg>
+</div>
+
+## The book as community
+
+<p>A heavily annotated book is a community of readers. The original author is one voice among many. Each annotator contributes their perspective, their knowledge, their disagreements. The book grows with each reading, accumulating meaning like a coral reef accumulates calcium. No single reader possesses the whole text. The complete text is the sum of all its readings, all its annotations, all its margin notes and underlines and brackets and corrections. The annotated book is a collective work, authored by everyone who has ever read it with a pen in hand.</p>
+
+<div class="margin-note-consumed">
+<p class="annotation-text-black">This is the final truth of marginalia: the book does not belong to its author. It belongs to its readers. And the proof of that ownership is the ink in the margins.</p>
+</div>
+
+## The living text
+
+<p>A text without annotations is a text that has not yet begun to live its full life. The printed words of the author are only the seed. The annotations are the growth. Each reader who marks the margin adds a ring to the tree, a layer to the palimpsest, a voice to the conversation. The consumed text -- the book whose margins have overwhelmed its center, whose annotations have devoured its original words -- is not a ruined text. It is a text that has been fully read. It is a text that has achieved its purpose: not to deliver a fixed message from author to reader, but to provoke an endless conversation between all readers, across all time, in the crowded, ink-stained space of the margin.</p>
+
+<div class="ink-bleed ink-bleed-large" aria-hidden="true">
+<svg viewBox="0 0 400 40" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="200" cy="20" rx="180" ry="16" fill="#c44" opacity="0.03"/>
+<ellipse cx="200" cy="20" rx="140" ry="13" fill="#c44" opacity="0.04"/>
+<ellipse cx="200" cy="20" rx="100" ry="10" fill="#c44" opacity="0.05"/>
+<ellipse cx="200" cy="20" rx="60" ry="7" fill="#c44" opacity="0.06"/>
+<text x="200" y="22" font-family="'Inter', sans-serif" font-size="8" fill="#c44" font-weight="900" text-anchor="middle" opacity="0.5">finis</text>
+</svg>
+</div>
+
+<blockquote>The palimpsest of reading is never finished. As long as the book exists, new readers will add new layers. The annotations will continue to grow, to bleed, to consume. The margin is infinite, and the conversation never ends.</blockquote>

--- a/marginalia-noir/content/annotations/_index.md
+++ b/marginalia-noir/content/annotations/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Annotations"
+description = "The five stages of marginal annotation, from gloss to consumption."
++++
+
+<p class="lede">Five annotations, each examining a stage in the life of marginalia. From the first tentative gloss to the final consumption of the original text, each annotation marks a further encroachment of the margin upon the page.</p>
+
+<p>The annotations are arranged in order of growing intensity, tracing the reader's voice as it moves from the margin to the center.</p>

--- a/marginalia-noir/content/colophon.md
+++ b/marginalia-noir/content/colophon.md
@@ -1,0 +1,39 @@
++++
+title = "Colophon"
+description = "Production details of this dark annotation publication."
++++
+
+<div class="colophon-page">
+<p class="codex-label">Colophon</p>
+
+<h1>Colophon</h1>
+
+<div class="ink-bleed ink-bleed-small" aria-hidden="true">
+<svg viewBox="0 0 240 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="30" y1="10" x2="210" y2="10" stroke="#333" stroke-width="0.5"/>
+<ellipse cx="120" cy="10" rx="15" ry="4" fill="#c44" opacity="0.08"/>
+</svg>
+</div>
+
+<p>This publication was designed as a study of marginalia: the margin annotations that grow to consume the text they serve.</p>
+
+<p class="colophon-detail"><strong>Original text</strong> is set in Cormorant and EB Garamond, formal serifs chosen for their classical authority. As the annotations grow, the original text fades: its color lightens, its opacity diminishes, and its voice dissolves beneath the weight of commentary.</p>
+
+<p class="colophon-detail"><strong>Annotation text</strong> is set in Inter, progressing from Bold (700) through Extra-Bold (800) to Black (900) weight. The increasing heaviness represents the growing authority of the annotator's voice as it overtakes the margins and then the main text itself.</p>
+
+<p class="colophon-detail"><strong>Ink bleed patterns</strong> are drawn as inline SVG, representing the spread of annotation ink from the margins into the body of the page. These elliptical forms suggest the organic, uncontrolled spread of ink through paper fibers.</p>
+
+<p class="colophon-detail"><strong>Bracket and brace marks</strong> are rendered as inline SVG in progressively thicker stroke weights. They represent the annotator's hand: the vertical lines, square brackets, and curly braces that mark passages for attention, growing heavier and more insistent with each successive reader.</p>
+
+<p class="colophon-detail"><strong>The dark ground</strong> (#0e0e0e) represents the page of a book that has been handled, annotated, and re-annotated so many times that the paper itself has darkened. The annotation red (#c44) cuts through this darkness like fresh ink on an ancient page.</p>
+
+<div class="ink-bleed ink-bleed-small" aria-hidden="true">
+<svg viewBox="0 0 240 20" xmlns="http://www.w3.org/2000/svg">
+<circle cx="110" cy="10" r="2" fill="#c44" opacity="0.3"/>
+<circle cx="120" cy="10" r="2" fill="#c44" opacity="0.3"/>
+<circle cx="130" cy="10" r="2" fill="#c44" opacity="0.3"/>
+</svg>
+</div>
+
+<p class="colophon-imprint">First annotated edition, 2026.</p>
+</div>

--- a/marginalia-noir/content/index.md
+++ b/marginalia-noir/content/index.md
@@ -1,0 +1,80 @@
++++
+title = "Marginalia Noir"
+description = "A dark annotation publication where margin notes have grown to consume the main text."
++++
+
+<div class="cover-page">
+<p class="codex-label">Dark Annotation Publication</p>
+<h1 class="cover-display">Marginalia Noir</h1>
+<p class="cover-subtitle">When the Margins Consume the Text</p>
+</div>
+
+<div class="bracket-mark" aria-hidden="true">
+<svg viewBox="0 0 400 36" xmlns="http://www.w3.org/2000/svg">
+<path d="M30 4 L16 4 L16 32 L30 32" stroke="#c44" stroke-width="2.5" fill="none"/>
+<path d="M370 4 L384 4 L384 32 L370 32" stroke="#c44" stroke-width="2.5" fill="none"/>
+<path d="M60 8 L50 8 L50 28 L60 28" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.5"/>
+<path d="M340 8 L350 8 L350 28 L340 28" stroke="#c44" stroke-width="1.5" fill="none" opacity="0.5"/>
+<line x1="70" y1="18" x2="330" y2="18" stroke="#333" stroke-width="0.4"/>
+<circle cx="120" cy="18" r="2" fill="#c44" opacity="0.4"/>
+<circle cx="200" cy="18" r="3" fill="#c44" opacity="0.25"/>
+<circle cx="280" cy="18" r="2" fill="#c44" opacity="0.3"/>
+</svg>
+</div>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 40" xmlns="http://www.w3.org/2000/svg">
+<text x="30" y="14" font-family="'Cormorant', serif" font-size="10" fill="#555" font-style="italic" opacity="0.4">the original text was written here in careful hand</text>
+<text x="20" y="30" font-family="'Inter', sans-serif" font-size="9" fill="#c44" font-weight="700" opacity="0.6">but the annotation grew and the margin note spread</text>
+<ellipse cx="150" cy="22" rx="40" ry="8" fill="#c44" opacity="0.06"/>
+<ellipse cx="300" cy="18" rx="30" ry="6" fill="#c44" opacity="0.04"/>
+</svg>
+</div>
+
+## On the marginalia
+
+<p class="lede">A book is never finished by its author alone. Every reader who marks a margin, underlines a passage, or scrawls a note beside a paragraph becomes a co-author. The margin is a space of private conversation between reader and text. But what happens when the annotations grow? When the marginal notes become longer than the passages they annotate? When the reader's voice overwhelms the author's?</p>
+
+## The margins as territory
+
+<p>In the history of the book, the margin has always been contested space. Medieval scribes left generous margins for glosses -- explanatory notes added by later scholars. Renaissance readers filled margins with concordances, cross-references, and running commentary. Some readers annotated so heavily that the original text became secondary, a mere pretext for the annotations that surrounded it.</p>
+
+<div class="ink-bleed" aria-hidden="true">
+<svg viewBox="0 0 400 20" xmlns="http://www.w3.org/2000/svg">
+<line x1="0" y1="10" x2="400" y2="10" stroke="#2a2a2a" stroke-width="0.4"/>
+<ellipse cx="80" cy="10" rx="25" ry="5" fill="#c44" opacity="0.05"/>
+<ellipse cx="220" cy="10" rx="35" ry="6" fill="#c44" opacity="0.04"/>
+<ellipse cx="340" cy="10" rx="20" ry="4" fill="#c44" opacity="0.06"/>
+</svg>
+</div>
+
+## The act of annotation
+
+<p>To annotate is to assert authority over a text. The annotator claims the right to interrupt, to clarify, to disagree, to expand. A margin note says: the author's words are not sufficient. They require my addition. At first, the annotation is modest -- a single word, a question mark, a bracket around a key phrase. But annotations breed. One note demands another. A correction requires a counter-correction. A cross-reference leads to further cross-references. The margins fill, and then the annotations begin to overflow into the text itself.</p>
+
+<div class="annotation-grid">
+<div class="annotation-card">
+<h3>The Gloss</h3>
+<p class="original-text" aria-hidden="true">original text fading beneath</p>
+<p>The medieval gloss began as a modest aid to reading: a Latin synonym above a difficult word, a brief explanation in the margin. Over centuries, glosses grew into elaborate networks of commentary that dwarfed the original text.</p>
+</div>
+<div class="annotation-card">
+<h3>The Bracket</h3>
+<p class="original-text" aria-hidden="true">passage marked for attention</p>
+<p>The bracket is the simplest annotation mark: a vertical line in the margin that says "pay attention here." But brackets multiply. One passage leads to another, and soon the entire page is bracketed.</p>
+</div>
+<div class="annotation-card">
+<h3>The Bleed</h3>
+<p class="original-text" aria-hidden="true">ink spreading from margin</p>
+<p>When annotation ink bleeds into the main text, the boundary between original and commentary dissolves. The reader's words merge with the author's, creating a hybrid text that belongs to neither alone.</p>
+</div>
+<div class="annotation-card">
+<h3>The Consumption</h3>
+<p class="original-text" aria-hidden="true">text devoured by notes</p>
+<p>In the final stage, the annotations have consumed the original entirely. The margin has expanded to fill the page. The reader's voice is the only voice that remains.</p>
+</div>
+</div>
+
+## Reading the consumed text
+
+<p>This publication is a study of that process: the slow, inevitable consumption of a text by its annotations. Each section traces a stage in the life of marginalia, from the first tentative gloss to the final absorption of the original into the apparatus that was meant to serve it. The design reflects the content: annotation red overtakes the fading serif of the original, heavy sans-serif weight overwhelms the dissolving text, and ink bleed patterns spread from the margins into the body of the page.</p>

--- a/marginalia-noir/static/css/style.css
+++ b/marginalia-noir/static/css/style.css
@@ -1,0 +1,538 @@
+/* =============================================================================
+   Marginalia Noir - Dark Annotation Publication
+   Issue #1537 | book, dark, annotated, consumed, experimental
+   Palette: very dark ground (#0e0e0e), annotation red (#c44), fading text gray
+   No gradients. Ink bleed patterns + bracket/brace marks as inline SVG.
+   ============================================================================= */
+
+:root {
+  --void: #0e0e0e;
+  --surface: #151515;
+  --surface-raised: #1c1c1c;
+  --surface-edge: #2e2e2e;
+  --text: #e0e0e0;
+  --text-soft: #aaa;
+  --text-dim: #666;
+  --text-fading: #555;
+  --annotation-red: #c44;
+  --annotation-red-dim: #822;
+  --annotation-red-faint: #511;
+  --ink-bleed: #c44;
+  --original-text: #777;
+  --original-text-fading: #444;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--void);
+  color: var(--text);
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 17px;
+  line-height: 1.72;
+  min-height: 100vh;
+}
+
+.page-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--surface-edge);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.logo-mark { width: 42px; height: 42px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Inter", sans-serif;
+  font-weight: 800;
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.logo-sub {
+  font-family: "Cormorant", serif;
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-soft);
+  font-family: "Inter", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--annotation-red); border-bottom-color: var(--annotation-red); }
+
+/* --- Codex page (main content container) --------------------------------- */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.codex-page {
+  position: relative;
+  background-color: var(--surface);
+  border: 1px solid var(--surface-edge);
+  min-height: 600px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+}
+
+.codex-page-narrow {
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.margin-bracket-border { text-align: center; padding: 1.25rem 1.5rem 0; }
+.margin-bracket-border svg { max-width: 100%; height: 14px; display: block; margin: 0 auto; }
+.margin-bracket-border-bottom { padding: 0 1.5rem 1.25rem; }
+
+.codex-body {
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.5rem, 4vw, 3.5rem);
+}
+
+/* --- Typography: original text (dissolving serif) ------------------------ */
+.codex-body h1,
+.codex-body h2,
+.codex-body h3 {
+  font-family: "Inter", sans-serif;
+  color: var(--text);
+  line-height: 1.25;
+  font-weight: 700;
+}
+.codex-body h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0 0 0.3em;
+  letter-spacing: -0.01em;
+}
+.codex-body h2 {
+  font-size: 1.3rem;
+  margin: 2.5em 0 0.4em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.codex-body h3 {
+  font-size: 1rem;
+  margin: 1.5em 0 0.2em;
+  color: var(--annotation-red);
+  text-align: left;
+}
+
+.codex-body p {
+  margin: 1em 0;
+  color: var(--text);
+  font-family: "Inter", sans-serif;
+  font-size: 0.95rem;
+  text-align: left;
+  line-height: 1.72;
+}
+
+.codex-body p.lede {
+  font-family: "Cormorant", serif;
+  font-size: 1.2rem;
+  line-height: 1.55;
+  color: var(--text-soft);
+  font-style: italic;
+  text-align: center;
+  max-width: 34em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.codex-label {
+  display: inline-block;
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--annotation-red);
+  margin: 0 0 0.5em;
+}
+
+.codex-head { margin-bottom: 2rem; text-align: center; }
+.codex-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 800;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.codex-body a {
+  color: var(--annotation-red);
+  text-decoration: none;
+  border-bottom: 1px solid var(--annotation-red-dim);
+}
+.codex-body a:hover { color: var(--text); border-bottom-color: var(--text); }
+
+/* --- Original text (fading serif for the consumed text) ------------------ */
+.original-text {
+  font-family: "Cormorant", serif;
+  color: var(--original-text);
+  font-size: 1rem;
+  line-height: 1.6;
+  font-style: italic;
+}
+
+.original-text-fading {
+  font-family: "EB Garamond", serif;
+  color: var(--original-text-fading);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  font-style: italic;
+  opacity: 0.6;
+}
+
+.original-text-dissolved {
+  font-family: "EB Garamond", serif;
+  color: var(--surface-edge);
+  font-size: 0.85rem;
+  font-style: italic;
+  opacity: 0.35;
+  letter-spacing: 0.08em;
+}
+
+/* --- Annotation text (heavy Inter sans overtaking margins) --------------- */
+.annotation-text {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--annotation-red);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.annotation-text-heavy {
+  font-family: "Inter", sans-serif;
+  font-weight: 800;
+  color: var(--annotation-red);
+  font-size: 1.05rem;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+.annotation-text-black {
+  font-family: "Inter", sans-serif;
+  font-weight: 900;
+  color: var(--text);
+  font-size: 1.15rem;
+  line-height: 1.35;
+  letter-spacing: -0.02em;
+}
+
+/* --- Margin note block --------------------------------------------------- */
+.margin-note {
+  border-left: 3px solid var(--annotation-red);
+  padding: 0.6rem 1rem;
+  margin: 1.2rem 0;
+  background-color: var(--surface-raised);
+}
+
+.margin-note-heavy {
+  border-left: 5px solid var(--annotation-red);
+  padding: 0.8rem 1.2rem;
+  margin: 1.2rem 0;
+  background-color: var(--surface-raised);
+}
+
+.margin-note-consumed {
+  border-left: 7px solid var(--annotation-red);
+  border-right: 3px solid var(--annotation-red-dim);
+  padding: 1rem 1.2rem;
+  margin: 1.5rem 0;
+  background-color: var(--surface-raised);
+}
+
+/* --- Ink bleed SVG containers -------------------------------------------- */
+.ink-bleed {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.ink-bleed svg {
+  max-width: 100%;
+  height: 40px;
+  display: inline-block;
+}
+.ink-bleed-small svg {
+  max-width: 240px;
+  height: 20px;
+}
+.ink-bleed-large svg {
+  max-width: 100%;
+  height: 60px;
+}
+
+/* --- Bracket mark containers --------------------------------------------- */
+.bracket-mark {
+  text-align: center;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+.bracket-mark svg {
+  max-width: 100%;
+  height: 36px;
+  display: inline-block;
+}
+
+/* --- Blockquote ---------------------------------------------------------- */
+blockquote {
+  margin: 2rem auto;
+  padding: 0.5rem 1.5rem;
+  border-left: 3px solid var(--annotation-red);
+  background-color: var(--surface-raised);
+  font-style: italic;
+  color: var(--text-soft);
+  font-family: "Cormorant", serif;
+  font-size: 1.1rem;
+  text-align: left;
+  max-width: 32em;
+}
+
+/* --- Lists --------------------------------------------------------------- */
+.codex-body ul,
+.codex-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  text-align: left;
+}
+.codex-body ul { list-style: disc; }
+.codex-body ol { list-style: decimal; }
+.codex-body li { padding: 0.2em 0; color: var(--text-soft); }
+
+/* --- Cover page ---------------------------------------------------------- */
+.cover-page {
+  padding: clamp(3rem, 8vw, 6rem) 0;
+  text-align: center;
+}
+.cover-display {
+  font-family: "Inter", sans-serif;
+  font-weight: 900;
+  font-size: clamp(2.2rem, 5.5vw, 3.5rem);
+  color: var(--text);
+  letter-spacing: -0.02em;
+  margin: 0 0 0.15em;
+}
+.cover-subtitle {
+  font-family: "Cormorant", serif;
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* --- Annotation card grid ------------------------------------------------ */
+.annotation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+.annotation-card {
+  background-color: var(--surface-raised);
+  border: 1px solid var(--surface-edge);
+  border-left: 3px solid var(--annotation-red);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.annotation-card h3 {
+  margin: 0 0 0.1em;
+  color: var(--annotation-red);
+  font-size: 0.95rem;
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+}
+.annotation-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+.annotation-card .original-text {
+  margin-bottom: 0.5em;
+}
+
+/* --- Colophon page ------------------------------------------------------- */
+.colophon-page {
+  text-align: center;
+  padding: 2rem 0;
+}
+.colophon-page h1 {
+  font-family: "Inter", sans-serif;
+  font-weight: 800;
+  font-size: 1.8rem;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.colophon-detail {
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--text-soft);
+}
+.colophon-detail strong {
+  color: var(--annotation-red);
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+}
+.colophon-imprint {
+  font-family: "Cormorant", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 1rem;
+  margin-top: 2rem;
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--surface-edge);
+  text-align: left;
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--surface-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Inter", sans-serif;
+}
+.section-list li::before {
+  content: "\005B";
+  color: var(--annotation-red);
+  font-size: 1em;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.section-list li::after {
+  content: "\005D";
+  color: var(--annotation-red);
+  font-size: 1em;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.section-list li a {
+  font-weight: 700;
+  color: var(--text);
+  border: none;
+  font-size: 0.95rem;
+  flex: 1;
+}
+.section-list li a:hover { color: var(--annotation-red); }
+
+.taxonomy-desc {
+  color: var(--text-dim);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  text-align: left;
+  font-family: "Cormorant", serif;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--surface-edge);
+  font-family: "Inter", sans-serif;
+  font-size: 0.82rem;
+  color: var(--text-soft);
+  text-decoration: none;
+  background-color: var(--surface-raised);
+}
+nav.pagination a:hover { color: var(--annotation-red); border-color: var(--annotation-red); }
+.pagination-current span { color: var(--text); border-color: var(--annotation-red); }
+
+/* --- Footer -------------------------------------------------------------- */
+.footer-device {
+  margin: 0 auto 0.8rem;
+}
+.footer-device svg {
+  width: 40px;
+  height: 40px;
+  display: block;
+  margin: 0 auto;
+}
+
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--surface-edge);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--text-soft);
+  margin: 0.2em 0;
+  letter-spacing: 0.01em;
+  font-size: 0.92rem;
+}
+.footer-line-small {
+  font-family: "Cormorant", serif;
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .codex-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .codex-title, .codex-body h1, .cover-display { font-size: 1.8rem; }
+  .codex-body h2 { font-size: 1.15rem; }
+  .cover-page { padding: 2.5rem 0; }
+}

--- a/marginalia-noir/templates/404.html
+++ b/marginalia-noir/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="codex-page codex-page-narrow">
+      <div class="codex-body">
+        <header class="codex-head">
+          <p class="codex-label">404</p>
+          <h1 class="codex-title">Annotation not found</h1>
+        </header>
+        <p>This margin is empty. No annotation was ever written here, or the ink has bled away entirely. Return to the cover page to begin reading again.</p>
+        <p><a href="{{ base_url }}/">Back to the cover</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/marginalia-noir/templates/footer.html
+++ b/marginalia-noir/templates/footer.html
@@ -1,0 +1,19 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-device" aria-hidden="true">
+        <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+          <rect x="14" y="10" width="22" height="30" fill="none" stroke="#444" stroke-width="0.6"/>
+          <line x1="18" y1="18" x2="32" y2="18" stroke="#333" stroke-width="0.3" opacity="0.2"/>
+          <line x1="18" y1="22" x2="28" y2="22" stroke="#333" stroke-width="0.3" opacity="0.15"/>
+          <path d="M12 14 L12 36" stroke="#c44" stroke-width="1.2" fill="none" opacity="0.5"/>
+          <text x="25" y="34" font-family="sans-serif" font-size="7" fill="#c44" text-anchor="middle" font-weight="800">MN</text>
+        </svg>
+      </div>
+      <p class="footer-line">Marginalia Noir</p>
+      <p class="footer-line-small">The annotations have consumed the text.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; annotated, overwritten, absorbed</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/marginalia-noir/templates/header.html
+++ b/marginalia-noir/templates/header.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;0,500;1,300;1,400&family=EB+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="page-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Marginalia Noir home">
+        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="8" y="4" width="32" height="40" fill="none" stroke="#555" stroke-width="0.7"/>
+          <line x1="14" y1="12" x2="34" y2="12" stroke="#444" stroke-width="0.4" opacity="0.35"/>
+          <line x1="14" y1="16" x2="30" y2="16" stroke="#444" stroke-width="0.4" opacity="0.25"/>
+          <line x1="14" y1="20" x2="32" y2="20" stroke="#444" stroke-width="0.4" opacity="0.15"/>
+          <path d="M6 10 L6 38" stroke="#c44" stroke-width="1.5" fill="none"/>
+          <path d="M42 14 L42 34" stroke="#c44" stroke-width="2" fill="none"/>
+          <text x="24" y="32" font-family="sans-serif" font-size="10" fill="#c44" text-anchor="middle" font-weight="800">M</text>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Marginalia Noir</span>
+          <span class="logo-sub">Annotations Consuming Text</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Cover</a>
+        <a href="{{ base_url }}/annotations/">Annotations</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/marginalia-noir/templates/page.html
+++ b/marginalia-noir/templates/page.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="codex-page">
+      <div class="margin-bracket-border" aria-hidden="true">
+        <svg viewBox="0 0 600 14" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20 2 L10 2 L10 12 L20 12" stroke="#c44" stroke-width="1.5" fill="none"/>
+          <line x1="30" y1="7" x2="570" y2="7" stroke="#333" stroke-width="0.4"/>
+          <path d="M580 2 L590 2 L590 12 L580 12" stroke="#c44" stroke-width="1.5" fill="none"/>
+          <circle cx="200" cy="7" r="1.5" fill="#c44" opacity="0.3"/>
+          <circle cx="400" cy="7" r="1" fill="#c44" opacity="0.2"/>
+        </svg>
+      </div>
+      <div class="codex-body">
+        {{ content }}
+      </div>
+      <div class="margin-bracket-border margin-bracket-border-bottom" aria-hidden="true">
+        <svg viewBox="0 0 600 14" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20 2 L10 2 L10 12 L20 12" stroke="#c44" stroke-width="1" fill="none" opacity="0.5"/>
+          <line x1="30" y1="7" x2="570" y2="7" stroke="#333" stroke-width="0.3"/>
+          <path d="M580 2 L590 2 L590 12 L580 12" stroke="#c44" stroke-width="1" fill="none" opacity="0.5"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/marginalia-noir/templates/section.html
+++ b/marginalia-noir/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="codex-page">
+      <div class="margin-bracket-border" aria-hidden="true">
+        <svg viewBox="0 0 600 14" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20 2 L10 2 L10 12 L20 12" stroke="#c44" stroke-width="1.8" fill="none"/>
+          <line x1="30" y1="7" x2="570" y2="7" stroke="#333" stroke-width="0.4"/>
+          <path d="M580 2 L590 2 L590 12 L580 12" stroke="#c44" stroke-width="1.8" fill="none"/>
+        </svg>
+      </div>
+      <div class="codex-body">
+        <header class="codex-head">
+          <p class="codex-label">Archive</p>
+          <h1 class="codex-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/marginalia-noir/templates/shortcodes/alert.html
+++ b/marginalia-noir/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #444; background-color: #1a1a1a; border-left: 4px solid #c44; margin: 1rem 0; color: #ccc;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/marginalia-noir/templates/taxonomy.html
+++ b/marginalia-noir/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="codex-page codex-page-narrow">
+      <div class="codex-body">
+        <header class="codex-head">
+          <p class="codex-label">Index</p>
+          <h1 class="codex-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All marks catalogued across the annotations:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/marginalia-noir/templates/taxonomy_term.html
+++ b/marginalia-noir/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="codex-page codex-page-narrow">
+      <div class="codex-body">
+        <header class="codex-head">
+          <p class="codex-label">Mark</p>
+          <h1 class="codex-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Annotations bearing this mark:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1,4661 +1,4668 @@
 {
-    "abstract-noir": [
-        "paper",
-        "dark",
-        "abstract",
-        "bold",
-        "typography"
-    ],
-    "abyss": [
-        "dark",
-        "blog",
-        "deep-sea",
-        "immersive"
-    ],
-    "acid-graphics": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "acme-docs": [
-        "light",
-        "docs"
-    ],
-    "acoustic-soundwaves": [
-        "dark",
-        "blog",
-        "sound",
-        "waveform"
-    ],
-    "adminpanel": [
-        "dark",
-        "dashboard",
-        "admin",
-        "sidebar"
-    ],
-    "aether": [
-        "dark",
-        "blog",
-        "elegant"
-    ],
-    "aetheria": [
-        "dark-mode",
-        "elegant",
-        "portfolio"
-    ],
-    "after-dark": [
-        "blog",
-        "dark",
-        "reading"
-    ],
-    "afterparty": [
-        "event",
-        "party",
-        "nightlife",
-        "club",
-        "late-night"
-    ],
-    "aftershock": [
-        "event",
-        "dark",
-        "post-event",
-        "retrospective",
-        "impact"
-    ],
-    "airwave": [
-        "dark",
-        "blog",
-        "podcast"
-    ],
-    "alexandrite": [
-        "dark",
-        "blog",
-        "glamorous",
-        "gemstone"
-    ],
-    "almanac": [
-        "light",
-        "blog",
-        "calendar"
-    ],
-    "almanac-docs": [
-        "light",
-        "docs",
-        "roadmap"
-    ],
-    "amber-preservation": [
-        "dark",
-        "blog",
-        "amber",
-        "fossil"
-    ],
-    "amethyst": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "anaglyph": [
-        "dark",
-        "blog",
-        "3d",
-        "stereoscopic"
-    ],
-    "analytics": [
-        "light",
-        "dashboard",
-        "analytics"
-    ],
-    "anamorphic": [
-        "dark",
-        "portfolio",
-        "anamorphic",
-        "optical"
-    ],
-    "anatomy-atlas": [
-        "dark",
-        "docs",
-        "medical",
-        "vintage"
-    ],
-    "annotation-layer": [
-        "book",
-        "light",
-        "scholarly",
-        "annotated",
-        "dense"
-    ],
-    "anthology": [
-        "light",
-        "docs",
-        "sdk-reference"
-    ],
-    "antimatter": [
-        "dark",
-        "blog",
-        "experimental",
-        "inverted"
-    ],
-    "anubis": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "anvil": [
-        "dark",
-        "blog",
-        "workshop"
-    ],
-    "apiary": [
-        "light",
-        "docs",
-        "api",
-        "two-column"
-    ],
-    "apolo": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "apothecary": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "appsite": [
-        "light",
-        "landing",
-        "app"
-    ],
-    "aquarium": [
-        "dark",
-        "blog",
-        "marine"
-    ],
-    "aquatint": [
-        "light",
-        "portfolio",
-        "creative",
-        "elegant",
-        "bold"
-    ],
-    "aqueduct": [
-        "light",
-        "blog",
-        "engineering"
-    ],
-    "arbor": [
-        "light",
-        "docs",
-        "git-workflow"
-    ],
-    "archipelago": [
-        "dark",
-        "landing",
-        "hub"
-    ],
-    "archive": [
-        "light",
-        "docs",
-        "archive"
-    ],
-    "archway-docs": [
-        "docs",
-        "light",
-        "architecture"
-    ],
-    "arctic-saas": [
-        "landing",
-        "light",
-        "saas",
-        "minimal"
-    ],
-    "arena": [
-        "dark",
-        "blog",
-        "sports"
-    ],
-    "artdeco": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "artnouveau": [
-        "light",
-        "portfolio",
-        "art-nouveau",
-        "botanical"
-    ],
-    "arxiv-preprint": [
-        "paper",
-        "light",
-        "preprint",
-        "self-published",
-        "raw"
-    ],
-    "ascii": [
-        "dark",
-        "terminal",
-        "ascii"
-    ],
-    "asymmetric": [
-        "light",
-        "portfolio",
-        "grid",
-        "asymmetric"
-    ],
-    "atelier": [
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "athena": [
-        "elegant",
-        "portfolio",
-        "light"
-    ],
-    "atlas": [
-        "light",
-        "blog",
-        "geography"
-    ],
-    "atlas-docs": [
-        "docs",
-        "light",
-        "navigation"
-    ],
-    "aurelia": [
-        "elegant",
-        "minimalist",
-        "blog"
-    ],
-    "aurora": [
-        "dark",
-        "blog",
-        "aurora"
-    ],
-    "aurora-glimmer": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "aurora-launch": [
-        "landing",
-        "dark",
-        "animation"
-    ],
-    "aurum": [
-        "elegant",
-        "dark",
-        "minimal",
-        "blog"
-    ],
-    "avalanche-event": [
-        "event",
-        "dark",
-        "momentum",
-        "cascading",
-        "overwhelming"
-    ],
-    "axiom": [
-        "light",
-        "design-system",
-        "geometric",
-        "mathematical"
-    ],
-    "bamboo": [
-        "light",
-        "blog",
-        "eco"
-    ],
-    "baroque": [
-        "dark",
-        "blog",
-        "ornamental",
-        "glamorous"
-    ],
-    "bas-relief": [
-        "light",
-        "artistic",
-        "minimal"
-    ],
-    "bastard-title": [
-        "book",
-        "light",
-        "preliminary",
-        "ceremonial",
-        "typography"
-    ],
-    "bastion": [
-        "dark",
-        "docs",
-        "zero-trust"
-    ],
-    "batik": [
-        "light",
-        "blog",
-        "elegant",
-        "batik"
-    ],
-    "bauhaus": [
-        "light",
-        "portfolio",
-        "design",
-        "geometric"
-    ],
-    "bayesian-prior": [
-        "paper",
-        "dark",
-        "bayesian",
-        "probabilistic",
-        "visualization"
-    ],
-    "bazaar": [
-        "light",
-        "landing",
-        "marketplace"
-    ],
-    "beacon": [
-        "dark",
-        "blog",
-        "alert"
-    ],
-    "beacon-docs": [
-        "light",
-        "docs",
-        "feature-flag"
-    ],
-    "beautiful-hwaro": [
-        "light",
-        "blog"
-    ],
-    "bejeweled": [
-        "elegant",
-        "glamorous",
-        "luxury"
-    ],
-    "bell-tower": [
-        "event",
-        "light",
-        "scheduled",
-        "clock",
-        "traditional"
-    ],
-    "bench-report": [
-        "paper",
-        "light",
-        "laboratory",
-        "bench",
-        "experimental"
-    ],
-    "bijou": [
-        "dark",
-        "elegant",
-        "jewelry",
-        "glamorous"
-    ],
-    "bioluminescence": [
-        "dark",
-        "blog",
-        "bioluminescence",
-        "minimal"
-    ],
-    "bismuth": [
-        "dark",
-        "collection",
-        "mineral",
-        "rainbow-metallic"
-    ],
-    "black-box": [
-        "event",
-        "dark",
-        "theater",
-        "intimate",
-        "minimal"
-    ],
-    "black-letter-bible": [
-        "book",
-        "dark",
-        "sacred",
-        "blackletter",
-        "dense"
-    ],
-    "blacklight": [
-        "dark",
-        "fluorescent",
-        "elegant"
-    ],
-    "blast-furnace": [
-        "event",
-        "dark",
-        "workshop",
-        "intense",
-        "industrial"
-    ],
-    "blockade-run": [
-        "event",
-        "dark",
-        "breakthrough",
-        "barriers",
-        "overcome"
-    ],
-    "blueprint": [
-        "dark",
-        "docs",
-        "spec"
-    ],
-    "blueprint-pro": [
-        "landing",
-        "dark",
-        "devtool"
-    ],
-    "bonfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "bonsai": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "book": [
-        "light",
-        "docs"
-    ],
-    "borealis": [
-        "dark",
-        "blog",
-        "aurora",
-        "nordic"
-    ],
-    "botanical-press": [
-        "blog",
-        "light",
-        "botanical",
-        "vintage"
-    ],
-    "boutique": [
-        "light",
-        "store",
-        "fashion",
-        "elegant"
-    ],
-    "box-office": [
-        "event",
-        "tickets",
-        "sales",
-        "urgency",
-        "countdown"
-    ],
-    "bramble": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "breeze": [
-        "landing",
-        "light",
-        "minimal",
-        "one-page"
-    ],
-    "brocade": [
-        "dark",
-        "blog",
-        "glamorous",
-        "luxury"
-    ],
-    "brutalist": [
-        "light",
-        "blog",
-        "brutalist"
-    ],
-    "brutopia": [
-        "dark",
-        "blog",
-        "brutalist",
-        "monospace"
-    ],
-    "bulwark": [
-        "dark",
-        "docs",
-        "disaster-recovery"
-    ],
-    "bureau": [
-        "light",
-        "docs",
-        "governance"
-    ],
-    "burlesque": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "burnt-charcoal": [
-        "dark",
-        "blog",
-        "charcoal",
-        "texture"
-    ],
-    "butterfly-wing": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "trendy",
-        "blog"
-    ],
-    "byzantine": [
-        "light",
-        "blog",
-        "byzantine",
-        "mosaic",
-        "imperial"
-    ],
-    "cabaret": [
-        "dark",
-        "blog",
-        "glamorous",
-        "theater"
-    ],
-    "cabin": [
-        "dark",
-        "blog",
-        "lifestyle"
-    ],
-    "cactus": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cafe": [
-        "light",
-        "landing",
-        "menu"
-    ],
-    "cage-match": [
-        "event",
-        "dark",
-        "competition",
-        "fight",
-        "enclosed"
-    ],
-    "call-to-stage": [
-        "event",
-        "talent",
-        "open-call",
-        "audition",
-        "stage"
-    ],
-    "calligraphy": [
-        "dark",
-        "blog",
-        "calligraphy",
-        "ink"
-    ],
-    "cameo": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "campfire": [
-        "dark",
-        "blog",
-        "storytelling"
-    ],
-    "cancel-leaf": [
-        "book",
-        "light",
-        "correction",
-        "repair",
-        "visible"
-    ],
-    "canopy": [
-        "light",
-        "blog",
-        "outdoor"
-    ],
-    "canvas-studio": [
-        "landing",
-        "light",
-        "portfolio",
-        "agency"
-    ],
-    "carbon-fiber": [
-        "dark",
-        "blog",
-        "tech"
-    ],
-    "carnival": [
-        "dark",
-        "blog",
-        "glamorous",
-        "event"
-    ],
-    "cartograph": [
-        "dark",
-        "docs",
-        "infrastructure"
-    ],
-    "cascade": [
-        "light",
-        "longform",
-        "waterfall",
-        "scroll-driven"
-    ],
-    "case-report": [
-        "paper",
-        "light",
-        "clinical",
-        "case-study",
-        "medical"
-    ],
-    "cassette": [
-        "dark",
-        "blog",
-        "retro",
-        "audio"
-    ],
-    "catacombs": [
-        "dark",
-        "blog",
-        "underground",
-        "adventure"
-    ],
-    "catalyst": [
-        "light",
-        "landing",
-        "science",
-        "chemistry"
-    ],
-    "cathedral": [
-        "light",
-        "portfolio",
-        "architecture"
-    ],
-    "cauldron": [
-        "dark",
-        "wiki",
-        "fantasy",
-        "potion"
-    ],
-    "celebrate": [
-        "light",
-        "landing",
-        "event"
-    ],
-    "celestial-burst": [
-        "dark",
-        "glamorous",
-        "celestial",
-        "trendy"
-    ],
-    "center-stage": [
-        "event",
-        "solo",
-        "show",
-        "spotlight",
-        "centered"
-    ],
-    "chain-reaction": [
-        "event",
-        "dark",
-        "sequential",
-        "cascade",
-        "connected"
-    ],
-    "chalkboard": [
-        "dark",
-        "blog",
-        "education"
-    ],
-    "champagne": [
-        "light",
-        "luxury",
-        "elegant",
-        "champagne"
-    ],
-    "chandelier": [
-        "light",
-        "blog",
-        "crystal",
-        "elegant",
-        "prismatic"
-    ],
-    "changelog": [
-        "dark",
-        "docs",
-        "changelog"
-    ],
-    "chase-frame": [
-        "book",
-        "dark",
-        "letterpress",
-        "mechanical",
-        "craft"
-    ],
-    "chiaroscuro": [
-        "dark",
-        "portfolio",
-        "chiaroscuro",
-        "contrast"
-    ],
-    "chinoiserie": [
-        "light",
-        "blog",
-        "chinese",
-        "porcelain",
-        "elegant"
-    ],
-    "chromatic": [
-        "dark",
-        "photoblog",
-        "chromatic",
-        "lens"
-    ],
-    "chromatic-wave": [
-        "dark",
-        "portfolio",
-        "glamorous",
-        "animation"
-    ],
-    "chromatophore": [
-        "dark",
-        "bold",
-        "minimal",
-        "creative"
-    ],
-    "chrome-pulse": [
-        "minimal",
-        "dark",
-        "landing"
-    ],
-    "chromolithograph": [
-        "book",
-        "light",
-        "color-plate",
-        "print",
-        "illustration"
-    ],
-    "chronicle": [
-        "light",
-        "blog",
-        "traditional",
-        "serif"
-    ],
-    "chronosphere": [
-        "dark",
-        "space",
-        "time"
-    ],
-    "chrysanthemum": [
-        "dark",
-        "blog",
-        "floral",
-        "glamorous"
-    ],
-    "cinder": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "cinema": [
-        "dark",
-        "blog",
-        "review"
-    ],
-    "cinema-silent": [
-        "dark",
-        "blog",
-        "retro",
-        "editorial"
-    ],
-    "cipher": [
-        "dark",
-        "docs",
-        "cryptography"
-    ],
-    "citation-graph": [
-        "paper",
-        "dark",
-        "network",
-        "citations",
-        "visualization"
-    ],
-    "clarity-docs": [
-        "docs",
-        "light",
-        "minimal",
-        "typography"
-    ],
-    "clocktower": [
-        "dark",
-        "landing",
-        "countdown"
-    ],
-    "cloisonne": [
-        "dark",
-        "portfolio",
-        "enamel",
-        "ornate"
-    ],
-    "cloister": [
-        "light",
-        "blog",
-        "meditation"
-    ],
-    "closed": [
-        "light",
-        "error",
-        "499",
-        "minimal"
-    ],
-    "cloudnest": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "cobblestone": [
-        "light",
-        "blog",
-        "culture"
-    ],
-    "cockpit": [
-        "dark",
-        "landing",
-        "telemetry"
-    ],
-    "codebook": [
-        "light",
-        "docs",
-        "styleguide"
-    ],
-    "codecraft": [
-        "api",
-        "dark",
-        "developer",
-        "docs"
-    ],
-    "codex": [
-        "light",
-        "blog",
-        "medieval"
-    ],
-    "codex-rotundus": [
-        "book",
-        "dark",
-        "circular",
-        "unusual",
-        "experimental"
-    ],
-    "cohort-study": [
-        "paper",
-        "light",
-        "cohort",
-        "survival",
-        "epidemiological"
-    ],
-    "cold-case": [
-        "paper",
-        "dark",
-        "forensic",
-        "investigation",
-        "reopened"
-    ],
-    "colosseum": [
-        "light",
-        "event",
-        "classical",
-        "grand"
-    ],
-    "comic": [
-        "light",
-        "blog",
-        "comic"
-    ],
-    "command-center": [
-        "docs",
-        "dark",
-        "cli",
-        "developer"
-    ],
-    "compass": [
-        "light",
-        "landing",
-        "career"
-    ],
-    "compass-docs": [
-        "light",
-        "docs",
-        "onboarding"
-    ],
-    "conduit": [
-        "light",
-        "docs",
-        "data-pipeline"
-    ],
-    "conference-poster": [
-        "paper",
-        "dark",
-        "poster",
-        "conference",
-        "visual"
-    ],
-    "confetti": [
-        "celebration",
-        "elegant",
-        "festive"
-    ],
-    "console": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "constellation": [
-        "dark",
-        "blog",
-        "astronomy"
-    ],
-    "controlroom": [
-        "dark",
-        "dashboard",
-        "monitoring"
-    ],
-    "copper-patina": [
-        "dark",
-        "blog",
-        "patina",
-        "industrial"
-    ],
-    "copper-wire": [
-        "blog",
-        "dark",
-        "industrial"
-    ],
-    "copperplate": [
-        "dark",
-        "blog",
-        "copperplate",
-        "engraving"
-    ],
-    "coral": [
-        "light",
-        "documentary",
-        "organic",
-        "ocean"
-    ],
-    "coral-bloom": [
-        "dark",
-        "blog",
-        "elegant",
-        "marine",
-        "glamorous"
-    ],
-    "corrigendum": [
-        "paper",
-        "light",
-        "correction",
-        "errata",
-        "formal"
-    ],
-    "cosmos": [
-        "dark",
-        "magazine",
-        "space",
-        "planetary"
-    ],
-    "cost-effectiveness": [
-        "paper",
-        "light",
-        "economics",
-        "cost-effectiveness",
-        "health"
-    ],
-    "countdown-zero": [
-        "event",
-        "dark",
-        "countdown",
-        "convergence",
-        "climactic"
-    ],
-    "creative-agency": [
-        "dark",
-        "portfolio",
-        "agency",
-        "bold"
-    ],
-    "cross-sectional": [
-        "paper",
-        "light",
-        "cross-sectional",
-        "snapshot",
-        "population"
-    ],
-    "crucible": [
-        "light",
-        "docs",
-        "testing"
-    ],
-    "cruciform": [
-        "light",
-        "design-system",
-        "grid",
-        "swiss"
-    ],
-    "crystalline": [
-        "light",
-        "portfolio",
-        "crystal",
-        "faceted"
-    ],
-    "cuneiform-tablet": [
-        "book",
-        "dark",
-        "ancient",
-        "impressed",
-        "archaeological"
-    ],
-    "curator": [
-        "light",
-        "portfolio",
-        "exhibition"
-    ],
-    "curtain-call": [
-        "event",
-        "dark",
-        "closing",
-        "ceremony",
-        "theatrical"
-    ],
-    "cyanotype": [
-        "light",
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "cyberpunk": [
-        "dark",
-        "magazine",
-        "cyberpunk",
-        "neon"
-    ],
-    "daguerreotype": [
-        "dark",
-        "blog",
-        "photography",
-        "vintage"
-    ],
-    "damask": [
-        "dark",
-        "blog",
-        "luxury",
-        "glamorous"
-    ],
-    "dark-manual": [
-        "docs",
-        "dark",
-        "technical",
-        "manual"
-    ],
-    "darkfolio": [
-        "dark",
-        "portfolio",
-        "developer",
-        "minimal"
-    ],
-    "darkmarket": [
-        "dark",
-        "marketplace",
-        "bold"
-    ],
-    "darkroom": [
-        "dark",
-        "portfolio",
-        "photography"
-    ],
-    "darkwave": [
-        "dark",
-        "blog",
-        "synthwave"
-    ],
-    "dashboard": [
-        "dark",
-        "landing",
-        "dashboard"
-    ],
-    "data-paper": [
-        "paper",
-        "light",
-        "dataset",
-        "schema",
-        "minimal-text"
-    ],
-    "deckle-edge": [
-        "book",
-        "light",
-        "craft",
-        "handmade",
-        "texture"
-    ],
-    "deconstructed": [
-        "light",
-        "agency",
-        "deconstructivism",
-        "architecture"
-    ],
-    "deconstructivist": [
-        "dark",
-        "portfolio",
-        "deconstructivist",
-        "architecture"
-    ],
-    "demolition-derby": [
-        "event",
-        "dark",
-        "competition",
-        "destruction",
-        "chaotic"
-    ],
-    "depot": [
-        "light",
-        "landing",
-        "tracker"
-    ],
-    "devconf": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "devlog": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "devtool": [
-        "dark",
-        "landing",
-        "developer"
-    ],
-    "dewdrop": [
-        "light",
-        "blog",
-        "wellness"
-    ],
-    "diamond-facet": [
-        "dark",
-        "blog",
-        "glamorous",
-        "prismatic"
-    ],
-    "diary": [
-        "light",
-        "blog",
-        "personal",
-        "journal"
-    ],
-    "diorama": [
-        "dark",
-        "landing",
-        "product"
-    ],
-    "disco-fever": [
-        "dark",
-        "blog",
-        "retro",
-        "disco",
-        "neon"
-    ],
-    "dispatch": [
-        "light",
-        "docs",
-        "event-driven"
-    ],
-    "dockhub": [
-        "dark",
-        "docs",
-        "devops"
-    ],
-    "dojo": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "dose-response": [
-        "paper",
-        "light",
-        "pharmacological",
-        "dose-response",
-        "clinical"
-    ],
-    "double-header": [
-        "event",
-        "dark",
-        "double",
-        "dual",
-        "packed"
-    ],
-    "driftwood": [
-        "light",
-        "blog",
-        "photo"
-    ],
-    "dropzone": [
-        "cloud",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "dune": [
-        "light",
-        "journal",
-        "desert",
-        "travel"
-    ],
-    "duodecimo": [
-        "book",
-        "light",
-        "compact",
-        "portable",
-        "efficient"
-    ],
-    "dusk": [
-        "dark",
-        "blog",
-        "sunset"
-    ],
-    "dynamo": [
-        "dark",
-        "docs",
-        "serverless"
-    ],
-    "easel": [
-        "light",
-        "docs",
-        "art"
-    ],
-    "eclipse": [
-        "dark",
-        "blog",
-        "celestial",
-        "dramatic"
-    ],
-    "editorial-letter": [
-        "paper",
-        "light",
-        "editorial",
-        "authority",
-        "statement"
-    ],
-    "electric-bloom": [
-        "dark",
-        "blog",
-        "glamorous",
-        "neon",
-        "botanical"
-    ],
-    "electroplate": [
-        "dark",
-        "blog",
-        "metallic",
-        "plating"
-    ],
-    "elevate": [
-        "landing",
-        "light",
-        "saas",
-        "enterprise"
-    ],
-    "elysian": [
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "elysium": [
-        "portfolio",
-        "minimal",
-        "dark"
-    ],
-    "elysium-portfolio": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "embargo-lift": [
-        "event",
-        "dark",
-        "embargo",
-        "release",
-        "timed"
-    ],
-    "ember": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "embroidery": [
-        "dark",
-        "blog",
-        "glamorous",
-        "trendy"
-    ],
-    "emerald": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "empyrean": [
-        "light",
-        "landing",
-        "divine",
-        "ethereal"
-    ],
-    "encaustic": [
-        "light",
-        "blog",
-        "art",
-        "painting"
-    ],
-    "encore": [
-        "event",
-        "dark",
-        "repeat",
-        "popular",
-        "demanded"
-    ],
-    "encore-night": [
-        "event",
-        "concert",
-        "farewell",
-        "encore",
-        "emotional"
-    ],
-    "endpaper": [
-        "book",
-        "dark",
-        "decorative",
-        "pattern",
-        "hidden"
-    ],
-    "enigma": [
-        "dark",
-        "puzzle",
-        "cryptography",
-        "mechanical"
-    ],
-    "entropy": [
-        "dual",
-        "magazine",
-        "experimental",
-        "asymmetric"
-    ],
-    "errata-sheet": [
-        "paper",
-        "light",
-        "errata",
-        "correction",
-        "transparent"
-    ],
-    "errata-slip": [
-        "book",
-        "light",
-        "correction",
-        "layered",
-        "meta"
-    ],
-    "etching": [
-        "dark",
-        "blog",
-        "etching",
-        "printmaking"
-    ],
-    "ethereal-canvas": [
-        "blog",
-        "dark",
-        "elegant",
-        "minimal",
-        "portfolio"
-    ],
-    "ethereal-vapor": [
-        "light",
-        "blog",
-        "ethereal",
-        "translucent"
-    ],
-    "ethos": [
-        "light",
-        "docs",
-        "culture"
-    ],
-    "even": [
-        "light",
-        "blog"
-    ],
-    "evergreen-docs": [
-        "docs",
-        "light",
-        "enterprise",
-        "classic"
-    ],
-    "experiment-log": [
-        "paper",
-        "dark",
-        "experimental",
-        "sequential",
-        "iterative"
-    ],
-    "faberge": [
-        "light",
-        "blog",
-        "luxury",
-        "jeweled",
-        "ornate"
-    ],
-    "faq": [
-        "light",
-        "docs",
-        "faq"
-    ],
-    "fascicle": [
-        "book",
-        "light",
-        "serial",
-        "unbound",
-        "installment"
-    ],
-    "fault-siren": [
-        "event",
-        "dark",
-        "warning",
-        "preparedness",
-        "civil-defense"
-    ],
-    "fauvist-wild": [
-        "dark",
-        "blog",
-        "fauvist",
-        "colorful"
-    ],
-    "ferrofluid": [
-        "dark",
-        "blog",
-        "ferrofluid",
-        "magnetic"
-    ],
-    "festival": [
-        "dark",
-        "event",
-        "elegant",
-        "glow",
-        "bold"
-    ],
-    "festival-ground": [
-        "event",
-        "festival",
-        "outdoor",
-        "grounds",
-        "map"
-    ],
-    "field-report": [
-        "paper",
-        "dark",
-        "field",
-        "expedition",
-        "rugged"
-    ],
-    "fiesta": [
-        "light",
-        "blog",
-        "colorful",
-        "celebration"
-    ],
-    "filigree": [
-        "dark",
-        "blog",
-        "filigree",
-        "metalwork"
-    ],
-    "fintech-pulse": [
-        "landing",
-        "dark",
-        "fintech",
-        "data-viz"
-    ],
-    "fireside": [
-        "dark",
-        "blog",
-        "book-review"
-    ],
-    "fireworks": [
-        "dark",
-        "elegant",
-        "animation",
-        "glow"
-    ],
-    "firing-range": [
-        "event",
-        "dark",
-        "precision",
-        "target",
-        "competitive"
-    ],
-    "fjord": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "flamingo": [
-        "light",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "flong-press": [
-        "book",
-        "dark",
-        "industrial",
-        "reversed",
-        "typography"
-    ],
-    "flowsync": [
-        "dark",
-        "landing"
-    ],
-    "fluorescent": [
-        "dark",
-        "blog",
-        "neon",
-        "pop-art"
-    ],
-    "folio": [
-        "light",
-        "portfolio"
-    ],
-    "folio-docs": [
-        "light",
-        "docs",
-        "design-system"
-    ],
-    "folio-gigante": [
-        "book",
-        "dark",
-        "oversized",
-        "monumental",
-        "maximal"
-    ],
-    "forge": [
-        "light",
-        "docs",
-        "opensource"
-    ],
-    "formulary": [
-        "light",
-        "docs",
-        "math"
-    ],
-    "forty": [
-        "dark",
-        "portfolio",
-        "gallery"
-    ],
-    "foundry": [
-        "dark",
-        "blog",
-        "maker"
-    ],
-    "foxhole": [
-        "dark",
-        "blog",
-        "security"
-    ],
-    "fractal": [
-        "dark",
-        "gallery",
-        "generative",
-        "mathematical"
-    ],
-    "frequency": [
-        "dark",
-        "blog",
-        "radio"
-    ],
-    "frottage": [
-        "light",
-        "minimal",
-        "art",
-        "clean"
-    ],
-    "frutiger-aero": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "furnace": [
-        "dark",
-        "docs",
-        "performance"
-    ],
-    "gala": [
-        "dark",
-        "event",
-        "landing"
-    ],
-    "garden": [
-        "light",
-        "blog",
-        "garden"
-    ],
-    "garnet": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "garrison": [
-        "dark",
-        "docs",
-        "firewall"
-    ],
-    "gateway": [
-        "dark",
-        "docs",
-        "auth"
-    ],
-    "gauntlet-run": [
-        "event",
-        "dark",
-        "endurance",
-        "challenge",
-        "sequential"
-    ],
-    "gazebo": [
-        "light",
-        "blog",
-        "event"
-    ],
-    "gazette": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "generative-art": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "glamorous"
-    ],
-    "genome-paper": [
-        "paper",
-        "dark",
-        "genomics",
-        "bioinformatics",
-        "data-intensive"
-    ],
-    "geodesic": [
-        "light",
-        "landing",
-        "geometric"
-    ],
-    "gilded": [
-        "dark",
-        "blog",
-        "luxury",
-        "gold"
-    ],
-    "gilt-edge": [
-        "book",
-        "dark",
-        "luxury",
-        "gilded",
-        "opulent"
-    ],
-    "glacial-blog": [
-        "blog",
-        "light",
-        "cool",
-        "minimal"
-    ],
-    "glacial-ice": [
-        "dark",
-        "blog",
-        "ice",
-        "frost"
-    ],
-    "glacier": [
-        "light",
-        "blog",
-        "tech"
-    ],
-    "glam-rock": [
-        "dark",
-        "blog",
-        "rock",
-        "glam",
-        "metallic"
-    ],
-    "glassmorphism": [
-        "dark",
-        "blog",
-        "glassmorphism"
-    ],
-    "glitch": [
-        "dark",
-        "blog",
-        "experimental",
-        "glitch-art"
-    ],
-    "glitch-elegance": [
-        "dark",
-        "blog",
-        "glitch",
-        "elegant"
-    ],
-    "glow-reef": [
-        "dark",
-        "blog",
-        "elegant",
-        "neon"
-    ],
-    "glyphic": [
-        "dark",
-        "blog",
-        "glyph",
-        "carved"
-    ],
-    "gong-show": [
-        "event",
-        "dark",
-        "competition",
-        "judgment",
-        "dramatic"
-    ],
-    "gossamer": [
-        "blog",
-        "minimal",
-        "elegant"
-    ],
-    "gothic": [
-        "dark",
-        "blog",
-        "gothic",
-        "medieval"
-    ],
-    "gradient-mesh": [
-        "dark",
-        "blog",
-        "gradient"
-    ],
-    "graffiti": [
-        "dark",
-        "blog",
-        "street-art",
-        "urban"
-    ],
-    "grand-finale": [
-        "event",
-        "festival",
-        "finale",
-        "closing",
-        "spectacular"
-    ],
-    "grant-proposal": [
-        "paper",
-        "light",
-        "proposal",
-        "funding",
-        "persuasive"
-    ],
-    "graphite-docs": [
-        "docs",
-        "dark",
-        "technical"
-    ],
-    "greenhouse": [
-        "light",
-        "blog",
-        "plant"
-    ],
-    "grisaille": [
-        "dark",
-        "blog",
-        "minimal",
-        "monochrome"
-    ],
-    "ground-zero": [
-        "event",
-        "dark",
-        "origin",
-        "impact",
-        "transformative"
-    ],
-    "guidebook": [
-        "light",
-        "docs",
-        "guide"
-    ],
-    "gunmetal": [
-        "dark",
-        "elegant",
-        "industrial",
-        "metallic"
-    ],
-    "gyroscope": [
-        "dark",
-        "dashboard",
-        "motion-sensor",
-        "3d-rotation"
-    ],
-    "habitat": [
-        "light",
-        "landing",
-        "listing"
-    ],
-    "hacker": [
-        "dark",
-        "blog"
-    ],
-    "hall-of-voices": [
-        "event",
-        "poetry",
-        "spoken-word",
-        "slam",
-        "voices"
-    ],
-    "hammer-drop": [
-        "event",
-        "light",
-        "auction",
-        "bidding",
-        "final"
-    ],
-    "hammock": [
-        "light",
-        "blog",
-        "slowlife"
-    ],
-    "handbook": [
-        "light",
-        "docs",
-        "corporate"
-    ],
-    "hangar": [
-        "dark",
-        "blog",
-        "aviation"
-    ],
-    "hardcore-pit": [
-        "event",
-        "punk",
-        "hardcore",
-        "show",
-        "chaotic"
-    ],
-    "haute-couture": [
-        "elegant",
-        "fashion",
-        "magazine"
-    ],
-    "headliner-bold": [
-        "event",
-        "festival",
-        "lineup",
-        "headliner",
-        "hierarchy"
-    ],
-    "hearth": [
-        "light",
-        "blog",
-        "traditional",
-        "elegant"
-    ],
-    "heavy-curtain": [
-        "event",
-        "theater",
-        "drama",
-        "production",
-        "heavy"
-    ],
-    "heliograph": [
-        "dark",
-        "blog",
-        "heliograph",
-        "sun-print"
-    ],
-    "helix": [
-        "light",
-        "landing",
-        "biotech",
-        "3d"
-    ],
-    "helix-docs": [
-        "docs",
-        "light",
-        "science"
-    ],
-    "herald": [
-        "light",
-        "magazine",
-        "editorial",
-        "news"
-    ],
-    "hermit": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "hibiscus": [
-        "dark",
-        "blog",
-        "glamorous",
-        "tropical"
-    ],
-    "hologram": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "holographic": [
-        "dark",
-        "showcase",
-        "holographic",
-        "3d"
-    ],
-    "horizon-ai": [
-        "landing",
-        "dark",
-        "ai",
-        "futuristic"
-    ],
-    "house-lights": [
-        "event",
-        "venue",
-        "concert",
-        "lighting",
-        "technical"
-    ],
-    "hwaro.386": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "hwaronight": [
-        "dark",
-        "blog"
-    ],
-    "hypercube": [
-        "dark",
-        "docs",
-        "3d",
-        "wireframe"
-    ],
-    "hyperpop": [
-        "dark",
-        "glamorous",
-        "neon",
-        "trendy",
-        "elegant"
-    ],
-    "igloo": [
-        "light",
-        "blog",
-        "nordic"
-    ],
-    "ignite": [
-        "landing",
-        "dark",
-        "startup"
-    ],
-    "ignition-sequence": [
-        "event",
-        "dark",
-        "phased",
-        "launch",
-        "sequential"
-    ],
-    "impasto": [
-        "light",
-        "blog",
-        "bold",
-        "artistic"
-    ],
-    "incunabula-noir": [
-        "book",
-        "dark",
-        "incunabulum",
-        "early-print",
-        "revolutionary"
-    ],
-    "inferno": [
-        "dark",
-        "community",
-        "fire",
-        "gaming"
-    ],
-    "infographic": [
-        "light",
-        "landing",
-        "infographic",
-        "data-viz"
-    ],
-    "ink-seoul": [
-        "light",
-        "blog",
-        "monochrome",
-        "seoul",
-        "minimal"
-    ],
-    "inkdrop-docs": [
-        "docs",
-        "dark",
-        "elegant",
-        "animation"
-    ],
-    "inkwell": [
-        "light",
-        "blog",
-        "poetry"
-    ],
-    "intaglio": [
-        "dark",
-        "portfolio",
-        "engraving",
-        "minimal"
-    ],
-    "intarsia": [
-        "light",
-        "portfolio",
-        "bold",
-        "clean",
-        "geometric"
-    ],
-    "interferogram": [
-        "dark",
-        "blog",
-        "interference",
-        "optical"
-    ],
-    "inventory": [
-        "light",
-        "dashboard",
-        "management"
-    ],
-    "iridescent-oil": [
-        "dark",
-        "blog",
-        "iridescent",
-        "oil"
-    ],
-    "iron-stage": [
-        "event",
-        "festival",
-        "metal",
-        "industrial",
-        "heavy"
-    ],
-    "ironclad": [
-        "dark",
-        "landing",
-        "metallic",
-        "security"
-    ],
-    "ironworks": [
-        "dark",
-        "blog",
-        "history"
-    ],
-    "isometric": [
-        "light",
-        "3d",
-        "dashboard",
-        "ui"
-    ],
-    "isthmus": [
-        "light",
-        "hub",
-        "bridge",
-        "horizontal-scroll"
-    ],
-    "jade-palace": [
-        "dark",
-        "blog",
-        "luxury",
-        "eastern"
-    ],
-    "japanese-industrial": [
-        "dark",
-        "blog",
-        "japanese",
-        "industrial"
-    ],
-    "jewel-tone": [
-        "dark",
-        "glamorous",
-        "jewel",
-        "elegant"
-    ],
-    "jugendstil": [
-        "light",
-        "blog",
-        "art-nouveau",
-        "organic",
-        "nature"
-    ],
-    "kaleidoscope": [
-        "light",
-        "event",
-        "psychedelic",
-        "pattern"
-    ],
-    "ketubah": [
-        "book",
-        "light",
-        "ceremonial",
-        "decorated",
-        "formal"
-    ],
-    "keynote-blast": [
-        "event",
-        "dark",
-        "conference",
-        "keynote",
-        "explosive"
-    ],
-    "keystone": [
-        "light",
-        "docs",
-        "architecture"
-    ],
-    "kiln": [
-        "light",
-        "portfolio",
-        "craft"
-    ],
-    "kinetic": [
-        "dark",
-        "agency",
-        "physics",
-        "interactive"
-    ],
-    "kinetic-mobile": [
-        "dark",
-        "blog",
-        "kinetic",
-        "mobile"
-    ],
-    "kinetic-typography": [
-        "dark",
-        "blog",
-        "kinetic",
-        "typography"
-    ],
-    "kintsugi": [
-        "dark",
-        "blog",
-        "kintsugi",
-        "gold-repair"
-    ],
-    "lab": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "lab-notebook": [
-        "paper",
-        "light",
-        "laboratory",
-        "raw",
-        "observational"
-    ],
-    "labyrinth": [
-        "dark",
-        "portfolio",
-        "maze",
-        "gamification"
-    ],
-    "lagoon": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "laser-show": [
-        "dark",
-        "blog",
-        "landing",
-        "concert",
-        "glamorous"
-    ],
-    "last-call": [
-        "event",
-        "dark",
-        "closing",
-        "final",
-        "urgent"
-    ],
-    "lattice": [
-        "light",
-        "docs",
-        "graph-db"
-    ],
-    "launchpad": [
-        "light",
-        "landing",
-        "saas"
-    ],
-    "launchpad-event": [
-        "event",
-        "dark",
-        "launch",
-        "space",
-        "countdown"
-    ],
-    "lava-flow": [
-        "dark",
-        "blog",
-        "lava",
-        "volcanic"
-    ],
-    "layered-docs": [
-        "light",
-        "docs",
-        "enterprise"
-    ],
-    "ledger": [
-        "light",
-        "docs",
-        "finance"
-    ],
-    "letter-to-editor": [
-        "paper",
-        "light",
-        "correspondence",
-        "urgent",
-        "brief"
-    ],
-    "letterbox": [
-        "light",
-        "blog",
-        "newsletter"
-    ],
-    "lexicon": [
-        "light",
-        "docs",
-        "glossary"
-    ],
-    "lichen-moss": [
-        "dark",
-        "blog",
-        "lichen",
-        "organic"
-    ],
-    "lighthouse": [
-        "light",
-        "docs",
-        "directory"
-    ],
-    "linktree": [
-        "dark",
-        "landing",
-        "links"
-    ],
-    "linocut": [
-        "light",
-        "printmaking",
-        "bold",
-        "creative"
-    ],
-    "liquid": [
-        "dark",
-        "interactive",
-        "gooey",
-        "svg"
-    ],
-    "liquid-chrome": [
-        "dark",
-        "blog",
-        "metallic",
-        "glamorous"
-    ],
-    "lithium": [
-        "dark",
-        "landing",
-        "electric",
-        "tech"
-    ],
-    "lithograph": [
-        "dark",
-        "blog",
-        "lithograph",
-        "printmaking"
-    ],
-    "logbook": [
-        "light",
-        "docs",
-        "compliance"
-    ],
-    "longitudinal": [
-        "paper",
-        "dark",
-        "longitudinal",
-        "temporal",
-        "tracking"
-    ],
-    "lookbook": [
-        "dark",
-        "portfolio",
-        "lookbook",
-        "fashion"
-    ],
-    "loom": [
-        "light",
-        "portfolio",
-        "fashion"
-    ],
-    "lumiere": [
-        "dark",
-        "elegant",
-        "minimal",
-        "luminescent"
-    ],
-    "lumina": [
-        "dark",
-        "portfolio",
-        "minimal"
-    ],
-    "luminary": [
-        "light",
-        "elegant",
-        "portfolio"
-    ],
-    "luminescent-mesh": [
-        "dark",
-        "blog",
-        "luminescent",
-        "mesh"
-    ],
-    "lumos": [
-        "blog",
-        "elegant",
-        "light",
-        "minimal"
-    ],
-    "lunar-base": [
-        "elegant",
-        "portfolio",
-        "dark"
-    ],
-    "lunar-breeze": [
-        "dark",
-        "blog",
-        "elegant",
-        "minimal"
-    ],
-    "luxe-noir": [
-        "dark",
-        "glamorous",
-        "luxury",
-        "elegant"
-    ],
-    "luxury-horology": [
-        "dark",
-        "portfolio",
-        "horology",
-        "luxury"
-    ],
-    "macro-snowflake": [
-        "dark",
-        "blog",
-        "snowflake",
-        "crystalline"
-    ],
-    "madhubani": [
-        "light",
-        "blog",
-        "indian",
-        "folk-art",
-        "geometric"
-    ],
-    "magenta-sunset": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "magma": [
-        "dark",
-        "dashboard",
-        "volcanic",
-        "animation"
-    ],
-    "magnetar": [
-        "dark",
-        "blog",
-        "magnetar",
-        "cosmic"
-    ],
-    "main-act": [
-        "event",
-        "concert",
-        "headline",
-        "performer",
-        "dramatic"
-    ],
-    "mainstage": [
-        "event",
-        "dark",
-        "performance",
-        "stage",
-        "dramatic"
-    ],
-    "manifesto": [
-        "dark",
-        "blog",
-        "opinion"
-    ],
-    "manifesto-press": [
-        "book",
-        "dark",
-        "revolutionary",
-        "bold",
-        "political"
-    ],
-    "manifold": [
-        "light",
-        "docs",
-        "saas"
-    ],
-    "marble": [
-        "light",
-        "gallery",
-        "luxury",
-        "marble-texture"
-    ],
-    "marbled-paper": [
-        "dark",
-        "blog",
-        "marbled",
-        "paper"
-    ],
-    "mardi-gras": [
-        "glamorous",
-        "trendy",
-        "bold",
-        "purple",
-        "gold",
-        "green"
-    ],
-    "marketplace": [
-        "light",
-        "store",
-        "marketplace"
-    ],
-    "marquetry": [
-        "light",
-        "portfolio",
-        "geometric",
-        "minimal"
-    ],
-    "masquerade": [
-        "dark",
-        "elegant",
-        "glamorous",
-        "luxury",
-        "mystery"
-    ],
-    "matcha": [
-        "blog",
-        "light",
-        "minimal",
-        "zen"
-    ],
-    "matrix": [
-        "light",
-        "docs",
-        "compatibility"
-    ],
-    "maximal-bloom": [
-        "elegant",
-        "floral",
-        "bold",
-        "glamorous"
-    ],
-    "maximalist": [
-        "dark",
-        "blog",
-        "bold",
-        "glamorous"
-    ],
-    "mayan-geometry": [
-        "dark",
-        "blog",
-        "mayan",
-        "geometric"
-    ],
-    "meadow": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "medieval-manuscript": [
-        "dark",
-        "blog",
-        "medieval",
-        "manuscript"
-    ],
-    "memoir": [
-        "light",
-        "blog",
-        "longform"
-    ],
-    "memphis": [
-        "light",
-        "retro",
-        "colorful",
-        "bold",
-        "portfolio"
-    ],
-    "mercury": [
-        "dark",
-        "blog",
-        "minimal",
-        "metallic",
-        "elegant"
-    ],
-    "meridian": [
-        "dark",
-        "landing",
-        "timezone"
-    ],
-    "meridian-docs": [
-        "light",
-        "docs",
-        "scheduling"
-    ],
-    "meridiem": [
-        "dual",
-        "dashboard",
-        "time-based",
-        "auto-theme"
-    ],
-    "meta-analysis": [
-        "paper",
-        "light",
-        "statistical",
-        "synthesis",
-        "evidence"
-    ],
-    "meteor": [
-        "dark",
-        "interactive",
-        "meteor-shower",
-        "cosmic"
-    ],
-    "methods-paper": [
-        "paper",
-        "light",
-        "methods",
-        "protocol",
-        "technical"
-    ],
-    "metronome": [
-        "dark",
-        "blog",
-        "music-production",
-        "rhythm"
-    ],
-    "mezzotint": [
-        "light",
-        "blog",
-        "bold",
-        "clean",
-        "monochrome"
-    ],
-    "micro": [
-        "light",
-        "blog",
-        "microblog"
-    ],
-    "midnight-blog": [
-        "dark",
-        "blog",
-        "reading"
-    ],
-    "midnight-launch": [
-        "landing",
-        "dark",
-        "animation",
-        "product"
-    ],
-    "migration": [
-        "light",
-        "docs",
-        "database"
-    ],
-    "minifolio": [
-        "light",
-        "portfolio",
-        "minimal"
-    ],
-    "minimalzen": [
-        "light",
-        "blog",
-        "minimal",
-        "zen"
-    ],
-    "mint-fresh": [
-        "landing",
-        "light",
-        "saas"
-    ],
-    "mirage": [
-        "light",
-        "gallery",
-        "desert",
-        "distortion"
-    ],
-    "misprint": [
-        "book",
-        "dark",
-        "error",
-        "accidental",
-        "artistic"
-    ],
-    "mixed-methods": [
-        "paper",
-        "light",
-        "mixed-methods",
-        "convergent",
-        "dual"
-    ],
-    "modern-blog": [
-        "dark",
-        "blog",
-        "modern"
-    ],
-    "molten": [
-        "dark",
-        "blog",
-        "metalwork",
-        "melting"
-    ],
-    "molten-gold": [
-        "elegant",
-        "gold",
-        "trendy"
-    ],
-    "monochrome": [
-        "light",
-        "photo-essay",
-        "monochrome",
-        "grayscale"
-    ],
-    "monograph": [
-        "book",
-        "light",
-        "academic",
-        "thorough",
-        "reference"
-    ],
-    "monolith": [
-        "dark",
-        "landing",
-        "onepage"
-    ],
-    "monolithic-dark": [
-        "dark",
-        "blog",
-        "monolithic",
-        "bold"
-    ],
-    "monoprint": [
-        "light",
-        "monoprint",
-        "bold",
-        "creative"
-    ],
-    "monorepo-docs": [
-        "docs",
-        "dark",
-        "developer",
-        "monorepo"
-    ],
-    "moonrise": [
-        "dark",
-        "blog",
-        "essay"
-    ],
-    "moonstone": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "moroccan-zellige": [
-        "light",
-        "blog",
-        "moroccan",
-        "mosaic",
-        "geometric"
-    ],
-    "morphogenesis": [
-        "dark",
-        "blog",
-        "generative",
-        "biology",
-        "patterns"
-    ],
-    "mortar": [
-        "dark",
-        "docs",
-        "build-system"
-    ],
-    "mosaic": [
-        "light",
-        "blog",
-        "magazine"
-    ],
-    "mosh-pit": [
-        "event",
-        "dark",
-        "punk",
-        "chaotic",
-        "raw"
-    ],
-    "mosstown": [
-        "light",
-        "blog",
-        "cozy"
-    ],
-    "mughal": [
-        "light",
-        "blog",
-        "mughal",
-        "ornate",
-        "gold"
-    ],
-    "murano-glass": [
-        "light",
-        "blog",
-        "glass",
-        "translucent",
-        "venetian"
-    ],
-    "mycelium": [
-        "dark",
-        "blog",
-        "mycelium",
-        "fungal"
-    ],
-    "nadir": [
-        "dark",
-        "blog",
-        "minimal",
-        "oled-black"
-    ],
-    "nautical": [
-        "dark",
-        "blog",
-        "nautical"
-    ],
-    "nebula": [
-        "dark",
-        "gallery",
-        "space",
-        "ethereal"
-    ],
-    "neo-deco": [
-        "dark",
-        "portfolio",
-        "artdeco",
-        "elegant"
-    ],
-    "neo-memphis-dark": [
-        "dark",
-        "blog",
-        "memphis",
-        "neo-memphis"
-    ],
-    "neobrutal": [
-        "light",
-        "landing",
-        "neo-brutalism",
-        "bold"
-    ],
-    "neoclassical": [
-        "light",
-        "gallery",
-        "marble-texture",
-        "elegant"
-    ],
-    "neon": [
-        "dark",
-        "blog",
-        "cyberpunk"
-    ],
-    "neon-jungle": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "neon"
-    ],
-    "neon-marquee": [
-        "event",
-        "theater",
-        "marquee",
-        "vintage",
-        "retro"
-    ],
-    "neon-tokyo": [
-        "dark",
-        "blog",
-        "cyberpunk",
-        "tokyo",
-        "glamorous"
-    ],
-    "network-meta": [
-        "paper",
-        "dark",
-        "network",
-        "meta-analysis",
-        "comparative"
-    ],
-    "neumorphism": [
-        "light",
-        "ui",
-        "soft",
-        "shadow"
-    ],
-    "neural-bloom": [
-        "dark",
-        "blog",
-        "neural",
-        "ai",
-        "synaptic"
-    ],
-    "newspaper": [
-        "light",
-        "blog",
-        "editorial",
-        "newspaper"
-    ],
-    "nexus": [
-        "dark",
-        "docs",
-        "microservice"
-    ],
-    "nexus-docs": [
-        "docs",
-        "dark",
-        "developer"
-    ],
-    "niello": [
-        "dark",
-        "blog",
-        "minimal"
-    ],
-    "no-style-please": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "noctis": [
-        "landing",
-        "dark",
-        "glassmorphism",
-        "neon"
-    ],
-    "nocturne": [
-        "dark",
-        "blog",
-        "classical-music",
-        "piano"
-    ],
-    "noir": [
-        "dark",
-        "blog",
-        "noir"
-    ],
-    "northern-lights": [
-        "dark",
-        "blog",
-        "aurora",
-        "arctic",
-        "atmospheric"
-    ],
-    "notebook": [
-        "light",
-        "blog",
-        "journal"
-    ],
-    "null-result": [
-        "paper",
-        "light",
-        "null",
-        "negative",
-        "honest"
-    ],
-    "oasis": [
-        "light",
-        "blog",
-        "relaxation"
-    ],
-    "obelisk": [
-        "light",
-        "one-page",
-        "monumental",
-        "vertical"
-    ],
-    "oblique": [
-        "light",
-        "blog",
-        "bold",
-        "angular"
-    ],
-    "oblong-quarto": [
-        "book",
-        "light",
-        "landscape",
-        "panoramic",
-        "unusual"
-    ],
-    "observatory": [
-        "dark",
-        "blog",
-        "space"
-    ],
-    "obsidian": [
-        "dark",
-        "wiki",
-        "glass",
-        "oled"
-    ],
-    "obsidian-docs": [
-        "docs",
-        "dark",
-        "wiki",
-        "knowledge"
-    ],
-    "obsidian-mirror": [
-        "dark",
-        "blog",
-        "obsidian",
-        "reflective"
-    ],
-    "old-map-cartography": [
-        "dark",
-        "blog",
-        "cartography",
-        "vintage"
-    ],
-    "onyx": [
-        "landing",
-        "dark",
-        "minimal",
-        "luxury"
-    ],
-    "op-art": [
-        "dark",
-        "blog",
-        "geometric",
-        "optical-illusion"
-    ],
-    "opalescent": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "opening-act": [
-        "event",
-        "opening",
-        "season",
-        "premiere",
-        "fresh"
-    ],
-    "opening-night": [
-        "event",
-        "dark",
-        "premiere",
-        "formal",
-        "electric"
-    ],
-    "opulent": [
-        "light",
-        "elegant",
-        "luxury",
-        "portfolio",
-        "bold"
-    ],
-    "orchard": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "orchid": [
-        "dark",
-        "blog",
-        "glamorous",
-        "botanical"
-    ],
-    "origami": [
-        "light",
-        "blog",
-        "material"
-    ],
-    "oscilloscope": [
-        "dark",
-        "blog",
-        "oscilloscope",
-        "retro"
-    ],
-    "overture": [
-        "event",
-        "dark",
-        "opening",
-        "orchestral",
-        "grand"
-    ],
-    "oxidation": [
-        "dark",
-        "blog",
-        "oxidation",
-        "rust"
-    ],
-    "oxide": [
-        "dark",
-        "gallery",
-        "industrial",
-        "rust-texture"
-    ],
-    "pagoda": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "palette": [
-        "light",
-        "docs",
-        "design"
-    ],
-    "palimpsest-noir": [
-        "book",
-        "dark",
-        "layered",
-        "erased",
-        "ghostly"
-    ],
-    "panopticon": [
-        "dark",
-        "brutalist",
-        "radial",
-        "experimental"
-    ],
-    "pantry": [
-        "light",
-        "docs",
-        "package-manager"
-    ],
-    "paper": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "paper-art": [
-        "light",
-        "blog",
-        "paper",
-        "collage"
-    ],
-    "papermod": [
-        "light",
-        "blog",
-        "minimal"
-    ],
-    "parallax": [
-        "light",
-        "storytelling",
-        "parallax",
-        "cinematic"
-    ],
-    "parallax-heavy": [
-        "dark",
-        "landing",
-        "gallery",
-        "parallax"
-    ],
-    "parchment": [
-        "light",
-        "docs",
-        "fantasy"
-    ],
-    "parquetry": [
-        "dark",
-        "blog",
-        "parquetry",
-        "woodwork"
-    ],
-    "particle-storm": [
-        "dark",
-        "blog",
-        "neon",
-        "particles",
-        "energy"
-    ],
-    "pastel-docs": [
-        "docs",
-        "light",
-        "friendly"
-    ],
-    "patina": [
-        "dark",
-        "blog",
-        "minimal",
-        "craft"
-    ],
-    "peacock": [
-        "elegant",
-        "glamorous",
-        "portfolio"
-    ],
-    "pearlescent": [
-        "light",
-        "blog",
-        "iridescent",
-        "luxury",
-        "soft"
-    ],
-    "peer-review": [
-        "paper",
-        "light",
-        "academic",
-        "review",
-        "transparent"
-    ],
-    "pendulum": [
-        "dark",
-        "blog",
-        "productivity"
-    ],
-    "pentimento": [
-        "light",
-        "portfolio",
-        "elegant",
-        "bold",
-        "clean"
-    ],
-    "permafrost": [
-        "light",
-        "archive",
-        "ice",
-        "frozen"
-    ],
-    "persian-carpet": [
-        "light",
-        "blog",
-        "persian",
-        "carpet",
-        "ornate"
-    ],
-    "perspective-piece": [
-        "paper",
-        "dark",
-        "opinion",
-        "viewpoint",
-        "argumentative"
-    ],
-    "petrified-wood": [
-        "dark",
-        "blog",
-        "fossil",
-        "wood"
-    ],
-    "phantom": [
-        "dark",
-        "blog",
-        "ghost",
-        "translucent"
-    ],
-    "phosphor": [
-        "dark",
-        "gallery",
-        "bioluminescence",
-        "glow"
-    ],
-    "photoblog": [
-        "dark",
-        "blog",
-        "photography",
-        "gallery"
-    ],
-    "photon": [
-        "dark",
-        "elegant",
-        "luminescent",
-        "portfolio"
-    ],
-    "pietra-dura": [
-        "dark",
-        "creative",
-        "bold",
-        "stone"
-    ],
-    "pinecone": [
-        "dark",
-        "blog",
-        "nature"
-    ],
-    "pipeline": [
-        "light",
-        "docs",
-        "cicd"
-    ],
-    "pit-stop": [
-        "event",
-        "dark",
-        "motorsport",
-        "speed",
-        "frantic"
-    ],
-    "pixel": [
-        "dark",
-        "blog",
-        "gaming"
-    ],
-    "plasma": [
-        "dark",
-        "science",
-        "plasma",
-        "visualization"
-    ],
-    "platinum": [
-        "light",
-        "minimal",
-        "luxury",
-        "portfolio"
-    ],
-    "playlist": [
-        "dark",
-        "blog",
-        "music"
-    ],
-    "podcast-fm": [
-        "dark",
-        "media",
-        "podcast"
-    ],
-    "podium-rush": [
-        "event",
-        "competition",
-        "awards",
-        "victory",
-        "podium"
-    ],
-    "pointillism": [
-        "dark",
-        "blog",
-        "pointillism",
-        "dots"
-    ],
-    "poison": [
-        "dark",
-        "blog",
-        "sidebar"
-    ],
-    "polaris": [
-        "dark",
-        "guide",
-        "astronomy",
-        "constellation"
-    ],
-    "polaroid": [
-        "light",
-        "blog",
-        "gallery"
-    ],
-    "pop-surreal": [
-        "dark",
-        "glamorous",
-        "elegant",
-        "surreal",
-        "trendy"
-    ],
-    "pop-up-page": [
-        "book",
-        "light",
-        "dimensional",
-        "paper-engineering",
-        "interactive"
-    ],
-    "portfolio-blog": [
-        "dark",
-        "blog",
-        "portfolio"
-    ],
-    "portico": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "position-paper": [
-        "paper",
-        "dark",
-        "position",
-        "argumentative",
-        "bold"
-    ],
-    "postcard": [
-        "light",
-        "blog",
-        "postcard"
-    ],
-    "powder-burn": [
-        "event",
-        "dark",
-        "rapid-fire",
-        "flash",
-        "quick"
-    ],
-    "prairie": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "preprint-rush": [
-        "paper",
-        "light",
-        "preprint",
-        "urgent",
-        "draft"
-    ],
-    "pressure-cooker": [
-        "event",
-        "dark",
-        "hackathon",
-        "pressure",
-        "deadline"
-    ],
-    "pricetable": [
-        "light",
-        "landing",
-        "saas",
-        "pricing"
-    ],
-    "primer": [
-        "light",
-        "docs",
-        "tutorial"
-    ],
-    "printer-devil": [
-        "book",
-        "dark",
-        "error",
-        "playful",
-        "craft"
-    ],
-    "prism": [
-        "dark",
-        "docs",
-        "data"
-    ],
-    "prism-docs": [
-        "docs",
-        "light",
-        "colorful"
-    ],
-    "prism-refraction": [
-        "dark",
-        "blog",
-        "prism",
-        "refraction"
-    ],
-    "prismify": [
-        "glassmorphism",
-        "landing",
-        "light",
-        "saas"
-    ],
-    "proof-sheet": [
-        "book",
-        "light",
-        "proof",
-        "unfinished",
-        "editorial"
-    ],
-    "protocol": [
-        "dark",
-        "docs",
-        "networking"
-    ],
-    "protocol-paper": [
-        "paper",
-        "light",
-        "protocol",
-        "pre-registration",
-        "rigorous"
-    ],
-    "psychedelic": [
-        "dark",
-        "minimal",
-        "elegant",
-        "glamorous"
-    ],
-    "pulp-fiction": [
-        "book",
-        "dark",
-        "pulp",
-        "lurid",
-        "cheap"
-    ],
-    "pulsar": [
-        "dark",
-        "blog",
-        "cosmic",
-        "pulse-animation"
-    ],
-    "pulse-api": [
-        "dark",
-        "docs"
-    ],
-    "pyrite": [
-        "dark",
-        "showcase",
-        "metallic",
-        "luxury"
-    ],
-    "pyrotechnic": [
-        "event",
-        "show",
-        "pyrotechnics",
-        "fireworks",
-        "explosive"
-    ],
-    "qualitative-study": [
-        "paper",
-        "light",
-        "qualitative",
-        "thematic",
-        "interpretive"
-    ],
-    "quantum": [
-        "dark",
-        "blog",
-        "quantum",
-        "science"
-    ],
-    "quarry": [
-        "dark",
-        "docs",
-        "data-warehouse"
-    ],
-    "quasar": [
-        "dark",
-        "portfolio",
-        "bold",
-        "minimal"
-    ],
-    "quill": [
-        "light",
-        "blog",
-        "fiction"
-    ],
-    "radiolaria": [
-        "dark",
-        "blog",
-        "radiolaria",
-        "skeletal"
-    ],
-    "rainbow-cascade": [
-        "elegant",
-        "glowing",
-        "box-shadow"
-    ],
-    "ramble": [
-        "light",
-        "blog",
-        "hiking"
-    ],
-    "randomized-trial": [
-        "paper",
-        "light",
-        "rct",
-        "clinical-trial",
-        "rigorous"
-    ],
-    "rave": [
-        "dark",
-        "blog",
-        "acid",
-        "rave",
-        "neon"
-    ],
-    "raw-data": [
-        "paper",
-        "light",
-        "raw",
-        "data",
-        "tables"
-    ],
-    "reactor": [
-        "dark",
-        "docs",
-        "reactive"
-    ],
-    "realty": [
-        "light",
-        "realestate",
-        "luxury",
-        "elegant"
-    ],
-    "recipe": [
-        "light",
-        "blog",
-        "recipe"
-    ],
-    "red-alert": [
-        "event",
-        "dark",
-        "emergency",
-        "crisis",
-        "urgent"
-    ],
-    "red-carpet": [
-        "event",
-        "premiere",
-        "celebrity",
-        "glamour",
-        "fashion"
-    ],
-    "reef": [
-        "dark",
-        "blog",
-        "diving"
-    ],
-    "relay": [
-        "light",
-        "docs",
-        "integration"
-    ],
-    "remainder-bin": [
-        "book",
-        "light",
-        "secondhand",
-        "discount",
-        "worn"
-    ],
-    "remedy": [
-        "light",
-        "docs",
-        "troubleshooting"
-    ],
-    "renaissance": [
-        "light",
-        "art",
-        "classic",
-        "serif",
-        "elegant"
-    ],
-    "repousse": [
-        "dark",
-        "blog",
-        "repousse",
-        "metalwork"
-    ],
-    "reproducibility": [
-        "paper",
-        "light",
-        "replication",
-        "comparison",
-        "verdict"
-    ],
-    "resume": [
-        "light",
-        "resume"
-    ],
-    "retraction-notice": [
-        "paper",
-        "light",
-        "retracted",
-        "warning",
-        "editorial"
-    ],
-    "retro-radar": [
-        "dark",
-        "blog",
-        "radar",
-        "retro"
-    ],
-    "retromac": [
-        "light",
-        "mac",
-        "os9",
-        "retro",
-        "system"
-    ],
-    "retrowave": [
-        "dark",
-        "blog",
-        "retro",
-        "synthwave"
-    ],
-    "reveille": [
-        "event",
-        "dark",
-        "military",
-        "assembly",
-        "urgent"
-    ],
-    "review-article": [
-        "paper",
-        "light",
-        "review",
-        "literature",
-        "synthesis"
-    ],
-    "ridgeline": [
-        "dark",
-        "blog",
-        "outdoor"
-    ],
-    "riftzone": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "dimensional"
-    ],
-    "ring-bell": [
-        "event",
-        "dark",
-        "boxing",
-        "fight",
-        "intense"
-    ],
-    "riverbank": [
-        "light",
-        "blog",
-        "nature-journal"
-    ],
-    "rococo": [
-        "light",
-        "blog",
-        "pastel",
-        "elegant"
-    ],
-    "roll-call": [
-        "event",
-        "light",
-        "assembly",
-        "formal",
-        "attendance"
-    ],
-    "roll-scroll": [
-        "book",
-        "light",
-        "scroll",
-        "continuous",
-        "ancient"
-    ],
-    "rooftop": [
-        "dark",
-        "blog",
-        "urban"
-    ],
-    "rose-gold": [
-        "elegant",
-        "luxury",
-        "minimal"
-    ],
-    "rosemary": [
-        "light",
-        "blog",
-        "cooking"
-    ],
-    "rosetta": [
-        "light",
-        "docs",
-        "i18n"
-    ],
-    "rosewood": [
-        "blog",
-        "dark",
-        "warm",
-        "classic"
-    ],
-    "rubric": [
-        "book",
-        "light",
-        "rubricated",
-        "two-color",
-        "traditional"
-    ],
-    "ruby-fire": [
-        "dark",
-        "blog",
-        "bold"
-    ],
-    "runbook": [
-        "light",
-        "docs",
-        "operations"
-    ],
-    "rune": [
-        "dark",
-        "archive",
-        "viking",
-        "mystic"
-    ],
-    "saffron": [
-        "light",
-        "blog",
-        "food"
-    ],
-    "sage-guide": [
-        "docs",
-        "light",
-        "tutorial",
-        "guide"
-    ],
-    "sakura-storm": [
-        "dark",
-        "blog",
-        "glamorous",
-        "sakura"
-    ],
-    "sandcastle": [
-        "light",
-        "blog",
-        "sand",
-        "beach"
-    ],
-    "sandstone": [
-        "light",
-        "blog",
-        "architecture"
-    ],
-    "sandstorm": [
-        "dark",
-        "blog",
-        "desert",
-        "particles"
-    ],
-    "sapphire": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "savanna": [
-        "light",
-        "blog",
-        "nature"
-    ],
-    "sawmill": [
-        "light",
-        "blog",
-        "woodworking"
-    ],
-    "scaffold": [
-        "dark",
-        "landing",
-        "comingsoon"
-    ],
-    "scaffold-docs": [
-        "dark",
-        "docs",
-        "scaffolding"
-    ],
-    "schematic": [
-        "light",
-        "docs",
-        "hardware"
-    ],
-    "scientific-journal": [
-        "dark",
-        "docs",
-        "scientific",
-        "academic"
-    ],
-    "scoping-review": [
-        "paper",
-        "light",
-        "scoping",
-        "mapping",
-        "landscape"
-    ],
-    "scrimshaw": [
-        "bold",
-        "elegant",
-        "clean",
-        "blog"
-    ],
-    "sentinel": [
-        "dark",
-        "docs",
-        "monitoring"
-    ],
-    "seraph": [
-        "minimal",
-        "elegant",
-        "portfolio"
-    ],
-    "serenity": [
-        "light",
-        "blog",
-        "elegant"
-    ],
-    "sextant": [
-        "light",
-        "docs",
-        "metrics"
-    ],
-    "sfumato": [
-        "dark",
-        "blog",
-        "atmospheric",
-        "minimal"
-    ],
-    "sgraffito": [
-        "dark",
-        "blog",
-        "sgraffito",
-        "scratched"
-    ],
-    "shutout": [
-        "event",
-        "dark",
-        "competition",
-        "dominant",
-        "perfect"
-    ],
-    "silhouette": [
-        "dark",
-        "landing",
-        "silhouette",
-        "dramatic"
-    ],
-    "silk-road": [
-        "elegant",
-        "glamorous",
-        "silk",
-        "cultural"
-    ],
-    "simulation-paper": [
-        "paper",
-        "dark",
-        "computational",
-        "simulation",
-        "model"
-    ],
-    "sketch": [
-        "light",
-        "blog",
-        "handdrawn"
-    ],
-    "skeuomorphic": [
-        "light",
-        "blog",
-        "skeuomorphic",
-        "realistic"
-    ],
-    "slide": [
-        "dark",
-        "docs",
-        "presentation"
-    ],
-    "snowfall": [
-        "light",
-        "blog",
-        "winter"
-    ],
-    "solar-punk": [
-        "light",
-        "blog",
-        "solarpunk",
-        "sustainable"
-    ],
-    "solarflare": [
-        "dark",
-        "landing",
-        "solar",
-        "energy"
-    ],
-    "solaris": [
-        "dark",
-        "dashboard",
-        "solar-system",
-        "space-mission"
-    ],
-    "solarium": [
-        "blog",
-        "light",
-        "warm"
-    ],
-    "solstice": [
-        "dual",
-        "blog",
-        "seasonal",
-        "time-based"
-    ],
-    "sonar": [
-        "dark",
-        "hub",
-        "radar",
-        "discovery"
-    ],
-    "spectra": [
-        "dark",
-        "data-science",
-        "spectrum",
-        "rainbow"
-    ],
-    "spectrum": [
-        "light",
-        "blog",
-        "a11y"
-    ],
-    "spectrum-docs": [
-        "light",
-        "docs",
-        "accessibility"
-    ],
-    "spire": [
-        "dark",
-        "blog",
-        "architecture"
-    ],
-    "split-tone": [
-        "light",
-        "blog",
-        "photography",
-        "cinematic",
-        "toning"
-    ],
-    "stained-glass": [
-        "light",
-        "blog",
-        "cathedral",
-        "colorful",
-        "gothic"
-    ],
-    "standing-ovation": [
-        "event",
-        "light",
-        "awards",
-        "acclaim",
-        "celebration"
-    ],
-    "starlight": [
-        "dark",
-        "portfolio",
-        "elegant",
-        "minimal"
-    ],
-    "starting-gun": [
-        "event",
-        "dark",
-        "race",
-        "competition",
-        "explosive"
-    ],
-    "statuspage": [
-        "light",
-        "landing",
-        "status"
-    ],
-    "stellar-launch": [
-        "landing",
-        "dark",
-        "parallax",
-        "animation"
-    ],
-    "stipple": [
-        "light",
-        "artistic",
-        "dot-art",
-        "gallery"
-    ],
-    "storefront": [
-        "light",
-        "landing",
-        "shop"
-    ],
-    "stratum": [
-        "dark",
-        "timeline",
-        "geological",
-        "layered"
-    ],
-    "strobe": [
-        "dark",
-        "event",
-        "club",
-        "strobe"
-    ],
-    "studio": [
-        "dark",
-        "landing",
-        "portfolio"
-    ],
-    "subzero": [
-        "dark",
-        "research",
-        "cryogenic",
-        "frozen"
-    ],
-    "summit": [
-        "dark",
-        "landing",
-        "conference"
-    ],
-    "summit-event": [
-        "conference",
-        "dark",
-        "event",
-        "landing"
-    ],
-    "summit-strike": [
-        "event",
-        "dark",
-        "conference",
-        "summit",
-        "ascending"
-    ],
-    "sunburst": [
-        "light",
-        "blog",
-        "warm",
-        "golden",
-        "radiant"
-    ],
-    "sundew": [
-        "light",
-        "blog",
-        "science"
-    ],
-    "supernova": [
-        "dark",
-        "landing",
-        "cosmic",
-        "particles"
-    ],
-    "supplementary": [
-        "paper",
-        "light",
-        "supplementary",
-        "data-heavy",
-        "exhaustive"
-    ],
-    "supreme-sun": [
-        "light",
-        "blog",
-        "community"
-    ],
-    "survey-instrument": [
-        "paper",
-        "light",
-        "survey",
-        "instrument",
-        "psychometric"
-    ],
-    "synthwave": [
-        "dark",
-        "retro",
-        "glamorous",
-        "trendy"
-    ],
-    "systematic-review": [
-        "paper",
-        "light",
-        "systematic",
-        "evidence",
-        "methodology"
-    ],
-    "tactile-fabric": [
-        "light",
-        "blog",
-        "fabric",
-        "textile"
-    ],
-    "talavera": [
-        "light",
-        "blog",
-        "mexican",
-        "pottery",
-        "colorful"
-    ],
-    "tale": [
-        "light",
-        "blog",
-        "traditional"
-    ],
-    "tangram": [
-        "light",
-        "portfolio",
-        "puzzle",
-        "geometric"
-    ],
-    "tapestry": [
-        "light",
-        "blog",
-        "timeline"
-    ],
-    "taskboard": [
-        "light",
-        "dashboard",
-        "kanban"
-    ],
-    "tavern": [
-        "dark",
-        "blog",
-        "rpg"
-    ],
-    "techbyte": [
-        "light",
-        "blog",
-        "tech",
-        "card"
-    ],
-    "technical-report": [
-        "paper",
-        "light",
-        "institutional",
-        "technical-report",
-        "formal"
-    ],
-    "tectonic": [
-        "dark",
-        "hub",
-        "geological",
-        "interactive"
-    ],
-    "telegraph": [
-        "light",
-        "blog",
-        "news"
-    ],
-    "tempera": [
-        "dark",
-        "blog",
-        "tempera",
-        "painting"
-    ],
-    "tempest": [
-        "dark",
-        "magazine",
-        "storm",
-        "dramatic"
-    ],
-    "tenebrism": [
-        "dark",
-        "creative",
-        "bold",
-        "clean"
-    ],
-    "terminal": [
-        "dark",
-        "blog"
-    ],
-    "terrace": [
-        "light",
-        "blog",
-        "lifestyle"
-    ],
-    "terracotta-studio": [
-        "landing",
-        "light",
-        "creative",
-        "artisan"
-    ],
-    "terracotta-tiles": [
-        "dark",
-        "blog",
-        "terracotta",
-        "tile"
-    ],
-    "terraform": [
-        "dark",
-        "dashboard",
-        "sci-fi",
-        "terraforming"
-    ],
-    "terraform-docs": [
-        "docs",
-        "dark",
-        "infra",
-        "devops"
-    ],
-    "terrarium": [
-        "light",
-        "portfolio",
-        "miniature"
-    ],
-    "terrazzo": [
-        "light",
-        "portfolio",
-        "terrazzo",
-        "speckled"
-    ],
-    "terrazzo-blog": [
-        "blog",
-        "light",
-        "colorful",
-        "memphis"
-    ],
-    "tessellation": [
-        "light",
-        "gallery",
-        "escher",
-        "pattern-art"
-    ],
-    "tesseract": [
-        "dark",
-        "education",
-        "4d",
-        "mathematical"
-    ],
-    "thermal": [
-        "dark",
-        "dashboard",
-        "thermal",
-        "heatmap"
-    ],
-    "thesis": [
-        "light",
-        "blog",
-        "academic"
-    ],
-    "thesis-defense": [
-        "paper",
-        "dark",
-        "thesis",
-        "formal",
-        "institutional"
-    ],
-    "thumb-bible": [
-        "book",
-        "light",
-        "miniature",
-        "dense",
-        "craft"
-    ],
-    "thunderdome": [
-        "event",
-        "dark",
-        "arena",
-        "competition",
-        "ultimate"
-    ],
-    "ticker-board": [
-        "event",
-        "dark",
-        "transit",
-        "departure",
-        "mechanical"
-    ],
-    "ticker-tape": [
-        "event",
-        "light",
-        "celebration",
-        "parade",
-        "festive"
-    ],
-    "tidal": [
-        "light",
-        "blog",
-        "ocean",
-        "wellness"
-    ],
-    "timber": [
-        "light",
-        "blog",
-        "craft"
-    ],
-    "titanium": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ],
-    "topaz": [
-        "dark",
-        "blog",
-        "glamorous"
-    ],
-    "topographic-gradient": [
-        "dark",
-        "blog",
-        "topographic",
-        "contour"
-    ],
-    "topographic-sand": [
-        "dark",
-        "blog",
-        "topographic",
-        "sand"
-    ],
-    "topography": [
-        "light",
-        "blog",
-        "topographic",
-        "outdoor"
-    ],
-    "torchlight": [
-        "dark",
-        "blog",
-        "adventure"
-    ],
-    "totem": [
-        "dark",
-        "portfolio",
-        "tribal",
-        "vertical-stack"
-    ],
-    "tremor": [
-        "dark",
-        "dashboard",
-        "seismic",
-        "data-viz"
-    ],
-    "trompe-loeil": [
-        "light",
-        "portfolio",
-        "creative",
-        "bold",
-        "illusion"
-    ],
-    "tropical-paradise": [
-        "elegant",
-        "vivid",
-        "botanical"
-    ],
-    "tundra": [
-        "dark",
-        "blog",
-        "expedition"
-    ],
-    "turbine": [
-        "light",
-        "corporate",
-        "energy",
-        "rotation"
-    ],
-    "turret": [
-        "dark",
-        "docs",
-        "waf"
-    ],
-    "twilight": [
-        "dark",
-        "blog",
-        "photo-essay"
-    ],
-    "typeface": [
-        "blog",
-        "light",
-        "typography",
-        "minimal"
-    ],
-    "typewriter": [
-        "light",
-        "blog",
-        "vintage"
-    ],
-    "typhoon": [
-        "dark",
-        "magazine",
-        "storm",
-        "spiral"
-    ],
-    "ukiyo-e": [
-        "light",
-        "blog",
-        "japanese",
-        "woodblock",
-        "traditional"
-    ],
-    "ultraviolet": [
-        "dark",
-        "blog",
-        "ultraviolet",
-        "neon"
-    ],
-    "umbra": [
-        "dark",
-        "portfolio",
-        "monochrome",
-        "shadow"
-    ],
-    "vapor": [
-        "light",
-        "blog",
-        "vaporwave",
-        "surreal"
-    ],
-    "vault": [
-        "dark",
-        "docs",
-        "security"
-    ],
-    "vellum": [
-        "light",
-        "blog",
-        "editorial"
-    ],
-    "velocity": [
-        "landing",
-        "dark",
-        "saas"
-    ],
-    "velvet": [
-        "dark",
-        "landing",
-        "luxury"
-    ],
-    "velvet-rope": [
-        "event",
-        "gala",
-        "exclusive",
-        "luxury",
-        "velvet"
-    ],
-    "venetian": [
-        "light",
-        "blog",
-        "renaissance",
-        "venetian",
-        "ornate"
-    ],
-    "verdigris": [
-        "dark",
-        "blog",
-        "editorial"
-    ],
-    "versailles": [
-        "dark",
-        "elegant",
-        "classic",
-        "luxury"
-    ],
-    "vertigo": [
-        "dark",
-        "one-page",
-        "experimental",
-        "perspective"
-    ],
-    "vibrant-brutalism": [
-        "dark",
-        "blog",
-        "brutalist",
-        "vibrant"
-    ],
-    "victorian": [
-        "dark",
-        "blog",
-        "gothic",
-        "classic"
-    ],
-    "vineyard": [
-        "dark",
-        "blog",
-        "wine"
-    ],
-    "vintage": [
-        "light",
-        "blog",
-        "retro"
-    ],
-    "vintagetv": [
-        "dark",
-        "blog",
-        "retro"
-    ],
-    "vinyl": [
-        "dark",
-        "blog",
-        "vinyl"
-    ],
-    "voltage": [
-        "dark",
-        "blog",
-        "electric",
-        "sparks"
-    ],
-    "volumetric": [
-        "dark",
-        "blog",
-        "3d",
-        "glow",
-        "atmospheric"
-    ],
-    "volvelle": [
-        "book",
-        "light",
-        "interactive",
-        "medieval",
-        "layered"
-    ],
-    "vortex": [
-        "dark",
-        "portfolio",
-        "experimental",
-        "animation"
-    ],
-    "wanderlust": [
-        "light",
-        "blog",
-        "travel"
-    ],
-    "war-room": [
-        "event",
-        "dark",
-        "strategy",
-        "military",
-        "command"
-    ],
-    "warpzone": [
-        "dark",
-        "portfolio",
-        "warp",
-        "gaming"
-    ],
-    "washi-bound": [
-        "book",
-        "light",
-        "japanese",
-        "stab-binding",
-        "paper"
-    ],
-    "wavelength": [
-        "audio",
-        "dark",
-        "landing",
-        "music"
-    ],
-    "weathervane": [
-        "light",
-        "blog",
-        "rural"
-    ],
-    "wedding": [
-        "light",
-        "wedding",
-        "elegant",
-        "event"
-    ],
-    "white-paper-noir": [
-        "paper",
-        "dark",
-        "industry",
-        "executive",
-        "authoritative"
-    ],
-    "wiki": [
-        "light",
-        "docs",
-        "wiki"
-    ],
-    "willow": [
-        "light",
-        "blog",
-        "literature"
-    ],
-    "windmill": [
-        "light",
-        "blog",
-        "european"
-    ],
-    "windows95": [
-        "light",
-        "retro",
-        "os",
-        "nostalgia"
-    ],
-    "woodblock": [
-        "dark",
-        "blog",
-        "woodblock",
-        "printmaking"
-    ],
-    "working-paper": [
-        "paper",
-        "light",
-        "working",
-        "in-progress",
-        "honest"
-    ],
-    "woven-tapestry": [
-        "dark",
-        "blog",
-        "tapestry",
-        "textile"
-    ],
-    "x-ray": [
-        "dark",
-        "blog",
-        "x-ray",
-        "transparent"
-    ],
-    "xerograph": [
-        "dark",
-        "blog",
-        "minimal",
-        "photocopy"
-    ],
-    "y2k": [
-        "dark",
-        "cyber",
-        "metallic",
-        "retro"
-    ],
-    "zen": [
-        "light",
-        "blog",
-        "zen"
-    ],
-    "zenith": [
-        "light",
-        "landing",
-        "minimal",
-        "altitude"
-    ],
-    "zenithpoint": [
-        "dark",
-        "portfolio",
-        "bold",
-        "elegant"
-    ]
+  "abstract-noir": [
+    "paper",
+    "dark",
+    "abstract",
+    "bold",
+    "typography"
+  ],
+  "abyss": [
+    "dark",
+    "blog",
+    "deep-sea",
+    "immersive"
+  ],
+  "acid-graphics": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "acme-docs": [
+    "light",
+    "docs"
+  ],
+  "acoustic-soundwaves": [
+    "dark",
+    "blog",
+    "sound",
+    "waveform"
+  ],
+  "adminpanel": [
+    "dark",
+    "dashboard",
+    "admin",
+    "sidebar"
+  ],
+  "aether": [
+    "dark",
+    "blog",
+    "elegant"
+  ],
+  "aetheria": [
+    "dark-mode",
+    "elegant",
+    "portfolio"
+  ],
+  "after-dark": [
+    "blog",
+    "dark",
+    "reading"
+  ],
+  "afterparty": [
+    "event",
+    "party",
+    "nightlife",
+    "club",
+    "late-night"
+  ],
+  "aftershock": [
+    "event",
+    "dark",
+    "post-event",
+    "retrospective",
+    "impact"
+  ],
+  "airwave": [
+    "dark",
+    "blog",
+    "podcast"
+  ],
+  "alexandrite": [
+    "dark",
+    "blog",
+    "glamorous",
+    "gemstone"
+  ],
+  "almanac": [
+    "light",
+    "blog",
+    "calendar"
+  ],
+  "almanac-docs": [
+    "light",
+    "docs",
+    "roadmap"
+  ],
+  "amber-preservation": [
+    "dark",
+    "blog",
+    "amber",
+    "fossil"
+  ],
+  "amethyst": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "anaglyph": [
+    "dark",
+    "blog",
+    "3d",
+    "stereoscopic"
+  ],
+  "analytics": [
+    "light",
+    "dashboard",
+    "analytics"
+  ],
+  "anamorphic": [
+    "dark",
+    "portfolio",
+    "anamorphic",
+    "optical"
+  ],
+  "anatomy-atlas": [
+    "dark",
+    "docs",
+    "medical",
+    "vintage"
+  ],
+  "annotation-layer": [
+    "book",
+    "light",
+    "scholarly",
+    "annotated",
+    "dense"
+  ],
+  "anthology": [
+    "light",
+    "docs",
+    "sdk-reference"
+  ],
+  "antimatter": [
+    "dark",
+    "blog",
+    "experimental",
+    "inverted"
+  ],
+  "anubis": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "anvil": [
+    "dark",
+    "blog",
+    "workshop"
+  ],
+  "apiary": [
+    "light",
+    "docs",
+    "api",
+    "two-column"
+  ],
+  "apolo": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "apothecary": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "appsite": [
+    "light",
+    "landing",
+    "app"
+  ],
+  "aquarium": [
+    "dark",
+    "blog",
+    "marine"
+  ],
+  "aquatint": [
+    "light",
+    "portfolio",
+    "creative",
+    "elegant",
+    "bold"
+  ],
+  "aqueduct": [
+    "light",
+    "blog",
+    "engineering"
+  ],
+  "arbor": [
+    "light",
+    "docs",
+    "git-workflow"
+  ],
+  "archipelago": [
+    "dark",
+    "landing",
+    "hub"
+  ],
+  "archive": [
+    "light",
+    "docs",
+    "archive"
+  ],
+  "archway-docs": [
+    "docs",
+    "light",
+    "architecture"
+  ],
+  "arctic-saas": [
+    "landing",
+    "light",
+    "saas",
+    "minimal"
+  ],
+  "arena": [
+    "dark",
+    "blog",
+    "sports"
+  ],
+  "artdeco": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "artnouveau": [
+    "light",
+    "portfolio",
+    "art-nouveau",
+    "botanical"
+  ],
+  "arxiv-preprint": [
+    "paper",
+    "light",
+    "preprint",
+    "self-published",
+    "raw"
+  ],
+  "ascii": [
+    "dark",
+    "terminal",
+    "ascii"
+  ],
+  "asymmetric": [
+    "light",
+    "portfolio",
+    "grid",
+    "asymmetric"
+  ],
+  "atelier": [
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "athena": [
+    "elegant",
+    "portfolio",
+    "light"
+  ],
+  "atlas": [
+    "light",
+    "blog",
+    "geography"
+  ],
+  "atlas-docs": [
+    "docs",
+    "light",
+    "navigation"
+  ],
+  "aurelia": [
+    "elegant",
+    "minimalist",
+    "blog"
+  ],
+  "aurora": [
+    "dark",
+    "blog",
+    "aurora"
+  ],
+  "aurora-glimmer": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "aurora-launch": [
+    "landing",
+    "dark",
+    "animation"
+  ],
+  "aurum": [
+    "elegant",
+    "dark",
+    "minimal",
+    "blog"
+  ],
+  "avalanche-event": [
+    "event",
+    "dark",
+    "momentum",
+    "cascading",
+    "overwhelming"
+  ],
+  "axiom": [
+    "light",
+    "design-system",
+    "geometric",
+    "mathematical"
+  ],
+  "bamboo": [
+    "light",
+    "blog",
+    "eco"
+  ],
+  "baroque": [
+    "dark",
+    "blog",
+    "ornamental",
+    "glamorous"
+  ],
+  "bas-relief": [
+    "light",
+    "artistic",
+    "minimal"
+  ],
+  "bastard-title": [
+    "book",
+    "light",
+    "preliminary",
+    "ceremonial",
+    "typography"
+  ],
+  "bastion": [
+    "dark",
+    "docs",
+    "zero-trust"
+  ],
+  "batik": [
+    "light",
+    "blog",
+    "elegant",
+    "batik"
+  ],
+  "bauhaus": [
+    "light",
+    "portfolio",
+    "design",
+    "geometric"
+  ],
+  "bayesian-prior": [
+    "paper",
+    "dark",
+    "bayesian",
+    "probabilistic",
+    "visualization"
+  ],
+  "bazaar": [
+    "light",
+    "landing",
+    "marketplace"
+  ],
+  "beacon": [
+    "dark",
+    "blog",
+    "alert"
+  ],
+  "beacon-docs": [
+    "light",
+    "docs",
+    "feature-flag"
+  ],
+  "beautiful-hwaro": [
+    "light",
+    "blog"
+  ],
+  "bejeweled": [
+    "elegant",
+    "glamorous",
+    "luxury"
+  ],
+  "bell-tower": [
+    "event",
+    "light",
+    "scheduled",
+    "clock",
+    "traditional"
+  ],
+  "bench-report": [
+    "paper",
+    "light",
+    "laboratory",
+    "bench",
+    "experimental"
+  ],
+  "bijou": [
+    "dark",
+    "elegant",
+    "jewelry",
+    "glamorous"
+  ],
+  "bioluminescence": [
+    "dark",
+    "blog",
+    "bioluminescence",
+    "minimal"
+  ],
+  "bismuth": [
+    "dark",
+    "collection",
+    "mineral",
+    "rainbow-metallic"
+  ],
+  "black-box": [
+    "event",
+    "dark",
+    "theater",
+    "intimate",
+    "minimal"
+  ],
+  "black-letter-bible": [
+    "book",
+    "dark",
+    "sacred",
+    "blackletter",
+    "dense"
+  ],
+  "blacklight": [
+    "dark",
+    "fluorescent",
+    "elegant"
+  ],
+  "blast-furnace": [
+    "event",
+    "dark",
+    "workshop",
+    "intense",
+    "industrial"
+  ],
+  "blockade-run": [
+    "event",
+    "dark",
+    "breakthrough",
+    "barriers",
+    "overcome"
+  ],
+  "blueprint": [
+    "dark",
+    "docs",
+    "spec"
+  ],
+  "blueprint-pro": [
+    "landing",
+    "dark",
+    "devtool"
+  ],
+  "bonfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "bonsai": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "book": [
+    "light",
+    "docs"
+  ],
+  "borealis": [
+    "dark",
+    "blog",
+    "aurora",
+    "nordic"
+  ],
+  "botanical-press": [
+    "blog",
+    "light",
+    "botanical",
+    "vintage"
+  ],
+  "boutique": [
+    "light",
+    "store",
+    "fashion",
+    "elegant"
+  ],
+  "box-office": [
+    "event",
+    "tickets",
+    "sales",
+    "urgency",
+    "countdown"
+  ],
+  "bramble": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "breeze": [
+    "landing",
+    "light",
+    "minimal",
+    "one-page"
+  ],
+  "brocade": [
+    "dark",
+    "blog",
+    "glamorous",
+    "luxury"
+  ],
+  "brutalist": [
+    "light",
+    "blog",
+    "brutalist"
+  ],
+  "brutopia": [
+    "dark",
+    "blog",
+    "brutalist",
+    "monospace"
+  ],
+  "bulwark": [
+    "dark",
+    "docs",
+    "disaster-recovery"
+  ],
+  "bureau": [
+    "light",
+    "docs",
+    "governance"
+  ],
+  "burlesque": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "burnt-charcoal": [
+    "dark",
+    "blog",
+    "charcoal",
+    "texture"
+  ],
+  "butterfly-wing": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "trendy",
+    "blog"
+  ],
+  "byzantine": [
+    "light",
+    "blog",
+    "byzantine",
+    "mosaic",
+    "imperial"
+  ],
+  "cabaret": [
+    "dark",
+    "blog",
+    "glamorous",
+    "theater"
+  ],
+  "cabin": [
+    "dark",
+    "blog",
+    "lifestyle"
+  ],
+  "cactus": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cafe": [
+    "light",
+    "landing",
+    "menu"
+  ],
+  "cage-match": [
+    "event",
+    "dark",
+    "competition",
+    "fight",
+    "enclosed"
+  ],
+  "call-to-stage": [
+    "event",
+    "talent",
+    "open-call",
+    "audition",
+    "stage"
+  ],
+  "calligraphy": [
+    "dark",
+    "blog",
+    "calligraphy",
+    "ink"
+  ],
+  "cameo": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "campfire": [
+    "dark",
+    "blog",
+    "storytelling"
+  ],
+  "cancel-leaf": [
+    "book",
+    "light",
+    "correction",
+    "repair",
+    "visible"
+  ],
+  "canopy": [
+    "light",
+    "blog",
+    "outdoor"
+  ],
+  "canvas-studio": [
+    "landing",
+    "light",
+    "portfolio",
+    "agency"
+  ],
+  "carbon-fiber": [
+    "dark",
+    "blog",
+    "tech"
+  ],
+  "carnival": [
+    "dark",
+    "blog",
+    "glamorous",
+    "event"
+  ],
+  "cartograph": [
+    "dark",
+    "docs",
+    "infrastructure"
+  ],
+  "cascade": [
+    "light",
+    "longform",
+    "waterfall",
+    "scroll-driven"
+  ],
+  "case-report": [
+    "paper",
+    "light",
+    "clinical",
+    "case-study",
+    "medical"
+  ],
+  "cassette": [
+    "dark",
+    "blog",
+    "retro",
+    "audio"
+  ],
+  "catacombs": [
+    "dark",
+    "blog",
+    "underground",
+    "adventure"
+  ],
+  "catalyst": [
+    "light",
+    "landing",
+    "science",
+    "chemistry"
+  ],
+  "cathedral": [
+    "light",
+    "portfolio",
+    "architecture"
+  ],
+  "cauldron": [
+    "dark",
+    "wiki",
+    "fantasy",
+    "potion"
+  ],
+  "celebrate": [
+    "light",
+    "landing",
+    "event"
+  ],
+  "celestial-burst": [
+    "dark",
+    "glamorous",
+    "celestial",
+    "trendy"
+  ],
+  "center-stage": [
+    "event",
+    "solo",
+    "show",
+    "spotlight",
+    "centered"
+  ],
+  "chain-reaction": [
+    "event",
+    "dark",
+    "sequential",
+    "cascade",
+    "connected"
+  ],
+  "chalkboard": [
+    "dark",
+    "blog",
+    "education"
+  ],
+  "champagne": [
+    "light",
+    "luxury",
+    "elegant",
+    "champagne"
+  ],
+  "chandelier": [
+    "light",
+    "blog",
+    "crystal",
+    "elegant",
+    "prismatic"
+  ],
+  "changelog": [
+    "dark",
+    "docs",
+    "changelog"
+  ],
+  "chase-frame": [
+    "book",
+    "dark",
+    "letterpress",
+    "mechanical",
+    "craft"
+  ],
+  "chiaroscuro": [
+    "dark",
+    "portfolio",
+    "chiaroscuro",
+    "contrast"
+  ],
+  "chinoiserie": [
+    "light",
+    "blog",
+    "chinese",
+    "porcelain",
+    "elegant"
+  ],
+  "chromatic": [
+    "dark",
+    "photoblog",
+    "chromatic",
+    "lens"
+  ],
+  "chromatic-wave": [
+    "dark",
+    "portfolio",
+    "glamorous",
+    "animation"
+  ],
+  "chromatophore": [
+    "dark",
+    "bold",
+    "minimal",
+    "creative"
+  ],
+  "chrome-pulse": [
+    "minimal",
+    "dark",
+    "landing"
+  ],
+  "chromolithograph": [
+    "book",
+    "light",
+    "color-plate",
+    "print",
+    "illustration"
+  ],
+  "chronicle": [
+    "light",
+    "blog",
+    "traditional",
+    "serif"
+  ],
+  "chronosphere": [
+    "dark",
+    "space",
+    "time"
+  ],
+  "chrysanthemum": [
+    "dark",
+    "blog",
+    "floral",
+    "glamorous"
+  ],
+  "cinder": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "cinema": [
+    "dark",
+    "blog",
+    "review"
+  ],
+  "cinema-silent": [
+    "dark",
+    "blog",
+    "retro",
+    "editorial"
+  ],
+  "cipher": [
+    "dark",
+    "docs",
+    "cryptography"
+  ],
+  "citation-graph": [
+    "paper",
+    "dark",
+    "network",
+    "citations",
+    "visualization"
+  ],
+  "clarity-docs": [
+    "docs",
+    "light",
+    "minimal",
+    "typography"
+  ],
+  "clocktower": [
+    "dark",
+    "landing",
+    "countdown"
+  ],
+  "cloisonne": [
+    "dark",
+    "portfolio",
+    "enamel",
+    "ornate"
+  ],
+  "cloister": [
+    "light",
+    "blog",
+    "meditation"
+  ],
+  "closed": [
+    "light",
+    "error",
+    "499",
+    "minimal"
+  ],
+  "cloudnest": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "cobblestone": [
+    "light",
+    "blog",
+    "culture"
+  ],
+  "cockpit": [
+    "dark",
+    "landing",
+    "telemetry"
+  ],
+  "codebook": [
+    "light",
+    "docs",
+    "styleguide"
+  ],
+  "codecraft": [
+    "api",
+    "dark",
+    "developer",
+    "docs"
+  ],
+  "codex": [
+    "light",
+    "blog",
+    "medieval"
+  ],
+  "codex-rotundus": [
+    "book",
+    "dark",
+    "circular",
+    "unusual",
+    "experimental"
+  ],
+  "cohort-study": [
+    "paper",
+    "light",
+    "cohort",
+    "survival",
+    "epidemiological"
+  ],
+  "cold-case": [
+    "paper",
+    "dark",
+    "forensic",
+    "investigation",
+    "reopened"
+  ],
+  "colosseum": [
+    "light",
+    "event",
+    "classical",
+    "grand"
+  ],
+  "comic": [
+    "light",
+    "blog",
+    "comic"
+  ],
+  "command-center": [
+    "docs",
+    "dark",
+    "cli",
+    "developer"
+  ],
+  "compass": [
+    "light",
+    "landing",
+    "career"
+  ],
+  "compass-docs": [
+    "light",
+    "docs",
+    "onboarding"
+  ],
+  "conduit": [
+    "light",
+    "docs",
+    "data-pipeline"
+  ],
+  "conference-poster": [
+    "paper",
+    "dark",
+    "poster",
+    "conference",
+    "visual"
+  ],
+  "confetti": [
+    "celebration",
+    "elegant",
+    "festive"
+  ],
+  "console": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "constellation": [
+    "dark",
+    "blog",
+    "astronomy"
+  ],
+  "controlroom": [
+    "dark",
+    "dashboard",
+    "monitoring"
+  ],
+  "copper-patina": [
+    "dark",
+    "blog",
+    "patina",
+    "industrial"
+  ],
+  "copper-wire": [
+    "blog",
+    "dark",
+    "industrial"
+  ],
+  "copperplate": [
+    "dark",
+    "blog",
+    "copperplate",
+    "engraving"
+  ],
+  "coral": [
+    "light",
+    "documentary",
+    "organic",
+    "ocean"
+  ],
+  "coral-bloom": [
+    "dark",
+    "blog",
+    "elegant",
+    "marine",
+    "glamorous"
+  ],
+  "corrigendum": [
+    "paper",
+    "light",
+    "correction",
+    "errata",
+    "formal"
+  ],
+  "cosmos": [
+    "dark",
+    "magazine",
+    "space",
+    "planetary"
+  ],
+  "cost-effectiveness": [
+    "paper",
+    "light",
+    "economics",
+    "cost-effectiveness",
+    "health"
+  ],
+  "countdown-zero": [
+    "event",
+    "dark",
+    "countdown",
+    "convergence",
+    "climactic"
+  ],
+  "creative-agency": [
+    "dark",
+    "portfolio",
+    "agency",
+    "bold"
+  ],
+  "cross-sectional": [
+    "paper",
+    "light",
+    "cross-sectional",
+    "snapshot",
+    "population"
+  ],
+  "crucible": [
+    "light",
+    "docs",
+    "testing"
+  ],
+  "cruciform": [
+    "light",
+    "design-system",
+    "grid",
+    "swiss"
+  ],
+  "crystalline": [
+    "light",
+    "portfolio",
+    "crystal",
+    "faceted"
+  ],
+  "cuneiform-tablet": [
+    "book",
+    "dark",
+    "ancient",
+    "impressed",
+    "archaeological"
+  ],
+  "curator": [
+    "light",
+    "portfolio",
+    "exhibition"
+  ],
+  "curtain-call": [
+    "event",
+    "dark",
+    "closing",
+    "ceremony",
+    "theatrical"
+  ],
+  "cyanotype": [
+    "light",
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "cyberpunk": [
+    "dark",
+    "magazine",
+    "cyberpunk",
+    "neon"
+  ],
+  "daguerreotype": [
+    "dark",
+    "blog",
+    "photography",
+    "vintage"
+  ],
+  "damask": [
+    "dark",
+    "blog",
+    "luxury",
+    "glamorous"
+  ],
+  "dark-manual": [
+    "docs",
+    "dark",
+    "technical",
+    "manual"
+  ],
+  "darkfolio": [
+    "dark",
+    "portfolio",
+    "developer",
+    "minimal"
+  ],
+  "darkmarket": [
+    "dark",
+    "marketplace",
+    "bold"
+  ],
+  "darkroom": [
+    "dark",
+    "portfolio",
+    "photography"
+  ],
+  "darkwave": [
+    "dark",
+    "blog",
+    "synthwave"
+  ],
+  "dashboard": [
+    "dark",
+    "landing",
+    "dashboard"
+  ],
+  "data-paper": [
+    "paper",
+    "light",
+    "dataset",
+    "schema",
+    "minimal-text"
+  ],
+  "deckle-edge": [
+    "book",
+    "light",
+    "craft",
+    "handmade",
+    "texture"
+  ],
+  "deconstructed": [
+    "light",
+    "agency",
+    "deconstructivism",
+    "architecture"
+  ],
+  "deconstructivist": [
+    "dark",
+    "portfolio",
+    "deconstructivist",
+    "architecture"
+  ],
+  "demolition-derby": [
+    "event",
+    "dark",
+    "competition",
+    "destruction",
+    "chaotic"
+  ],
+  "depot": [
+    "light",
+    "landing",
+    "tracker"
+  ],
+  "devconf": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "devlog": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "devtool": [
+    "dark",
+    "landing",
+    "developer"
+  ],
+  "dewdrop": [
+    "light",
+    "blog",
+    "wellness"
+  ],
+  "diamond-facet": [
+    "dark",
+    "blog",
+    "glamorous",
+    "prismatic"
+  ],
+  "diary": [
+    "light",
+    "blog",
+    "personal",
+    "journal"
+  ],
+  "diorama": [
+    "dark",
+    "landing",
+    "product"
+  ],
+  "disco-fever": [
+    "dark",
+    "blog",
+    "retro",
+    "disco",
+    "neon"
+  ],
+  "dispatch": [
+    "light",
+    "docs",
+    "event-driven"
+  ],
+  "dockhub": [
+    "dark",
+    "docs",
+    "devops"
+  ],
+  "dojo": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "dose-response": [
+    "paper",
+    "light",
+    "pharmacological",
+    "dose-response",
+    "clinical"
+  ],
+  "double-header": [
+    "event",
+    "dark",
+    "double",
+    "dual",
+    "packed"
+  ],
+  "driftwood": [
+    "light",
+    "blog",
+    "photo"
+  ],
+  "dropzone": [
+    "cloud",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "dune": [
+    "light",
+    "journal",
+    "desert",
+    "travel"
+  ],
+  "duodecimo": [
+    "book",
+    "light",
+    "compact",
+    "portable",
+    "efficient"
+  ],
+  "dusk": [
+    "dark",
+    "blog",
+    "sunset"
+  ],
+  "dynamo": [
+    "dark",
+    "docs",
+    "serverless"
+  ],
+  "easel": [
+    "light",
+    "docs",
+    "art"
+  ],
+  "eclipse": [
+    "dark",
+    "blog",
+    "celestial",
+    "dramatic"
+  ],
+  "editorial-letter": [
+    "paper",
+    "light",
+    "editorial",
+    "authority",
+    "statement"
+  ],
+  "electric-bloom": [
+    "dark",
+    "blog",
+    "glamorous",
+    "neon",
+    "botanical"
+  ],
+  "electroplate": [
+    "dark",
+    "blog",
+    "metallic",
+    "plating"
+  ],
+  "elevate": [
+    "landing",
+    "light",
+    "saas",
+    "enterprise"
+  ],
+  "elysian": [
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "elysium": [
+    "portfolio",
+    "minimal",
+    "dark"
+  ],
+  "elysium-portfolio": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "embargo-lift": [
+    "event",
+    "dark",
+    "embargo",
+    "release",
+    "timed"
+  ],
+  "ember": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "embroidery": [
+    "dark",
+    "blog",
+    "glamorous",
+    "trendy"
+  ],
+  "emerald": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "empyrean": [
+    "light",
+    "landing",
+    "divine",
+    "ethereal"
+  ],
+  "encaustic": [
+    "light",
+    "blog",
+    "art",
+    "painting"
+  ],
+  "encore": [
+    "event",
+    "dark",
+    "repeat",
+    "popular",
+    "demanded"
+  ],
+  "encore-night": [
+    "event",
+    "concert",
+    "farewell",
+    "encore",
+    "emotional"
+  ],
+  "endpaper": [
+    "book",
+    "dark",
+    "decorative",
+    "pattern",
+    "hidden"
+  ],
+  "enigma": [
+    "dark",
+    "puzzle",
+    "cryptography",
+    "mechanical"
+  ],
+  "entropy": [
+    "dual",
+    "magazine",
+    "experimental",
+    "asymmetric"
+  ],
+  "errata-sheet": [
+    "paper",
+    "light",
+    "errata",
+    "correction",
+    "transparent"
+  ],
+  "errata-slip": [
+    "book",
+    "light",
+    "correction",
+    "layered",
+    "meta"
+  ],
+  "etching": [
+    "dark",
+    "blog",
+    "etching",
+    "printmaking"
+  ],
+  "ethereal-canvas": [
+    "blog",
+    "dark",
+    "elegant",
+    "minimal",
+    "portfolio"
+  ],
+  "ethereal-vapor": [
+    "light",
+    "blog",
+    "ethereal",
+    "translucent"
+  ],
+  "ethos": [
+    "light",
+    "docs",
+    "culture"
+  ],
+  "even": [
+    "light",
+    "blog"
+  ],
+  "evergreen-docs": [
+    "docs",
+    "light",
+    "enterprise",
+    "classic"
+  ],
+  "experiment-log": [
+    "paper",
+    "dark",
+    "experimental",
+    "sequential",
+    "iterative"
+  ],
+  "faberge": [
+    "light",
+    "blog",
+    "luxury",
+    "jeweled",
+    "ornate"
+  ],
+  "faq": [
+    "light",
+    "docs",
+    "faq"
+  ],
+  "fascicle": [
+    "book",
+    "light",
+    "serial",
+    "unbound",
+    "installment"
+  ],
+  "fault-siren": [
+    "event",
+    "dark",
+    "warning",
+    "preparedness",
+    "civil-defense"
+  ],
+  "fauvist-wild": [
+    "dark",
+    "blog",
+    "fauvist",
+    "colorful"
+  ],
+  "ferrofluid": [
+    "dark",
+    "blog",
+    "ferrofluid",
+    "magnetic"
+  ],
+  "festival": [
+    "dark",
+    "event",
+    "elegant",
+    "glow",
+    "bold"
+  ],
+  "festival-ground": [
+    "event",
+    "festival",
+    "outdoor",
+    "grounds",
+    "map"
+  ],
+  "field-report": [
+    "paper",
+    "dark",
+    "field",
+    "expedition",
+    "rugged"
+  ],
+  "fiesta": [
+    "light",
+    "blog",
+    "colorful",
+    "celebration"
+  ],
+  "filigree": [
+    "dark",
+    "blog",
+    "filigree",
+    "metalwork"
+  ],
+  "fintech-pulse": [
+    "landing",
+    "dark",
+    "fintech",
+    "data-viz"
+  ],
+  "fireside": [
+    "dark",
+    "blog",
+    "book-review"
+  ],
+  "fireworks": [
+    "dark",
+    "elegant",
+    "animation",
+    "glow"
+  ],
+  "firing-range": [
+    "event",
+    "dark",
+    "precision",
+    "target",
+    "competitive"
+  ],
+  "fjord": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "flamingo": [
+    "light",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "flong-press": [
+    "book",
+    "dark",
+    "industrial",
+    "reversed",
+    "typography"
+  ],
+  "flowsync": [
+    "dark",
+    "landing"
+  ],
+  "fluorescent": [
+    "dark",
+    "blog",
+    "neon",
+    "pop-art"
+  ],
+  "folio": [
+    "light",
+    "portfolio"
+  ],
+  "folio-docs": [
+    "light",
+    "docs",
+    "design-system"
+  ],
+  "folio-gigante": [
+    "book",
+    "dark",
+    "oversized",
+    "monumental",
+    "maximal"
+  ],
+  "forge": [
+    "light",
+    "docs",
+    "opensource"
+  ],
+  "formulary": [
+    "light",
+    "docs",
+    "math"
+  ],
+  "forty": [
+    "dark",
+    "portfolio",
+    "gallery"
+  ],
+  "foundry": [
+    "dark",
+    "blog",
+    "maker"
+  ],
+  "foxhole": [
+    "dark",
+    "blog",
+    "security"
+  ],
+  "fractal": [
+    "dark",
+    "gallery",
+    "generative",
+    "mathematical"
+  ],
+  "frequency": [
+    "dark",
+    "blog",
+    "radio"
+  ],
+  "frottage": [
+    "light",
+    "minimal",
+    "art",
+    "clean"
+  ],
+  "frutiger-aero": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "furnace": [
+    "dark",
+    "docs",
+    "performance"
+  ],
+  "gala": [
+    "dark",
+    "event",
+    "landing"
+  ],
+  "garden": [
+    "light",
+    "blog",
+    "garden"
+  ],
+  "garnet": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "garrison": [
+    "dark",
+    "docs",
+    "firewall"
+  ],
+  "gateway": [
+    "dark",
+    "docs",
+    "auth"
+  ],
+  "gauntlet-run": [
+    "event",
+    "dark",
+    "endurance",
+    "challenge",
+    "sequential"
+  ],
+  "gazebo": [
+    "light",
+    "blog",
+    "event"
+  ],
+  "gazette": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "generative-art": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "glamorous"
+  ],
+  "genome-paper": [
+    "paper",
+    "dark",
+    "genomics",
+    "bioinformatics",
+    "data-intensive"
+  ],
+  "geodesic": [
+    "light",
+    "landing",
+    "geometric"
+  ],
+  "gilded": [
+    "dark",
+    "blog",
+    "luxury",
+    "gold"
+  ],
+  "gilt-edge": [
+    "book",
+    "dark",
+    "luxury",
+    "gilded",
+    "opulent"
+  ],
+  "glacial-blog": [
+    "blog",
+    "light",
+    "cool",
+    "minimal"
+  ],
+  "glacial-ice": [
+    "dark",
+    "blog",
+    "ice",
+    "frost"
+  ],
+  "glacier": [
+    "light",
+    "blog",
+    "tech"
+  ],
+  "glam-rock": [
+    "dark",
+    "blog",
+    "rock",
+    "glam",
+    "metallic"
+  ],
+  "glassmorphism": [
+    "dark",
+    "blog",
+    "glassmorphism"
+  ],
+  "glitch": [
+    "dark",
+    "blog",
+    "experimental",
+    "glitch-art"
+  ],
+  "glitch-elegance": [
+    "dark",
+    "blog",
+    "glitch",
+    "elegant"
+  ],
+  "glow-reef": [
+    "dark",
+    "blog",
+    "elegant",
+    "neon"
+  ],
+  "glyphic": [
+    "dark",
+    "blog",
+    "glyph",
+    "carved"
+  ],
+  "gong-show": [
+    "event",
+    "dark",
+    "competition",
+    "judgment",
+    "dramatic"
+  ],
+  "gossamer": [
+    "blog",
+    "minimal",
+    "elegant"
+  ],
+  "gothic": [
+    "dark",
+    "blog",
+    "gothic",
+    "medieval"
+  ],
+  "gradient-mesh": [
+    "dark",
+    "blog",
+    "gradient"
+  ],
+  "graffiti": [
+    "dark",
+    "blog",
+    "street-art",
+    "urban"
+  ],
+  "grand-finale": [
+    "event",
+    "festival",
+    "finale",
+    "closing",
+    "spectacular"
+  ],
+  "grant-proposal": [
+    "paper",
+    "light",
+    "proposal",
+    "funding",
+    "persuasive"
+  ],
+  "graphite-docs": [
+    "docs",
+    "dark",
+    "technical"
+  ],
+  "greenhouse": [
+    "light",
+    "blog",
+    "plant"
+  ],
+  "grisaille": [
+    "dark",
+    "blog",
+    "minimal",
+    "monochrome"
+  ],
+  "ground-zero": [
+    "event",
+    "dark",
+    "origin",
+    "impact",
+    "transformative"
+  ],
+  "guidebook": [
+    "light",
+    "docs",
+    "guide"
+  ],
+  "gunmetal": [
+    "dark",
+    "elegant",
+    "industrial",
+    "metallic"
+  ],
+  "gyroscope": [
+    "dark",
+    "dashboard",
+    "motion-sensor",
+    "3d-rotation"
+  ],
+  "habitat": [
+    "light",
+    "landing",
+    "listing"
+  ],
+  "hacker": [
+    "dark",
+    "blog"
+  ],
+  "hall-of-voices": [
+    "event",
+    "poetry",
+    "spoken-word",
+    "slam",
+    "voices"
+  ],
+  "hammer-drop": [
+    "event",
+    "light",
+    "auction",
+    "bidding",
+    "final"
+  ],
+  "hammock": [
+    "light",
+    "blog",
+    "slowlife"
+  ],
+  "handbook": [
+    "light",
+    "docs",
+    "corporate"
+  ],
+  "hangar": [
+    "dark",
+    "blog",
+    "aviation"
+  ],
+  "hardcore-pit": [
+    "event",
+    "punk",
+    "hardcore",
+    "show",
+    "chaotic"
+  ],
+  "haute-couture": [
+    "elegant",
+    "fashion",
+    "magazine"
+  ],
+  "headliner-bold": [
+    "event",
+    "festival",
+    "lineup",
+    "headliner",
+    "hierarchy"
+  ],
+  "hearth": [
+    "light",
+    "blog",
+    "traditional",
+    "elegant"
+  ],
+  "heavy-curtain": [
+    "event",
+    "theater",
+    "drama",
+    "production",
+    "heavy"
+  ],
+  "heliograph": [
+    "dark",
+    "blog",
+    "heliograph",
+    "sun-print"
+  ],
+  "helix": [
+    "light",
+    "landing",
+    "biotech",
+    "3d"
+  ],
+  "helix-docs": [
+    "docs",
+    "light",
+    "science"
+  ],
+  "herald": [
+    "light",
+    "magazine",
+    "editorial",
+    "news"
+  ],
+  "hermit": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "hibiscus": [
+    "dark",
+    "blog",
+    "glamorous",
+    "tropical"
+  ],
+  "hologram": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "holographic": [
+    "dark",
+    "showcase",
+    "holographic",
+    "3d"
+  ],
+  "horizon-ai": [
+    "landing",
+    "dark",
+    "ai",
+    "futuristic"
+  ],
+  "house-lights": [
+    "event",
+    "venue",
+    "concert",
+    "lighting",
+    "technical"
+  ],
+  "hwaro.386": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "hwaronight": [
+    "dark",
+    "blog"
+  ],
+  "hypercube": [
+    "dark",
+    "docs",
+    "3d",
+    "wireframe"
+  ],
+  "hyperpop": [
+    "dark",
+    "glamorous",
+    "neon",
+    "trendy",
+    "elegant"
+  ],
+  "igloo": [
+    "light",
+    "blog",
+    "nordic"
+  ],
+  "ignite": [
+    "landing",
+    "dark",
+    "startup"
+  ],
+  "ignition-sequence": [
+    "event",
+    "dark",
+    "phased",
+    "launch",
+    "sequential"
+  ],
+  "impasto": [
+    "light",
+    "blog",
+    "bold",
+    "artistic"
+  ],
+  "incunabula-noir": [
+    "book",
+    "dark",
+    "incunabulum",
+    "early-print",
+    "revolutionary"
+  ],
+  "inferno": [
+    "dark",
+    "community",
+    "fire",
+    "gaming"
+  ],
+  "infographic": [
+    "light",
+    "landing",
+    "infographic",
+    "data-viz"
+  ],
+  "ink-seoul": [
+    "light",
+    "blog",
+    "monochrome",
+    "seoul",
+    "minimal"
+  ],
+  "inkdrop-docs": [
+    "docs",
+    "dark",
+    "elegant",
+    "animation"
+  ],
+  "inkwell": [
+    "light",
+    "blog",
+    "poetry"
+  ],
+  "intaglio": [
+    "dark",
+    "portfolio",
+    "engraving",
+    "minimal"
+  ],
+  "intarsia": [
+    "light",
+    "portfolio",
+    "bold",
+    "clean",
+    "geometric"
+  ],
+  "interferogram": [
+    "dark",
+    "blog",
+    "interference",
+    "optical"
+  ],
+  "inventory": [
+    "light",
+    "dashboard",
+    "management"
+  ],
+  "iridescent-oil": [
+    "dark",
+    "blog",
+    "iridescent",
+    "oil"
+  ],
+  "iron-stage": [
+    "event",
+    "festival",
+    "metal",
+    "industrial",
+    "heavy"
+  ],
+  "ironclad": [
+    "dark",
+    "landing",
+    "metallic",
+    "security"
+  ],
+  "ironworks": [
+    "dark",
+    "blog",
+    "history"
+  ],
+  "isometric": [
+    "light",
+    "3d",
+    "dashboard",
+    "ui"
+  ],
+  "isthmus": [
+    "light",
+    "hub",
+    "bridge",
+    "horizontal-scroll"
+  ],
+  "jade-palace": [
+    "dark",
+    "blog",
+    "luxury",
+    "eastern"
+  ],
+  "japanese-industrial": [
+    "dark",
+    "blog",
+    "japanese",
+    "industrial"
+  ],
+  "jewel-tone": [
+    "dark",
+    "glamorous",
+    "jewel",
+    "elegant"
+  ],
+  "jugendstil": [
+    "light",
+    "blog",
+    "art-nouveau",
+    "organic",
+    "nature"
+  ],
+  "kaleidoscope": [
+    "light",
+    "event",
+    "psychedelic",
+    "pattern"
+  ],
+  "ketubah": [
+    "book",
+    "light",
+    "ceremonial",
+    "decorated",
+    "formal"
+  ],
+  "keynote-blast": [
+    "event",
+    "dark",
+    "conference",
+    "keynote",
+    "explosive"
+  ],
+  "keystone": [
+    "light",
+    "docs",
+    "architecture"
+  ],
+  "kiln": [
+    "light",
+    "portfolio",
+    "craft"
+  ],
+  "kinetic": [
+    "dark",
+    "agency",
+    "physics",
+    "interactive"
+  ],
+  "kinetic-mobile": [
+    "dark",
+    "blog",
+    "kinetic",
+    "mobile"
+  ],
+  "kinetic-typography": [
+    "dark",
+    "blog",
+    "kinetic",
+    "typography"
+  ],
+  "kintsugi": [
+    "dark",
+    "blog",
+    "kintsugi",
+    "gold-repair"
+  ],
+  "lab": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "lab-notebook": [
+    "paper",
+    "light",
+    "laboratory",
+    "raw",
+    "observational"
+  ],
+  "labyrinth": [
+    "dark",
+    "portfolio",
+    "maze",
+    "gamification"
+  ],
+  "lagoon": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "laser-show": [
+    "dark",
+    "blog",
+    "landing",
+    "concert",
+    "glamorous"
+  ],
+  "last-call": [
+    "event",
+    "dark",
+    "closing",
+    "final",
+    "urgent"
+  ],
+  "lattice": [
+    "light",
+    "docs",
+    "graph-db"
+  ],
+  "launchpad": [
+    "light",
+    "landing",
+    "saas"
+  ],
+  "launchpad-event": [
+    "event",
+    "dark",
+    "launch",
+    "space",
+    "countdown"
+  ],
+  "lava-flow": [
+    "dark",
+    "blog",
+    "lava",
+    "volcanic"
+  ],
+  "layered-docs": [
+    "light",
+    "docs",
+    "enterprise"
+  ],
+  "ledger": [
+    "light",
+    "docs",
+    "finance"
+  ],
+  "letter-to-editor": [
+    "paper",
+    "light",
+    "correspondence",
+    "urgent",
+    "brief"
+  ],
+  "letterbox": [
+    "light",
+    "blog",
+    "newsletter"
+  ],
+  "lexicon": [
+    "light",
+    "docs",
+    "glossary"
+  ],
+  "lichen-moss": [
+    "dark",
+    "blog",
+    "lichen",
+    "organic"
+  ],
+  "lighthouse": [
+    "light",
+    "docs",
+    "directory"
+  ],
+  "linktree": [
+    "dark",
+    "landing",
+    "links"
+  ],
+  "linocut": [
+    "light",
+    "printmaking",
+    "bold",
+    "creative"
+  ],
+  "liquid": [
+    "dark",
+    "interactive",
+    "gooey",
+    "svg"
+  ],
+  "liquid-chrome": [
+    "dark",
+    "blog",
+    "metallic",
+    "glamorous"
+  ],
+  "lithium": [
+    "dark",
+    "landing",
+    "electric",
+    "tech"
+  ],
+  "lithograph": [
+    "dark",
+    "blog",
+    "lithograph",
+    "printmaking"
+  ],
+  "logbook": [
+    "light",
+    "docs",
+    "compliance"
+  ],
+  "longitudinal": [
+    "paper",
+    "dark",
+    "longitudinal",
+    "temporal",
+    "tracking"
+  ],
+  "lookbook": [
+    "dark",
+    "portfolio",
+    "lookbook",
+    "fashion"
+  ],
+  "loom": [
+    "light",
+    "portfolio",
+    "fashion"
+  ],
+  "lumiere": [
+    "dark",
+    "elegant",
+    "minimal",
+    "luminescent"
+  ],
+  "lumina": [
+    "dark",
+    "portfolio",
+    "minimal"
+  ],
+  "luminary": [
+    "light",
+    "elegant",
+    "portfolio"
+  ],
+  "luminescent-mesh": [
+    "dark",
+    "blog",
+    "luminescent",
+    "mesh"
+  ],
+  "lumos": [
+    "blog",
+    "elegant",
+    "light",
+    "minimal"
+  ],
+  "lunar-base": [
+    "elegant",
+    "portfolio",
+    "dark"
+  ],
+  "lunar-breeze": [
+    "dark",
+    "blog",
+    "elegant",
+    "minimal"
+  ],
+  "luxe-noir": [
+    "dark",
+    "glamorous",
+    "luxury",
+    "elegant"
+  ],
+  "luxury-horology": [
+    "dark",
+    "portfolio",
+    "horology",
+    "luxury"
+  ],
+  "macro-snowflake": [
+    "dark",
+    "blog",
+    "snowflake",
+    "crystalline"
+  ],
+  "madhubani": [
+    "light",
+    "blog",
+    "indian",
+    "folk-art",
+    "geometric"
+  ],
+  "magenta-sunset": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "magma": [
+    "dark",
+    "dashboard",
+    "volcanic",
+    "animation"
+  ],
+  "magnetar": [
+    "dark",
+    "blog",
+    "magnetar",
+    "cosmic"
+  ],
+  "main-act": [
+    "event",
+    "concert",
+    "headline",
+    "performer",
+    "dramatic"
+  ],
+  "mainstage": [
+    "event",
+    "dark",
+    "performance",
+    "stage",
+    "dramatic"
+  ],
+  "manifesto": [
+    "dark",
+    "blog",
+    "opinion"
+  ],
+  "manifesto-press": [
+    "book",
+    "dark",
+    "revolutionary",
+    "bold",
+    "political"
+  ],
+  "manifold": [
+    "light",
+    "docs",
+    "saas"
+  ],
+  "marble": [
+    "light",
+    "gallery",
+    "luxury",
+    "marble-texture"
+  ],
+  "marbled-paper": [
+    "dark",
+    "blog",
+    "marbled",
+    "paper"
+  ],
+  "mardi-gras": [
+    "glamorous",
+    "trendy",
+    "bold",
+    "purple",
+    "gold",
+    "green"
+  ],
+  "marginalia-noir": [
+    "book",
+    "dark",
+    "annotated",
+    "consumed",
+    "experimental"
+  ],
+  "marketplace": [
+    "light",
+    "store",
+    "marketplace"
+  ],
+  "marquetry": [
+    "light",
+    "portfolio",
+    "geometric",
+    "minimal"
+  ],
+  "masquerade": [
+    "dark",
+    "elegant",
+    "glamorous",
+    "luxury",
+    "mystery"
+  ],
+  "matcha": [
+    "blog",
+    "light",
+    "minimal",
+    "zen"
+  ],
+  "matrix": [
+    "light",
+    "docs",
+    "compatibility"
+  ],
+  "maximal-bloom": [
+    "elegant",
+    "floral",
+    "bold",
+    "glamorous"
+  ],
+  "maximalist": [
+    "dark",
+    "blog",
+    "bold",
+    "glamorous"
+  ],
+  "mayan-geometry": [
+    "dark",
+    "blog",
+    "mayan",
+    "geometric"
+  ],
+  "meadow": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "medieval-manuscript": [
+    "dark",
+    "blog",
+    "medieval",
+    "manuscript"
+  ],
+  "memoir": [
+    "light",
+    "blog",
+    "longform"
+  ],
+  "memphis": [
+    "light",
+    "retro",
+    "colorful",
+    "bold",
+    "portfolio"
+  ],
+  "mercury": [
+    "dark",
+    "blog",
+    "minimal",
+    "metallic",
+    "elegant"
+  ],
+  "meridian": [
+    "dark",
+    "landing",
+    "timezone"
+  ],
+  "meridian-docs": [
+    "light",
+    "docs",
+    "scheduling"
+  ],
+  "meridiem": [
+    "dual",
+    "dashboard",
+    "time-based",
+    "auto-theme"
+  ],
+  "meta-analysis": [
+    "paper",
+    "light",
+    "statistical",
+    "synthesis",
+    "evidence"
+  ],
+  "meteor": [
+    "dark",
+    "interactive",
+    "meteor-shower",
+    "cosmic"
+  ],
+  "methods-paper": [
+    "paper",
+    "light",
+    "methods",
+    "protocol",
+    "technical"
+  ],
+  "metronome": [
+    "dark",
+    "blog",
+    "music-production",
+    "rhythm"
+  ],
+  "mezzotint": [
+    "light",
+    "blog",
+    "bold",
+    "clean",
+    "monochrome"
+  ],
+  "micro": [
+    "light",
+    "blog",
+    "microblog"
+  ],
+  "midnight-blog": [
+    "dark",
+    "blog",
+    "reading"
+  ],
+  "midnight-launch": [
+    "landing",
+    "dark",
+    "animation",
+    "product"
+  ],
+  "migration": [
+    "light",
+    "docs",
+    "database"
+  ],
+  "minifolio": [
+    "light",
+    "portfolio",
+    "minimal"
+  ],
+  "minimalzen": [
+    "light",
+    "blog",
+    "minimal",
+    "zen"
+  ],
+  "mint-fresh": [
+    "landing",
+    "light",
+    "saas"
+  ],
+  "mirage": [
+    "light",
+    "gallery",
+    "desert",
+    "distortion"
+  ],
+  "misprint": [
+    "book",
+    "dark",
+    "error",
+    "accidental",
+    "artistic"
+  ],
+  "mixed-methods": [
+    "paper",
+    "light",
+    "mixed-methods",
+    "convergent",
+    "dual"
+  ],
+  "modern-blog": [
+    "dark",
+    "blog",
+    "modern"
+  ],
+  "molten": [
+    "dark",
+    "blog",
+    "metalwork",
+    "melting"
+  ],
+  "molten-gold": [
+    "elegant",
+    "gold",
+    "trendy"
+  ],
+  "monochrome": [
+    "light",
+    "photo-essay",
+    "monochrome",
+    "grayscale"
+  ],
+  "monograph": [
+    "book",
+    "light",
+    "academic",
+    "thorough",
+    "reference"
+  ],
+  "monolith": [
+    "dark",
+    "landing",
+    "onepage"
+  ],
+  "monolithic-dark": [
+    "dark",
+    "blog",
+    "monolithic",
+    "bold"
+  ],
+  "monoprint": [
+    "light",
+    "monoprint",
+    "bold",
+    "creative"
+  ],
+  "monorepo-docs": [
+    "docs",
+    "dark",
+    "developer",
+    "monorepo"
+  ],
+  "moonrise": [
+    "dark",
+    "blog",
+    "essay"
+  ],
+  "moonstone": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "moroccan-zellige": [
+    "light",
+    "blog",
+    "moroccan",
+    "mosaic",
+    "geometric"
+  ],
+  "morphogenesis": [
+    "dark",
+    "blog",
+    "generative",
+    "biology",
+    "patterns"
+  ],
+  "mortar": [
+    "dark",
+    "docs",
+    "build-system"
+  ],
+  "mosaic": [
+    "light",
+    "blog",
+    "magazine"
+  ],
+  "mosh-pit": [
+    "event",
+    "dark",
+    "punk",
+    "chaotic",
+    "raw"
+  ],
+  "mosstown": [
+    "light",
+    "blog",
+    "cozy"
+  ],
+  "mughal": [
+    "light",
+    "blog",
+    "mughal",
+    "ornate",
+    "gold"
+  ],
+  "murano-glass": [
+    "light",
+    "blog",
+    "glass",
+    "translucent",
+    "venetian"
+  ],
+  "mycelium": [
+    "dark",
+    "blog",
+    "mycelium",
+    "fungal"
+  ],
+  "nadir": [
+    "dark",
+    "blog",
+    "minimal",
+    "oled-black"
+  ],
+  "nautical": [
+    "dark",
+    "blog",
+    "nautical"
+  ],
+  "nebula": [
+    "dark",
+    "gallery",
+    "space",
+    "ethereal"
+  ],
+  "neo-deco": [
+    "dark",
+    "portfolio",
+    "artdeco",
+    "elegant"
+  ],
+  "neo-memphis-dark": [
+    "dark",
+    "blog",
+    "memphis",
+    "neo-memphis"
+  ],
+  "neobrutal": [
+    "light",
+    "landing",
+    "neo-brutalism",
+    "bold"
+  ],
+  "neoclassical": [
+    "light",
+    "gallery",
+    "marble-texture",
+    "elegant"
+  ],
+  "neon": [
+    "dark",
+    "blog",
+    "cyberpunk"
+  ],
+  "neon-jungle": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "neon"
+  ],
+  "neon-marquee": [
+    "event",
+    "theater",
+    "marquee",
+    "vintage",
+    "retro"
+  ],
+  "neon-tokyo": [
+    "dark",
+    "blog",
+    "cyberpunk",
+    "tokyo",
+    "glamorous"
+  ],
+  "network-meta": [
+    "paper",
+    "dark",
+    "network",
+    "meta-analysis",
+    "comparative"
+  ],
+  "neumorphism": [
+    "light",
+    "ui",
+    "soft",
+    "shadow"
+  ],
+  "neural-bloom": [
+    "dark",
+    "blog",
+    "neural",
+    "ai",
+    "synaptic"
+  ],
+  "newspaper": [
+    "light",
+    "blog",
+    "editorial",
+    "newspaper"
+  ],
+  "nexus": [
+    "dark",
+    "docs",
+    "microservice"
+  ],
+  "nexus-docs": [
+    "docs",
+    "dark",
+    "developer"
+  ],
+  "niello": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
+  "no-style-please": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "noctis": [
+    "landing",
+    "dark",
+    "glassmorphism",
+    "neon"
+  ],
+  "nocturne": [
+    "dark",
+    "blog",
+    "classical-music",
+    "piano"
+  ],
+  "noir": [
+    "dark",
+    "blog",
+    "noir"
+  ],
+  "northern-lights": [
+    "dark",
+    "blog",
+    "aurora",
+    "arctic",
+    "atmospheric"
+  ],
+  "notebook": [
+    "light",
+    "blog",
+    "journal"
+  ],
+  "null-result": [
+    "paper",
+    "light",
+    "null",
+    "negative",
+    "honest"
+  ],
+  "oasis": [
+    "light",
+    "blog",
+    "relaxation"
+  ],
+  "obelisk": [
+    "light",
+    "one-page",
+    "monumental",
+    "vertical"
+  ],
+  "oblique": [
+    "light",
+    "blog",
+    "bold",
+    "angular"
+  ],
+  "oblong-quarto": [
+    "book",
+    "light",
+    "landscape",
+    "panoramic",
+    "unusual"
+  ],
+  "observatory": [
+    "dark",
+    "blog",
+    "space"
+  ],
+  "obsidian": [
+    "dark",
+    "wiki",
+    "glass",
+    "oled"
+  ],
+  "obsidian-docs": [
+    "docs",
+    "dark",
+    "wiki",
+    "knowledge"
+  ],
+  "obsidian-mirror": [
+    "dark",
+    "blog",
+    "obsidian",
+    "reflective"
+  ],
+  "old-map-cartography": [
+    "dark",
+    "blog",
+    "cartography",
+    "vintage"
+  ],
+  "onyx": [
+    "landing",
+    "dark",
+    "minimal",
+    "luxury"
+  ],
+  "op-art": [
+    "dark",
+    "blog",
+    "geometric",
+    "optical-illusion"
+  ],
+  "opalescent": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "opening-act": [
+    "event",
+    "opening",
+    "season",
+    "premiere",
+    "fresh"
+  ],
+  "opening-night": [
+    "event",
+    "dark",
+    "premiere",
+    "formal",
+    "electric"
+  ],
+  "opulent": [
+    "light",
+    "elegant",
+    "luxury",
+    "portfolio",
+    "bold"
+  ],
+  "orchard": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "orchid": [
+    "dark",
+    "blog",
+    "glamorous",
+    "botanical"
+  ],
+  "origami": [
+    "light",
+    "blog",
+    "material"
+  ],
+  "oscilloscope": [
+    "dark",
+    "blog",
+    "oscilloscope",
+    "retro"
+  ],
+  "overture": [
+    "event",
+    "dark",
+    "opening",
+    "orchestral",
+    "grand"
+  ],
+  "oxidation": [
+    "dark",
+    "blog",
+    "oxidation",
+    "rust"
+  ],
+  "oxide": [
+    "dark",
+    "gallery",
+    "industrial",
+    "rust-texture"
+  ],
+  "pagoda": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "palette": [
+    "light",
+    "docs",
+    "design"
+  ],
+  "palimpsest-noir": [
+    "book",
+    "dark",
+    "layered",
+    "erased",
+    "ghostly"
+  ],
+  "panopticon": [
+    "dark",
+    "brutalist",
+    "radial",
+    "experimental"
+  ],
+  "pantry": [
+    "light",
+    "docs",
+    "package-manager"
+  ],
+  "paper": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "paper-art": [
+    "light",
+    "blog",
+    "paper",
+    "collage"
+  ],
+  "papermod": [
+    "light",
+    "blog",
+    "minimal"
+  ],
+  "parallax": [
+    "light",
+    "storytelling",
+    "parallax",
+    "cinematic"
+  ],
+  "parallax-heavy": [
+    "dark",
+    "landing",
+    "gallery",
+    "parallax"
+  ],
+  "parchment": [
+    "light",
+    "docs",
+    "fantasy"
+  ],
+  "parquetry": [
+    "dark",
+    "blog",
+    "parquetry",
+    "woodwork"
+  ],
+  "particle-storm": [
+    "dark",
+    "blog",
+    "neon",
+    "particles",
+    "energy"
+  ],
+  "pastel-docs": [
+    "docs",
+    "light",
+    "friendly"
+  ],
+  "patina": [
+    "dark",
+    "blog",
+    "minimal",
+    "craft"
+  ],
+  "peacock": [
+    "elegant",
+    "glamorous",
+    "portfolio"
+  ],
+  "pearlescent": [
+    "light",
+    "blog",
+    "iridescent",
+    "luxury",
+    "soft"
+  ],
+  "peer-review": [
+    "paper",
+    "light",
+    "academic",
+    "review",
+    "transparent"
+  ],
+  "pendulum": [
+    "dark",
+    "blog",
+    "productivity"
+  ],
+  "pentimento": [
+    "light",
+    "portfolio",
+    "elegant",
+    "bold",
+    "clean"
+  ],
+  "permafrost": [
+    "light",
+    "archive",
+    "ice",
+    "frozen"
+  ],
+  "persian-carpet": [
+    "light",
+    "blog",
+    "persian",
+    "carpet",
+    "ornate"
+  ],
+  "perspective-piece": [
+    "paper",
+    "dark",
+    "opinion",
+    "viewpoint",
+    "argumentative"
+  ],
+  "petrified-wood": [
+    "dark",
+    "blog",
+    "fossil",
+    "wood"
+  ],
+  "phantom": [
+    "dark",
+    "blog",
+    "ghost",
+    "translucent"
+  ],
+  "phosphor": [
+    "dark",
+    "gallery",
+    "bioluminescence",
+    "glow"
+  ],
+  "photoblog": [
+    "dark",
+    "blog",
+    "photography",
+    "gallery"
+  ],
+  "photon": [
+    "dark",
+    "elegant",
+    "luminescent",
+    "portfolio"
+  ],
+  "pietra-dura": [
+    "dark",
+    "creative",
+    "bold",
+    "stone"
+  ],
+  "pinecone": [
+    "dark",
+    "blog",
+    "nature"
+  ],
+  "pipeline": [
+    "light",
+    "docs",
+    "cicd"
+  ],
+  "pit-stop": [
+    "event",
+    "dark",
+    "motorsport",
+    "speed",
+    "frantic"
+  ],
+  "pixel": [
+    "dark",
+    "blog",
+    "gaming"
+  ],
+  "plasma": [
+    "dark",
+    "science",
+    "plasma",
+    "visualization"
+  ],
+  "platinum": [
+    "light",
+    "minimal",
+    "luxury",
+    "portfolio"
+  ],
+  "playlist": [
+    "dark",
+    "blog",
+    "music"
+  ],
+  "podcast-fm": [
+    "dark",
+    "media",
+    "podcast"
+  ],
+  "podium-rush": [
+    "event",
+    "competition",
+    "awards",
+    "victory",
+    "podium"
+  ],
+  "pointillism": [
+    "dark",
+    "blog",
+    "pointillism",
+    "dots"
+  ],
+  "poison": [
+    "dark",
+    "blog",
+    "sidebar"
+  ],
+  "polaris": [
+    "dark",
+    "guide",
+    "astronomy",
+    "constellation"
+  ],
+  "polaroid": [
+    "light",
+    "blog",
+    "gallery"
+  ],
+  "pop-surreal": [
+    "dark",
+    "glamorous",
+    "elegant",
+    "surreal",
+    "trendy"
+  ],
+  "pop-up-page": [
+    "book",
+    "light",
+    "dimensional",
+    "paper-engineering",
+    "interactive"
+  ],
+  "portfolio-blog": [
+    "dark",
+    "blog",
+    "portfolio"
+  ],
+  "portico": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "position-paper": [
+    "paper",
+    "dark",
+    "position",
+    "argumentative",
+    "bold"
+  ],
+  "postcard": [
+    "light",
+    "blog",
+    "postcard"
+  ],
+  "powder-burn": [
+    "event",
+    "dark",
+    "rapid-fire",
+    "flash",
+    "quick"
+  ],
+  "prairie": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "preprint-rush": [
+    "paper",
+    "light",
+    "preprint",
+    "urgent",
+    "draft"
+  ],
+  "pressure-cooker": [
+    "event",
+    "dark",
+    "hackathon",
+    "pressure",
+    "deadline"
+  ],
+  "pricetable": [
+    "light",
+    "landing",
+    "saas",
+    "pricing"
+  ],
+  "primer": [
+    "light",
+    "docs",
+    "tutorial"
+  ],
+  "printer-devil": [
+    "book",
+    "dark",
+    "error",
+    "playful",
+    "craft"
+  ],
+  "prism": [
+    "dark",
+    "docs",
+    "data"
+  ],
+  "prism-docs": [
+    "docs",
+    "light",
+    "colorful"
+  ],
+  "prism-refraction": [
+    "dark",
+    "blog",
+    "prism",
+    "refraction"
+  ],
+  "prismify": [
+    "glassmorphism",
+    "landing",
+    "light",
+    "saas"
+  ],
+  "proof-sheet": [
+    "book",
+    "light",
+    "proof",
+    "unfinished",
+    "editorial"
+  ],
+  "protocol": [
+    "dark",
+    "docs",
+    "networking"
+  ],
+  "protocol-paper": [
+    "paper",
+    "light",
+    "protocol",
+    "pre-registration",
+    "rigorous"
+  ],
+  "psychedelic": [
+    "dark",
+    "minimal",
+    "elegant",
+    "glamorous"
+  ],
+  "pulp-fiction": [
+    "book",
+    "dark",
+    "pulp",
+    "lurid",
+    "cheap"
+  ],
+  "pulsar": [
+    "dark",
+    "blog",
+    "cosmic",
+    "pulse-animation"
+  ],
+  "pulse-api": [
+    "dark",
+    "docs"
+  ],
+  "pyrite": [
+    "dark",
+    "showcase",
+    "metallic",
+    "luxury"
+  ],
+  "pyrotechnic": [
+    "event",
+    "show",
+    "pyrotechnics",
+    "fireworks",
+    "explosive"
+  ],
+  "qualitative-study": [
+    "paper",
+    "light",
+    "qualitative",
+    "thematic",
+    "interpretive"
+  ],
+  "quantum": [
+    "dark",
+    "blog",
+    "quantum",
+    "science"
+  ],
+  "quarry": [
+    "dark",
+    "docs",
+    "data-warehouse"
+  ],
+  "quasar": [
+    "dark",
+    "portfolio",
+    "bold",
+    "minimal"
+  ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
+  "radiolaria": [
+    "dark",
+    "blog",
+    "radiolaria",
+    "skeletal"
+  ],
+  "rainbow-cascade": [
+    "elegant",
+    "glowing",
+    "box-shadow"
+  ],
+  "ramble": [
+    "light",
+    "blog",
+    "hiking"
+  ],
+  "randomized-trial": [
+    "paper",
+    "light",
+    "rct",
+    "clinical-trial",
+    "rigorous"
+  ],
+  "rave": [
+    "dark",
+    "blog",
+    "acid",
+    "rave",
+    "neon"
+  ],
+  "raw-data": [
+    "paper",
+    "light",
+    "raw",
+    "data",
+    "tables"
+  ],
+  "reactor": [
+    "dark",
+    "docs",
+    "reactive"
+  ],
+  "realty": [
+    "light",
+    "realestate",
+    "luxury",
+    "elegant"
+  ],
+  "recipe": [
+    "light",
+    "blog",
+    "recipe"
+  ],
+  "red-alert": [
+    "event",
+    "dark",
+    "emergency",
+    "crisis",
+    "urgent"
+  ],
+  "red-carpet": [
+    "event",
+    "premiere",
+    "celebrity",
+    "glamour",
+    "fashion"
+  ],
+  "reef": [
+    "dark",
+    "blog",
+    "diving"
+  ],
+  "relay": [
+    "light",
+    "docs",
+    "integration"
+  ],
+  "remainder-bin": [
+    "book",
+    "light",
+    "secondhand",
+    "discount",
+    "worn"
+  ],
+  "remedy": [
+    "light",
+    "docs",
+    "troubleshooting"
+  ],
+  "renaissance": [
+    "light",
+    "art",
+    "classic",
+    "serif",
+    "elegant"
+  ],
+  "repousse": [
+    "dark",
+    "blog",
+    "repousse",
+    "metalwork"
+  ],
+  "reproducibility": [
+    "paper",
+    "light",
+    "replication",
+    "comparison",
+    "verdict"
+  ],
+  "resume": [
+    "light",
+    "resume"
+  ],
+  "retraction-notice": [
+    "paper",
+    "light",
+    "retracted",
+    "warning",
+    "editorial"
+  ],
+  "retro-radar": [
+    "dark",
+    "blog",
+    "radar",
+    "retro"
+  ],
+  "retromac": [
+    "light",
+    "mac",
+    "os9",
+    "retro",
+    "system"
+  ],
+  "retrowave": [
+    "dark",
+    "blog",
+    "retro",
+    "synthwave"
+  ],
+  "reveille": [
+    "event",
+    "dark",
+    "military",
+    "assembly",
+    "urgent"
+  ],
+  "review-article": [
+    "paper",
+    "light",
+    "review",
+    "literature",
+    "synthesis"
+  ],
+  "ridgeline": [
+    "dark",
+    "blog",
+    "outdoor"
+  ],
+  "riftzone": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "dimensional"
+  ],
+  "ring-bell": [
+    "event",
+    "dark",
+    "boxing",
+    "fight",
+    "intense"
+  ],
+  "riverbank": [
+    "light",
+    "blog",
+    "nature-journal"
+  ],
+  "rococo": [
+    "light",
+    "blog",
+    "pastel",
+    "elegant"
+  ],
+  "roll-call": [
+    "event",
+    "light",
+    "assembly",
+    "formal",
+    "attendance"
+  ],
+  "roll-scroll": [
+    "book",
+    "light",
+    "scroll",
+    "continuous",
+    "ancient"
+  ],
+  "rooftop": [
+    "dark",
+    "blog",
+    "urban"
+  ],
+  "rose-gold": [
+    "elegant",
+    "luxury",
+    "minimal"
+  ],
+  "rosemary": [
+    "light",
+    "blog",
+    "cooking"
+  ],
+  "rosetta": [
+    "light",
+    "docs",
+    "i18n"
+  ],
+  "rosewood": [
+    "blog",
+    "dark",
+    "warm",
+    "classic"
+  ],
+  "rubric": [
+    "book",
+    "light",
+    "rubricated",
+    "two-color",
+    "traditional"
+  ],
+  "ruby-fire": [
+    "dark",
+    "blog",
+    "bold"
+  ],
+  "runbook": [
+    "light",
+    "docs",
+    "operations"
+  ],
+  "rune": [
+    "dark",
+    "archive",
+    "viking",
+    "mystic"
+  ],
+  "saffron": [
+    "light",
+    "blog",
+    "food"
+  ],
+  "sage-guide": [
+    "docs",
+    "light",
+    "tutorial",
+    "guide"
+  ],
+  "sakura-storm": [
+    "dark",
+    "blog",
+    "glamorous",
+    "sakura"
+  ],
+  "sandcastle": [
+    "light",
+    "blog",
+    "sand",
+    "beach"
+  ],
+  "sandstone": [
+    "light",
+    "blog",
+    "architecture"
+  ],
+  "sandstorm": [
+    "dark",
+    "blog",
+    "desert",
+    "particles"
+  ],
+  "sapphire": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "savanna": [
+    "light",
+    "blog",
+    "nature"
+  ],
+  "sawmill": [
+    "light",
+    "blog",
+    "woodworking"
+  ],
+  "scaffold": [
+    "dark",
+    "landing",
+    "comingsoon"
+  ],
+  "scaffold-docs": [
+    "dark",
+    "docs",
+    "scaffolding"
+  ],
+  "schematic": [
+    "light",
+    "docs",
+    "hardware"
+  ],
+  "scientific-journal": [
+    "dark",
+    "docs",
+    "scientific",
+    "academic"
+  ],
+  "scoping-review": [
+    "paper",
+    "light",
+    "scoping",
+    "mapping",
+    "landscape"
+  ],
+  "scrimshaw": [
+    "bold",
+    "elegant",
+    "clean",
+    "blog"
+  ],
+  "sentinel": [
+    "dark",
+    "docs",
+    "monitoring"
+  ],
+  "seraph": [
+    "minimal",
+    "elegant",
+    "portfolio"
+  ],
+  "serenity": [
+    "light",
+    "blog",
+    "elegant"
+  ],
+  "sextant": [
+    "light",
+    "docs",
+    "metrics"
+  ],
+  "sfumato": [
+    "dark",
+    "blog",
+    "atmospheric",
+    "minimal"
+  ],
+  "sgraffito": [
+    "dark",
+    "blog",
+    "sgraffito",
+    "scratched"
+  ],
+  "shutout": [
+    "event",
+    "dark",
+    "competition",
+    "dominant",
+    "perfect"
+  ],
+  "silhouette": [
+    "dark",
+    "landing",
+    "silhouette",
+    "dramatic"
+  ],
+  "silk-road": [
+    "elegant",
+    "glamorous",
+    "silk",
+    "cultural"
+  ],
+  "simulation-paper": [
+    "paper",
+    "dark",
+    "computational",
+    "simulation",
+    "model"
+  ],
+  "sketch": [
+    "light",
+    "blog",
+    "handdrawn"
+  ],
+  "skeuomorphic": [
+    "light",
+    "blog",
+    "skeuomorphic",
+    "realistic"
+  ],
+  "slide": [
+    "dark",
+    "docs",
+    "presentation"
+  ],
+  "snowfall": [
+    "light",
+    "blog",
+    "winter"
+  ],
+  "solar-punk": [
+    "light",
+    "blog",
+    "solarpunk",
+    "sustainable"
+  ],
+  "solarflare": [
+    "dark",
+    "landing",
+    "solar",
+    "energy"
+  ],
+  "solaris": [
+    "dark",
+    "dashboard",
+    "solar-system",
+    "space-mission"
+  ],
+  "solarium": [
+    "blog",
+    "light",
+    "warm"
+  ],
+  "solstice": [
+    "dual",
+    "blog",
+    "seasonal",
+    "time-based"
+  ],
+  "sonar": [
+    "dark",
+    "hub",
+    "radar",
+    "discovery"
+  ],
+  "spectra": [
+    "dark",
+    "data-science",
+    "spectrum",
+    "rainbow"
+  ],
+  "spectrum": [
+    "light",
+    "blog",
+    "a11y"
+  ],
+  "spectrum-docs": [
+    "light",
+    "docs",
+    "accessibility"
+  ],
+  "spire": [
+    "dark",
+    "blog",
+    "architecture"
+  ],
+  "split-tone": [
+    "light",
+    "blog",
+    "photography",
+    "cinematic",
+    "toning"
+  ],
+  "stained-glass": [
+    "light",
+    "blog",
+    "cathedral",
+    "colorful",
+    "gothic"
+  ],
+  "standing-ovation": [
+    "event",
+    "light",
+    "awards",
+    "acclaim",
+    "celebration"
+  ],
+  "starlight": [
+    "dark",
+    "portfolio",
+    "elegant",
+    "minimal"
+  ],
+  "starting-gun": [
+    "event",
+    "dark",
+    "race",
+    "competition",
+    "explosive"
+  ],
+  "statuspage": [
+    "light",
+    "landing",
+    "status"
+  ],
+  "stellar-launch": [
+    "landing",
+    "dark",
+    "parallax",
+    "animation"
+  ],
+  "stipple": [
+    "light",
+    "artistic",
+    "dot-art",
+    "gallery"
+  ],
+  "storefront": [
+    "light",
+    "landing",
+    "shop"
+  ],
+  "stratum": [
+    "dark",
+    "timeline",
+    "geological",
+    "layered"
+  ],
+  "strobe": [
+    "dark",
+    "event",
+    "club",
+    "strobe"
+  ],
+  "studio": [
+    "dark",
+    "landing",
+    "portfolio"
+  ],
+  "subzero": [
+    "dark",
+    "research",
+    "cryogenic",
+    "frozen"
+  ],
+  "summit": [
+    "dark",
+    "landing",
+    "conference"
+  ],
+  "summit-event": [
+    "conference",
+    "dark",
+    "event",
+    "landing"
+  ],
+  "summit-strike": [
+    "event",
+    "dark",
+    "conference",
+    "summit",
+    "ascending"
+  ],
+  "sunburst": [
+    "light",
+    "blog",
+    "warm",
+    "golden",
+    "radiant"
+  ],
+  "sundew": [
+    "light",
+    "blog",
+    "science"
+  ],
+  "supernova": [
+    "dark",
+    "landing",
+    "cosmic",
+    "particles"
+  ],
+  "supplementary": [
+    "paper",
+    "light",
+    "supplementary",
+    "data-heavy",
+    "exhaustive"
+  ],
+  "supreme-sun": [
+    "light",
+    "blog",
+    "community"
+  ],
+  "survey-instrument": [
+    "paper",
+    "light",
+    "survey",
+    "instrument",
+    "psychometric"
+  ],
+  "synthwave": [
+    "dark",
+    "retro",
+    "glamorous",
+    "trendy"
+  ],
+  "systematic-review": [
+    "paper",
+    "light",
+    "systematic",
+    "evidence",
+    "methodology"
+  ],
+  "tactile-fabric": [
+    "light",
+    "blog",
+    "fabric",
+    "textile"
+  ],
+  "talavera": [
+    "light",
+    "blog",
+    "mexican",
+    "pottery",
+    "colorful"
+  ],
+  "tale": [
+    "light",
+    "blog",
+    "traditional"
+  ],
+  "tangram": [
+    "light",
+    "portfolio",
+    "puzzle",
+    "geometric"
+  ],
+  "tapestry": [
+    "light",
+    "blog",
+    "timeline"
+  ],
+  "taskboard": [
+    "light",
+    "dashboard",
+    "kanban"
+  ],
+  "tavern": [
+    "dark",
+    "blog",
+    "rpg"
+  ],
+  "techbyte": [
+    "light",
+    "blog",
+    "tech",
+    "card"
+  ],
+  "technical-report": [
+    "paper",
+    "light",
+    "institutional",
+    "technical-report",
+    "formal"
+  ],
+  "tectonic": [
+    "dark",
+    "hub",
+    "geological",
+    "interactive"
+  ],
+  "telegraph": [
+    "light",
+    "blog",
+    "news"
+  ],
+  "tempera": [
+    "dark",
+    "blog",
+    "tempera",
+    "painting"
+  ],
+  "tempest": [
+    "dark",
+    "magazine",
+    "storm",
+    "dramatic"
+  ],
+  "tenebrism": [
+    "dark",
+    "creative",
+    "bold",
+    "clean"
+  ],
+  "terminal": [
+    "dark",
+    "blog"
+  ],
+  "terrace": [
+    "light",
+    "blog",
+    "lifestyle"
+  ],
+  "terracotta-studio": [
+    "landing",
+    "light",
+    "creative",
+    "artisan"
+  ],
+  "terracotta-tiles": [
+    "dark",
+    "blog",
+    "terracotta",
+    "tile"
+  ],
+  "terraform": [
+    "dark",
+    "dashboard",
+    "sci-fi",
+    "terraforming"
+  ],
+  "terraform-docs": [
+    "docs",
+    "dark",
+    "infra",
+    "devops"
+  ],
+  "terrarium": [
+    "light",
+    "portfolio",
+    "miniature"
+  ],
+  "terrazzo": [
+    "light",
+    "portfolio",
+    "terrazzo",
+    "speckled"
+  ],
+  "terrazzo-blog": [
+    "blog",
+    "light",
+    "colorful",
+    "memphis"
+  ],
+  "tessellation": [
+    "light",
+    "gallery",
+    "escher",
+    "pattern-art"
+  ],
+  "tesseract": [
+    "dark",
+    "education",
+    "4d",
+    "mathematical"
+  ],
+  "thermal": [
+    "dark",
+    "dashboard",
+    "thermal",
+    "heatmap"
+  ],
+  "thesis": [
+    "light",
+    "blog",
+    "academic"
+  ],
+  "thesis-defense": [
+    "paper",
+    "dark",
+    "thesis",
+    "formal",
+    "institutional"
+  ],
+  "thumb-bible": [
+    "book",
+    "light",
+    "miniature",
+    "dense",
+    "craft"
+  ],
+  "thunderdome": [
+    "event",
+    "dark",
+    "arena",
+    "competition",
+    "ultimate"
+  ],
+  "ticker-board": [
+    "event",
+    "dark",
+    "transit",
+    "departure",
+    "mechanical"
+  ],
+  "ticker-tape": [
+    "event",
+    "light",
+    "celebration",
+    "parade",
+    "festive"
+  ],
+  "tidal": [
+    "light",
+    "blog",
+    "ocean",
+    "wellness"
+  ],
+  "timber": [
+    "light",
+    "blog",
+    "craft"
+  ],
+  "titanium": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ],
+  "topaz": [
+    "dark",
+    "blog",
+    "glamorous"
+  ],
+  "topographic-gradient": [
+    "dark",
+    "blog",
+    "topographic",
+    "contour"
+  ],
+  "topographic-sand": [
+    "dark",
+    "blog",
+    "topographic",
+    "sand"
+  ],
+  "topography": [
+    "light",
+    "blog",
+    "topographic",
+    "outdoor"
+  ],
+  "torchlight": [
+    "dark",
+    "blog",
+    "adventure"
+  ],
+  "totem": [
+    "dark",
+    "portfolio",
+    "tribal",
+    "vertical-stack"
+  ],
+  "tremor": [
+    "dark",
+    "dashboard",
+    "seismic",
+    "data-viz"
+  ],
+  "trompe-loeil": [
+    "light",
+    "portfolio",
+    "creative",
+    "bold",
+    "illusion"
+  ],
+  "tropical-paradise": [
+    "elegant",
+    "vivid",
+    "botanical"
+  ],
+  "tundra": [
+    "dark",
+    "blog",
+    "expedition"
+  ],
+  "turbine": [
+    "light",
+    "corporate",
+    "energy",
+    "rotation"
+  ],
+  "turret": [
+    "dark",
+    "docs",
+    "waf"
+  ],
+  "twilight": [
+    "dark",
+    "blog",
+    "photo-essay"
+  ],
+  "typeface": [
+    "blog",
+    "light",
+    "typography",
+    "minimal"
+  ],
+  "typewriter": [
+    "light",
+    "blog",
+    "vintage"
+  ],
+  "typhoon": [
+    "dark",
+    "magazine",
+    "storm",
+    "spiral"
+  ],
+  "ukiyo-e": [
+    "light",
+    "blog",
+    "japanese",
+    "woodblock",
+    "traditional"
+  ],
+  "ultraviolet": [
+    "dark",
+    "blog",
+    "ultraviolet",
+    "neon"
+  ],
+  "umbra": [
+    "dark",
+    "portfolio",
+    "monochrome",
+    "shadow"
+  ],
+  "vapor": [
+    "light",
+    "blog",
+    "vaporwave",
+    "surreal"
+  ],
+  "vault": [
+    "dark",
+    "docs",
+    "security"
+  ],
+  "vellum": [
+    "light",
+    "blog",
+    "editorial"
+  ],
+  "velocity": [
+    "landing",
+    "dark",
+    "saas"
+  ],
+  "velvet": [
+    "dark",
+    "landing",
+    "luxury"
+  ],
+  "velvet-rope": [
+    "event",
+    "gala",
+    "exclusive",
+    "luxury",
+    "velvet"
+  ],
+  "venetian": [
+    "light",
+    "blog",
+    "renaissance",
+    "venetian",
+    "ornate"
+  ],
+  "verdigris": [
+    "dark",
+    "blog",
+    "editorial"
+  ],
+  "versailles": [
+    "dark",
+    "elegant",
+    "classic",
+    "luxury"
+  ],
+  "vertigo": [
+    "dark",
+    "one-page",
+    "experimental",
+    "perspective"
+  ],
+  "vibrant-brutalism": [
+    "dark",
+    "blog",
+    "brutalist",
+    "vibrant"
+  ],
+  "victorian": [
+    "dark",
+    "blog",
+    "gothic",
+    "classic"
+  ],
+  "vineyard": [
+    "dark",
+    "blog",
+    "wine"
+  ],
+  "vintage": [
+    "light",
+    "blog",
+    "retro"
+  ],
+  "vintagetv": [
+    "dark",
+    "blog",
+    "retro"
+  ],
+  "vinyl": [
+    "dark",
+    "blog",
+    "vinyl"
+  ],
+  "voltage": [
+    "dark",
+    "blog",
+    "electric",
+    "sparks"
+  ],
+  "volumetric": [
+    "dark",
+    "blog",
+    "3d",
+    "glow",
+    "atmospheric"
+  ],
+  "volvelle": [
+    "book",
+    "light",
+    "interactive",
+    "medieval",
+    "layered"
+  ],
+  "vortex": [
+    "dark",
+    "portfolio",
+    "experimental",
+    "animation"
+  ],
+  "wanderlust": [
+    "light",
+    "blog",
+    "travel"
+  ],
+  "war-room": [
+    "event",
+    "dark",
+    "strategy",
+    "military",
+    "command"
+  ],
+  "warpzone": [
+    "dark",
+    "portfolio",
+    "warp",
+    "gaming"
+  ],
+  "washi-bound": [
+    "book",
+    "light",
+    "japanese",
+    "stab-binding",
+    "paper"
+  ],
+  "wavelength": [
+    "audio",
+    "dark",
+    "landing",
+    "music"
+  ],
+  "weathervane": [
+    "light",
+    "blog",
+    "rural"
+  ],
+  "wedding": [
+    "light",
+    "wedding",
+    "elegant",
+    "event"
+  ],
+  "white-paper-noir": [
+    "paper",
+    "dark",
+    "industry",
+    "executive",
+    "authoritative"
+  ],
+  "wiki": [
+    "light",
+    "docs",
+    "wiki"
+  ],
+  "willow": [
+    "light",
+    "blog",
+    "literature"
+  ],
+  "windmill": [
+    "light",
+    "blog",
+    "european"
+  ],
+  "windows95": [
+    "light",
+    "retro",
+    "os",
+    "nostalgia"
+  ],
+  "woodblock": [
+    "dark",
+    "blog",
+    "woodblock",
+    "printmaking"
+  ],
+  "working-paper": [
+    "paper",
+    "light",
+    "working",
+    "in-progress",
+    "honest"
+  ],
+  "woven-tapestry": [
+    "dark",
+    "blog",
+    "tapestry",
+    "textile"
+  ],
+  "x-ray": [
+    "dark",
+    "blog",
+    "x-ray",
+    "transparent"
+  ],
+  "xerograph": [
+    "dark",
+    "blog",
+    "minimal",
+    "photocopy"
+  ],
+  "y2k": [
+    "dark",
+    "cyber",
+    "metallic",
+    "retro"
+  ],
+  "zen": [
+    "light",
+    "blog",
+    "zen"
+  ],
+  "zenith": [
+    "light",
+    "landing",
+    "minimal",
+    "altitude"
+  ],
+  "zenithpoint": [
+    "dark",
+    "portfolio",
+    "bold",
+    "elegant"
+  ]
 }


### PR DESCRIPTION
Closes #1537

## Summary
- Add marginalia-noir (dark annotation publication) example site
- Dark theme where margin annotations progressively consume the main text
- SVG ink bleed patterns spreading from margin annotations into main text
- SVG bracket and brace annotation marks in progressively thicker weights
- Typography: Cormorant / EB Garamond for fading original text; Inter Bold to Black for overtaking annotations
- 5 annotations covering the gloss, the bracket, the bleed, the consumption, and the palimpsest of reading
- Tags: book, dark, annotated, consumed, experimental

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of annotation weight progression and ink bleed SVGs
- [ ] Check responsive behavior on narrow viewports