### PR TITLE
feat: add index-card example site (closes #1536)

### DIFF
--- a/index-card/AGENTS.md
+++ b/index-card/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/index-card/config.toml
+++ b/index-card/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Index Card - Card Catalog Publication
+# Issue #1536 | Tags: book, light, catalog, organized, vintage
+# =============================================================================
+
+title = "Index Card"
+description = "A light, vintage publication modeled on library card catalogs with typed index cards. SVG index card outlines with ruled lines for content, tab divider cuts at section separators. Courier Prime and Special Elite for typewritten headings and body text."
+base_url = "http://localhost:3000"
+
+sections = ["cards"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/index-card/content/about.md
+++ b/index-card/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About"
+description = "About the Index Card publication and its design principles."
++++
+
+<p class="card-label">Reference</p>
+
+# About This Catalog
+
+<p class="lede">Index Card is a publication designed around the conventions of the library card catalog. Every visual and typographic decision references the physical artifacts of library cataloging: the three-by-five card, the ruled lines, the typewritten entry, the wooden drawer, and the brass label holder.</p>
+
+## Design principles
+
+<p>The card catalog was a system built on consistency. Every card was the same size. Every entry followed the same format. The typewriter enforced uniform spacing. The filing rules imposed alphabetical discipline. This publication adopts those same principles: uniform cards, consistent formatting, typed text, and ordered filing.</p>
+
+## The typewriter aesthetic
+
+<p>The card catalog was a product of the typewriter era. Catalog cards were typed on manual typewriters, giving each entry a distinctive mechanical character -- slightly uneven baselines, variable ink density, and the monospaced rhythm of Courier. This publication uses Courier Prime for headings and labels, and Special Elite for body text, preserving the typed quality of the original cards.</p>
+
+## The ruled card
+
+<p>A standard library catalog card measures 7.5 by 12.5 centimeters (roughly three by five inches). It has horizontal ruled lines in blue and a vertical red margin line on the left side. The main entry (usually the author's surname) is typed on the first line above the red margin. The title, publication details, and subject tracings follow on subsequent lines. This publication reproduces these visual elements as inline SVG ruled lines and margin markers on every page.</p>
+
+<blockquote>The card catalog is not merely a finding tool. It is a statement about the organization of knowledge -- a declaration that every book has a place, every subject has a heading, and every entry can be found if you know the rules of filing.</blockquote>

--- a/index-card/content/cards/1-the-catalog.md
+++ b/index-card/content/cards/1-the-catalog.md
@@ -1,0 +1,49 @@
++++
+title = "The Catalog"
+description = "The history of the card catalog and its role in organizing library collections."
+tags = ["history", "libraries"]
++++
+
+<p class="card-label">Card I</p>
+
+# The Catalog
+
+<p class="lede">The card catalog is one of the great information technologies of the modern era. For more than a hundred years, it was the primary interface between a reader and a library's collection -- a system so effective that it shaped how we think about organizing knowledge itself.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="100" fill="#ece6d5"/>
+<rect x="40" y="15" width="520" height="70" fill="#c4a265" stroke="#8b7355" stroke-width="0.8" rx="2"/>
+<rect x="60" y="22" width="480" height="4" fill="#8b7355" rx="1"/>
+<rect x="100" y="35" width="80" height="40" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="105" y1="44" x2="175" y2="44" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="105" y1="52" x2="175" y2="52" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="105" y1="60" x2="175" y2="60" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<rect x="220" y="35" width="80" height="40" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="225" y1="44" x2="295" y2="44" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="225" y1="52" x2="295" y2="52" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="225" y1="60" x2="295" y2="60" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<rect x="340" y="35" width="80" height="40" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="345" y1="44" x2="415" y2="44" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="345" y1="52" x2="415" y2="52" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="345" y1="60" x2="415" y2="60" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<rect x="460" y="35" width="80" height="40" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="465" y1="44" x2="535" y2="44" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="465" y1="52" x2="535" y2="52" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+<line x1="465" y1="60" x2="535" y2="60" stroke="#4a7ab5" stroke-width="0.3" opacity="0.5"/>
+</svg>
+</div>
+
+## Origins
+
+<p>The card catalog as we know it emerged in the late eighteenth and early nineteenth centuries. Before the card catalog, libraries used bound volumes -- manuscript lists or printed catalogs -- to record their holdings. These book catalogs were expensive to produce, immediately out of date upon publication, and impossible to update without reprinting. The French Revolution provided an unlikely catalyst: when the revolutionary government confiscated the libraries of dissolved religious houses, it needed a fast way to inventory millions of seized books. The solution was to write each title on the back of a playing card. These cards could be sorted, rearranged, and interfiled as new acquisitions arrived.</p>
+
+## The American system
+
+<p>The card catalog reached its mature form in American libraries during the late nineteenth century. Charles Ammi Cutter published his Rules for a Dictionary Catalog in 1876, establishing the principle that a catalog should have entries for author, title, and subject in a single alphabetical sequence. Melvil Dewey standardized the physical card at 7.5 by 12.5 centimeters and promoted the use of a uniform card stock. The Library of Congress began distributing printed catalog cards in 1901, allowing libraries across the country to purchase professionally prepared entries rather than typing their own.</p>
+
+## Peak and decline
+
+<p>By the mid-twentieth century, the card catalog was universal in American and European libraries. The Library of Congress printed and distributed over seventy million cards per year at its peak. But the system was reaching its limits. Large research libraries maintained catalogs of several million cards, occupying entire rooms filled with hundreds of wooden cabinets. Filing new cards into a catalog of that size was a full-time job for a team of clerks. The transition to machine-readable cataloging (MARC) began in the 1960s, and by the 1990s most libraries had replaced their card catalogs with online systems.</p>
+
+<blockquote>The card catalog was not just a tool for finding books. It was a representation of the library's entire intellectual content, organized by a set of rules so consistent that a trained user could navigate any catalog in any library.</blockquote>

--- a/index-card/content/cards/2-the-card.md
+++ b/index-card/content/cards/2-the-card.md
@@ -1,0 +1,70 @@
++++
+title = "The Card"
+description = "The anatomy of a standard library catalog card and its typed elements."
+tags = ["cataloging", "standards"]
++++
+
+<p class="card-label">Card II</p>
+
+# The Card
+
+<p class="lede">The standard library catalog card is a small object with a precise anatomy. Every element has a defined position, and a trained cataloger can read the card at a glance, extracting author, title, edition, publisher, date, physical description, and subject headings from a few typed lines.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 160" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="160" fill="#ece6d5"/>
+<rect x="50" y="10" width="500" height="140" fill="#faf7f0" stroke="#c4bda8" stroke-width="1" rx="1"/>
+<line x1="120" y1="10" x2="120" y2="150" stroke="#d4576a" stroke-width="0.8" opacity="0.5"/>
+<line x1="55" y1="36" x2="545" y2="36" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<line x1="55" y1="54" x2="545" y2="54" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<line x1="55" y1="72" x2="545" y2="72" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<line x1="55" y1="90" x2="545" y2="90" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<line x1="55" y1="108" x2="545" y2="108" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<line x1="55" y1="126" x2="545" y2="126" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+<circle cx="300" cy="145" r="4" fill="none" stroke="#c4bda8" stroke-width="0.6"/>
+<text x="125" y="33" font-family="Courier,monospace" font-size="9" fill="#2c2416" opacity="0.7">Smith, John, 1925-2003.</text>
+<text x="135" y="51" font-family="Courier,monospace" font-size="9" fill="#2c2416" opacity="0.7">The art of cataloging / John Smith.</text>
+<text x="135" y="69" font-family="Courier,monospace" font-size="9" fill="#2c2416" opacity="0.7">-- 2nd ed. -- New York : Library Press,</text>
+<text x="135" y="87" font-family="Courier,monospace" font-size="9" fill="#2c2416" opacity="0.7">1968. -- xii, 342 p. ; 22 cm.</text>
+<text x="135" y="123" font-family="Courier,monospace" font-size="8" fill="#5a4e3a" opacity="0.6">1. Cataloging. 2. Libraries. I. Title.</text>
+</svg>
+</div>
+
+## Physical specifications
+
+<p>The standard catalog card measures 7.5 by 12.5 centimeters (approximately 3 by 5 inches). It is printed on medium-weight card stock in cream or white. The face of the card is ruled with horizontal lines in pale blue, spaced approximately 4 millimeters apart. A vertical red line is printed near the left edge, creating a margin. A hole is punched near the bottom center of the card, allowing it to be secured on a rod that runs through the drawer to prevent theft or disarrangement.</p>
+
+## Anatomy of the typed entry
+
+<div class="filing-grid">
+<div class="filing-item">
+<h3>Main entry</h3>
+<p>The first line, typed at the left margin. Usually the author's surname, inverted (Smith, John). This is the filing element -- the word that determines where the card is placed in the alphabet.</p>
+</div>
+<div class="filing-item">
+<h3>Title statement</h3>
+<p>The title of the work, indented from the main entry. The first word of the title (excluding articles) is the filing element for the title card.</p>
+</div>
+<div class="filing-item">
+<h3>Imprint</h3>
+<p>The place of publication, publisher, and date. For example: "New York : Library Press, 1968." This tells the reader which edition and printing to look for on the shelf.</p>
+</div>
+<div class="filing-item">
+<h3>Collation</h3>
+<p>The physical description of the book: number of pages (xii, 342 p.), illustrations if any, and height in centimeters. This helps distinguish among editions.</p>
+</div>
+<div class="filing-item">
+<h3>Subject tracings</h3>
+<p>A numbered list of subject headings assigned to the work, printed at the bottom of the card. These tracings tell the filer which additional cards to make for the subject catalog.</p>
+</div>
+<div class="filing-item">
+<h3>The hole</h3>
+<p>A round hole punched near the bottom center of the card. A metal rod passes through the holes of all cards in a drawer, securing them in place. The rod must be withdrawn before cards can be removed or interfiled.</p>
+</div>
+</div>
+
+## The unit card system
+
+<p>The Library of Congress introduced the unit card system: a single master card was printed with the full cataloging information, and copies were made for each entry point (author, title, each subject heading). The additional heading was typed above the main entry on each copy. This system made it efficient to produce a complete set of cards for each book, ensuring that the reader could find the work no matter which access point they used.</p>
+
+<blockquote>Every catalog card tells the same story in the same order: who wrote it, what it is called, where and when it was published, how big it is, and what it is about. The format never varies.</blockquote>

--- a/index-card/content/cards/3-the-drawer.md
+++ b/index-card/content/cards/3-the-drawer.md
@@ -1,0 +1,90 @@
++++
+title = "The Drawer"
+description = "The catalog drawer and the filing system that holds the cards in order."
+tags = ["cataloging", "furniture"]
++++
+
+<p class="card-label">Card III</p>
+
+# The Drawer
+
+<p class="lede">The catalog drawer is the container that gives the card catalog its physical form. A wooden tray approximately 40 centimeters long, fitted with a brass pull and a label holder, the drawer slides out of the cabinet to reveal a tightly packed sequence of cards filed edge-on, each visible only by its top edge.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="120" fill="#ece6d5"/>
+<rect x="40" y="10" width="520" height="100" fill="#c4a265" stroke="#8b7355" stroke-width="1" rx="2"/>
+<rect x="50" y="18" width="500" height="6" fill="#8b7355" rx="1"/>
+<rect x="250" y="30" width="100" height="14" fill="#faf7f0" stroke="#8b7355" stroke-width="0.5" rx="1"/>
+<text x="270" y="41" font-family="Courier,monospace" font-size="8" fill="#2c2416" opacity="0.7">Ca -- Cu</text>
+<line x1="60" y1="55" x2="540" y2="55" stroke="#8b7355" stroke-width="0.3" opacity="0.4"/>
+<rect x="70" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="76" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="82" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="88" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="94" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="100" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="106" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="112" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="118" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="130" y="50" width="3" height="50" fill="#c4a265" stroke="#8b7355" stroke-width="0.3"/>
+<rect x="128" y="48" width="8" height="6" fill="#c4a265" stroke="#8b7355" stroke-width="0.3" rx="1"/>
+<rect x="140" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="146" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="152" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="158" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="164" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="170" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="250" y="50" width="3" height="50" fill="#c4a265" stroke="#8b7355" stroke-width="0.3"/>
+<rect x="248" y="48" width="8" height="6" fill="#c4a265" stroke="#8b7355" stroke-width="0.3" rx="1"/>
+<rect x="260" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="266" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="272" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="278" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="380" y="50" width="3" height="50" fill="#c4a265" stroke="#8b7355" stroke-width="0.3"/>
+<rect x="378" y="48" width="8" height="6" fill="#c4a265" stroke="#8b7355" stroke-width="0.3" rx="1"/>
+<rect x="390" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="396" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="402" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="408" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="414" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="420" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<rect x="500" y="50" width="3" height="50" fill="#c4a265" stroke="#8b7355" stroke-width="0.3"/>
+<rect x="498" y="48" width="8" height="6" fill="#c4a265" stroke="#8b7355" stroke-width="0.3" rx="1"/>
+<rect x="510" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.7"/>
+<rect x="516" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.65"/>
+<rect x="522" y="56" width="2" height="44" fill="#faf7f0" stroke="none" opacity="0.6"/>
+<line x1="60" y1="102" x2="540" y2="102" stroke="#8b7355" stroke-width="0.4"/>
+</svg>
+</div>
+
+## The cabinet
+
+<p>A standard card catalog cabinet contains sixty drawers, arranged in columns of five and rows of twelve. Each drawer holds approximately one thousand cards when full. The cabinet itself is made of oak or birch, finished to a warm honey color, and mounted on a flat base or on legs. The drawers are fitted with anti-tilt mechanisms so that pulling one drawer does not tip the cabinet forward. A fully loaded sixty-drawer cabinet weighs several hundred kilograms and holds sixty thousand cards -- representing perhaps twenty thousand books.</p>
+
+## Anatomy of the drawer
+
+<div class="filing-grid">
+<div class="filing-item">
+<h3>The pull</h3>
+<p>A brass or chrome handle mounted on the front of the drawer. The user grips the pull and slides the drawer outward on wooden runners. Some pulls are cup-shaped; others are flat bars.</p>
+</div>
+<div class="filing-item">
+<h3>The label holder</h3>
+<p>A small brass frame on the front of the drawer, directly above or below the pull, holding a card that indicates the alphabetical range of the contents. For example: "Ca -- Cu" means the drawer contains all entries from Ca through Cu.</p>
+</div>
+<div class="filing-item">
+<h3>The rod</h3>
+<p>A metal rod running through the bottom-center hole of every card in the drawer. The rod is secured at the back of the drawer with a thumb-screw. It prevents cards from being accidentally removed but must be withdrawn for filing or consultation.</p>
+</div>
+<div class="filing-item">
+<h3>The guide cards</h3>
+<p>Heavier cards with protruding tabs, interspersed among the regular cards at regular intervals. The tab is labeled with a letter combination (e.g., "CAR," "CAS," "CAT") to help the user navigate quickly to the right section of the drawer.</p>
+</div>
+</div>
+
+## Using the drawer
+
+<p>To consult the catalog, the user identifies the appropriate drawer by reading the label on its pull, slides the drawer out, and flips through the cards from front to back. The cards are packed tightly and stand on edge. The user fans through them with one hand, reading the top line of each card (the main entry or added heading) until the desired entry is found. The card is then read in place; removing it from the rod requires unscrewing the rod lock. In practice, most users read the cards without removing them, bending each card forward slightly to read the full text.</p>
+
+<blockquote>A well-used catalog drawer shows its age: the cards at the front are darker and more worn than those at the back, the guide card tabs are softened by thousands of fingers, and the brass pull is polished to a mirror finish by daily use.</blockquote>

--- a/index-card/content/cards/4-the-filing.md
+++ b/index-card/content/cards/4-the-filing.md
@@ -1,0 +1,71 @@
++++
+title = "The Filing"
+description = "The rules of alphabetical filing that govern the order of catalog cards."
+tags = ["cataloging", "standards"]
++++
+
+<p class="card-label">Card IV</p>
+
+# The Filing
+
+<p class="lede">Filing is the act of placing catalog cards into their correct alphabetical position in the drawer. It sounds simple, but the rules of library filing are surprisingly complex. Every library system maintained a detailed filing code, and professional filers trained for months before being trusted with the catalog.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 80" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="80" fill="#ece6d5"/>
+<rect x="40" y="10" width="100" height="60" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.6" rx="1"/>
+<line x1="60" y1="10" x2="60" y2="70" stroke="#d4576a" stroke-width="0.4" opacity="0.4"/>
+<line x1="45" y1="26" x2="135" y2="26" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="45" y1="38" x2="135" y2="38" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<text x="63" y="24" font-family="Courier,monospace" font-size="7" fill="#2c2416" opacity="0.6">Adams, J.</text>
+<rect x="160" y="10" width="100" height="60" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.6" rx="1"/>
+<line x1="180" y1="10" x2="180" y2="70" stroke="#d4576a" stroke-width="0.4" opacity="0.4"/>
+<line x1="165" y1="26" x2="255" y2="26" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="165" y1="38" x2="255" y2="38" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<text x="183" y="24" font-family="Courier,monospace" font-size="7" fill="#2c2416" opacity="0.6">Baker, T.</text>
+<rect x="280" y="10" width="100" height="60" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.6" rx="1"/>
+<line x1="300" y1="10" x2="300" y2="70" stroke="#d4576a" stroke-width="0.4" opacity="0.4"/>
+<line x1="285" y1="26" x2="375" y2="26" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="285" y1="38" x2="375" y2="38" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<text x="303" y="24" font-family="Courier,monospace" font-size="7" fill="#2c2416" opacity="0.6">Clark, M.</text>
+<rect x="400" y="10" width="100" height="60" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.6" rx="1"/>
+<line x1="420" y1="10" x2="420" y2="70" stroke="#d4576a" stroke-width="0.4" opacity="0.4"/>
+<line x1="405" y1="26" x2="495" y2="26" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="405" y1="38" x2="495" y2="38" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<text x="423" y="24" font-family="Courier,monospace" font-size="7" fill="#2c2416" opacity="0.6">Davis, R.</text>
+<path d="M520,30 L560,15 L560,65 L520,50 Z" fill="#c4a265" stroke="#8b7355" stroke-width="0.5" opacity="0.6"/>
+</svg>
+</div>
+
+## Letter-by-letter versus word-by-word
+
+<p>There are two fundamental approaches to alphabetical filing, and the choice between them determines the order of every card in the catalog. In letter-by-letter filing, spaces and punctuation are ignored: "New York" files before "Newark" because N-E-W-Y comes before N-E-W-A when you ignore the space. In word-by-word filing, the space is treated as a character that sorts before any letter: "New York" files before "Newark" because "New" (as a complete word) comes before "Newa" (the beginning of a longer word). Most American libraries adopted word-by-word filing, but the choice was never universal.</p>
+
+## The ALA filing rules
+
+<p>The American Library Association published its filing rules in 1942, revised them in 1968, and published a simplified version in 1980. These rules addressed hundreds of special cases that arise in alphabetical filing. How do you file a name beginning with "Mc" -- as though it were spelled "Mac," or strictly as "Mc"? How do you file numbers -- before or after letters? How do you file an entry that begins with an article in a foreign language? The ALA rules provided answers to all these questions, and every library that used them could guarantee that its filing was consistent and predictable.</p>
+
+<div class="filing-grid">
+<div class="filing-item">
+<h3>Initial articles</h3>
+<p>Articles at the beginning of a title (A, An, The) are disregarded in filing. "The Art of War" files under A for Art, not T for The. Foreign-language articles follow the same rule.</p>
+</div>
+<div class="filing-item">
+<h3>Abbreviations</h3>
+<p>Abbreviations are filed as though spelled out. "Dr." files as "Doctor." "St." files as "Saint." "Mr." files as "Mister." The filer must know the expansion of every abbreviation.</p>
+</div>
+<div class="filing-item">
+<h3>Numbers</h3>
+<p>Numbers are filed as though spelled out in the language of the entry. "100 Poems" files as "One hundred poems." "3 Musketeers" files as "Three musketeers."</p>
+</div>
+<div class="filing-item">
+<h3>Surname prefixes</h3>
+<p>Names with prefixes (De, Von, Van, Mac, Mc, O') follow specific rules that vary by language of origin. "De Gaulle" may file under D or G depending on the filing code in use.</p>
+</div>
+</div>
+
+## The filer's discipline
+
+<p>Professional filing was exacting work. A misfiled card was effectively lost: if a card for "Smith, John" was accidentally placed among the "Sm" entries instead of "Smi," a reader searching for Smith would never find it. Libraries maintained strict quality control, with supervisors reviewing newly filed cards by pulling random samples and checking their position. Some large libraries employed dedicated filing departments whose sole responsibility was to maintain the alphabetical integrity of the catalog.</p>
+
+<blockquote>Nothing is ever lost in a card catalog -- only misfiled. And a misfiled card, in a catalog of three million entries, might as well not exist at all.</blockquote>

--- a/index-card/content/cards/5-the-digital.md
+++ b/index-card/content/cards/5-the-digital.md
@@ -1,0 +1,75 @@
++++
+title = "The Digital"
+description = "The transition from the physical card catalog to the online public access catalog."
+tags = ["history", "technology"]
++++
+
+<p class="card-label">Card V</p>
+
+# The Digital
+
+<p class="lede">The card catalog did not die suddenly. Its replacement by the online public access catalog (OPAC) was a gradual process that took three decades, driven by the economics of card production, the limitations of physical filing, and the possibilities of machine-readable cataloging.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 600 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="600" height="100" fill="#ece6d5"/>
+<rect x="40" y="15" width="120" height="70" fill="#c4a265" stroke="#8b7355" stroke-width="0.8" rx="2"/>
+<rect x="55" y="22" width="90" height="4" fill="#8b7355" rx="1"/>
+<rect x="65" y="35" width="70" height="40" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.4"/>
+<line x1="70" y1="44" x2="130" y2="44" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="70" y1="52" x2="130" y2="52" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<line x1="70" y1="60" x2="130" y2="60" stroke="#4a7ab5" stroke-width="0.3" opacity="0.4"/>
+<path d="M200,50 L240,50" stroke="#8b7355" stroke-width="1.5" stroke-dasharray="4,3"/>
+<polygon points="245,50 238,46 238,54" fill="#8b7355"/>
+<rect x="280" y="20" width="140" height="60" fill="#faf7f0" stroke="#c4bda8" stroke-width="1" rx="2"/>
+<rect x="290" y="28" width="120" height="40" fill="#ece6d5" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="296" y1="38" x2="404" y2="38" stroke="#4a7ab5" stroke-width="0.3" opacity="0.3"/>
+<line x1="296" y1="46" x2="404" y2="46" stroke="#4a7ab5" stroke-width="0.3" opacity="0.3"/>
+<line x1="296" y1="54" x2="404" y2="54" stroke="#4a7ab5" stroke-width="0.3" opacity="0.3"/>
+<text x="300" y="37" font-family="Courier,monospace" font-size="6" fill="#2c2416" opacity="0.5">SEARCH: _________</text>
+<text x="300" y="53" font-family="Courier,monospace" font-size="6" fill="#2c2416" opacity="0.5">RESULTS: 47 found</text>
+<rect x="290" y="70" width="30" height="6" fill="#c4bda8" rx="1"/>
+<rect x="325" y="70" width="30" height="6" fill="#c4bda8" rx="1"/>
+<rect x="360" y="70" width="30" height="6" fill="#c4bda8" rx="1"/>
+<path d="M460,50 L500,50" stroke="#8b7355" stroke-width="1.5" stroke-dasharray="4,3"/>
+<polygon points="505,50 498,46 498,54" fill="#8b7355"/>
+<rect x="520" y="25" width="50" height="50" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.8" rx="3"/>
+<rect x="528" y="33" width="34" height="20" fill="#ece6d5" stroke="#c4bda8" stroke-width="0.4"/>
+<line x1="532" y1="40" x2="558" y2="40" stroke="#4a7ab5" stroke-width="0.2" opacity="0.3"/>
+<line x1="532" y1="46" x2="558" y2="46" stroke="#4a7ab5" stroke-width="0.2" opacity="0.3"/>
+<rect x="536" y="58" width="18" height="10" fill="#c4bda8" rx="1"/>
+</svg>
+</div>
+
+## MARC and the machine-readable record
+
+<p>The transition began in 1966, when the Library of Congress developed the MARC (Machine-Readable Cataloging) format. MARC encoded the same information that appeared on a catalog card -- author, title, subject headings, publication details -- into a structured digital record that could be stored on magnetic tape and processed by computers. The key insight was that the catalog record and the catalog card were not the same thing: the record was the information, and the card was merely one way of displaying it. Once the record existed in machine-readable form, it could be displayed on a screen, printed on a card, or transmitted over a network.</p>
+
+## The economics of transition
+
+<p>The card catalog was expensive to maintain. Each new book required a set of cards to be typed or purchased, checked, and filed. Each card that wore out had to be replaced. Each change in subject heading vocabulary required pulling and refiling thousands of cards. The Library of Congress spent millions of dollars per year on card production and distribution. Online catalogs promised to eliminate the cost of physical cards entirely: a single database could serve any number of simultaneous users, and updates took effect instantly without any filing.</p>
+
+<div class="filing-grid">
+<div class="filing-item">
+<h3>1966: MARC</h3>
+<p>The Library of Congress creates the MARC format, establishing a standard for machine-readable catalog records. The foundation for all future digital catalogs.</p>
+</div>
+<div class="filing-item">
+<h3>1971: OCLC</h3>
+<p>The Ohio College Library Center (now OCLC) launches a shared online cataloging system. Libraries can now search and copy catalog records from a central database rather than creating each record from scratch.</p>
+</div>
+<div class="filing-item">
+<h3>1981: First OPACs</h3>
+<p>The first generation of online public access catalogs appears in academic libraries. Users can search by keyword rather than browsing alphabetically -- a fundamental change in how the catalog is used.</p>
+</div>
+<div class="filing-item">
+<h3>1993: The freeze</h3>
+<p>The Library of Congress freezes its card catalog, ceasing to file new cards. The physical catalog becomes a historical artifact. All new cataloging is done exclusively in the online system.</p>
+</div>
+</div>
+
+## What was lost
+
+<p>The online catalog gained searchability but lost browsability. A card catalog allowed the user to see adjacent entries -- to discover related books by flipping through the cards near the desired entry. This serendipitous discovery was a feature of the physical medium. Keyword searching, by contrast, returns only exact matches: you find what you are looking for, but you do not see what is filed next to it. Some librarians mourned this loss; others argued that the gains in access and efficiency more than compensated for the loss of browsability.</p>
+
+<blockquote>The last card filed in the Library of Congress card catalog marked the end of an era. The catalog contained over 25 million cards, filling 23,000 drawers in a room the size of a football field. It remains in place today as a historical monument to the organization of knowledge.</blockquote>

--- a/index-card/content/cards/_index.md
+++ b/index-card/content/cards/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Cards"
+description = "The card catalog: five entries on the history and anatomy of the index card system."
++++
+
+<p class="lede">Five cards filed in order, tracing the card catalog from its origins in the eighteenth century to its replacement by the online public access catalog. Pull each card from the drawer and read it in sequence.</p>
+
+<p>Each entry is typed on a standard ruled card with blue lines and a red margin. The cards are filed in the order they would appear in a catalog drawer: from general to specific, from history to practice to legacy.</p>

--- a/index-card/content/colophon.md
+++ b/index-card/content/colophon.md
@@ -1,0 +1,26 @@
++++
+title = "Colophon"
+description = "Technical details about the construction of this card catalog publication."
++++
+
+<p class="card-label">Colophon</p>
+
+# Colophon
+
+<p class="lede">Technical specifications for this catalog, filed under production details.</p>
+
+## Typography
+
+<p>Display headings and labels are set in Courier Prime, a typewriter face designed by Alan Dague-Greene for readable screen display at all sizes. It preserves the monospaced rhythm and mechanical character of the original Courier while improving legibility. Body text is set in Special Elite, a typewriter font by Astigmatic that captures the slightly irregular strike pattern of a manual typewriter.</p>
+
+## Color palette
+
+<p>The palette is drawn from the physical materials of a card catalog. Card stock is cream-white (#faf7f0), the warm off-white of acid-free library cards. Ruled lines are blue (#4a7ab5), matching the pale blue horizontal rules printed on standard catalog cards. The margin line is red (#d4576a). Tab dividers and drawer labels use brown (#c4a265 and #8b7355), the color of manila card stock and wooden drawer fronts. The background is a slightly darker cream (#f0ebe0), suggesting the wooden surface of a catalog cabinet.</p>
+
+## Construction
+
+<p>All decorative elements are rendered as inline SVG: card outlines, ruled lines, margin markers, tab divider cuts, and the catalog drawer illustration on the home page. No raster images are used. No CSS gradients are used. The card-frame shadow is achieved with solid box-shadow offsets to suggest stacked cards behind the current one. The ruled-line background pattern in the card body uses an SVG data URI in the background-image property.</p>
+
+## Platform
+
+<p>Built with Hwaro, a static site generator. Content is written in Markdown with TOML frontmatter. Templates use the Jinja2 syntax.</p>

--- a/index-card/content/index.md
+++ b/index-card/content/index.md
@@ -1,0 +1,72 @@
++++
+title = "Index Card"
+description = "A card catalog publication modeled on library index cards."
++++
+
+<p class="card-label">Catalog</p>
+
+# Index Card
+
+<p class="lede">A publication modeled on the library card catalog: each entry typed on a standard three-by-five card, filed in alphabetical order, cross-referenced by subject, author, and title. The card catalog was the search engine of the printed age.</p>
+
+<div class="catalog-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 180" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="180" fill="#ece6d5"/>
+<rect x="60" y="20" width="160" height="140" fill="#c4a265" stroke="#8b7355" stroke-width="1" rx="2"/>
+<rect x="80" y="30" width="120" height="8" fill="#8b7355" rx="1"/>
+<circle cx="140" cy="60" r="6" fill="none" stroke="#8b7355" stroke-width="1"/>
+<rect x="90" y="75" width="100" height="55" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="95" y1="85" x2="185" y2="85" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="95" y1="93" x2="185" y2="93" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="95" y1="101" x2="185" y2="101" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="95" y1="109" x2="185" y2="109" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="95" y1="117" x2="175" y2="117" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<rect x="280" y="20" width="160" height="140" fill="#c4a265" stroke="#8b7355" stroke-width="1" rx="2"/>
+<rect x="300" y="30" width="120" height="8" fill="#8b7355" rx="1"/>
+<circle cx="360" cy="60" r="6" fill="none" stroke="#8b7355" stroke-width="1"/>
+<rect x="310" y="75" width="100" height="55" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="315" y1="85" x2="405" y2="85" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="315" y1="93" x2="405" y2="93" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="315" y1="101" x2="405" y2="101" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="315" y1="109" x2="405" y2="109" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="315" y1="117" x2="395" y2="117" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<rect x="500" y="20" width="160" height="140" fill="#c4a265" stroke="#8b7355" stroke-width="1" rx="2"/>
+<rect x="520" y="30" width="120" height="8" fill="#8b7355" rx="1"/>
+<circle cx="580" cy="60" r="6" fill="none" stroke="#8b7355" stroke-width="1"/>
+<rect x="530" y="75" width="100" height="55" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+<line x1="535" y1="85" x2="625" y2="85" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="535" y1="93" x2="625" y2="93" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="535" y1="101" x2="625" y2="101" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="535" y1="109" x2="625" y2="109" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+<line x1="535" y1="117" x2="615" y2="117" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+</svg>
+</div>
+
+## The card catalog system
+
+<p>For more than a century, the card catalog was the primary tool for locating books in a library. Every book received a set of catalog cards -- at minimum one for the author, one for the title, and one for each subject heading. These cards were filed alphabetically in wooden drawers, and each drawer was labeled on its brass pull with the range of entries it contained. A well-maintained card catalog could hold hundreds of thousands of entries, providing access to the entire collection.</p>
+
+## How this publication works
+
+<div class="filing-grid">
+<div class="filing-item">
+<h3>The Cards</h3>
+<p>Each page is formatted as a typed index card with ruled lines, a red margin, and typewriter text. The card is the fundamental unit of the catalog.</p>
+</div>
+<div class="filing-item">
+<h3>The Tabs</h3>
+<p>Section dividers use tab cuts -- the protruding tabs that separate alphabetical ranges in a card drawer. Brown tabs mark the divisions.</p>
+</div>
+<div class="filing-item">
+<h3>The Filing</h3>
+<p>Cards are filed in order. Each entry follows the next in a logical sequence, as they would in a drawer pulled from the cabinet.</p>
+</div>
+<div class="filing-item">
+<h3>The Type</h3>
+<p>All text is set in typewriter faces: Courier Prime for headings and labels, Special Elite for body text. Every character is typed, not typeset.</p>
+</div>
+</div>
+
+## Browse the catalog
+
+<p>Pull open the drawer and begin with the <a href="/cards/">cards section</a>, where five entries trace the history and anatomy of the card catalog from its origins to its digital successor. Each card is filed in order.</p>

--- a/index-card/static/css/style.css
+++ b/index-card/static/css/style.css
@@ -1,0 +1,395 @@
+/* =============================================================================
+   Index Card - Card Catalog Publication
+   Issue #1536 | book, light, catalog, organized, vintage
+   Palette: cream card stock, blue ruled lines, brown tab dividers
+   No gradients. Index card outlines + ruled lines + tab dividers as inline SVG.
+   ============================================================================= */
+
+:root {
+  --card-stock: #faf7f0;
+  --card-soft: #f5f0e4;
+  --card-deep: #ece6d5;
+  --card-edge: #c4bda8;
+  --ink: #2c2416;
+  --ink-soft: #5a4e3a;
+  --ink-dim: #8a7e6a;
+  --blue-rule: #4a7ab5;        /* ruled line blue */
+  --blue-soft: #7a9ec8;
+  --red-margin: #d4576a;       /* margin line red */
+  --brown-tab: #c4a265;        /* tab divider brown */
+  --brown-dark: #8b7355;       /* dark brown accent */
+  --brown-light: #d4c4a0;      /* light brown */
+  --bg: #f0ebe0;               /* outer background */
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  font-family: "Special Elite", "Courier New", Courier, monospace;
+  font-size: 17px;
+  line-height: 1.78;
+  min-height: 100vh;
+}
+
+.catalog-shell {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 2px solid var(--brown-dark);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+.logo-mark { width: 60px; height: 44px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.15; }
+.logo-main {
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.logo-sub {
+  font-family: "Special Elite", "Courier New", monospace;
+  font-size: 0.78rem;
+  color: var(--brown-dark);
+  letter-spacing: 0.02em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--blue-rule); border-bottom-color: var(--blue-rule); }
+
+/* --- Card frame (page wrapper) ------------------------------------------- */
+.site-main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.card-frame {
+  position: relative;
+  background-color: var(--card-stock);
+  border: 1px solid var(--card-edge);
+  box-shadow:
+    2px 2px 0 var(--card-deep),
+    4px 4px 0 var(--card-edge),
+    0 8px 24px rgba(139, 115, 85, 0.08);
+  overflow: hidden;
+}
+
+.card-narrow {
+  max-width: 680px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.card-svg-outline svg,
+.card-svg-bottom svg,
+.card-tab-divider svg {
+  width: 100%;
+  display: block;
+}
+
+/* Ruled lines via SVG data URI background pattern */
+.card-body {
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 4vw, 3rem);
+  border-left: 2px solid var(--red-margin);
+  margin-left: 2.5rem;
+  position: relative;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='32'%3E%3Cline x1='0' y1='31' x2='1' y2='31' stroke='%234a7ab5' stroke-width='0.5' opacity='0.18'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 1px 32px;
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.card-body h1,
+.card-body h2,
+.card-body h3 {
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  color: var(--ink);
+  line-height: 1.3;
+  font-weight: 700;
+}
+.card-body h1 {
+  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  margin: 0 0 0.3em;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.card-body h2 {
+  font-size: 1.2rem;
+  margin: 2em 0 0.4em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--card-edge);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.card-body h3 {
+  font-size: 1rem;
+  margin: 1.6em 0 0.3em;
+  color: var(--brown-dark);
+  letter-spacing: 0.01em;
+}
+
+.card-body p {
+  margin: 1em 0;
+  color: var(--ink);
+  font-family: "Special Elite", "Courier New", Courier, monospace;
+  max-width: 62ch;
+}
+.card-body p.lede {
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--ink-soft);
+  font-style: italic;
+  max-width: 55ch;
+}
+
+.card-label {
+  display: inline-block;
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--brown-dark);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.6em;
+  background-color: var(--brown-light);
+  border: 1px solid var(--brown-dark);
+}
+
+.card-head { margin-bottom: 1.5rem; }
+.card-title {
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  margin: 0;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+.card-body a {
+  color: var(--blue-rule);
+  text-decoration: none;
+  border-bottom: 1px solid var(--blue-soft);
+}
+.card-body a:hover { color: var(--ink); border-bottom-color: var(--ink); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--brown-tab);
+  background-color: var(--card-soft);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-family: "Special Elite", "Courier New", monospace;
+  font-size: 1rem;
+  max-width: 55ch;
+}
+
+.card-body ul,
+.card-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  font-family: "Special Elite", "Courier New", Courier, monospace;
+}
+.card-body ul { list-style: disc; }
+.card-body ol { list-style: decimal; }
+.card-body li { padding: 0.2em 0; max-width: 62ch; }
+
+/* --- Catalog illustration ------------------------------------------------ */
+.catalog-illustration {
+  margin: 1.5rem 0;
+  border: 1px solid var(--card-edge);
+  background-color: var(--card-soft);
+}
+.catalog-illustration svg {
+  width: 100%;
+  display: block;
+}
+
+/* --- Filing card grid ---------------------------------------------------- */
+.filing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.filing-item {
+  background-color: var(--card-soft);
+  border: 1px solid var(--card-edge);
+  padding: 1rem 1.1rem;
+  position: relative;
+  box-shadow: 1px 1px 0 var(--card-deep);
+}
+.filing-item h3 {
+  margin: 0 0 0.3em;
+  color: var(--brown-dark);
+  font-size: 0.92rem;
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.filing-item p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--card-edge);
+}
+.section-list li {
+  padding: 0.7rem 0.25rem;
+  border-bottom: 1px solid var(--card-edge);
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+}
+.section-list li::before {
+  content: "\25B8";               /* right-pointing triangle -- tab marker */
+  color: var(--brown-tab);
+  flex-shrink: 0;
+  font-size: 0.8em;
+}
+.section-list li a {
+  font-weight: 700;
+  color: var(--ink);
+  border: none;
+  font-size: 0.98rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.section-list li a:hover { color: var(--blue-rule); }
+
+.taxonomy-desc {
+  color: var(--ink-soft);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--card-edge);
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-size: 0.82rem;
+  color: var(--ink);
+  text-decoration: none;
+  background-color: var(--card-soft);
+}
+nav.pagination a:hover { color: var(--blue-rule); border-color: var(--blue-rule); }
+.pagination-current span { color: var(--blue-rule); border-color: var(--blue-rule); }
+
+/* --- Tab divider separator (between sections in content) ---------------- */
+.tab-divider {
+  margin: 2rem 0;
+  text-align: center;
+}
+.tab-divider svg {
+  width: 100%;
+  max-width: 500px;
+  display: inline-block;
+}
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 2px solid var(--brown-dark);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-rule { width: 100%; max-width: 400px; display: block; margin: 0 auto 1rem; }
+.footer-line {
+  font-family: "Courier Prime", "Courier New", Courier, monospace;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0.2em 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.footer-line-small {
+  font-family: "Special Elite", "Courier New", monospace;
+  color: var(--ink-dim);
+  font-size: 0.88rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .card-body {
+    padding: 1.5rem 1.25rem 2rem;
+    margin-left: 1rem;
+  }
+  .site-header {
+    padding: 1.5rem 0 1rem;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .site-nav { gap: 1rem; }
+  .card-title, .card-body h1 { font-size: 1.5rem; }
+  .card-body h2 { font-size: 1.05rem; }
+  .card-body p, .card-body li { max-width: none; }
+  .catalog-shell { max-width: 100%; }
+}

--- a/index-card/templates/404.html
+++ b/index-card/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="card-frame card-narrow">
+      <div class="card-body">
+        <header class="card-head">
+          <p class="card-label">404</p>
+          <h1 class="card-title">Card Not Found</h1>
+        </header>
+        <p>This card has been misfiled or removed from the catalog. The drawer has been checked, but the entry you requested is not present. Please return to the main catalog and try another subject heading.</p>
+        <p><a href="{{ base_url }}/">Back to the catalog</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/index-card/templates/footer.html
+++ b/index-card/templates/footer.html
@@ -1,0 +1,16 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-card" aria-hidden="true">
+        <svg viewBox="0 0 400 12" xmlns="http://www.w3.org/2000/svg" class="footer-rule">
+          <line x1="0" y1="6" x2="400" y2="6" stroke="#4a7ab5" stroke-width="0.5" opacity="0.3"/>
+          <line x1="0" y1="10" x2="400" y2="10" stroke="#4a7ab5" stroke-width="0.5" opacity="0.3"/>
+        </svg>
+      </div>
+      <p class="footer-line">Index Card</p>
+      <p class="footer-line-small">A card catalog publication, typed and filed.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; cataloged, indexed, cross-referenced</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/index-card/templates/header.html
+++ b/index-card/templates/header.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Special+Elite&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="catalog-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Index Card home">
+        <svg viewBox="0 0 60 44" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <rect x="2" y="6" width="56" height="36" fill="#faf7f0" stroke="#8b7355" stroke-width="0.8" rx="1"/>
+          <rect x="22" y="2" width="16" height="8" fill="#c4a265" stroke="#8b7355" stroke-width="0.6" rx="1"/>
+          <line x1="8" y1="16" x2="52" y2="16" stroke="#4a7ab5" stroke-width="0.4" opacity="0.6"/>
+          <line x1="8" y1="22" x2="52" y2="22" stroke="#4a7ab5" stroke-width="0.4" opacity="0.6"/>
+          <line x1="8" y1="28" x2="52" y2="28" stroke="#4a7ab5" stroke-width="0.4" opacity="0.6"/>
+          <line x1="8" y1="34" x2="42" y2="34" stroke="#4a7ab5" stroke-width="0.4" opacity="0.6"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Index Card</span>
+          <span class="logo-sub">Card Catalog Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/cards/">Cards</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/index-card/templates/page.html
+++ b/index-card/templates/page.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="card-frame">
+      <div class="card-svg-outline" aria-hidden="true">
+        <svg viewBox="0 0 700 24" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="0" width="700" height="24" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+          <line x1="0" y1="8" x2="700" y2="8" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+          <line x1="0" y1="16" x2="700" y2="16" stroke="#4a7ab5" stroke-width="0.4" opacity="0.5"/>
+          <line x1="56" y1="0" x2="56" y2="24" stroke="#d4576a" stroke-width="0.5" opacity="0.4"/>
+        </svg>
+      </div>
+      <div class="card-body">
+        {{ content | safe }}
+      </div>
+      <div class="card-svg-bottom" aria-hidden="true">
+        <svg viewBox="0 0 700 16" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <line x1="0" y1="4" x2="700" y2="4" stroke="#4a7ab5" stroke-width="0.4" opacity="0.35"/>
+          <line x1="0" y1="10" x2="700" y2="10" stroke="#4a7ab5" stroke-width="0.4" opacity="0.35"/>
+          <rect x="0" y="14" width="700" height="2" fill="#c4bda8" opacity="0.3"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/index-card/templates/section.html
+++ b/index-card/templates/section.html
@@ -1,0 +1,25 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="card-frame">
+      <div class="card-tab-divider" aria-hidden="true">
+        <svg viewBox="0 0 700 28" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="8" width="700" height="20" fill="#faf7f0" stroke="#c4bda8" stroke-width="0.5"/>
+          <rect x="40" y="0" width="120" height="12" fill="#c4a265" stroke="#8b7355" stroke-width="0.5" rx="2" ry="0"/>
+          <line x1="0" y1="18" x2="700" y2="18" stroke="#4a7ab5" stroke-width="0.4" opacity="0.4"/>
+          <line x1="56" y1="8" x2="56" y2="28" stroke="#d4576a" stroke-width="0.5" opacity="0.4"/>
+        </svg>
+      </div>
+      <div class="card-body">
+        <header class="card-head">
+          <p class="card-label">Section</p>
+          <h1 class="card-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content | safe }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/index-card/templates/shortcodes/alert.html
+++ b/index-card/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #c4bda8; background-color: #f5f0e4; border-left: 5px solid #4a7ab5; margin: 1rem 0; font-family: 'Special Elite', 'Courier New', monospace;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/index-card/templates/taxonomy.html
+++ b/index-card/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="card-frame card-narrow">
+      <div class="card-body">
+        <header class="card-head">
+          <p class="card-label">Subject Index</p>
+          <h1 class="card-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subject headings filed in this catalog:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/index-card/templates/taxonomy_term.html
+++ b/index-card/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="card-frame card-narrow">
+      <div class="card-body">
+        <header class="card-head">
+          <p class="card-label">Subject Heading</p>
+          <h1 class="card-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Cards filed under this subject heading:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2025,6 +2025,13 @@
     "early-print",
     "revolutionary"
   ],
+  "index-card": [
+    "book",
+    "light",
+    "catalog",
+    "organized",
+    "vintage"
+  ],
   "inferno": [
     "dark",
     "community",


### PR DESCRIPTION
Closes #1536

## Summary
- Add index-card (card catalog publication) example site
- Light theme with cream card stock, blue ruled lines, brown tab dividers
- SVG index card outlines with ruled lines for content
- SVG tab divider cuts at card section separators
- Typography: Courier Prime for typed card headings; Special Elite for typewriter card content
- 5 cards covering the catalog, the card, the drawer, the filing, and the digital transition
- Tags: book, light, catalog, organized, vintage

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of card catalog theme and ruled-line SVGs
- [ ] Check responsive behavior on narrow viewports