### PR TITLE
feat: add burn-book example site (closes #1535)

### DIFF
--- a/burn-book/AGENTS.md
+++ b/burn-book/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/burn-book/config.toml
+++ b/burn-book/config.toml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Burn Book - Incendiary Publication
+# Issue #1535 | Tags: book, dark, forbidden, burnt, intense
+# =============================================================================
+
+title = "Burn Book"
+description = "An incendiary publication of forbidden texts with charred edges and ember effects. A dark volume dedicated to the history, destruction, and survival of banned and burned books."
+base_url = "http://localhost:3000"
+
+sections = ["flames"]
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = false
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/burn-book/content/about.md
+++ b/burn-book/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About"
+description = "About the Burn Book project and its purpose."
++++
+
+<p class="page-label">About</p>
+
+# About This Volume
+
+<p class="lede">The Burn Book is a dark meditation on the destruction and survival of forbidden texts. It exists as a record of what has been lost to fire and what has endured despite it.</p>
+
+## Purpose
+
+This publication is not a celebration of destruction. It is an accounting. Every book that has been burned represents a deliberate act of erasure -- an attempt to remove ideas from the world. By documenting these acts, we preserve the memory of what was destroyed and honor the persistence of knowledge that refused to die.
+
+## The name
+
+The term "burn book" carries its own weight. It suggests both a book that has been burned and a book that burns -- a text so dangerous, so incendiary, that its mere existence is an act of defiance. Every banned book is a burn book. Every censored text is a burn book. Every volume that someone, somewhere, decided the world should not be allowed to read.
+
+## Design
+
+The visual language of this publication reflects its subject. Pages are rendered on charcoal-black backgrounds, as if recovered from a fire. The edges are charred and irregular, eaten away by flames. Ember particles glow at the margins, the last traces of the fire that tried to consume these words. The typography is heavy and distressed, as though the letters themselves have been scarred by heat.
+
+> A book is a loaded gun in the house next door. Burn it. Take the shot from the weapon. -- Ray Bradbury, Fahrenheit 451

--- a/burn-book/content/colophon.md
+++ b/burn-book/content/colophon.md
@@ -1,0 +1,28 @@
++++
+title = "Colophon"
+description = "Production details and credits for the Burn Book."
++++
+
+<p class="page-label">Colophon</p>
+
+# Colophon
+
+<p class="lede">Production notes for this incendiary volume. The materials and methods used to construct a book about the destruction of books.</p>
+
+## Typography
+
+Display headings are set in Permanent Marker, a heavy distressed typeface that suggests text written in haste, under duress, or recovered from damage. The irregular letterforms evoke the imperfection of burned and partially destroyed documents.
+
+Body text is set in Inter and Roboto, clean sans-serif typefaces chosen for stark legibility against the dark charcoal backgrounds. The contrast between the distressed display type and the precise body text mirrors the tension between destruction and preservation that runs through this volume.
+
+## Color palette
+
+The palette is drawn from fire and its aftermath. Charcoal-black for the backgrounds, the color of pages reduced to carbon. Ember-orange for accents and headings, the color of coals still glowing after the flames have died. Ash-gray for secondary text, the color of cooled residue. Hot white for body text, the color of pages that survived.
+
+## Construction
+
+Every page border carries inline SVG renderings of charred edges -- irregular jagged dark paths that suggest paper consumed by fire. Ember particles rendered as small circles in varying opacities of ember-orange float at the margins, the last visible traces of the combustion process. No CSS gradients are used. All decorative elements are constructed from SVG paths and shapes.
+
+## Credits
+
+Built with Hwaro. Set in Google Fonts. Dedicated to every book that was burned and every reader who remembered it.

--- a/burn-book/content/flames/1-the-pyre.md
+++ b/burn-book/content/flames/1-the-pyre.md
@@ -1,0 +1,64 @@
++++
+title = "The Pyre"
+description = "A history of book burning from antiquity to the modern era."
+tags = ["history", "destruction", "censorship"]
++++
+
+<p class="page-label">Chapter I</p>
+
+# The Pyre
+
+<p class="lede">The first act is destruction. The pyre is lit, the books are thrown upon it, and the flames consume what took years or centuries to create. The history of book burning is as old as the history of books themselves.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#0a0a0a"/>
+<path d="M100,90 L120,60 L140,80 L160,45 L180,70 L200,40 L220,65 L240,35 L260,60 L280,50 L300,70 L320,42 L340,65 L360,38 L380,58 L400,30 L420,55 L440,40 L460,62 L480,35 L500,58 L520,45 L540,68 L560,42 L580,60 L600,38 L620,65 L640,50 L660,72 L680,48 L700,65" fill="none" stroke="#e86a1a" stroke-width="1.5" opacity="0.4"/>
+<path d="M150,90 L170,70 L190,85 L210,55 L230,75 L250,50 L270,72 L290,48 L310,68 L330,52 L350,75 L370,45 L390,65 L410,40 L430,62 L450,48 L470,70 L490,42 L510,65 L530,50 L550,72 L570,48 L590,68 L610,55 L630,75 L650,50" fill="none" stroke="#e86a1a" stroke-width="1" opacity="0.25"/>
+<circle cx="200" cy="50" r="2.5" fill="#e86a1a" opacity="0.7"/>
+<circle cx="350" cy="40" r="2" fill="#e86a1a" opacity="0.5"/>
+<circle cx="500" cy="45" r="3" fill="#e86a1a" opacity="0.6"/>
+<circle cx="650" cy="55" r="2.2" fill="#e86a1a" opacity="0.4"/>
+<circle cx="280" cy="60" r="1.5" fill="#e86a1a" opacity="0.8"/>
+<circle cx="580" cy="50" r="1.8" fill="#e86a1a" opacity="0.5"/>
+</svg>
+</div>
+
+## The ancient fires
+
+The earliest recorded book burning dates to the Qin dynasty in 213 BCE, when Emperor Qin Shi Huang ordered the destruction of most books in China. The Confucian classics, histories of rival states, and works of philosophy were consigned to the flames. Scholars who resisted were buried alive. The emperor's goal was total: to erase all knowledge that preceded his reign and to make his dynasty the beginning of history itself.
+
+The burning was not complete. Copies survived in hiding, in the walls of houses, in the memories of scholars who had memorized entire texts. The act of destruction created a tradition of covert preservation that would persist for millennia.
+
+## The Library of Alexandria
+
+The destruction of the Library of Alexandria remains the most symbolic book burning in Western history, though the reality is more complex than the myth. The library was not destroyed in a single fire but declined over centuries through a series of incidents: Caesar's fire in 48 BCE, religious conflicts in the fourth century, and the gradual decay of institutional support. The loss was real but slow, a death by a thousand cuts rather than a single conflagration.
+
+What matters is what was lost. The library contained the accumulated knowledge of the ancient Mediterranean world: works of science, mathematics, literature, philosophy, and history that existed in no other copies. When the last scrolls were destroyed, entire branches of knowledge disappeared from the human record.
+
+## The medieval bonfires
+
+The medieval period saw systematic book burning as an instrument of religious authority. The Talmud was burned in Paris in 1242, with twenty-four cartloads of manuscripts consigned to the flames. Arabic philosophical and scientific texts were destroyed during the Reconquista. Heretical Christian texts were burned wherever they were found.
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>Paris, 1242</h3>
+<p>Twenty-four cartloads of the Talmud and other Jewish manuscripts burned by order of Louis IX. The largest single destruction of Jewish texts in the medieval period.</p>
+</div>
+<div class="flame-card">
+<h3>Savonarola, 1497</h3>
+<p>The Bonfire of the Vanities in Florence: books, artworks, cosmetics, and musical instruments burned in a frenzy of religious purification.</p>
+</div>
+<div class="flame-card">
+<h3>The Conquistadors</h3>
+<p>Spanish missionaries destroyed virtually all Maya codices in the sixteenth century. Only four survived. An entire civilization's written record, reduced to ash.</p>
+</div>
+</div>
+
+## The modern pyres
+
+The twentieth century brought book burning to an industrial scale. The Nazi book burnings of May 1933 targeted works by Jewish, communist, and other "un-German" authors. Students and brownshirts threw thousands of volumes into bonfires across German cities while crowds cheered and bands played. The images became iconic: the organized destruction of knowledge as public spectacle.
+
+> The paper burns, but the words fly away. -- Akiba ben Joseph, as he was burned alive with a Torah scroll, c. 135 CE
+
+The burning did not end in 1945. Books were burned in Chile under Pinochet, in China during the Cultural Revolution, in Sarajevo during the siege of 1992. The pyre is always being rebuilt. The match is always being struck.

--- a/burn-book/content/flames/2-the-index.md
+++ b/burn-book/content/flames/2-the-index.md
@@ -1,0 +1,67 @@
++++
+title = "The Index"
+description = "The Index Librorum Prohibitorum and the bureaucracy of banned book lists."
+tags = ["censorship", "prohibition", "authority"]
++++
+
+<p class="page-label">Chapter II</p>
+
+# The Index
+
+<p class="lede">Before the fire comes the list. Every act of book burning begins with an enumeration: which books are dangerous, which authors are forbidden, which ideas must be suppressed. The index of prohibited books is the bureaucratic prelude to the pyre.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#0a0a0a"/>
+<line x1="100" y1="20" x2="700" y2="20" stroke="#333" stroke-width="0.5"/>
+<line x1="100" y1="35" x2="650" y2="35" stroke="#333" stroke-width="0.5"/>
+<line x1="100" y1="50" x2="680" y2="50" stroke="#333" stroke-width="0.5"/>
+<line x1="100" y1="65" x2="620" y2="65" stroke="#333" stroke-width="0.5"/>
+<line x1="100" y1="80" x2="700" y2="80" stroke="#333" stroke-width="0.5"/>
+<line x1="95" y1="18" x2="95" y2="22" stroke="#e86a1a" stroke-width="2"/>
+<line x1="95" y1="33" x2="95" y2="37" stroke="#e86a1a" stroke-width="2"/>
+<line x1="95" y1="48" x2="95" y2="52" stroke="#e86a1a" stroke-width="2"/>
+<line x1="95" y1="63" x2="95" y2="67" stroke="#e86a1a" stroke-width="2"/>
+<line x1="95" y1="78" x2="95" y2="82" stroke="#e86a1a" stroke-width="2"/>
+<circle cx="750" cy="20" r="1.5" fill="#e86a1a" opacity="0.6"/>
+<circle cx="720" cy="50" r="2" fill="#e86a1a" opacity="0.4"/>
+<circle cx="740" cy="80" r="1.8" fill="#e86a1a" opacity="0.5"/>
+</svg>
+</div>
+
+## The Index Librorum Prohibitorum
+
+The most famous list of banned books in history was the Index Librorum Prohibitorum, maintained by the Catholic Church from 1559 to 1966. Over four centuries, the Index catalogued thousands of titles deemed heretical, immoral, or dangerous to the faith. Its reach was enormous: in Catholic countries, possession of an indexed book could result in excommunication, imprisonment, or death.
+
+The Index was not a crude instrument. It was maintained by a dedicated bureaucracy, the Sacred Congregation of the Index, which employed theologians, censors, and administrators. Books were reviewed, debated, and classified with careful attention to the specific nature of their offenses. The machinery of suppression was methodical and thorough.
+
+## The authors on the list
+
+The Index read like a canon of Western intellectual achievement. Galileo, Copernicus, Kepler -- the founders of modern astronomy. Descartes, Locke, Hume, Kant -- the architects of modern philosophy. Voltaire, Rousseau, Diderot -- the voices of the Enlightenment. Hugo, Balzac, Flaubert, Zola -- the masters of the French novel. To be placed on the Index was, in many cases, a mark of intellectual distinction.
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>Science</h3>
+<p>Copernicus, Galileo, and Kepler were all indexed for their astronomical works. The heliocentric model remained on the Index until 1758.</p>
+</div>
+<div class="flame-card">
+<h3>Philosophy</h3>
+<p>Descartes, Spinoza, Hume, Kant, Sartre, and Beauvoir all appeared on the Index. Nearly every major philosopher after the Reformation was banned.</p>
+</div>
+<div class="flame-card">
+<h3>Literature</h3>
+<p>Hugo, Dumas, Stendhal, Flaubert, Zola, and Richardson were indexed. The novel as a form was viewed with deep suspicion.</p>
+</div>
+</div>
+
+## Other lists, other regimes
+
+The Catholic Index was the most enduring, but every authoritarian regime has compiled its own list of forbidden books. The Nazi regime published lists of authors whose works were to be removed from libraries and burned. The Soviet Union maintained a vast system of censorship that controlled which books could be published, distributed, or even discussed. China's system of internet censorship extends the tradition of the banned book list into the digital age.
+
+## The paradox of the list
+
+Every banned book list contains a paradox. The list is intended to suppress, but it also advertises. Readers who might never have heard of a book seek it out precisely because it has been forbidden. The Index Librorum Prohibitorum served as a reading list for freethinkers across Europe. The Nazi book burnings made international headlines and drew attention to the very authors the regime wanted to silence.
+
+> Wherever they burn books they will also, in the end, burn human beings. -- Heinrich Heine
+
+The act of banning a book acknowledges the book's power. If the words were harmless, there would be no need for the list.

--- a/burn-book/content/flames/3-the-survival.md
+++ b/burn-book/content/flames/3-the-survival.md
@@ -1,0 +1,64 @@
++++
+title = "The Survival"
+description = "Books that endured systematic destruction and survived their own burning."
+tags = ["survival", "preservation", "resistance"]
++++
+
+<p class="page-label">Chapter III</p>
+
+# The Survival
+
+<p class="lede">Not every book that is burned stays burned. Some survive in hidden copies, smuggled across borders, buried in walls, memorized by readers who refused to let the words die. The survival of a forbidden book is an act of resistance.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#0a0a0a"/>
+<rect x="350" y="15" width="100" height="70" fill="#1a1a1a" stroke="#2a2a2a" stroke-width="0.8"/>
+<path d="M350,15 L355,10 L360,18 L365,12 L370,17 L380,11 L390,16 L400,10 L410,17 L420,12 L430,16 L440,11 L450,15 Z" fill="#1a1008"/>
+<line x1="365" y1="35" x2="435" y2="35" stroke="#666" stroke-width="0.3"/>
+<line x1="365" y1="45" x2="430" y2="45" stroke="#666" stroke-width="0.3"/>
+<line x1="365" y1="55" x2="432" y2="55" stroke="#666" stroke-width="0.3"/>
+<line x1="365" y1="65" x2="425" y2="65" stroke="#666" stroke-width="0.3"/>
+<circle cx="360" cy="25" r="1.5" fill="#e86a1a" opacity="0.6"/>
+<circle cx="440" cy="20" r="1.2" fill="#e86a1a" opacity="0.5"/>
+<circle cx="400" cy="12" r="1" fill="#e86a1a" opacity="0.7"/>
+<path d="M200,90 Q250,85 300,88 Q350,82 400,87 Q450,80 500,85 Q550,82 600,88" fill="none" stroke="#2a2a2a" stroke-width="0.5"/>
+</svg>
+</div>
+
+## The hidden copy
+
+The most common form of survival is the simplest: someone hid a copy. When Qin Shi Huang ordered the burning of the Confucian classics, scholars concealed texts in the walls of their houses, in tombs, and in remote caves. Centuries later, these hidden copies were rediscovered, and the texts were restored. The Confucian canon survived because individuals chose concealment over compliance.
+
+The same pattern repeats across history. During the Nazi era, Jewish communities hid sacred texts in walls, floors, and cemeteries. During the Soviet period, samizdat -- self-published, hand-copied texts -- circulated in secret networks of readers who copied and recopied forbidden works. Each copy was an act of defiance.
+
+## The smuggled manuscript
+
+Some books survived by crossing borders. When the Catholic Church placed a book on the Index, copies were smuggled from countries where the ban was enforced to countries where it was not. The Netherlands became a center for publishing and distributing banned books in the seventeenth and eighteenth centuries. Protestant publishers in Amsterdam, Leiden, and Rotterdam printed editions of works that could not be published in France, Spain, or Italy.
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>Samizdat</h3>
+<p>The Soviet underground publishing network. Readers typed copies of forbidden texts on thin paper with multiple carbon sheets. Each copy was read and recopied until it fell apart.</p>
+</div>
+<div class="flame-card">
+<h3>The Genizah</h3>
+<p>Jewish tradition forbids the destruction of texts containing the name of God. Worn-out manuscripts are stored in a genizah. The Cairo Genizah preserved over 300,000 fragments spanning a thousand years.</p>
+</div>
+<div class="flame-card">
+<h3>The Timbuktu manuscripts</h3>
+<p>When jihadists occupied Timbuktu in 2012, librarians smuggled 350,000 ancient manuscripts out of the city in footlockers, rice sacks, and donkey carts, saving them from destruction.</p>
+</div>
+</div>
+
+## The memorized text
+
+The most radical form of preservation is memorization. In Bradbury's Fahrenheit 451, a community of exiles preserves literature by committing entire books to memory, each person becoming a living book. This is not entirely fiction. During the Soviet period, poets memorized their own works and the works of banned colleagues. Anna Akhmatova's "Requiem" existed only in the memories of trusted friends for decades before it could be published.
+
+In oral cultures, memorization is the primary technology of preservation. The Homeric epics were transmitted orally for centuries before being written down. The Vedas were memorized and recited for generations. When the written text is destroyed, the memorized text endures.
+
+## The price of survival
+
+Preservation always has a cost. The scholars who hid books from Qin Shi Huang risked execution. The samizdat copyists risked imprisonment in the Gulag. The librarians of Timbuktu risked their lives. The survival of a forbidden book is never automatic. It requires individuals who value the text more than their own safety.
+
+> Books are not made to be believed, but to be subjected to inquiry. -- Umberto Eco

--- a/burn-book/content/flames/4-the-memory.md
+++ b/burn-book/content/flames/4-the-memory.md
@@ -1,0 +1,68 @@
++++
+title = "The Memory"
+description = "Burned books that persist in memory, fragments, and reconstructions."
+tags = ["memory", "reconstruction", "loss"]
++++
+
+<p class="page-label">Chapter IV</p>
+
+# The Memory
+
+<p class="lede">Some burned books are gone forever. No copy survived, no reader memorized the text, no fragment was preserved. Yet these books are not entirely lost. They persist as ghosts in the margins of other texts, as references, quotations, and descriptions that tell us a lost book once existed.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#0a0a0a"/>
+<rect x="150" y="20" width="80" height="60" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="3,3"/>
+<rect x="290" y="20" width="80" height="60" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="3,3"/>
+<rect x="430" y="20" width="80" height="60" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="3,3"/>
+<rect x="570" y="20" width="80" height="60" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="3,3"/>
+<circle cx="190" cy="50" r="3" fill="#e86a1a" opacity="0.15"/>
+<circle cx="330" cy="50" r="3" fill="#e86a1a" opacity="0.15"/>
+<circle cx="470" cy="50" r="3" fill="#e86a1a" opacity="0.15"/>
+<circle cx="610" cy="50" r="3" fill="#e86a1a" opacity="0.15"/>
+<circle cx="190" cy="50" r="1" fill="#e86a1a" opacity="0.7"/>
+<circle cx="330" cy="50" r="1" fill="#e86a1a" opacity="0.5"/>
+<circle cx="470" cy="50" r="1" fill="#e86a1a" opacity="0.6"/>
+<circle cx="610" cy="50" r="1" fill="#e86a1a" opacity="0.4"/>
+</svg>
+</div>
+
+## The ghost library
+
+Scholars estimate that we have lost more than ninety percent of all classical Greek and Roman literature. The works that survived did so largely by accident: a single manuscript copy happened to be preserved in a monastery, or a particular text was popular enough to be copied many times. The vast majority of ancient literature was lost to fire, decay, neglect, and deliberate destruction.
+
+We know these lost works existed because other surviving texts mention them. Aristotle is said to have written dialogues that rivaled Plato's in literary quality, but none survive. Sophocles wrote over 120 plays; we have seven. Livy's history of Rome originally comprised 142 books; 107 are lost. Each reference to a lost work is a ghost in the library, a title on the shelf with nothing behind it.
+
+## Fragments and quotations
+
+Some lost works survive only as fragments: sentences or passages quoted by other authors. The pre-Socratic philosophers -- Heraclitus, Parmenides, Empedocles -- are known almost entirely through fragments preserved in the works of later writers who quoted them. These fragments are all we have, and scholars have spent centuries trying to reconstruct the original works from these scattered pieces.
+
+The process is like reconstructing a burned book from the ashes. Each fragment is a surviving word or phrase, charred at the edges, incomplete, but still legible. The reconstruction is always partial, always uncertain, but it preserves something of the original.
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>The lost plays</h3>
+<p>Of the hundreds of Greek tragedies performed in Athens, fewer than forty survive complete. The lost plays of Aeschylus, Sophocles, and Euripides are known only from titles, fragments, and descriptions.</p>
+</div>
+<div class="flame-card">
+<h3>The Herculaneum scrolls</h3>
+<p>Papyrus scrolls carbonized by Vesuvius in 79 CE are now being read using X-ray technology. Texts unreadable for two thousand years are slowly being deciphered from their charred remains.</p>
+</div>
+<div class="flame-card">
+<h3>The palimpsest</h3>
+<p>Medieval scribes scraped old texts off parchment to reuse the material. Modern imaging technology can recover the erased text beneath, revealing lost works hidden under later writing.</p>
+</div>
+</div>
+
+## The reconstruction
+
+In rare cases, a lost book can be substantially reconstructed from its surviving traces. The most famous example is the reconstruction of the Hebrew Bible's original text from the Dead Sea Scrolls and other manuscript traditions. Another is the ongoing effort to reconstruct lost classical texts from papyrus fragments found in the Egyptian desert, particularly at Oxyrhynchus, where thousands of fragments have been recovered.
+
+These reconstructions are never complete. They are approximations, best guesses, scholarly constructions built from partial evidence. But they are also acts of recovery. Each reconstruction pulls a burned book back from the edge of oblivion, restoring something of what was lost.
+
+## What remains
+
+The memory of a lost book is itself a form of preservation. When we know that a work existed, when we know its title, its author, and something of its contents, the book is not entirely gone. It exists as an absence, a shaped void in the record. The ghost library is still a library. The burned book still has a title on the shelf.
+
+> The dead are not absent; they are merely invisible. -- Saint Augustine

--- a/burn-book/content/flames/5-the-ember.md
+++ b/burn-book/content/flames/5-the-ember.md
@@ -1,0 +1,70 @@
++++
+title = "The Ember"
+description = "The ember that survives -- knowledge persisting despite destruction."
+tags = ["persistence", "knowledge", "resilience"]
++++
+
+<p class="page-label">Chapter V</p>
+
+# The Ember
+
+<p class="lede">After the fire dies, after the smoke clears and the ash cools, something remains. Not the book as it was, but something of it: a glowing point of knowledge that refuses to go out. The ember is what survives when everything else has burned.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 100" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="100" fill="#0a0a0a"/>
+<circle cx="400" cy="50" r="20" fill="#e86a1a" opacity="0.08"/>
+<circle cx="400" cy="50" r="12" fill="#e86a1a" opacity="0.15"/>
+<circle cx="400" cy="50" r="6" fill="#e86a1a" opacity="0.3"/>
+<circle cx="400" cy="50" r="3" fill="#e86a1a" opacity="0.7"/>
+<circle cx="370" cy="35" r="1.5" fill="#e86a1a" opacity="0.4"/>
+<circle cx="435" cy="40" r="1.2" fill="#e86a1a" opacity="0.35"/>
+<circle cx="385" cy="70" r="1.8" fill="#e86a1a" opacity="0.3"/>
+<circle cx="420" cy="65" r="1" fill="#e86a1a" opacity="0.45"/>
+<circle cx="360" cy="55" r="0.8" fill="#e86a1a" opacity="0.5"/>
+<circle cx="445" cy="52" r="1.3" fill="#e86a1a" opacity="0.25"/>
+<circle cx="390" cy="28" r="0.7" fill="#e86a1a" opacity="0.6"/>
+<circle cx="415" cy="75" r="1.1" fill="#e86a1a" opacity="0.2"/>
+</svg>
+</div>
+
+## The persistence of ideas
+
+Ideas are harder to burn than paper. A book is a physical object that can be destroyed, but the ideas it contains exist in the minds of everyone who has read it, discussed it, or been influenced by it. When the Nazis burned the works of Freud, they did not destroy psychoanalysis. When the Church banned Copernicus, they did not return the Earth to the center of the solar system. The ideas had already escaped the pages and entered the culture.
+
+This is the fundamental failure of every act of book burning. The fire can destroy the physical book, but it cannot reach the idea. By the time a book is dangerous enough to burn, its ideas have already spread beyond the capacity of any fire to contain them.
+
+## The digital ember
+
+The digital age has transformed the calculus of book burning. A text that exists in digital form can be copied infinitely, transmitted instantly, and stored in millions of locations simultaneously. Burning a digital book would require destroying every server, every hard drive, every backup, every device on which a copy exists. For practical purposes, a widely distributed digital text is indestructible.
+
+But digital texts are vulnerable in other ways. They can be altered silently, their distribution can be controlled through platform policies, and their accessibility depends on infrastructure that can be disrupted. The ember in the digital age is not immune to destruction; it is simply harder to locate and extinguish.
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>The Streisand effect</h3>
+<p>Attempts to suppress information online often make it more widely known. Censorship in the digital age frequently achieves the opposite of its intended effect.</p>
+</div>
+<div class="flame-card">
+<h3>Digital preservation</h3>
+<p>The Internet Archive, Project Gutenberg, and other digital libraries work to ensure that texts remain accessible regardless of physical book destruction or commercial availability.</p>
+</div>
+<div class="flame-card">
+<h3>Encryption</h3>
+<p>Encrypted text is the modern equivalent of the hidden manuscript: words that exist but cannot be read without the key. A book hidden in plain sight.</p>
+</div>
+</div>
+
+## The unburnable book
+
+Every attempt to destroy knowledge has ultimately failed. The Qin dynasty's burning created a tradition of textual preservation that endured for millennia. The Catholic Index inadvertently created a reading list for Europe's freethinkers. The Nazi bonfires turned obscure authors into international symbols of intellectual freedom. The suppression of samizdat literature in the Soviet Union produced a literary underground that ultimately outlasted the regime.
+
+The pattern is consistent: the act of burning creates the conditions for survival. The forbidden text becomes more valuable, more sought-after, more carefully preserved precisely because it has been targeted for destruction. The ember glows brighter when you try to stamp it out.
+
+## The final page
+
+This volume ends where it began: with fire. But the fire that closes this book is not the fire of destruction. It is the fire of persistence, the glow of the ember that survives every attempt to extinguish it. Knowledge burns, but it does not burn away. It transforms, it disperses, it hides, it waits, and it returns.
+
+The book in your hands is proof. These words were written to be read. That simple fact -- that you are reading them now -- is the ember's victory over the pyre.
+
+> If all printers were determined not to print anything till they were sure it would offend nobody, there would be very little printed. -- Benjamin Franklin

--- a/burn-book/content/flames/_index.md
+++ b/burn-book/content/flames/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Flames"
+description = "The five chapters of the Burn Book, from the first pyre to the last ember."
++++
+
+<p class="lede">Five chapters trace the arc of book burning from the act of destruction to the persistence of knowledge. Each chapter is a stage in the life of a forbidden text: the pyre, the index, the survival, the memory, the ember.</p>
+
+The flames section moves from destruction to preservation, from the moment of burning to the long afterlife of texts that refuse to disappear. Begin with the first chapter and read in sequence, or choose the chapter that calls to you.

--- a/burn-book/content/index.md
+++ b/burn-book/content/index.md
@@ -1,0 +1,75 @@
++++
+title = "Burn Book"
+description = "An incendiary publication of forbidden texts with charred edges and ember effects."
++++
+
+<p class="page-label">Forbidden Volume</p>
+
+# Burn Book
+
+<p class="lede">A volume that should not exist. These are the pages that survived the fire, the texts that refused to turn to ash, the words that glowed in the embers long after the pyre had cooled. This is a book about burning books.</p>
+
+<div class="cover-illustration" aria-hidden="true">
+<svg viewBox="0 0 800 260" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="800" height="260" fill="#0a0a0a"/>
+<rect x="200" y="20" width="400" height="220" fill="#1a1a1a" stroke="#2a2a2a" stroke-width="1"/>
+<path d="M200,20 L205,15 L210,22 L215,13 L220,20 L228,16 L235,22 L240,14 L248,20 L255,12 L262,21 L270,15 L278,22 L285,13 L295,20 L305,16 L315,22 L325,14 L335,20 L345,12 L355,21 L365,15 L375,22 L385,13 L395,20 L405,16 L415,22 L425,14 L435,20 L445,12 L455,21 L465,15 L475,22 L485,13 L495,20 L505,16 L515,22 L525,14 L535,20 L545,12 L555,21 L565,15 L575,22 L585,13 L595,20 L600,16 Z" fill="#1a1008"/>
+<path d="M200,240 L205,245 L212,238 L220,248 L230,240 L238,246 L248,238 L255,248 L265,240 L275,246 L285,238 L295,248 L305,240 L315,246 L325,238 L335,248 L345,240 L355,246 L365,238 L375,248 L385,240 L395,246 L405,238 L415,248 L425,240 L435,246 L445,238 L455,248 L465,240 L475,246 L485,238 L495,248 L505,240 L515,246 L525,238 L535,248 L545,240 L555,246 L565,238 L575,248 L585,240 L595,246 L600,242 Z" fill="#1a1008"/>
+<path d="M200,20 L195,25 L202,35 L196,45 L203,55 L197,65 L204,75 L198,85 L205,95 L199,105 L206,115 L200,125 L207,135 L200,145 L206,155 L200,165 L207,175 L200,185 L206,195 L200,205 L206,215 L200,225 L205,235 L200,240" fill="#1a1008" stroke="none"/>
+<path d="M600,20 L605,25 L598,35 L604,45 L597,55 L603,65 L596,75 L602,85 L595,95 L601,105 L594,115 L600,125 L593,135 L600,145 L594,155 L600,165 L593,175 L600,185 L594,195 L600,205 L594,215 L600,225 L595,235 L600,240" fill="#1a1008" stroke="none"/>
+<line x1="260" y1="80" x2="540" y2="80" stroke="#666" stroke-width="0.5"/>
+<line x1="260" y1="100" x2="520" y2="100" stroke="#666" stroke-width="0.5"/>
+<line x1="260" y1="120" x2="530" y2="120" stroke="#666" stroke-width="0.5"/>
+<line x1="260" y1="140" x2="510" y2="140" stroke="#666" stroke-width="0.5"/>
+<line x1="260" y1="160" x2="540" y2="160" stroke="#666" stroke-width="0.5"/>
+<line x1="260" y1="180" x2="500" y2="180" stroke="#666" stroke-width="0.5"/>
+<text x="400" y="55" text-anchor="middle" fill="#e86a1a" font-family="serif" font-size="16" opacity="0.8">LIBER COMBUSTUS</text>
+<circle cx="220" cy="35" r="3" fill="#e86a1a" opacity="0.8"/>
+<circle cx="570" cy="30" r="2.5" fill="#e86a1a" opacity="0.6"/>
+<circle cx="235" cy="230" r="2" fill="#e86a1a" opacity="0.7"/>
+<circle cx="580" cy="235" r="2.8" fill="#e86a1a" opacity="0.5"/>
+<circle cx="210" cy="130" r="1.8" fill="#e86a1a" opacity="0.6"/>
+<circle cx="590" cy="160" r="2.2" fill="#e86a1a" opacity="0.4"/>
+<circle cx="350" cy="25" r="1.5" fill="#e86a1a" opacity="0.7"/>
+<circle cx="450" cy="245" r="2" fill="#e86a1a" opacity="0.6"/>
+<circle cx="300" cy="240" r="1.3" fill="#e86a1a" opacity="0.5"/>
+<circle cx="500" cy="22" r="1.8" fill="#e86a1a" opacity="0.4"/>
+<circle cx="250" cy="60" r="1.2" fill="#e86a1a" opacity="0.5"/>
+<circle cx="555" cy="90" r="1.6" fill="#e86a1a" opacity="0.3"/>
+</svg>
+</div>
+
+## The incendiary act
+
+Every civilization that has produced books has also burned them. The destruction of written knowledge is as old as writing itself. From the Library of Alexandria to the Nazi bonfires of 1933, from the Qin dynasty's biblioclasm to the destruction of Sarajevo's National Library in 1992, the burning of books has served as an instrument of power, censorship, and cultural erasure. Yet the act of burning a book is also an admission of the book's power. You do not burn what you do not fear.
+
+## What this volume contains
+
+<div class="flame-grid">
+<div class="flame-card">
+<h3>The Pyre</h3>
+<p>A history of book burning from antiquity to the present day. The fires that consumed libraries, the regimes that lit them, and the knowledge that was lost.</p>
+</div>
+<div class="flame-card">
+<h3>The Index</h3>
+<p>The Index Librorum Prohibitorum and other lists of banned books. The bureaucracy of censorship and the machinery of suppression.</p>
+</div>
+<div class="flame-card">
+<h3>The Survival</h3>
+<p>Books that survived their own burning. Texts preserved in hidden copies, smuggled manuscripts, and clandestine editions.</p>
+</div>
+<div class="flame-card">
+<h3>The Memory</h3>
+<p>Burned books that persist through memory, oral tradition, and reconstruction. The ghost library of texts that exist only in fragments and references.</p>
+</div>
+<div class="flame-card">
+<h3>The Ember</h3>
+<p>The ember that survives the fire. How knowledge persists despite systematic destruction, and why the burned book is never truly gone.</p>
+</div>
+</div>
+
+## Reading this volume
+
+Each page in this publication bears the marks of fire: charred edges, ember particles glowing at the margins, the smell of smoke between the lines. Navigate to the <a href="/flames/">flames index</a> to read the full account, or follow the links above.
+
+> Where they burn books, they will ultimately burn people also. -- Heinrich Heine, 1820

--- a/burn-book/static/css/style.css
+++ b/burn-book/static/css/style.css
@@ -1,0 +1,349 @@
+/* =============================================================================
+   Burn Book - Incendiary Publication
+   Issue #1535 | book, dark, forbidden, burnt, intense
+   Palette: charcoal-black (#111), ember-orange (#e86a1a), ash-gray (#666), hot white (#f0f0f0)
+   No gradients. Charred edge borders + ember particles as inline SVG.
+   ============================================================================= */
+
+:root {
+  --charcoal: #111;
+  --charcoal-deep: #0a0a0a;
+  --charcoal-soft: #1a1a1a;
+  --charcoal-border: #2a2a2a;
+  --ember: #e86a1a;
+  --ember-soft: #c45a16;
+  --ember-glow: #ff8533;
+  --ash: #666;
+  --ash-soft: #555;
+  --hot-white: #f0f0f0;
+  --hot-white-dim: #ccc;
+  --burnt-edge: #1a1008;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--charcoal-deep);
+  color: var(--hot-white);
+}
+
+body {
+  font-family: "Inter", "Roboto", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 17px;
+  line-height: 1.76;
+  min-height: 100vh;
+}
+
+.burn-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Header -------------------------------------------------------------- */
+.site-header {
+  padding: 2rem 0 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--charcoal-border);
+  flex-wrap: wrap;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  text-decoration: none;
+  color: var(--hot-white);
+}
+.logo-mark { width: 48px; height: 56px; display: block; }
+.logo-text { display: flex; flex-direction: column; line-height: 1.1; }
+.logo-main {
+  font-family: "Permanent Marker", cursive;
+  font-size: 1.3rem;
+  letter-spacing: 0.04em;
+  color: var(--ember);
+}
+.logo-sub {
+  font-family: "Inter", "Roboto", sans-serif;
+  font-weight: 500;
+  font-size: 0.78rem;
+  color: var(--ash);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--ash);
+  font-family: "Inter", "Roboto", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+.site-nav a:hover { color: var(--ember); border-bottom-color: var(--ember); }
+
+/* --- Charred page (article wrapper) -------------------------------------- */
+.site-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.charred-page {
+  position: relative;
+  background-color: var(--charcoal-soft);
+  border: 1px solid var(--charcoal-border);
+  min-height: 480px;
+  overflow: hidden;
+}
+
+.charred-narrow {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.charred-edge-top,
+.charred-edge-bottom {
+  width: 100%;
+}
+.charred-edge-top svg,
+.charred-edge-bottom svg {
+  width: 100%;
+  display: block;
+}
+
+.page-body {
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1.25rem, 4vw, 3.5rem);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+.page-body h1,
+.page-body h2,
+.page-body h3 {
+  font-family: "Permanent Marker", cursive;
+  color: var(--ember);
+  line-height: 1.25;
+  letter-spacing: 0.02em;
+}
+.page-body h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 0.2em;
+}
+.page-body h2 {
+  font-size: 1.35rem;
+  margin: 2em 0 0.3em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--charcoal-border);
+}
+.page-body h3 {
+  font-size: 1.05rem;
+  margin: 1.6em 0 0.2em;
+  color: var(--ember-glow);
+}
+
+.page-body p {
+  margin: 1em 0;
+  color: var(--hot-white);
+  font-family: "Inter", "Roboto", sans-serif;
+  max-width: 70ch;
+}
+.page-body p.lede {
+  font-size: 1.12rem;
+  line-height: 1.6;
+  color: var(--hot-white-dim);
+  font-style: italic;
+  max-width: 60ch;
+}
+
+.page-label {
+  display: inline-block;
+  font-family: "Inter", "Roboto", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ember);
+  margin: 0 0 0.4em;
+  padding: 0.2em 0.7em;
+  background-color: var(--charcoal);
+  border: 1px solid var(--charcoal-border);
+}
+
+.page-head { margin-bottom: 2rem; }
+.page-title {
+  font-family: "Permanent Marker", cursive;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0;
+  color: var(--ember);
+}
+
+.page-body a {
+  color: var(--ember);
+  text-decoration: none;
+  border-bottom: 1px solid var(--ember-soft);
+}
+.page-body a:hover { color: var(--ember-glow); border-bottom-color: var(--ember-glow); }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 1.25rem;
+  border-left: 3px solid var(--ember);
+  background-color: var(--charcoal);
+  font-style: italic;
+  color: var(--hot-white-dim);
+  font-family: "Inter", "Roboto", sans-serif;
+  font-size: 1.02rem;
+  max-width: 60ch;
+}
+
+.page-body ul,
+.page-body ol {
+  margin: 1em 0 1em 1.5em;
+  padding: 0;
+  color: var(--hot-white);
+}
+.page-body ul { list-style: disc; }
+.page-body ol { list-style: decimal; }
+.page-body li { padding: 0.2em 0; max-width: 70ch; }
+
+/* --- Cover illustration -------------------------------------------------- */
+.cover-illustration {
+  margin: 1.5rem 0;
+  border: 1px solid var(--charcoal-border);
+}
+.cover-illustration svg {
+  width: 100%;
+  display: block;
+}
+
+/* --- Flame card grid ----------------------------------------------------- */
+.flame-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.flame-card {
+  background-color: var(--charcoal);
+  border: 1px solid var(--charcoal-border);
+  padding: 1rem 1.1rem;
+  position: relative;
+}
+.flame-card h3 {
+  margin: 0 0 0.3em;
+  color: var(--ember);
+  font-size: 0.95rem;
+  font-family: "Permanent Marker", cursive;
+}
+.flame-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--ash);
+}
+
+/* --- Section list -------------------------------------------------------- */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--charcoal-border);
+}
+.section-list li {
+  padding: 0.75rem 0.25rem;
+  border-bottom: 1px solid var(--charcoal-border);
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-family: "Inter", "Roboto", sans-serif;
+}
+.section-list li::before {
+  content: "\2022";
+  color: var(--ember);
+  flex-shrink: 0;
+  font-size: 1.2em;
+}
+.section-list li a {
+  font-weight: 600;
+  color: var(--hot-white);
+  border: none;
+  font-size: 1.02rem;
+  letter-spacing: 0.01em;
+}
+.section-list li a:hover { color: var(--ember); }
+
+.taxonomy-desc {
+  color: var(--ash);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+}
+
+nav.pagination { margin-top: 2rem; }
+nav.pagination .pagination-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+nav.pagination a,
+.pagination-current span,
+.pagination-disabled span {
+  display: inline-block;
+  padding: 0.3em 0.6em;
+  border: 1px solid var(--charcoal-border);
+  font-family: "Inter", "Roboto", sans-serif;
+  font-size: 0.85rem;
+  color: var(--hot-white);
+  text-decoration: none;
+  background-color: var(--charcoal);
+}
+nav.pagination a:hover { color: var(--ember); border-color: var(--ember); }
+.pagination-current span { color: var(--ember); border-color: var(--ember); }
+
+/* --- Footer -------------------------------------------------------------- */
+.site-footer {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+  border-top: 1px solid var(--charcoal-border);
+  text-align: center;
+}
+.footer-inner { padding-top: 1.5rem; }
+.footer-line {
+  font-family: "Permanent Marker", cursive;
+  color: var(--ember);
+  margin: 0.2em 0;
+  letter-spacing: 0.02em;
+}
+.footer-line-small {
+  font-family: "Inter", "Roboto", sans-serif;
+  color: var(--ash);
+  font-size: 0.9rem;
+  margin: 0.2em 0;
+}
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .page-body { padding: 1.5rem 1.25rem 2rem; }
+  .site-header { padding: 1.5rem 0 1rem; flex-direction: column; align-items: flex-start; }
+  .site-nav { gap: 1rem; }
+  .page-title, .page-body h1 { font-size: 1.8rem; }
+  .page-body h2 { font-size: 1.15rem; }
+  .page-body p, .page-body li { max-width: none; }
+  .burn-shell { max-width: 100%; }
+}

--- a/burn-book/templates/404.html
+++ b/burn-book/templates/404.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="charred-page charred-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="page-label">404</p>
+          <h1 class="page-title">Page consumed by fire</h1>
+        </header>
+        <p>This page has been reduced to ash. The text that was here has been lost to the flames. Nothing remains but cinders and the faint smell of smoke. Return to the volume and seek another passage.</p>
+        <p><a href="{{ base_url }}/">Back to the book</a></p>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/burn-book/templates/footer.html
+++ b/burn-book/templates/footer.html
@@ -1,0 +1,10 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-line">Burn Book</p>
+      <p class="footer-line-small">What burns is never truly lost.</p>
+      <p class="footer-line-small">&copy; 2026 &middot; charred pages, surviving words</p>
+    </div>
+  </footer>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/burn-book/templates/header.html
+++ b/burn-book/templates/header.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ auto_includes_css }}
+</head>
+<body>
+  <div class="burn-shell">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo" aria-label="Burn Book home">
+        <svg viewBox="0 0 48 56" xmlns="http://www.w3.org/2000/svg" class="logo-mark" aria-hidden="true">
+          <path d="M4,2 L44,2 L44,54 L4,54 Z" fill="#1a1a1a" stroke="#333" stroke-width="0.6"/>
+          <path d="M4,2 L7,0 L9,3 L6,2 Z" fill="#2a1a0a"/>
+          <path d="M38,2 L41,0 L44,2 L42,3 Z" fill="#2a1a0a"/>
+          <path d="M4,54 L6,52 L9,54 L7,56 Z" fill="#2a1a0a"/>
+          <path d="M38,54 L42,52 L44,54 L41,56 Z" fill="#2a1a0a"/>
+          <circle cx="14" cy="16" r="1.2" fill="#e86a1a" opacity="0.8"/>
+          <circle cx="34" cy="12" r="0.9" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="24" cy="8" r="1" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="38" cy="44" r="0.8" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="10" cy="48" r="1.1" fill="#e86a1a" opacity="0.6"/>
+          <line x1="12" y1="24" x2="36" y2="24" stroke="#666" stroke-width="0.4"/>
+          <line x1="12" y1="30" x2="32" y2="30" stroke="#666" stroke-width="0.4"/>
+          <line x1="12" y1="36" x2="34" y2="36" stroke="#666" stroke-width="0.4"/>
+        </svg>
+        <span class="logo-text">
+          <span class="logo-main">Burn Book</span>
+          <span class="logo-sub">Incendiary Publication</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/flames/">Flames</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/colophon/">Colophon</a>
+      </nav>
+    </header>
+  </div>

--- a/burn-book/templates/page.html
+++ b/burn-book/templates/page.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="charred-page">
+      <div class="charred-edge-top" aria-hidden="true">
+        <svg viewBox="0 0 1200 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0,40 L0,12 L15,14 L30,8 L48,16 L65,6 L80,13 L100,4 L120,15 L140,7 L160,14 L185,5 L200,12 L225,9 L245,16 L268,6 L290,14 L310,4 L335,13 L360,8 L380,15 L405,5 L425,14 L450,7 L475,16 L500,6 L520,13 L545,4 L570,15 L590,7 L615,14 L640,5 L660,12 L685,9 L710,16 L735,6 L755,14 L780,4 L800,13 L825,8 L845,15 L870,5 L895,14 L920,7 L940,16 L965,6 L985,13 L1010,4 L1030,15 L1055,7 L1080,14 L1100,5 L1125,12 L1150,9 L1175,16 L1200,8 L1200,40 Z" fill="#1a1008"/>
+          <path d="M0,40 L0,18 L20,20 L40,15 L60,22 L85,13 L110,20 L130,14 L155,21 L180,12 L200,19 L225,15 L250,22 L275,13 L300,20 L320,16 L345,22 L370,14 L395,21 L420,13 L440,19 L465,15 L490,22 L515,12 L540,20 L560,14 L585,21 L610,13 L635,19 L660,15 L685,22 L710,12 L735,20 L755,16 L780,22 L805,14 L830,20 L850,13 L875,19 L900,15 L925,22 L950,12 L975,20 L1000,14 L1025,21 L1050,13 L1075,19 L1100,15 L1120,22 L1145,14 L1170,20 L1200,16 L1200,40 Z" fill="#111"/>
+          <circle cx="80" cy="28" r="2" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="250" cy="32" r="1.5" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="430" cy="26" r="1.8" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="620" cy="30" r="1.3" fill="#e86a1a" opacity="0.4"/>
+          <circle cx="780" cy="28" r="2.1" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="950" cy="34" r="1.4" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="1100" cy="27" r="1.7" fill="#e86a1a" opacity="0.6"/>
+        </svg>
+      </div>
+      <div class="page-body">
+        {{ content }}
+      </div>
+      <div class="charred-edge-bottom" aria-hidden="true">
+        <svg viewBox="0 0 1200 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0,0 L1200,0 L1200,28 L1185,26 L1170,32 L1150,24 L1130,34 L1110,27 L1090,36 L1065,25 L1040,33 L1015,26 L990,35 L965,24 L940,32 L915,27 L890,36 L865,25 L840,34 L815,26 L790,33 L765,24 L740,35 L715,27 L690,36 L665,25 L640,32 L615,26 L590,35 L565,24 L540,33 L515,27 L490,36 L465,25 L440,34 L415,26 L390,33 L365,24 L340,35 L315,27 L290,36 L265,25 L240,32 L215,26 L190,35 L165,24 L140,34 L115,27 L90,36 L65,25 L40,32 L15,26 L0,34 Z" fill="#1a1008"/>
+          <path d="M0,0 L1200,0 L1200,22 L1180,20 L1160,25 L1135,18 L1110,26 L1085,19 L1060,25 L1035,17 L1010,24 L985,18 L960,26 L935,19 L910,25 L885,17 L860,24 L835,18 L810,26 L785,19 L760,25 L735,17 L710,24 L685,18 L660,26 L635,19 L610,25 L585,17 L560,24 L535,18 L510,26 L485,19 L460,25 L435,17 L410,24 L385,18 L360,26 L335,19 L310,25 L285,17 L260,24 L235,18 L210,26 L185,19 L160,25 L135,17 L110,24 L85,18 L60,26 L35,19 L10,25 L0,22 Z" fill="#111"/>
+          <circle cx="120" cy="10" r="1.6" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="310" cy="8" r="2" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="500" cy="12" r="1.4" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="700" cy="9" r="1.8" fill="#e86a1a" opacity="0.4"/>
+          <circle cx="870" cy="11" r="1.5" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="1060" cy="7" r="1.9" fill="#e86a1a" opacity="0.5"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/burn-book/templates/section.html
+++ b/burn-book/templates/section.html
@@ -1,0 +1,42 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="charred-page">
+      <div class="charred-edge-top" aria-hidden="true">
+        <svg viewBox="0 0 1200 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0,40 L0,12 L15,14 L30,8 L48,16 L65,6 L80,13 L100,4 L120,15 L140,7 L160,14 L185,5 L200,12 L225,9 L245,16 L268,6 L290,14 L310,4 L335,13 L360,8 L380,15 L405,5 L425,14 L450,7 L475,16 L500,6 L520,13 L545,4 L570,15 L590,7 L615,14 L640,5 L660,12 L685,9 L710,16 L735,6 L755,14 L780,4 L800,13 L825,8 L845,15 L870,5 L895,14 L920,7 L940,16 L965,6 L985,13 L1010,4 L1030,15 L1055,7 L1080,14 L1100,5 L1125,12 L1150,9 L1175,16 L1200,8 L1200,40 Z" fill="#1a1008"/>
+          <path d="M0,40 L0,18 L20,20 L40,15 L60,22 L85,13 L110,20 L130,14 L155,21 L180,12 L200,19 L225,15 L250,22 L275,13 L300,20 L320,16 L345,22 L370,14 L395,21 L420,13 L440,19 L465,15 L490,22 L515,12 L540,20 L560,14 L585,21 L610,13 L635,19 L660,15 L685,22 L710,12 L735,20 L755,16 L780,22 L805,14 L830,20 L850,13 L875,19 L900,15 L925,22 L950,12 L975,20 L1000,14 L1025,21 L1050,13 L1075,19 L1100,15 L1120,22 L1145,14 L1170,20 L1200,16 L1200,40 Z" fill="#111"/>
+          <circle cx="80" cy="28" r="2" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="250" cy="32" r="1.5" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="430" cy="26" r="1.8" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="620" cy="30" r="1.3" fill="#e86a1a" opacity="0.4"/>
+          <circle cx="780" cy="28" r="2.1" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="950" cy="34" r="1.4" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="1100" cy="27" r="1.7" fill="#e86a1a" opacity="0.6"/>
+        </svg>
+      </div>
+      <div class="page-body">
+        <header class="page-head">
+          <p class="page-label">Flames</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        {{ content }}
+        <ul class="section-list">
+          {{ section.list }}
+        </ul>
+        {{ pagination }}
+      </div>
+      <div class="charred-edge-bottom" aria-hidden="true">
+        <svg viewBox="0 0 1200 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0,0 L1200,0 L1200,28 L1185,26 L1170,32 L1150,24 L1130,34 L1110,27 L1090,36 L1065,25 L1040,33 L1015,26 L990,35 L965,24 L940,32 L915,27 L890,36 L865,25 L840,34 L815,26 L790,33 L765,24 L740,35 L715,27 L690,36 L665,25 L640,32 L615,26 L590,35 L565,24 L540,33 L515,27 L490,36 L465,25 L440,34 L415,26 L390,33 L365,24 L340,35 L315,27 L290,36 L265,25 L240,32 L215,26 L190,35 L165,24 L140,34 L115,27 L90,36 L65,25 L40,32 L15,26 L0,34 Z" fill="#1a1008"/>
+          <path d="M0,0 L1200,0 L1200,22 L1180,20 L1160,25 L1135,18 L1110,26 L1085,19 L1060,25 L1035,17 L1010,24 L985,18 L960,26 L935,19 L910,25 L885,17 L860,24 L835,18 L810,26 L785,19 L760,25 L735,17 L710,24 L685,18 L660,26 L635,19 L610,25 L585,17 L560,24 L535,18 L510,26 L485,19 L460,25 L435,17 L410,24 L385,18 L360,26 L335,19 L310,25 L285,17 L260,24 L235,18 L210,26 L185,19 L160,25 L135,17 L110,24 L85,18 L60,26 L35,19 L10,25 L0,22 Z" fill="#111"/>
+          <circle cx="120" cy="10" r="1.6" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="310" cy="8" r="2" fill="#e86a1a" opacity="0.5"/>
+          <circle cx="500" cy="12" r="1.4" fill="#e86a1a" opacity="0.7"/>
+          <circle cx="700" cy="9" r="1.8" fill="#e86a1a" opacity="0.4"/>
+          <circle cx="870" cy="11" r="1.5" fill="#e86a1a" opacity="0.6"/>
+          <circle cx="1060" cy="7" r="1.9" fill="#e86a1a" opacity="0.5"/>
+        </svg>
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/burn-book/templates/shortcodes/alert.html
+++ b/burn-book/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #333; background-color: #1a1a1a; border-left: 5px solid #e86a1a; margin: 1rem 0; color: #f0f0f0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/burn-book/templates/taxonomy.html
+++ b/burn-book/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="charred-page charred-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="page-label">Index</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">All subjects catalogued in this forbidden volume:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/burn-book/templates/taxonomy_term.html
+++ b/burn-book/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="charred-page charred-narrow">
+      <div class="page-body">
+        <header class="page-head">
+          <p class="page-label">Subject</p>
+          <h1 class="page-title">{{ page.title | e }}</h1>
+        </header>
+        <p class="taxonomy-desc">Pages filed under this subject:</p>
+        {{ content }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -532,6 +532,13 @@
     "glamorous",
     "theater"
   ],
+  "burn-book": [
+    "book",
+    "dark",
+    "forbidden",
+    "burnt",
+    "intense"
+  ],
   "burnt-charcoal": [
     "dark",
     "blog",


### PR DESCRIPTION
Closes #1535

## Summary
- Add burn-book (incendiary publication) example site
- Dark charcoal theme with ember-orange accents
- SVG charred/burned edge effects on every page border
- SVG ember particle patterns glowing at page margins
- Typography: Permanent Marker in ember-orange for display; Inter / Roboto Light in stark white for body
- 5 flames covering the pyre, the index, the survival, the memory, and the ember
- Tags: book, dark, forbidden, burnt, intense

## Test plan
- [x] `hwaro build` succeeds (9 pages generated)
- [ ] Visual review of charred edge effects and ember particle SVGs
- [ ] Check responsive behavior on narrow viewports