### PR TITLE
feat: add breaking-tape example site (closes #1517)

### DIFF
--- a/breaking-tape/AGENTS.md
+++ b/breaking-tape/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/breaking-tape/config.toml
+++ b/breaking-tape/config.toml
@@ -1,0 +1,29 @@
+title = "Breaking Tape"
+description = "A breaking-announcement newswire for product launches, urgent bulletins, and on-the-hour releases."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[markdown]
+safe = false

--- a/breaking-tape/content/about.md
+++ b/breaking-tape/content/about.md
@@ -1,0 +1,48 @@
++++
+title = "The Wire"
+description = "Breaking Tape has been on the wire since 1919. Here is how we work."
+tags = ["announcement", "urgent"]
++++
+
+## A newswire for breaking announcements
+
+Breaking Tape has been on the wire since 1919, when it was first carried on the New York Consolidated Ticker as a four-column supplement to the principal market feed. We have been a standalone wire since 1949, in print since 1957, and on the internet since 1996.
+
+We do one job: we put breaking announcements on the wire as fast as they can be verified, and no sooner.
+
+## What we cover
+
+- **Product launches** from the six programmes we track, with spec sheets, technical documents, and official photography.
+- **Urgent bulletins** &mdash; range holds, recalls, stop-ships, regulatory action, emergency patches.
+- **Scheduled releases** &mdash; quarterly roadmaps, half-year reports, annual bulletins.
+- **Retractions and corrections** &mdash; printed at the front of the next cycle without exception.
+
+## The cycle
+
+The wire runs on a twelve-hour cycle, starting at 06:00 and 18:00 Pacific. Each cycle is numbered consecutively from the beginning of the calendar year. Today&rsquo;s cycle is **214**.
+
+A new cycle begins with a five-minute silent hold, during which the wire carries a single line &mdash; the date, the cycle number, and the phrase &ldquo;no traffic.&rdquo; Readers use the hold to check that their wire equipment is still receiving.
+
+## Embargoes
+
+Embargoes are absolute. An embargoed bulletin is distributed to the wire at the embargo time, not before, and no amount of industry pressure has ever moved the wire on this. We have refused embargoes from heads of state and we have refused embargoes from our own advertisers. It is the single rule the wire does not bend.
+
+If you miss an embargo, you read about it in the next cycle.
+
+## Corrections &amp; retractions
+
+A correction is a change of fact. A retraction is a removal of a bulletin we should not have carried. Both run at the front of the next cycle, under the heading the founder specified in 1919: `FROM THE WIRE ROOM`.
+
+In the last five years, we have issued sixty-four corrections and eleven retractions. The retraction rate is published at the end of each year in our annual bulletin.
+
+## Contact
+
+The wire room is open every day, every hour. No weekends, no holidays &mdash; there is always a desk on. Write `desk@breakingtape.example` for editorial queries. For trade subscriptions, which require a verified institutional address, the rate card is available on request.
+
+The wire itself is at `tape://breakingtape.example:1919` &mdash; the port is historical &mdash; and our public feed is mirrored at the address on the back of this page.
+
+## History
+
+Founded in 1919 by the Stern family as a supplement to the New York Consolidated Ticker, the wire became independent in 1949 when the principal ticker moved to electronic distribution and the supplement was judged, by the family and by the ticker, to be an anachronism. The wire has been continuously in operation since.
+
+The founder&rsquo;s great-granddaughter, Iris Stern, is the current managing editor. Her desk is in the corner of the wire room, next to the window, under a framed copy of the first wire of 1919.

--- a/breaking-tape/content/bulletins/_index.md
+++ b/breaking-tape/content/bulletins/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Bulletins"
+description = "Every bulletin on the wire, newest first. Retractions and corrections noted in place."
+sort_by = "date"
+reverse = true
+template = "section"
++++
+
+Each bulletin is numbered cycle-dot-serial. Retractions append an `r`; corrections append a `c`. The full traffic log for the last thirty days is held at the wire room; older archives are at the Stern Library on West 49th.

--- a/breaking-tape/content/bulletins/kestrel-spec-sheet.md
+++ b/breaking-tape/content/bulletins/kestrel-spec-sheet.md
@@ -1,0 +1,39 @@
++++
+title = "KESTREL Upper Stage Spec Sheet"
+description = "Twenty-four pages. Embargo lifts on the wire at 09:35; public at 10:00."
+date = 2026-04-15
+tags = ["launch", "announcement", "ticker"]
++++
+
+## Released &#183; 09:35 PT
+
+The KESTREL upper-stage specification sheet has been cleared for distribution on the wire at 09:35 PT. Public release follows at 10:00.
+
+## Contents
+
+The spec sheet is twenty-four pages and covers:
+
+- Propellant and oxidizer masses, with tolerances.
+- Single-restart envelope, including the thirty-six hour orbital coast case.
+- Single-fault tolerance analysis, with fault-tree graphics.
+- Avionics block diagram and the three-axis control authorities.
+- Range safety interfaces, including the destruct system.
+- Payload adapter dimensions for the three supported fittings.
+- Mission profile templates for the four nominal orbits.
+
+## Redactions
+
+Four pages are partially redacted under the standing export-control agreement with the Proctorate. The redactions concern specific mass fractions and the destruct-system interlock. Redacted text is replaced with a black bar; the surrounding text is complete.
+
+## Distribution
+
+The spec sheet is distributed over the wire at 09:35 in both text and graphic forms. Public PDF at 10:00 from the North Station press room at `press@northstation.example`.
+
+## Further reading
+
+- [NORTH-11 cleared for 14:00 PT](../north-11-launch-cleared/)
+- [Q2 roadmap bulletin issued](../q2-roadmap/)
+
+## Corrections
+
+None at this time.

--- a/breaking-tape/content/bulletins/north-11-launch-cleared.md
+++ b/breaking-tape/content/bulletins/north-11-launch-cleared.md
@@ -1,0 +1,34 @@
++++
+title = "NORTH-11 Cleared for 14:00 PT"
+description = "Range safety lifts the hold on North Station's orbital launch; press pool gathers at Pad 4 from 13:15."
+date = 2026-04-16
+tags = ["launch", "urgent", "ticker"]
++++
+
+## Breaking &#183; 09:14 PT
+
+Range safety has lifted the overnight hold on NORTH-11, clearing the vehicle for a 14:00 PT launch from Pad 4. The hold was placed at 03:22 for an anomaly in the upper-level wind readings; the 09:45 balloon showed winds within the 18-knot envelope at altitude, and the hold was released at 09:12.
+
+## The vehicle
+
+NORTH-11 is a three-stage orbital launcher built by North Station on contract to the Proctorate. The upper stage is the KESTREL, a single-restart hydrogen stage with a four-burn flight profile.
+
+## Window
+
+The launch window opens at 14:00 PT and is firm for forty-two minutes. There is no second opportunity this cycle; the next window is at 14:00 PT on 19 April.
+
+## Access
+
+- **Press pool** gathers at Pad 4 from 13:15. Current press laminate required.
+- **Badging** at the North gate media desk until 11:00. No issuance after that.
+- **Viewing** for invited guests at the Vance Pavilion from 13:00. The pavilion closes at 14:50 regardless of launch outcome.
+
+## Further bulletins
+
+- [KESTREL upper stage spec sheet](../kestrel-spec-sheet/) &mdash; embargo lifted at 09:35
+- [Press pool badges required](../press-pool-badges/) &mdash; urgent, 09:22
+- [Upper-level winds within envelope](../weather-call/) &mdash; Range Met, 09:54
+
+## Corrections
+
+None at this time.

--- a/breaking-tape/content/bulletins/press-pool-badges.md
+++ b/breaking-tape/content/bulletins/press-pool-badges.md
@@ -1,0 +1,32 @@
++++
+title = "Press Pool Badges Required"
+description = "Badge check at the North gate from 12:00. No entry without a current press laminate."
+date = 2026-04-13
+tags = ["urgent", "event", "announcement"]
++++
+
+## Urgent &#183; 09:22 PT
+
+Press access to Pad 4 for the NORTH-11 launch is by current press laminate only. The North gate will begin badge checks at 12:00. Members of the pool without a current laminate will not be admitted.
+
+## Issuance
+
+The media desk at the North gate issues laminates until 11:00. There is no issuance after 11:00. Applications require:
+
+- A letter of assignment from the editor on company letterhead.
+- A government-issued photograph identification.
+- A signed standing-range-rules waiver (available at the desk).
+
+## Pool rules
+
+- **Pool footage** is distributed by the wire at 14:45, regardless of launch outcome.
+- **Still photography** is by Pad 4 pool only. No individual cameras at the gate.
+- **Voice recording** is permitted from the pavilion but not from within the pad perimeter.
+
+## Denied entry
+
+Members denied entry at the gate may request a seat at the Vance Pavilion. Seats are limited and are allocated by the media desk on a first-come basis.
+
+## Corrections
+
+None at this time.

--- a/breaking-tape/content/bulletins/q2-roadmap.md
+++ b/breaking-tape/content/bulletins/q2-roadmap.md
@@ -1,0 +1,36 @@
++++
+title = "Q2 Roadmap Bulletin Issued"
+description = "Six programme additions and two retirements, with range availability and staffing notes."
+date = 2026-04-14
+tags = ["announcement", "launch"]
++++
+
+## Released &#183; 09:48 PT
+
+The Q2 roadmap bulletin is now on the wire in full. A precis is on the front; the bulletin itself is on page 11 of the current cycle.
+
+## Additions
+
+| Programme | Pad | First launch |
+|-----------|-----|--------------|
+| KESTREL-2 | Pad 4 | 02 Jun 2026 |
+| VERMILION-9 | Pad 7 | 14 Jun 2026 |
+| BONDI-B | Pad 2 | 22 Jun 2026 |
+| LANTERN-A | Pad 9 | 04 Jul 2026 |
+| NORTH-12 | Pad 4 | 18 Jul 2026 |
+| OSSUARY-1 | Pad 11 | 30 Jul 2026 |
+
+## Retirements
+
+Two programmes are being retired at the close of Q2:
+
+- **BONDI-A**, effective 31 June after fourteen successful launches.
+- **LEVANT-2**, effective 30 June after its planned five-launch demonstration campaign.
+
+## Staffing
+
+The wire notes a consequent reallocation of range staffing, with fourteen staff moving from the BONDI-A line to the new KESTREL-2 line during May and June. Range training for KESTREL-2 begins 01 May.
+
+## Corrections
+
+None at this time.

--- a/breaking-tape/content/bulletins/retraction-vance.md
+++ b/breaking-tape/content/bulletins/retraction-vance.md
@@ -1,0 +1,29 @@
++++
+title = "Retraction: Vance Board Seat"
+description = "Bulletin 214.01 is retracted in full. Avery Vance has not joined the NorthCo board."
+date = 2026-04-11
+tags = ["urgent", "announcement"]
++++
+
+## From the Wire Room &#183; 08:58 PT
+
+Bulletin 214.01, published on the wire at 06:04 this cycle under the headline &ldquo;Vance takes board seat at NorthCo,&rdquo; is retracted in full.
+
+## The error
+
+The bulletin stated that Avery Vance had accepted a non-executive seat on the NorthCo board, effective the close of business 16 April. This is not the case. Ms. Vance has neither accepted nor been offered such a seat. The story rested on a misread document, which the reporter did not verify with either the Vance office or the NorthCo board secretary before filing.
+
+## What happens next
+
+- The bulletin is retracted in full, not corrected.
+- The reporting has been reassigned to the main desk.
+- The reporter is on leave pending a review by the managing editor.
+- An apology to Ms. Vance has been sent at 07:45.
+
+## Standing rule
+
+The wire does not sleep on a holding paragraph: if we are not certain, we do not run it; and if we run it in error, we retract it as soon as the error is known. This is the standing rule of the wire room since 1919, and the rule has not changed.
+
+## Corrections
+
+This bulletin corrects bulletin 214.01 in full. No further corrections are expected.

--- a/breaking-tape/content/bulletins/weather-call.md
+++ b/breaking-tape/content/bulletins/weather-call.md
@@ -1,0 +1,30 @@
++++
+title = "Upper-Level Winds Within Envelope"
+description = "09:45 balloon shows winds within the 18-knot envelope; hold watch lifted."
+date = 2026-04-12
+tags = ["launch", "announcement"]
++++
+
+## Cleared &#183; 09:54 PT
+
+The 09:45 weather balloon shows upper-level winds within the 18-knot envelope at all altitudes of interest. The hold watch posted at 06:00 has been lifted.
+
+## Figures
+
+| Altitude | Direction | Speed |
+|----------|-----------|-------|
+| 10 km | 267&deg; | 12 knots |
+| 15 km | 272&deg; | 14 knots |
+| 20 km | 281&deg; | 16 knots |
+| 25 km | 289&deg; | 17 knots |
+| 30 km | 294&deg; | 17 knots |
+
+All readings are within the 18-knot envelope for NORTH-11, with approximately six knots of margin.
+
+## Next call
+
+The next weather call is at 12:00 PT. If winds remain within envelope at 12:00 and again at 13:30, launch proceeds. The 13:30 call is the final go/no-go for weather.
+
+## Corrections
+
+None at this time.

--- a/breaking-tape/content/index.md
+++ b/breaking-tape/content/index.md
@@ -1,0 +1,220 @@
++++
+description = "A breaking-announcement newswire for product launches, urgent bulletins, and on-the-hour releases."
+template = "index"
++++
+
+<div class="alert-card">
+  <svg class="alert-card-icon" width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <title>Urgent warning</title>
+    <g fill="#d1141a" stroke="#141210" stroke-width="2" stroke-linejoin="round">
+      <polygon points="48,6 90,84 6,84"/>
+    </g>
+    <g fill="#fffcf2">
+      <rect x="44.8" y="30" width="6.4" height="28" rx="1"/>
+      <rect x="44.8" y="64" width="6.4" height="8" rx="1"/>
+    </g>
+  </svg>
+  <div class="alert-card-body">
+    <div class="ac-kicker">Breaking &#183; 09:14 PT &#183; April 17</div>
+    <h2>NORTH-11 launch cleared for 14:00 PT</h2>
+    <p>Range safety lifts the hold on North Station&rsquo;s orbital launch; press pool gathers at Pad 4 from 13:15. The embargoed spec sheet for the KESTREL upper stage is cleared for release at 09:35.</p>
+  </div>
+  <a class="alert-card-action" href="{{ base_url }}/bulletins/north-11-launch-cleared/">Read Bulletin</a>
+</div>
+
+<div class="section-head">
+  <h2>This Hour on the Wire</h2>
+  <div class="section-head-mark">Cycle 214 &#183; 09:00 &ndash; 10:00</div>
+</div>
+
+<div class="bulletin-grid">
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/north-11-launch-cleared/">
+    <span class="bulletin-ribbon urgent">Breaking</span>
+    <div class="bulletin-kicker">09:14 &#183; Launch</div>
+    <div class="bulletin-title">NORTH-11 Cleared for 14:00 PT</div>
+    <div class="bulletin-body">Range safety lifts the hold; press pool gathers at Pad 4 from 13:15. Three-stage vehicle, polar orbit, 42-minute window.</div>
+    <div class="bulletin-meta"><span>Pad 4</span><span>Wire 214.02</span></div>
+  </a>
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/kestrel-spec-sheet/">
+    <span class="bulletin-ribbon">Embargo lifted</span>
+    <div class="bulletin-kicker">09:35 &#183; Release</div>
+    <div class="bulletin-title">KESTREL Upper Stage Spec Sheet</div>
+    <div class="bulletin-body">Twenty-four pages, including the restart envelope and the single-fault tolerance analysis. Distributed to the wire at 09:35; public at 10:00.</div>
+    <div class="bulletin-meta"><span>North Station</span><span>Wire 214.03</span></div>
+  </a>
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/q2-roadmap/">
+    <span class="bulletin-ribbon">New</span>
+    <div class="bulletin-kicker">09:48 &#183; Roadmap</div>
+    <div class="bulletin-title">Q2 Roadmap Bulletin Issued</div>
+    <div class="bulletin-body">Six new programme additions and two retirements, with range-availability and staffing notes. A precis is on the front of the wire; the bulletin itself is on page 11.</div>
+    <div class="bulletin-meta"><span>Programmes</span><span>Wire 214.04</span></div>
+  </a>
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/press-pool-badges/">
+    <span class="bulletin-ribbon urgent">Urgent</span>
+    <div class="bulletin-kicker">09:22 &#183; Access</div>
+    <div class="bulletin-title">Press Pool Badges Required</div>
+    <div class="bulletin-body">Badge check at the North gate from 12:00. Members without a current press laminate will not be admitted. Issuance at the media desk until 11:00.</div>
+    <div class="bulletin-meta"><span>Pad 4 gate</span><span>Wire 214.05</span></div>
+  </a>
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/weather-call/">
+    <span class="bulletin-ribbon">Hold watch</span>
+    <div class="bulletin-kicker">09:54 &#183; Weather</div>
+    <div class="bulletin-title">Upper-Level Winds Within Envelope</div>
+    <div class="bulletin-body">The 09:45 balloon shows winds within the 18-knot envelope at altitude. Hold watch lifted; next call at 12:00.</div>
+    <div class="bulletin-meta"><span>Range Met</span><span>Wire 214.06</span></div>
+  </a>
+
+  <a class="bulletin" href="{{ base_url }}/bulletins/retraction-vance/">
+    <span class="bulletin-ribbon">Retraction</span>
+    <div class="bulletin-kicker">08:58 &#183; Correction</div>
+    <div class="bulletin-title">Vance Board Seat: Retraction</div>
+    <div class="bulletin-body">Bulletin 214.01 is retracted in full. Avery Vance has not joined the NorthCo board. The wire regrets the error, and the reporting has been reassigned to the desk.</div>
+    <div class="bulletin-meta"><span>Front of wire</span><span>Wire 214.01r</span></div>
+  </a>
+
+</div>
+
+<div class="countdown-block">
+  <h3>Launch Window Opens</h3>
+  <p>NORTH-11 to polar orbit from Pad 4. The window is firm for forty-two minutes; no second opportunity this cycle.</p>
+  <div class="countdown-grid">
+    <div class="countdown-cell">
+      <div class="countdown-cell-num">04</div>
+      <div class="countdown-cell-label">Hours</div>
+    </div>
+    <div class="countdown-cell">
+      <div class="countdown-cell-num">46</div>
+      <div class="countdown-cell-label">Minutes</div>
+    </div>
+    <div class="countdown-cell">
+      <div class="countdown-cell-num">18</div>
+      <div class="countdown-cell-label">Seconds</div>
+    </div>
+    <div class="countdown-cell">
+      <div class="countdown-cell-num">T&minus;</div>
+      <div class="countdown-cell-label">To launch</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-head">
+  <h2>Wire Traffic</h2>
+  <div class="section-head-mark">Last Six Hours &#183; Sorted By Cycle</div>
+</div>
+
+<table class="wire-list">
+  <thead>
+    <tr>
+      <th>Time</th>
+      <th>Bulletin</th>
+      <th style="text-align:right;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="wl-time">09:54 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/weather-call/">Upper-level winds within envelope</a></div>
+        <div class="wl-note">Range Met &#183; Hold watch lifted</div>
+      </td>
+      <td class="wl-status ok">Cleared</td>
+    </tr>
+    <tr>
+      <td class="wl-time">09:48 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/q2-roadmap/">Q2 roadmap bulletin</a></div>
+        <div class="wl-note">Programmes &#183; Front of wire, page 11</div>
+      </td>
+      <td class="wl-status ok">Released</td>
+    </tr>
+    <tr>
+      <td class="wl-time">09:35 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/kestrel-spec-sheet/">KESTREL spec sheet, embargo lifted</a></div>
+        <div class="wl-note">North Station &#183; Public at 10:00</div>
+      </td>
+      <td class="wl-status ok">Released</td>
+    </tr>
+    <tr>
+      <td class="wl-time">09:22 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/press-pool-badges/">Press pool badges required</a></div>
+        <div class="wl-note">Pad 4 gate &#183; Issuance at media desk</div>
+      </td>
+      <td class="wl-status urgent">Urgent</td>
+    </tr>
+    <tr>
+      <td class="wl-time">09:14 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/north-11-launch-cleared/">NORTH-11 cleared for 14:00 PT</a></div>
+        <div class="wl-note">Pad 4 &#183; Three-stage, polar orbit</div>
+      </td>
+      <td class="wl-status urgent">Breaking</td>
+    </tr>
+    <tr>
+      <td class="wl-time">08:58 PT</td>
+      <td>
+        <div class="wl-title"><a href="{{ base_url }}/bulletins/retraction-vance/">Retraction: Vance board seat</a></div>
+        <div class="wl-note">Corrects bulletin 214.01</div>
+      </td>
+      <td class="wl-status hold">Retracted</td>
+    </tr>
+    <tr>
+      <td class="wl-time">08:15 PT</td>
+      <td>
+        <div class="wl-title">Bondi-class launcher retirement</div>
+        <div class="wl-note">Programmes &#183; Effective 31 Dec</div>
+      </td>
+      <td class="wl-status ok">Filed</td>
+    </tr>
+    <tr>
+      <td class="wl-time">07:40 PT</td>
+      <td>
+        <div class="wl-title">Engineering call log, overnight</div>
+        <div class="wl-note">Pad 4 &#183; Two minor holds, cleared</div>
+      </td>
+      <td class="wl-status ok">Filed</td>
+    </tr>
+    <tr>
+      <td class="wl-time">06:12 PT</td>
+      <td>
+        <div class="wl-title">Overnight range schedule</div>
+        <div class="wl-note">Range ops &#183; 14-hour window</div>
+      </td>
+      <td class="wl-status ok">Filed</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-head">
+  <h2>At a Glance</h2>
+  <div class="section-head-mark">The Next Six Hours</div>
+</div>
+
+<div class="details-grid">
+  <div class="detail-item">
+    <div class="detail-label">Pad &amp; Vehicle</div>
+    <div class="detail-value">Pad 4 &#183; NORTH-11</div>
+    <div class="detail-note">Three-stage launcher with KESTREL upper stage</div>
+  </div>
+  <div class="detail-item">
+    <div class="detail-label">Window opens</div>
+    <div class="detail-value">14:00 PT</div>
+    <div class="detail-note">42 minutes, no second opportunity</div>
+  </div>
+  <div class="detail-item">
+    <div class="detail-label">Press pool</div>
+    <div class="detail-value">13:15 PT</div>
+    <div class="detail-note">North gate &#183; current laminate required</div>
+  </div>
+  <div class="detail-item">
+    <div class="detail-label">Next cycle</div>
+    <div class="detail-value">10:00 PT</div>
+    <div class="detail-note">New wire, full traffic resumes</div>
+  </div>
+</div>

--- a/breaking-tape/static/css/style.css
+++ b/breaking-tape/static/css/style.css
@@ -1,0 +1,703 @@
+@import url('https://fonts.googleapis.com/css2?family=Fjalla+One&family=Roboto+Condensed:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --bg: #faf6ed;
+  --bg-soft: #f0ead9;
+  --paper: #fffcf2;
+  --ink: #141210;
+  --ink-soft: #3a342d;
+  --ink-faint: #7a6f5e;
+  --urgent: #d1141a;
+  --urgent-deep: #8a0b0f;
+  --warn: #f4b300;
+  --rule: #1a1713;
+  --accent: #0e3b2e;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--urgent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--urgent);
+}
+a:hover { color: var(--urgent-deep); border-bottom-color: var(--urgent-deep); }
+
+/* ===== TICKER TAPE TOP ===== */
+.ticker-tape {
+  width: 100%;
+  height: 48px;
+  background: var(--ink);
+  color: var(--warn);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+  border-bottom: 3px solid var(--urgent);
+}
+.ticker-tape-inner {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 0 2rem;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 700;
+  white-space: nowrap;
+  color: var(--warn);
+}
+.ticker-tape-inner span { display: inline-block; }
+.ticker-tape-inner .t-urgent { color: var(--urgent); }
+.ticker-tape-inner .t-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn);
+}
+.ticker-tape-inner .t-dot.urgent { background: var(--urgent); }
+
+/* ===== MASTHEAD ===== */
+.masthead {
+  padding: 3rem 3rem 2rem;
+  background: var(--paper);
+  border-bottom: 6px solid var(--ink);
+  position: relative;
+}
+
+.masthead-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.bulletin-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: var(--urgent);
+  color: var(--paper);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+  margin-bottom: 0.8rem;
+}
+
+.headline {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 160px;
+  line-height: 0.9;
+  letter-spacing: -0.01em;
+  margin: 0 0 1rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+
+.subhead {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 500;
+  font-size: 1.45rem;
+  color: var(--ink-soft);
+  max-width: 70ch;
+  margin: 0 0 1.5rem;
+  line-height: 1.4;
+}
+
+.masthead-meta {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin-top: 1.2rem;
+  padding-top: 1.2rem;
+  border-top: 2px solid var(--ink);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+.masthead-meta strong { color: var(--urgent); font-weight: 700; }
+
+/* ===== NAV ===== */
+.navbar {
+  background: var(--ink);
+  color: var(--paper);
+}
+.navbar-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0.9rem 3rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.navbar-inner a {
+  color: var(--paper);
+  border: none;
+  padding: 0.3rem 0;
+  border-bottom: 2px solid transparent;
+}
+.navbar-inner a:hover {
+  border-bottom-color: var(--warn);
+  color: var(--warn);
+}
+.navbar-left, .navbar-right {
+  display: flex;
+  gap: 1.8rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.navbar-right { color: var(--warn); }
+
+/* ===== MAIN ===== */
+.wire {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 3rem;
+}
+
+/* ===== URGENT ALERT CARD (with exclamation SVG) ===== */
+.alert-card {
+  display: grid;
+  grid-template-columns: 96px 1fr auto;
+  gap: 2rem;
+  align-items: center;
+  padding: 2rem 2.2rem;
+  background: var(--paper);
+  border: 3px solid var(--urgent);
+  border-left: 12px solid var(--urgent);
+  margin: 2rem 0 3rem;
+  position: relative;
+}
+.alert-card-icon { flex: 0 0 auto; }
+.alert-card-body h2 {
+  font-family: 'Fjalla One', sans-serif;
+  font-size: 2.4rem;
+  margin: 0 0 0.3rem;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.alert-card-body .ac-kicker {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.alert-card-body p {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 1.05rem;
+  color: var(--ink-soft);
+  margin: 0;
+  line-height: 1.5;
+}
+.alert-card-action {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper);
+  background: var(--ink);
+  padding: 0.75rem 1.2rem;
+  font-weight: 700;
+  white-space: nowrap;
+  border: none;
+}
+.alert-card-action:hover { background: var(--urgent); color: var(--paper); }
+
+/* ===== SECTION HEADER ===== */
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0 0 0.8rem;
+  margin: 3rem 0 1.8rem;
+  border-bottom: 4px solid var(--ink);
+}
+.section-head h2 {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 2.6rem;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.section-head-mark {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+}
+
+/* ===== BULLETIN GRID ===== */
+.bulletin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0 3rem;
+}
+
+.bulletin {
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  padding: 1.6rem 1.5rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 260px;
+  text-decoration: none;
+  color: inherit;
+  position: relative;
+}
+.bulletin:hover {
+  border-color: var(--urgent);
+}
+
+.bulletin-ribbon {
+  display: inline-block;
+  background: var(--ink);
+  color: var(--warn);
+  padding: 0.2rem 0.7rem;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.26em;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 0.9rem;
+  align-self: flex-start;
+}
+.bulletin-ribbon.urgent { background: var(--urgent); color: var(--paper); }
+
+.bulletin-kicker {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.bulletin-title {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 1.5rem;
+  line-height: 1.08;
+  color: var(--ink);
+  margin: 0 0 0.6rem;
+  text-transform: uppercase;
+}
+
+.bulletin-body {
+  color: var(--ink-soft);
+  font-size: 0.98rem;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.bulletin-meta {
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px dashed var(--ink);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  font-weight: 500;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+/* ===== LAUNCH COUNTDOWN ===== */
+.countdown-block {
+  margin: 2.5rem 0 3.5rem;
+  padding: 2.5rem 2rem;
+  background: var(--ink);
+  color: var(--paper);
+  border-top: 6px solid var(--urgent);
+  border-bottom: 6px solid var(--urgent);
+}
+.countdown-block h3 {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 1.8rem;
+  color: var(--warn);
+  text-transform: uppercase;
+  margin: 0 0 0.5rem;
+}
+.countdown-block p {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 1.05rem;
+  color: var(--bg-soft);
+  margin: 0 0 1.5rem;
+  max-width: 60ch;
+}
+.countdown-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  max-width: 560px;
+  border: 2px solid var(--warn);
+}
+.countdown-cell {
+  padding: 1rem 0.5rem;
+  text-align: center;
+  border-right: 2px solid var(--warn);
+  font-family: 'Fjalla One', sans-serif;
+}
+.countdown-cell:last-child { border-right: none; }
+.countdown-cell-num {
+  font-size: 2.5rem;
+  line-height: 1;
+  color: var(--warn);
+}
+.countdown-cell-label {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--paper);
+  font-weight: 700;
+  margin-top: 0.4rem;
+}
+
+/* ===== WIRE LIST ===== */
+.wire-list {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0 3rem;
+  font-family: 'Roboto Condensed', sans-serif;
+}
+.wire-list th, .wire-list td {
+  padding: 0.9rem 0.6rem;
+  text-align: left;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: top;
+}
+.wire-list th {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+  background: var(--bg-soft);
+  border-bottom: 3px solid var(--ink);
+}
+.wire-list tr:hover td { background: var(--bg-soft); }
+.wire-list .wl-time {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+  font-weight: 700;
+  white-space: nowrap;
+}
+.wire-list .wl-title {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 1.15rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.wire-list .wl-title a { border: none; color: inherit; }
+.wire-list .wl-note {
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  font-family: 'Roboto Condensed', sans-serif;
+  margin-top: 0.2rem;
+}
+.wire-list .wl-status {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  font-weight: 700;
+  text-align: right;
+  white-space: nowrap;
+}
+.wire-list .wl-status.urgent { color: var(--urgent); }
+.wire-list .wl-status.ok { color: var(--accent); }
+.wire-list .wl-status.hold { color: var(--warn); }
+
+/* ===== DETAILS ROW ===== */
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0 3rem;
+}
+.detail-item {
+  padding: 1.2rem 0 0;
+  border-top: 4px solid var(--urgent);
+}
+.detail-label {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--urgent);
+  margin-bottom: 0.4rem;
+}
+.detail-value {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 1.5rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.detail-note {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  margin-top: 0.3rem;
+}
+
+/* ===== PAGE ARTICLE ===== */
+.page-article {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+.page-article h1 {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 3.8rem;
+  line-height: 0.98;
+  margin: 0 0 0.8rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.page-article h2 {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 2rem;
+  margin: 2.5rem 0 0.8rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 3px solid var(--urgent);
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.page-article h3 {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  margin: 2rem 0 0.5rem;
+  color: var(--urgent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.page-article p { margin: 0 0 1.1rem; font-size: 20px; line-height: 1.6; }
+.page-article p strong { color: var(--urgent); }
+.page-article blockquote {
+  margin: 1.6rem 0;
+  padding: 0.6rem 0 0.6rem 1.5rem;
+  border-left: 4px solid var(--urgent);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.2rem;
+}
+.page-article ul { padding-left: 1.4rem; font-size: 20px; }
+.page-article li { margin-bottom: 0.35rem; }
+.page-article code {
+  font-family: 'Roboto Mono', monospace;
+  background: var(--bg-soft);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--rule);
+  color: var(--urgent-deep);
+  font-size: 0.9rem;
+}
+.page-article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 0.98rem;
+}
+.page-article th, .page-article td {
+  padding: 0.7rem 0.6rem;
+  text-align: left;
+  border-bottom: 1px solid var(--rule);
+}
+.page-article th {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+  border-bottom: 3px solid var(--ink);
+}
+
+/* ===== SECTION LIST ===== */
+.section-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 3rem;
+}
+.section-list li {
+  border-bottom: 2px solid var(--rule);
+  padding: 1.4rem 0;
+  display: grid;
+  grid-template-columns: 180px 1fr auto;
+  gap: 2rem;
+  align-items: baseline;
+}
+.section-list .sl-date {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--urgent);
+  font-weight: 700;
+}
+.section-list .sl-title {
+  font-family: 'Fjalla One', sans-serif;
+  font-weight: 400;
+  font-size: 1.5rem;
+  color: var(--ink);
+  text-transform: uppercase;
+}
+.section-list .sl-title a { border: none; color: inherit; }
+.section-list .sl-title a:hover { color: var(--urgent); }
+
+/* ===== TAPE RIBBON DIVIDER ===== */
+.tape-ribbon {
+  display: block;
+  width: 100%;
+  height: 50px;
+  margin: 3rem 0;
+}
+
+/* ===== FOOTER ===== */
+.stop-press {
+  margin-top: 4rem;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 3rem;
+  border-top: 6px solid var(--urgent);
+}
+.stop-press-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+}
+.stop-press h4 {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--warn);
+  margin: 0 0 1rem;
+  font-weight: 700;
+}
+.stop-press p, .stop-press ul {
+  font-size: 0.98rem;
+  color: var(--bg-soft);
+  margin: 0;
+  padding: 0;
+  line-height: 1.55;
+  font-family: 'Roboto Condensed', sans-serif;
+}
+.stop-press ul { list-style: none; }
+.stop-press li { margin-bottom: 0.4rem; }
+.stop-press a { color: var(--bg-soft); border: none; }
+.stop-press a:hover { color: var(--warn); }
+.stop-press-meta {
+  max-width: 1280px;
+  margin: 2.5rem auto 0;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--ink-faint);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  text-align: center;
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 0.9rem;
+  margin: 2rem 0 3rem;
+}
+.tag-cloud a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+  font-weight: 700;
+}
+.tag-cloud a:hover { background: var(--ink); color: var(--warn); border-color: var(--ink); }
+
+@media (max-width: 720px) {
+  .masthead { padding: 2rem 1.5rem 1.5rem; }
+  .headline { font-size: 64px; }
+  .wire { padding: 2rem 1.5rem; }
+  .navbar-inner { padding: 0.8rem 1.5rem; }
+  .stop-press { padding: 2rem 1.5rem; }
+  .section-list li { grid-template-columns: 1fr; gap: 0.4rem; }
+  .alert-card { grid-template-columns: 1fr; }
+  .countdown-grid { grid-template-columns: repeat(2, 1fr); }
+  .countdown-cell:nth-child(2) { border-right: none; }
+}

--- a/breaking-tape/templates/404.html
+++ b/breaking-tape/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="wire">
+    <article class="page-article">
+      <div class="eyebrow">Error 404 &#183; Bulletin Not Found</div>
+      <h1>Off the Wire</h1>
+      <p>This bulletin has been retracted, superseded, or never crossed the wire in the first place. No archived copy is held at this address.</p>
+      <p><a href="{{ base_url }}/">Return to the newsroom</a>.</p>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/breaking-tape/templates/footer.html
+++ b/breaking-tape/templates/footer.html
@@ -1,0 +1,107 @@
+  <svg class="tape-ribbon" viewBox="0 0 1200 50" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" preserveAspectRatio="none">
+    <title>Ticker-tape ribbon border</title>
+    <rect x="0" y="0" width="1200" height="50" fill="#faf6ed"/>
+    <g fill="#141210">
+      <rect x="0" y="10" width="1200" height="8"/>
+      <rect x="0" y="32" width="1200" height="8"/>
+    </g>
+    <g fill="#f4b300">
+      <rect x="0" y="18" width="1200" height="14"/>
+    </g>
+    <g fill="#141210">
+      <rect x="10" y="22" width="4" height="6"/>
+      <rect x="30" y="22" width="4" height="6"/>
+      <rect x="50" y="22" width="4" height="6"/>
+      <rect x="70" y="22" width="4" height="6"/>
+      <rect x="90" y="22" width="4" height="6"/>
+      <rect x="110" y="22" width="4" height="6"/>
+      <rect x="130" y="22" width="4" height="6"/>
+      <rect x="150" y="22" width="4" height="6"/>
+      <rect x="170" y="22" width="4" height="6"/>
+      <rect x="190" y="22" width="4" height="6"/>
+      <rect x="210" y="22" width="4" height="6"/>
+      <rect x="230" y="22" width="4" height="6"/>
+      <rect x="250" y="22" width="4" height="6"/>
+      <rect x="270" y="22" width="4" height="6"/>
+      <rect x="290" y="22" width="4" height="6"/>
+      <rect x="310" y="22" width="4" height="6"/>
+      <rect x="330" y="22" width="4" height="6"/>
+      <rect x="350" y="22" width="4" height="6"/>
+      <rect x="370" y="22" width="4" height="6"/>
+      <rect x="390" y="22" width="4" height="6"/>
+      <rect x="410" y="22" width="4" height="6"/>
+      <rect x="430" y="22" width="4" height="6"/>
+      <rect x="450" y="22" width="4" height="6"/>
+      <rect x="470" y="22" width="4" height="6"/>
+      <rect x="490" y="22" width="4" height="6"/>
+      <rect x="510" y="22" width="4" height="6"/>
+      <rect x="530" y="22" width="4" height="6"/>
+      <rect x="550" y="22" width="4" height="6"/>
+      <rect x="570" y="22" width="4" height="6"/>
+      <rect x="590" y="22" width="4" height="6"/>
+      <rect x="610" y="22" width="4" height="6"/>
+      <rect x="630" y="22" width="4" height="6"/>
+      <rect x="650" y="22" width="4" height="6"/>
+      <rect x="670" y="22" width="4" height="6"/>
+      <rect x="690" y="22" width="4" height="6"/>
+      <rect x="710" y="22" width="4" height="6"/>
+      <rect x="730" y="22" width="4" height="6"/>
+      <rect x="750" y="22" width="4" height="6"/>
+      <rect x="770" y="22" width="4" height="6"/>
+      <rect x="790" y="22" width="4" height="6"/>
+      <rect x="810" y="22" width="4" height="6"/>
+      <rect x="830" y="22" width="4" height="6"/>
+      <rect x="850" y="22" width="4" height="6"/>
+      <rect x="870" y="22" width="4" height="6"/>
+      <rect x="890" y="22" width="4" height="6"/>
+      <rect x="910" y="22" width="4" height="6"/>
+      <rect x="930" y="22" width="4" height="6"/>
+      <rect x="950" y="22" width="4" height="6"/>
+      <rect x="970" y="22" width="4" height="6"/>
+      <rect x="990" y="22" width="4" height="6"/>
+      <rect x="1010" y="22" width="4" height="6"/>
+      <rect x="1030" y="22" width="4" height="6"/>
+      <rect x="1050" y="22" width="4" height="6"/>
+      <rect x="1070" y="22" width="4" height="6"/>
+      <rect x="1090" y="22" width="4" height="6"/>
+      <rect x="1110" y="22" width="4" height="6"/>
+      <rect x="1130" y="22" width="4" height="6"/>
+      <rect x="1150" y="22" width="4" height="6"/>
+      <rect x="1170" y="22" width="4" height="6"/>
+      <rect x="1190" y="22" width="4" height="6"/>
+    </g>
+  </svg>
+  <footer class="stop-press">
+    <div class="stop-press-inner">
+      <div>
+        <h4>The Wire</h4>
+        <p>Breaking Tape is a breaking-announcement newswire covering product launches, urgent bulletins, and on-the-hour releases. First published 1919, on the wire since.</p>
+      </div>
+      <div>
+        <h4>Wire Room</h4>
+        <ul>
+          <li>desk@breakingtape.example</li>
+          <li>24-hour cycle, no weekends off</li>
+          <li>12 West 49th, New York</li>
+          <li>Wire: BRKTAPE@TRADES</li>
+        </ul>
+      </div>
+      <div>
+        <h4>Navigate</h4>
+        <ul>
+          <li><a href="{{ base_url }}/">Newsroom</a></li>
+          <li><a href="{{ base_url }}/bulletins/">Bulletins</a></li>
+          <li><a href="{{ base_url }}/about/">The Wire</a></li>
+          <li><a href="{{ base_url }}/tags/">Tags</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Standing Orders</h4>
+        <p>Copy deadline: top of the hour. Embargoes are absolute. Retractions are front-of-wire. The wire does not sleep on a holding paragraph.</p>
+      </div>
+    </div>
+    <div class="stop-press-meta">Set in Fjalla One &amp; Roboto Condensed &#183; &copy; {{ current_year }} Breaking Tape &#183; Built with Hwaro</div>
+  </footer>
+  {{ highlight_js }}
+</body>
+</html>

--- a/breaking-tape/templates/header.html
+++ b/breaking-tape/templates/header.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} &#8212; {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+</head>
+<body>
+  <div class="ticker-tape">
+    <div class="ticker-tape-inner">
+      <svg width="34" height="18" viewBox="0 0 34 18" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <title>Ticker tape ribbon</title>
+        <g fill="#f4b300">
+          <rect x="0" y="6" width="34" height="6"/>
+        </g>
+        <g fill="#141210">
+          <rect x="2" y="8" width="2" height="2"/>
+          <rect x="7" y="8" width="2" height="2"/>
+          <rect x="12" y="8" width="2" height="2"/>
+          <rect x="17" y="8" width="2" height="2"/>
+          <rect x="22" y="8" width="2" height="2"/>
+          <rect x="27" y="8" width="2" height="2"/>
+          <rect x="32" y="8" width="2" height="2"/>
+        </g>
+      </svg>
+      <span class="t-urgent">BRK</span>
+      <span class="t-dot urgent"></span>
+      <span>09:14 &#183; Launch window opens for NORTH-11 at 14:00 PT</span>
+      <span class="t-dot"></span>
+      <span class="t-urgent">URG</span>
+      <span class="t-dot urgent"></span>
+      <span>09:22 &#183; Press pool gathers at Pad 4 &#183; badges required</span>
+      <span class="t-dot"></span>
+      <span class="t-urgent">NEW</span>
+      <span class="t-dot urgent"></span>
+      <span>09:35 &#183; Embargo lifts on KESTREL spec sheet</span>
+      <span class="t-dot"></span>
+      <span class="t-urgent">RLS</span>
+      <span class="t-dot urgent"></span>
+      <span>09:48 &#183; Q2 roadmap bulletin issued</span>
+      <span class="t-dot"></span>
+    </div>
+  </div>
+  <header class="masthead">
+    <div class="masthead-top">
+      <span><strong style="color:#d1141a;">WIRE 2026-04-17</strong> &#183; ISSUE 214 &#183; 12-HOUR CYCLE</span>
+      <span class="bulletin-chip">
+        <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <polygon points="7,1 13,12 1,12" fill="none" stroke="#fffcf2" stroke-width="1.4"/>
+          <rect x="6.3" y="4.5" width="1.4" height="4" fill="#fffcf2"/>
+          <rect x="6.3" y="9.5" width="1.4" height="1.4" fill="#fffcf2"/>
+        </svg>
+        LIVE
+      </span>
+      <span>BY WIRE &#183; FIRST PUBLISHED 1919</span>
+    </div>
+    <div class="eyebrow">Breaking Announcement</div>
+    <h1 class="headline">{{ site.title }}</h1>
+    <p class="subhead">{{ site.description }}</p>
+    <div class="masthead-meta">
+      <span>Bulletins in the last hour <strong>14</strong></span>
+      <span>Pending embargo <strong>03</strong></span>
+      <span>Holds <strong>01</strong></span>
+      <span>Next cycle <strong>10:00</strong></span>
+    </div>
+  </header>
+  <nav class="navbar">
+    <div class="navbar-inner">
+      <div class="navbar-left">
+        <a href="{{ base_url }}/">Newsroom</a>
+        <a href="{{ base_url }}/bulletins/">Bulletins</a>
+        <a href="{{ base_url }}/about/">The Wire</a>
+        <a href="{{ base_url }}/tags/">Index</a>
+      </div>
+      <div class="navbar-right">
+        <span>NEXT BULLETIN &#183; 10:00 PT</span>
+      </div>
+    </div>
+  </nav>

--- a/breaking-tape/templates/index.html
+++ b/breaking-tape/templates/index.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="wire">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/breaking-tape/templates/page.html
+++ b/breaking-tape/templates/page.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="wire">
+    <article class="page-article">
+      {% if page.title is present %}
+        <div class="eyebrow">{% if page.section is present %}{{ page.section }}{% else %}Bulletin{% endif %}</div>
+        <h1>{{ page.title }}</h1>
+        {% if page.description is present %}
+          <p style="font-family:'Roboto Condensed',sans-serif;font-size:1.3rem;color:#3a342d;font-weight:500;margin-bottom:2rem;line-height:1.4;">{{ page.description }}</p>
+        {% endif %}
+      {% endif %}
+      {{ content }}
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/breaking-tape/templates/section.html
+++ b/breaking-tape/templates/section.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="wire">
+    <div class="eyebrow">Section</div>
+    <h1 style="font-family:'Fjalla One',sans-serif;font-weight:400;font-size:3.8rem;text-transform:uppercase;line-height:0.98;margin:0.3rem 0 0.5rem;color:#141210;">{{ page.title | e }}</h1>
+    {% if page.description is present %}
+      <p style="font-family:'Roboto Condensed',sans-serif;font-size:1.25rem;color:#3a342d;margin-bottom:2rem;line-height:1.4;">{{ page.description }}</p>
+    {% endif %}
+    <div class="page-article" style="max-width:960px;margin:0;">{{ content }}</div>
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/breaking-tape/templates/shortcodes/alert.html
+++ b/breaking-tape/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/breaking-tape/templates/taxonomy.html
+++ b/breaking-tape/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="wire">
+    <div class="eyebrow">Index</div>
+    <h1 style="font-family:'Fjalla One',sans-serif;font-weight:400;font-size:3.8rem;text-transform:uppercase;margin:0.3rem 0 0.5rem;">{{ page.title | e }}</h1>
+    <p style="font-family:'Roboto Condensed',sans-serif;font-size:1.2rem;color:#3a342d;margin:0 0 1.5rem;">Browse the wire by topic.</p>
+    <div class="tag-cloud">{{ content }}</div>
+  </main>
+{% include "footer.html" %}

--- a/breaking-tape/templates/taxonomy_term.html
+++ b/breaking-tape/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% include "header.html" %}
+  <main class="wire">
+    <div class="eyebrow">Tagged</div>
+    <h1 style="font-family:'Fjalla One',sans-serif;font-weight:400;font-size:3.8rem;text-transform:uppercase;margin:0.3rem 0 0.5rem;">{{ page.title | e }}</h1>
+    <p style="font-family:'Roboto Condensed',sans-serif;font-size:1.2rem;color:#3a342d;margin:0 0 1.5rem;">All bulletins under this rubric.</p>
+    <ul class="section-list">{{ content }}</ul>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -527,6 +527,13 @@
     "blog",
     "nature"
   ],
+  "breaking-tape": [
+    "event",
+    "launch",
+    "announcement",
+    "urgent",
+    "ticker"
+  ],
   "breeze": [
     "landing",
     "light",


### PR DESCRIPTION
Closes #1517

Note: renamed from "ticker-tape" (the slug requested in the issue) because an unrelated "ticker-tape" site already exists on main.