### PR TITLE
feat: add aurora-design example template

### DIFF
--- a/aurora-design/AGENTS.md
+++ b/aurora-design/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/aurora-design/config.toml
+++ b/aurora-design/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Aurora Design"
+description = "An elegant, subtle theme showcasing refined aesthetics."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/aurora-design/content/about.md
+++ b/aurora-design/content/about.md
@@ -1,0 +1,7 @@
++++
+title = "About"
++++
+
+This is the **Aurora Design** theme. It is a minimalist, elegant dark theme crafted for the Hwaro static site generator.
+
+Designed with a focus on readability and subtle aesthetic details, it provides a quiet canvas for writers, designers, and creatives.

--- a/aurora-design/content/archives.md
+++ b/aurora-design/content/archives.md
@@ -1,0 +1,7 @@
++++
+title = "Archives"
++++
+
+A complete chronological record of thoughts, essays, and notes published over time.
+
+*(Note: An archive timeline implementation would typically reside here, iterating over `site.pages`.)*

--- a/aurora-design/content/index.md
+++ b/aurora-design/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Aurora"
++++
+
+A space dedicated to the subtle art of digital aesthetics, where design meets introspection.
+
+Explore the journal in the [Posts](/posts/) section, or discover themes through carefully curated [Tags](/tags/).
+
+> "Design is the silent ambassador of your brand." — Paul Rand

--- a/aurora-design/content/posts/_index.md
+++ b/aurora-design/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+paginate = 10
+generate_feeds = true
+transparent = false
++++

--- a/aurora-design/content/posts/elegant-design.md
+++ b/aurora-design/content/posts/elegant-design.md
@@ -1,0 +1,29 @@
++++
+title = "The Philosophy of Elegance"
+date = "2025-01-01"
+description = "Exploring the delicate balance of dark themes, generous whitespace, and purposeful typography."
+tags = ["design", "typography", "aurora"]
+categories = ["thoughts"]
++++
+
+Elegance in digital design is often characterized by restraint. It is not the abundance of elements, but rather the deliberate exclusion of the unnecessary, allowing the core content to breathe and resonate.
+
+<!-- more -->
+
+### The Role of Darkness
+
+Dark themes inherently offer a canvas of quiet contemplation. When executed carefully, with pure blacks avoided in favor of rich, subtle charcoals (`#0b0e14`), the screen emits less harsh light, reducing cognitive load and inviting the reader to immerse themselves deeply in the text.
+
+### Typography as the Anchor
+
+When visual noise is stripped away, typography becomes the primary architectural element. The pairing of a structural sans-serif like *Inter* for metadata and interface elements, alongside the sweeping, sophisticated curves of *Playfair Display* for headings, creates a dynamic tension that is both modern and timeless.
+
+```css
+/* The fundamental balance */
+:root {
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-serif: 'Playfair Display', Georgia, serif;
+}
+```
+
+Ultimately, an elegant interface respects the user's time and attention. It guides quietly, presenting ideas with clarity and an understated grace that outlasts fleeting design trends.

--- a/aurora-design/static/css/style.css
+++ b/aurora-design/static/css/style.css
@@ -1,0 +1,382 @@
+:root {
+  --bg-color: #0b0e14;
+  --text-color: #d1d5db;
+  --heading-color: #f8fafc;
+  --accent-color: #94a3b8;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --glass-bg: rgba(11, 14, 20, 0.75);
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-serif: 'Playfair Display', Georgia, serif;
+
+  --container-width: 720px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-image: radial-gradient(circle at 15% 50%, rgba(45, 55, 72, 0.15) 0%, transparent 50%),
+                    radial-gradient(circle at 85% 30%, rgba(26, 32, 44, 0.15) 0%, transparent 50%);
+  background-attachment: fixed;
+}
+
+a {
+  color: var(--heading-color);
+  text-decoration: none;
+  transition: color 0.3s ease, opacity 0.3s ease;
+}
+
+a:hover {
+  opacity: 0.7;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--heading-color);
+  font-family: var(--font-serif);
+  font-weight: 400;
+  line-height: 1.3;
+  margin-bottom: 1rem;
+}
+
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.header-inner {
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 1.5rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-style: italic;
+}
+
+.site-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-nav a {
+  font-size: 0.9rem;
+  color: var(--accent-color);
+  text-transform: lowercase;
+  letter-spacing: 0.05em;
+}
+
+.site-nav a:hover {
+  color: var(--heading-color);
+  opacity: 1;
+}
+
+.search-trigger {
+  background: none;
+  border: none;
+  color: var(--accent-color);
+  cursor: pointer;
+  padding: 0.5rem;
+  transition: color 0.3s ease;
+  display: flex;
+  align-items: center;
+}
+
+.search-trigger:hover {
+  color: var(--heading-color);
+}
+
+/* Main Content */
+.site-main {
+  flex: 1;
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 4rem 2rem;
+  width: 100%;
+}
+
+/* Post Styling */
+.post-header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.post-title {
+  font-size: 2.75rem;
+  margin-bottom: 1rem;
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  color: var(--accent-color);
+  font-family: var(--font-sans);
+  font-weight: 300;
+}
+
+.meta-separator {
+  margin: 0 0.5rem;
+}
+
+.tag {
+  color: var(--accent-color);
+  border-bottom: 1px solid transparent;
+}
+
+.tag:hover {
+  color: var(--heading-color);
+  border-bottom-color: var(--border-color);
+}
+
+.post-content {
+  font-size: 1.1rem;
+}
+
+.post-content p {
+  margin-bottom: 1.75rem;
+}
+
+.post-content a {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.post-content a:hover {
+  border-bottom-color: var(--heading-color);
+}
+
+/* Lists */
+.post-item {
+  margin-bottom: 3rem;
+  padding-bottom: 3rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.post-item:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.post-item-title {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-item-meta {
+  font-size: 0.85rem;
+  color: var(--accent-color);
+  margin-bottom: 1rem;
+}
+
+.post-item-summary {
+  color: var(--text-color);
+}
+
+/* Search Overlay */
+.search-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(11, 14, 20, 0.9);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.search-overlay.active {
+  display: flex;
+  opacity: 1;
+}
+
+.search-modal {
+  width: 100%;
+  max-width: 600px;
+  background: #11151e;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+  overflow: hidden;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.search-input-wrap svg {
+  color: var(--accent-color);
+  margin-right: 1rem;
+}
+
+#searchInput {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--heading-color);
+  font-size: 1.2rem;
+  font-family: var(--font-sans);
+  outline: none;
+}
+
+.search-esc {
+  font-size: 0.75rem;
+  color: var(--accent-color);
+  background: rgba(255,255,255,0.05);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search-results {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.search-result-item {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+  transition: background 0.2s;
+}
+
+.search-result-item:hover, .search-result-item.active {
+  background: rgba(255,255,255,0.03);
+}
+
+.search-result-title {
+  color: var(--heading-color);
+  font-size: 1.1rem;
+  margin-bottom: 0.25rem;
+  font-family: var(--font-serif);
+}
+
+.search-result-url {
+  font-size: 0.8rem;
+  color: var(--accent-color);
+}
+
+/* Taxonomies & Sections */
+.section-header, .taxonomy-header, .page-header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.section-title, .taxonomy-title, .page-title {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.section-description, .taxonomy-desc {
+  color: var(--accent-color);
+  font-size: 1.1rem;
+}
+
+.term-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.term-list li {
+  margin: 0;
+}
+
+.term-link {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 30px;
+  font-size: 0.9rem;
+  color: var(--text-color);
+}
+
+.term-link:hover {
+  border-color: var(--heading-color);
+  color: var(--heading-color);
+  opacity: 1;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.footer-inner {
+  font-size: 0.85rem;
+  color: var(--accent-color);
+}
+
+.powered-by {
+  opacity: 0.7;
+}
+
+/* 404 */
+.error-page {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.error-code {
+  font-size: 6rem;
+  margin-bottom: 1rem;
+  color: var(--heading-color);
+}
+
+.error-desc {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+  color: var(--accent-color);
+}
+
+.btn-return {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  transition: all 0.3s ease;
+}
+
+.btn-return:hover {
+  background: var(--heading-color);
+  color: var(--bg-color);
+  opacity: 1;
+}

--- a/aurora-design/static/js/search.js
+++ b/aurora-design/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/aurora-design/templates/404.html
+++ b/aurora-design/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-page">
+  <h1 class="error-code">404</h1>
+  <p class="error-desc">The page you are looking for has drifted into the void.</p>
+  <a href="{{ base_url }}/" class="btn-return">Return to Home</a>
+</div>
+{% endblock %}

--- a/aurora-design/templates/base.html
+++ b/aurora-design/templates/base.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page and page.title %}{{ page.title | e }} - {% elif section and section.title %}{{ section.title | e }} - {% elif taxonomy_term %}{{ taxonomy_term | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Playfair+Display:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+  <meta name="base-url" content="{{ base_url }}">
+</head>
+<body data-section="{% if page and page.section %}{{ page.section }}{% endif %}">
+
+<div class="site-wrapper">
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/posts/">Journal</a>
+        <a href="{{ base_url }}/archives/">Archives</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+      <div class="header-right">
+        <button class="search-trigger" onclick="openSearch()" title="Search">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="searchInput" placeholder="Search..." autocomplete="off">
+        <kbd onclick="closeSearch()" class="search-esc">ESC</kbd>
+      </div>
+      <div class="search-results" id="searchResults"></div>
+    </div>
+  </div>
+
+  <main class="site-main">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p>&copy; {{ current_year }} {{ site.title }}. <span class="powered-by">Powered by Hwaro.</span></p>
+    </div>
+  </footer>
+</div>
+
+{{ highlight_js | safe }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js | safe }}
+</body>
+</html>

--- a/aurora-design/templates/page.html
+++ b/aurora-design/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+  <h1 class="page-title">{{ page.title | e }}</h1>
+</div>
+<div class="page-content">
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/aurora-design/templates/post.html
+++ b/aurora-design/templates/post.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title | e }}</h1>
+    <div class="post-meta">
+      <time class="post-date">{{ page.date | date("%B %d, %Y") }}</time>
+      {% if page.tags and page.tags | length > 0 %}
+        <span class="meta-separator">&middot;</span>
+        <span class="post-tags">
+          {% for tag in page.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </span>
+      {% endif %}
+    </div>
+  </header>
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/aurora-design/templates/section.html
+++ b/aurora-design/templates/section.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header">
+  <h1 class="section-title">{{ section.title | default(page.title | default("Section")) | e }}</h1>
+  {% if section.description or page.description %}
+    <p class="section-description">{{ section.description | default(page.description) | e }}</p>
+  {% endif %}
+</div>
+
+<div class="section-content">
+  {{ content | safe }}
+</div>
+
+<div class="post-list">
+  {% if section and section.pages %}
+    {% for post in section.pages %}
+      <article class="post-item">
+        <h2 class="post-item-title"><a href="{{ post.url }}">{{ post.title | e }}</a></h2>
+        <div class="post-item-meta">
+          <time>{{ post.date | date("%B %d, %Y") }}</time>
+        </div>
+        {% if post.summary %}
+          <p class="post-item-summary">{{ post.summary | strip_html }}</p>
+        {% endif %}
+      </article>
+    {% endfor %}
+  {% else %}
+    <ul class="section-list-default">
+      {{ section.list | safe }}
+    </ul>
+  {% endif %}
+</div>
+
+{% if pagination %}
+<div class="pagination-wrapper">
+  {{ pagination | safe }}
+</div>
+{% endif %}
+{% endblock %}

--- a/aurora-design/templates/shortcodes/alert.html
+++ b/aurora-design/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/aurora-design/templates/taxonomy.html
+++ b/aurora-design/templates/taxonomy.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-header">
+  <h1 class="taxonomy-title">{{ taxonomy_name | title | e }}</h1>
+  <p class="taxonomy-desc">Explore by {{ taxonomy_name | e }}.</p>
+</div>
+
+<div class="taxonomy-terms">
+  {% if taxonomy_terms and taxonomy_terms | length > 0 %}
+    <ul class="term-list">
+      {% for term in taxonomy_terms %}
+        <li>
+          <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term | slugify }}/" class="term-link">{{ term }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>No terms found.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/aurora-design/templates/taxonomy_term.html
+++ b/aurora-design/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-term-header">
+  <span class="taxonomy-label">{{ taxonomy_name | title }}</span>
+  <h1 class="taxonomy-term-title">{{ taxonomy_term | e }}</h1>
+</div>
+
+<div class="post-list">
+  {% if taxonomy_pages and taxonomy_pages | length > 0 %}
+    {% for post in taxonomy_pages %}
+      <article class="post-item">
+        <h2 class="post-item-title"><a href="{{ post.url }}">{{ post.title | e }}</a></h2>
+        <div class="post-item-meta">
+          <time>{{ post.date | date("%B %d, %Y") }}</time>
+        </div>
+      </article>
+    {% endfor %}
+  {% else %}
+    <p>No posts found for this term.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -287,6 +287,12 @@
     "blog",
     "aurora"
   ],
+  "aurora-design": [
+    "blog",
+    "dark",
+    "minimal",
+    "portfolio"
+  ],
   "aurora-glimmer": [
     "light",
     "blog",


### PR DESCRIPTION
This PR introduces the `aurora-design` static site example to the Hwaro examples repository. It features a custom-built, highly refined dark theme focused on elegant typography and minimalist aesthetics. The scaffold templates have also been heavily refactored from basic includes to proper Jinja2 block inheritance to demonstrate best practices for template structures in Hwaro.

---
*PR created automatically by Jules for task [17297177850982190623](https://jules.google.com/task/17297177850982190623) started by @chei-l*