### PR TITLE
Add new example site: ephemeral-ink

### DIFF
--- a/ephemeral-ink/AGENTS.md
+++ b/ephemeral-ink/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/ephemeral-ink/config.toml
+++ b/ephemeral-ink/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Ephemeral Ink"
+description = "A minimalist space for thoughts and words."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/ephemeral-ink/content/about.md
+++ b/ephemeral-ink/content/about.md
@@ -1,0 +1,15 @@
++++
+title = "About"
+date = "2024-01-01"
+description = "About this space and the author."
++++
+
+I am an observer, a writer, and a collector of quiet moments.
+
+This journal, *Ephemeral Ink*, serves as a repository for musings that might otherwise drift away. The design reflects a desire for simplicity—a canvas where the words themselves are the focus, uncluttered by unnecessary elements.
+
+My work often explores themes of solitude, memory, and the passage of time. If you find resonance here, I am glad.
+
+### Contact
+
+If you wish to reach out, you can send a message into the ether at `hello@example.com`. I read everything, though I reply slowly.

--- a/ephemeral-ink/content/index.md
+++ b/ephemeral-ink/content/index.md
@@ -1,0 +1,19 @@
++++
+title = "Home"
+date = "2024-01-01"
+description = "A minimalist space for thoughts and words."
++++
+
+Welcome to a quiet corner of the internet. Here, ideas are captured in their simplest form.
+
+This space is dedicated to the beauty of typography, the power of whitespace, and the enduring nature of written words, even as they exist briefly in the digital realm.
+
+### Recent Thoughts
+
+- *The Art of Stillness*: Finding calm amidst the noise.
+- *Shadows and Light*: A study in contrast.
+- *On Impermanence*: Why the fleeting moments matter most.
+
+> "To write is to carve a new path through the terrain of the imagination."
+
+Feel free to wander. The words will remain.

--- a/ephemeral-ink/content/posts/_index.md
+++ b/ephemeral-ink/content/posts/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Essays & Musings"
+sort_by = "date"
+reverse = true
+paginate = 5
+template = "section"
+generate_feeds = true
++++

--- a/ephemeral-ink/content/posts/art-of-stillness.md
+++ b/ephemeral-ink/content/posts/art-of-stillness.md
@@ -1,0 +1,16 @@
++++
+title = "The Art of Stillness"
+date = "2024-04-15"
+description = "Finding calm amidst the noise."
+tags = ["reflection", "minimalism"]
++++
+
+We are surrounded by constant motion. The endless scroll, the incessant notifications, the feeling that we are always behind on something.
+
+In the midst of this, stillness becomes a radical act. To sit quietly in a room, without a screen, without a task, is to confront oneself directly.
+
+It is uncomfortable at first. The mind resists. But eventually, the dust settles.
+
+> The quieter you become, the more you can hear.
+
+This space is an attempt to cultivate that stillness digitally. No pop-ups, no infinite feeds. Just words on a page, waiting to be read at your own pace.

--- a/ephemeral-ink/content/posts/shadows-and-light.md
+++ b/ephemeral-ink/content/posts/shadows-and-light.md
@@ -1,0 +1,14 @@
++++
+title = "Shadows and Light"
+date = "2024-03-22"
+description = "A study in contrast."
+tags = ["design", "observation"]
++++
+
+Design is as much about what you leave out as what you include.
+
+In typography, the space between the letters (the kerning and tracking) is just as vital as the letterforms themselves. Without the emptiness, there is no form. Without the silence, there is no music.
+
+This principle applies everywhere. The shadows define the light. The breaks in conversation give meaning to the words spoken.
+
+When we strip away the superfluous, we are left with the essential. And the essential is usually enough.

--- a/ephemeral-ink/templates/404.html
+++ b/ephemeral-ink/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<div style="text-align: center; padding: 4rem 0;">
+  <h1 style="font-size: 4rem; margin-bottom: 0;">404</h1>
+  <p style="font-family: var(--font-sans); letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 2rem;">Page Not Found</p>
+  <p>The page you are looking for has faded into the ether.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; font-family: var(--font-sans); letter-spacing: 0.05em; text-transform: uppercase; font-size: 0.85rem;">Return Home</a>
+</div>
+
+{% include "footer.html" %}

--- a/ephemeral-ink/templates/footer.html
+++ b/ephemeral-ink/templates/footer.html
@@ -1,0 +1,20 @@
+    </main>
+    <footer>
+      <p>&copy; {{ current_year }} {{ site.title | e }}. Elegance in simplicity.</p>
+    </footer>
+  </div>
+  <style>
+    footer {
+      margin-top: 4rem;
+      padding: 3rem 0;
+      border-top: 1px solid var(--border);
+      text-align: center;
+      font-family: var(--font-sans);
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      letter-spacing: 0.05em;
+    }
+  </style>
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/ephemeral-ink/templates/header.html
+++ b/ephemeral-ink/templates/header.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #faf9f7;
+      --text: #2a2a2a;
+      --text-muted: #6b6b6b;
+      --border: #e8e4dc;
+      --accent: #111111;
+      --link: #3a3a3a;
+      --font-serif: 'Playfair Display', serif;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: var(--font-serif);
+      background-color: var(--bg);
+      color: var(--text);
+      line-height: 1.8;
+      font-size: 1.1rem;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    /* Layout */
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    header {
+      padding: 4rem 0 3rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 3rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    .site-title {
+      font-family: var(--font-sans);
+      font-weight: 300;
+      font-size: 1.2rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      text-decoration: none;
+      color: var(--accent);
+    }
+
+    nav {
+      font-family: var(--font-sans);
+      font-size: 0.9rem;
+      letter-spacing: 0.05em;
+    }
+
+    nav a {
+      margin-left: 2rem;
+      color: var(--text-muted);
+      text-decoration: none;
+      transition: color 0.3s ease;
+    }
+
+    nav a:hover {
+      color: var(--accent);
+    }
+
+    main {
+      min-height: 60vh;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      font-weight: 600;
+      color: var(--accent);
+      line-height: 1.3;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+    }
+
+    h1 { font-size: 2.5rem; font-style: italic; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.4rem; }
+
+    p {
+      margin-bottom: 1.5rem;
+      color: var(--text);
+    }
+
+    a {
+      color: var(--link);
+      text-decoration-color: var(--border);
+      text-decoration-thickness: 1px;
+      text-underline-offset: 4px;
+      transition: all 0.3s ease;
+    }
+
+    a:hover {
+      color: var(--accent);
+      text-decoration-color: var(--accent);
+    }
+
+    hr {
+      border: 0;
+      height: 1px;
+      background: var(--border);
+      margin: 3rem 0;
+    }
+
+    blockquote {
+      margin: 2rem 0;
+      padding-left: 1.5rem;
+      border-left: 2px solid var(--accent);
+      font-style: italic;
+      color: var(--text-muted);
+    }
+
+    /* Lists */
+    ul, ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    /* Posts List */
+    .post-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    .post-item {
+      margin-bottom: 2.5rem;
+    }
+
+    .post-item a {
+      text-decoration: none;
+    }
+
+    .post-title {
+      font-size: 1.5rem;
+      margin: 0 0 0.5rem 0;
+      font-weight: 600;
+    }
+
+    .post-meta {
+      font-family: var(--font-sans);
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    .post-summary {
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      header {
+        flex-direction: column;
+        gap: 1.5rem;
+        padding: 3rem 0 2rem;
+      }
+      nav a {
+        margin-left: 0;
+        margin-right: 1.5rem;
+      }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body>
+  <div class="container">
+    <header>
+      <a href="{{ base_url }}/" class="site-title">{{ site.title | e }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+    <main>

--- a/ephemeral-ink/templates/page.html
+++ b/ephemeral-ink/templates/page.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+
+<article class="page">
+  <header class="page-header">
+    <h1>{{ page.title | e }}</h1>
+    {% if page.date %}
+      <div class="post-meta">{{ page.date | date("%B %d, %Y") }}</div>
+    {% endif %}
+  </header>
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+</article>
+
+{% include "footer.html" %}

--- a/ephemeral-ink/templates/section.html
+++ b/ephemeral-ink/templates/section.html
@@ -1,0 +1,24 @@
+{% include "header.html" %}
+
+<div class="section-header">
+  <h1>{{ section.title | e }}</h1>
+  {% if section.description %}
+    <p class="section-description">{{ section.description | e }}</p>
+  {% endif %}
+</div>
+
+<ul class="post-list">
+  {% for page in section.pages %}
+    <li class="post-item">
+      <div class="post-meta">{{ page.date | date("%B %d, %Y") }}</div>
+      <h2 class="post-title"><a href="{{ page.url }}">{{ page.title | e }}</a></h2>
+      {% if page.summary %}
+        <p class="post-summary">{{ page.summary | strip_html | truncate_words(30) | e }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+
+{{ pagination | safe }}
+
+{% include "footer.html" %}

--- a/ephemeral-ink/templates/shortcodes/alert.html
+++ b/ephemeral-ink/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/ephemeral-ink/templates/taxonomy.html
+++ b/ephemeral-ink/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+
+<h1>{{ taxonomy_name | capitalize | e }}</h1>
+
+<ul class="post-list" style="margin-top: 2rem;">
+  {% for term in taxonomy_terms %}
+    <li class="post-item" style="margin-bottom: 1rem;">
+      <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term | slugify }}/" style="font-size: 1.2rem;">{{ term | e }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/ephemeral-ink/templates/taxonomy_term.html
+++ b/ephemeral-ink/templates/taxonomy_term.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<div class="section-header">
+  <div class="post-meta">{{ taxonomy_name | capitalize | e }}</div>
+  <h1 style="margin-top: 0.5rem;">{{ taxonomy_term | e }}</h1>
+</div>
+
+<ul class="post-list" style="margin-top: 3rem;">
+  {% for page in taxonomy_pages %}
+    <li class="post-item">
+      <div class="post-meta">{{ page.date | date("%B %d, %Y") }}</div>
+      <h2 class="post-title"><a href="{{ page.url }}">{{ page.title | e }}</a></h2>
+      {% if page.summary %}
+        <p class="post-summary">{{ page.summary | strip_html | truncate_words(30) | e }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1465,6 +1465,12 @@
     "experimental",
     "asymmetric"
   ],
+  "ephemeral-ink": [
+    "minimal",
+    "editorial",
+    "blog",
+    "elegant"
+  ],
   "errata-sheet": [
     "paper",
     "light",


### PR DESCRIPTION
Created a new example site named `ephemeral-ink`. The site features an elegant, minimalist design focused on typography and whitespace, adhering to the user's request for a subtle aesthetic without emojis or gradients. The templates were rewritten to use 'Playfair Display' for serif headings and 'Inter' for sans-serif UI elements. Appropriate sample content and configurations were added, and `tags.json` was updated.

---
*PR created automatically by Jules for task [117033155915380515](https://jules.google.com/task/117033155915380515) started by @chei-l*