### PR TITLE
feat: add new elegant dark landing page example 'apolloo'

### DIFF
--- a/apolloo/AGENTS.md
+++ b/apolloo/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/apolloo/config.toml
+++ b/apolloo/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/apolloo/content/about.md
+++ b/apolloo/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/apolloo/content/index.md
+++ b/apolloo/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Apolloo"
+tags = ["elegant", "dark", "landing"]
++++
+
+# Apolloo
+
+The cosmos within reach. Explore the darkest corners of space with minimal friction.
+
+## Features
+
+- **Dark Mode First**: Hand-crafted dark theme with carefully selected #0f0f11 and subtle contrasting grays.
+- **Refined Typography**: Focused on readability, utilizing "Inter" and precise letter-spacing.
+- **Minimal Interference**: Zero bloat layout to present your landing page effortlessly.
+
+[Get Started](/about/)

--- a/apolloo/templates/404.html
+++ b/apolloo/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/apolloo/templates/footer.html
+++ b/apolloo/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>Powered by Hwaro</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/apolloo/templates/header.html
+++ b/apolloo/templates/header.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <style>
+    :root {
+      --primary: #e2e8f0;
+      --text: #e2e8f0;
+      --text-muted: #a1a1aa;
+      --border: #27272a;
+      --bg: #0f0f11;
+      --bg-subtle: #18181b;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.7; margin: 0; color: var(--text); background: var(--bg); font-weight: 300; }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 2rem; }
+    .site-header { display: flex; align-items: center; justify-content: space-between; padding: 3rem 0; border-bottom: 1px solid var(--border); margin-bottom: 4rem; }
+    .site-logo { font-weight: 500; font-size: 1.25rem; color: var(--text); text-decoration: none; letter-spacing: 0.05em; text-transform: uppercase; }
+    .site-logo:hover { opacity: 0.8; }
+    .site-header nav { display: flex; gap: 2rem; }
+    .site-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.95rem; text-transform: lowercase; letter-spacing: 0.05em; border-bottom: 1px solid transparent; padding-bottom: 2px; transition: all 0.3s ease; }
+    .site-header nav a:hover { color: var(--primary); border-bottom-color: var(--primary); }
+    .site-main { min-height: calc(100vh - 250px); }
+    .site-footer { margin-top: 5rem; padding: 2rem 0; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.85rem; text-align: center; letter-spacing: 0.02em; }
+
+    /* Typography */
+    h1, h2, h3 { line-height: 1.2; margin-top: 2em; margin-bottom: 0.75em; font-weight: 400; letter-spacing: -0.02em; }
+    h1 { font-size: 2.5rem; margin-top: 0; color: #ffffff; }
+    h2 { font-size: 1.75rem; color: #f8fafc; }
+    h3 { font-size: 1.25rem; }
+    p { margin: 1.5em 0; color: var(--text-muted); font-size: 1.05rem; }
+    a { color: var(--primary); text-decoration: none; border-bottom: 1px solid rgba(226, 232, 240, 0.3); transition: border-color 0.2s ease; }
+    a:hover { border-bottom-color: var(--primary); text-decoration: none; }
+    code { background: var(--bg-subtle); padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; border: 1px solid var(--border); }
+    pre { background: var(--bg-subtle); padding: 1.5rem; border-radius: 8px; overflow-x: auto; border: 1px solid var(--border); box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
+    pre code { background: none; padding: 0; border: none; }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; display: grid; gap: 1rem; }
+    ul.section-list li { padding: 1.25rem; background: var(--bg-subtle); border-radius: 8px; border: 1px solid var(--border); transition: transform 0.2s ease, border-color 0.2s ease; }
+    ul.section-list li:hover { transform: translateY(-2px); border-color: rgba(226, 232, 240, 0.2); }
+    ul.section-list li a { font-weight: 400; border-bottom: none; font-size: 1.1rem; }
+    ul.section-list li a:hover { color: #ffffff; }
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 2rem; font-size: 1.1rem; }
+    nav.pagination { margin: 3rem 0; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; justify-content: center; }
+    nav.pagination a { display: inline-block; padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); text-decoration: none; transition: all 0.2s ease; }
+    nav.pagination a:hover { color: var(--bg); background-color: var(--primary); border-color: var(--primary); }
+    .pagination-current span { display: inline-block; padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--primary); background: transparent; color: var(--primary); }
+    .pagination-disabled span { display: inline-block; padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border); color: var(--border); cursor: not-allowed; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1.5rem; align-items: center; padding: 2rem 0; }
+      .site-wrapper { padding: 0 1.5rem; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+            <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/apolloo/templates/page.html
+++ b/apolloo/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/apolloo/templates/section.html
+++ b/apolloo/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+    <ul class="section-list">
+      {{ section.list | safe }}
+    </ul>
+    {{ pagination | safe }}
+  </main>
+{% include "footer.html" %}

--- a/apolloo/templates/shortcodes/alert.html
+++ b/apolloo/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/apolloo/templates/taxonomy.html
+++ b/apolloo/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/apolloo/templates/taxonomy_term.html
+++ b/apolloo/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content | safe }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -40,12 +40,6 @@
     "admin",
     "sidebar"
   ],
-  "aetherial-echoes": [
-    "elegant",
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
   "aether": [
     "dark",
     "blog",
@@ -55,6 +49,12 @@
     "dark-mode",
     "elegant",
     "portfolio"
+  ],
+  "aetherial-echoes": [
+    "elegant",
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "after-dark": [
     "blog",
@@ -163,6 +163,12 @@
     "docs",
     "api",
     "two-column"
+  ],
+  "apolloo": [
+    "elegant",
+    "dark",
+    "minimal",
+    "landing"
   ],
   "apolo": [
     "elegant",
@@ -3635,17 +3641,17 @@
     "bold",
     "minimal"
   ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
   "quire-fold": [
     "book",
     "light",
     "craft",
     "structure",
     "traditional"
-  ],
-  "quill": [
-    "light",
-    "blog",
-    "fiction"
   ],
   "radiolaria": [
     "dark",


### PR DESCRIPTION
This PR creates a new minimal and elegant dark landing page example for Hwaro named `apolloo`. It registers the example correctly with `tags.json` and implements a clean typography and dark styling format using standard framework components without complex bloat.

---
*PR created automatically by Jules for task [12812977959666507470](https://jules.google.com/task/12812977959666507470) started by @chei-l*