### PR TITLE
Add lucid-glass example site

### DIFF
--- a/lucid-glass/AGENTS.md
+++ b/lucid-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/lucid-glass/config.toml
+++ b/lucid-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lucid Glass"
+description = "An elegant glassmorphism portfolio."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/lucid-glass/content/about.md
+++ b/lucid-glass/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About"
+description = "A brief introduction."
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+We believe in the power of simplicity and elegance. Our goal is to provide a platform that allows creators to showcase their work without distractions.
+
+> "Simplicity is the ultimate sophistication." — Leonardo da Vinci
+
+This theme was built with attention to detail, ensuring that every element serves a purpose. The subtle glassmorphism effects create a sense of depth and modernity while maintaining a clean, uncluttered interface.
+
+### Our Values
+
+1. **Elegance**: Design should be beautiful but unobtrusive.
+2. **Performance**: Speed and efficiency are paramount.
+3. **Clarity**: Content must always remain the central focus.

--- a/lucid-glass/content/index.md
+++ b/lucid-glass/content/index.md
@@ -1,0 +1,15 @@
++++
+title = "Lucid Glass"
+description = "A sophisticated space showcasing creative endeavors."
++++
+
+Welcome to a minimal, elegant portfolio theme built with Hwaro. The design focuses on subtle glassmorphism effects, clean typography, and a refined aesthetic to make your content shine.
+
+## Features
+
+- **Glassmorphism UI**: Beautiful, subtle blur effects and translucent backgrounds.
+- **Responsive Design**: Looks great on desktop, tablet, and mobile devices.
+- **Typography Focus**: Clean, legible fonts that prioritize content readability.
+- **Lightweight**: Fast loading times with minimal CSS and no heavy JavaScript dependencies.
+
+Feel free to explore the [About](/about/) page for more information.

--- a/lucid-glass/templates/404.html
+++ b/lucid-glass/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div style="text-align: center; padding: 4rem 0;">
+    <h1 style="font-size: 5rem; margin-bottom: 0; color: var(--accent);">404</h1>
+    <h2 style="margin-top: 0; font-weight: 300;">Page Not Found</h2>
+    <p style="color: var(--text-muted); margin-bottom: 2rem;">The page you are looking for has been moved or no longer exists.</p>
+    <a href="{{ base_url | default('/') }}" style="display: inline-block; padding: 0.75rem 1.5rem; background: var(--glass-bg); border: 1px solid var(--glass-border); border-radius: 8px; font-weight: 500;">
+      &larr; Return to Home
+    </a>
+  </div>
+{% endblock %}

--- a/lucid-glass/templates/base.html
+++ b/lucid-glass/templates/base.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default('en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | default('') | e }}">
+  <title>{% if page.title is defined and page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --glass-bg: rgba(255, 255, 255, 0.6);
+      --glass-border: rgba(255, 255, 255, 0.4);
+      --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.05);
+      --text-main: #2c3e50;
+      --text-muted: #7f8c8d;
+      --accent: #3498db;
+      --accent-hover: #2980b9;
+      --bg-color: #f0f4f8;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--text-main);
+      background-color: var(--bg-color);
+      /* A very subtle, elegant background */
+      background-image: radial-gradient(circle at 15% 50%, rgba(220, 230, 240, 0.5), transparent 25%),
+                        radial-gradient(circle at 85% 30%, rgba(210, 220, 230, 0.5), transparent 25%);
+      background-attachment: fixed;
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: var(--accent);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    a:hover {
+      color: var(--accent-hover);
+    }
+
+    /* Glassmorphism Container */
+    .glass-container {
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      border-radius: 16px;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 0 1.5rem;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    .site-header {
+      padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .site-logo {
+      font-size: 1.5rem;
+      font-weight: 300;
+      letter-spacing: 1px;
+      color: var(--text-main);
+    }
+
+    .site-logo strong {
+      font-weight: 600;
+    }
+
+    .site-nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-nav a {
+      color: var(--text-main);
+      font-weight: 500;
+      position: relative;
+    }
+
+    .site-nav a::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 2px;
+      bottom: -4px;
+      left: 0;
+      background-color: var(--accent);
+      transition: width 0.3s ease;
+    }
+
+    .site-nav a:hover::after {
+      width: 100%;
+    }
+
+    .site-main {
+      padding: 2.5rem;
+      flex: 1;
+      margin-bottom: 2rem;
+    }
+
+    .site-footer {
+      padding: 1.5rem;
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      margin-top: auto;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      font-weight: 400;
+      margin-bottom: 1rem;
+      color: var(--text-main);
+    }
+
+    h1 { font-size: 2.5rem; letter-spacing: -0.5px; }
+    h2 { font-size: 1.8rem; margin-top: 2rem; }
+
+    p { margin-bottom: 1.2rem; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header {
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.5rem;
+      }
+      .site-main {
+        padding: 1.5rem;
+      }
+      .site-wrapper {
+        margin: 1rem auto;
+      }
+    }
+  </style>
+  {% if highlight_css is defined %}{{ highlight_css | safe }}{% endif %}
+  {% if auto_includes_css is defined %}{{ auto_includes_css | safe }}{% endif %}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header glass-container">
+      <a href="{{ base_url | default('/') }}" class="site-logo">
+        <strong>Lucid</strong>Glass
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url | default('/') }}/">Home</a>
+        <a href="{{ base_url | default('/') }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main glass-container">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer glass-container">
+      <p>&copy; {{ current_year | default('2025') }} {{ site.title | e }}. Powered by Hwaro.</p>
+    </footer>
+  </div>
+
+  {% if highlight_js is defined %}{{ highlight_js | safe }}{% endif %}
+  {% if auto_includes_js is defined %}{{ auto_includes_js | safe }}{% endif %}
+</body>
+</html>

--- a/lucid-glass/templates/index.html
+++ b/lucid-glass/templates/index.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero" style="text-align: center; margin-bottom: 3rem;">
+  <h1 style="font-size: 3rem; margin-bottom: 0.5rem;">{{ page.title | e }}</h1>
+  <p style="font-size: 1.2rem; color: var(--text-muted); max-width: 600px; margin: 0 auto;">
+    A sophisticated space showcasing creative endeavors.
+  </p>
+</div>
+
+<div class="page-content">
+  {{ content | safe }}
+</div>
+
+{% if site.pages and site.pages | length > 0 %}
+<div class="portfolio-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 3rem;">
+  {% for p in site.pages %}
+    {% if p.url != page.url %}
+    <div class="portfolio-card glass-container" style="padding: 1.5rem; transition: transform 0.3s ease;">
+      <h3 style="margin-top: 0;"><a href="{{ p.url }}" style="color: inherit;">{{ p.title | e }}</a></h3>
+      {% if p.description %}
+      <p style="font-size: 0.95rem; color: var(--text-muted);">{{ p.description | e }}</p>
+      {% endif %}
+      <a href="{{ p.url }}" style="font-size: 0.9rem; font-weight: 500;">View Details &rarr;</a>
+    </div>
+    {% endif %}
+  {% endfor %}
+</div>
+{% endif %}
+
+<style>
+  .portfolio-card:hover {
+    transform: translateY(-5px);
+  }
+</style>
+{% endblock %}

--- a/lucid-glass/templates/page.html
+++ b/lucid-glass/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <article class="page-content">
+    {% if page.title is defined and page.title %}
+      <h1 style="border-bottom: 1px solid var(--glass-border); padding-bottom: 1rem; margin-bottom: 2rem;">{{ page.title | e }}</h1>
+    {% endif %}
+    {{ content | safe }}
+  </article>
+{% endblock %}

--- a/lucid-glass/templates/section.html
+++ b/lucid-glass/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <header style="margin-bottom: 2.5rem; text-align: center;">
+    <h1 style="margin-bottom: 0.5rem;">{{ page.title | e }}</h1>
+    {% if page.description is defined and page.description %}
+      <p style="color: var(--text-muted); font-size: 1.1rem;">{{ page.description | e }}</p>
+    {% endif %}
+  </header>
+
+  <div class="section-content" style="margin-bottom: 2.5rem;">
+    {{ content | safe }}
+  </div>
+
+  {% if section.list is defined %}
+    <div class="section-list-wrapper" style="margin-bottom: 2rem;">
+      {{ section.list | safe }}
+    </div>
+  {% endif %}
+
+  {% if pagination is defined %}
+    <div class="pagination-wrapper" style="display: flex; justify-content: center; margin-top: 3rem;">
+      {{ pagination | safe }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/lucid-glass/templates/shortcodes/alert.html
+++ b/lucid-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/lucid-glass/templates/taxonomy.html
+++ b/lucid-glass/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <header style="margin-bottom: 2.5rem; text-align: center;">
+    <h1 style="margin-bottom: 0.5rem;">{{ page.title | default('Taxonomy') | e }}</h1>
+    <p style="color: var(--text-muted); font-size: 1.1rem;">Browse all terms in this taxonomy</p>
+  </header>
+
+  <div class="taxonomy-content glass-container" style="padding: 2rem; background: rgba(255, 255, 255, 0.4);">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/lucid-glass/templates/taxonomy_term.html
+++ b/lucid-glass/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <header style="margin-bottom: 2.5rem; text-align: center;">
+    <h1 style="margin-bottom: 0.5rem;">{{ page.title | default('Term') | e }}</h1>
+    <p style="color: var(--text-muted); font-size: 1.1rem;">Posts tagged with this term</p>
+  </header>
+
+  <div class="taxonomy-term-content glass-container" style="padding: 2rem; background: rgba(255, 255, 255, 0.4);">
+    {{ content | safe }}
+  </div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2503,6 +2503,12 @@
     "minimal",
     "dark"
   ],
+  "lucid-glass": [
+    "elegant",
+    "glassmorphism",
+    "minimal",
+    "portfolio"
+  ],
   "lumiere": [
     "dark",
     "elegant",


### PR DESCRIPTION
This PR adds a new Hwaro example site named `lucid-glass`. It features an elegant "glassmorphism" aesthetic with semi-transparent frosted glass elements, clean typography, and a subtle soft background.

**Changes:**
- Generated basic scaffold under `lucid-glass/`.
- Refactored basic `header.html`/`footer.html` scaffold into a unified `base.html` using template inheritance.
- Implemented elegant CSS styling inside `base.html`.
- Updated configuration and sample content (`index.md`, `about.md`) to reflect the portfolio theme.
- Registered the example in `tags.json` with appropriate descriptors.
- Frontend rendering verified via Playwright.

---
*PR created automatically by Jules for task [15736160025080644647](https://jules.google.com/task/15736160025080644647) started by @chei-l*