### PR TITLE
feat: add serenata example site

### DIFF
--- a/serenata/AGENTS.md
+++ b/serenata/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/serenata/config.toml
+++ b/serenata/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Serenata"
+description = "An elegant, minimalistic portfolio and landing page theme for Hwaro."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/serenata/content/about.md
+++ b/serenata/content/about.md
@@ -1,0 +1,20 @@
++++
+title = "About"
+description = "A brief introduction."
++++
+
+I am a digital designer and developer focused on creating clean, elegant, and minimal web experiences. My work revolves around typography, space, and subtle interactions that enhance rather than distract.
+
+### Philosophy
+
+I believe that design should be invisible. When an interface is well-crafted, the user doesn't notice the design; they only experience the content.
+
+> "Simplicity is the ultimate sophistication." — Leonardo da Vinci
+
+### Contact
+
+If you'd like to collaborate on a project or simply say hello, feel free to reach out.
+
+- Email: [hello@example.com](mailto:hello@example.com)
+- Twitter: [@example](https://twitter.com/example)
+- GitHub: [example](https://github.com/example)

--- a/serenata/content/index.md
+++ b/serenata/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Selected Works"
+description = "A curation of recent design projects and artistic explorations."
++++

--- a/serenata/content/work/_index.md
+++ b/serenata/content/work/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Work"
+sort_by = "weight"
+transparent = false
++++

--- a/serenata/content/work/elysium.md
+++ b/serenata/content/work/elysium.md
@@ -1,0 +1,11 @@
++++
+title = "Elysium App"
+date = "2023-11-02"
+description = "UI/UX design for a mindfulness and meditation application."
+weight = 2
+tags = ["app", "ui"]
++++
+
+Elysium is a mobile application designed to help users find moments of peace throughout their day. The interface relies heavily on muted color palettes, soft transitions, and intuitive gestures.
+
+The challenge was to create an interface that felt completely frictionless, ensuring the user could begin their meditation practice within seconds of opening the app.

--- a/serenata/content/work/lumina.md
+++ b/serenata/content/work/lumina.md
@@ -1,0 +1,11 @@
++++
+title = "Lumina Redesign"
+date = "2024-01-15"
+description = "A complete brand and web redesign for a boutique architecture firm."
+weight = 1
+tags = ["branding", "web"]
++++
+
+The Lumina project involved a complete overhaul of their visual identity and digital presence. The goal was to reflect the firm's focus on natural light and minimalist spaces.
+
+We developed a new logo, typography system, and a bespoke portfolio website that allows their work to speak for itself without unnecessary embellishments.

--- a/serenata/content/work/type-specimen.md
+++ b/serenata/content/work/type-specimen.md
@@ -1,0 +1,11 @@
++++
+title = "Type Specimen: Inter"
+date = "2023-08-20"
+description = "An interactive exploration of the Inter typeface family."
+weight = 3
+tags = ["typography", "web"]
++++
+
+This project is a love letter to the Inter typeface, designed by Rasmus Andersson. It serves as an interactive specimen, showcasing the font's versatility across different weights, sizes, and contexts.
+
+The site is built with a focus on fluid typography and precise grid alignments, ensuring the text remains perfectly legible across all devices.

--- a/serenata/templates/404.html
+++ b/serenata/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-page" style="text-align: center; padding: 5rem 0;">
+  <h1 style="font-size: 4rem; margin-bottom: 1rem;">404</h1>
+  <p class="hero-subtitle" style="margin: 0 auto 2rem auto;">The page you are looking for does not exist or has been moved.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 4px; text-decoration: none;">Return Home</a>
+</div>
+{% endblock %}

--- a/serenata/templates/base.html
+++ b/serenata/templates/base.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #2a2a2a;
+      --text: #333333;
+      --text-muted: #777777;
+      --border: #eaeaea;
+      --bg: #fafafa;
+      --bg-alt: #ffffff;
+      --font-serif: 'Playfair Display', serif;
+      --font-sans: 'Inter', -apple-system, sans-serif;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --primary: #e0e0e0;
+        --text: #d4d4d4;
+        --text-muted: #999999;
+        --border: #333333;
+        --bg: #121212;
+        --bg-alt: #1a1a1a;
+      }
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: var(--font-sans);
+      line-height: 1.7;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 3rem 0;
+    }
+
+    .site-logo {
+      font-family: var(--font-serif);
+      font-weight: 600;
+      font-size: 1.5rem;
+      color: var(--primary);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+    }
+
+    .site-header nav {
+      display: flex;
+      gap: 2rem;
+    }
+
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 400;
+      transition: color 0.3s ease;
+    }
+
+    .site-header nav a:hover {
+      color: var(--primary);
+    }
+
+    .site-main {
+      flex: 1;
+      padding: 2rem 0;
+      animation: fadeIn 0.8s ease-out forwards;
+    }
+
+    .site-footer {
+      padding: 3rem 0;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+      border-top: 1px solid var(--border);
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-serif);
+      color: var(--primary);
+      line-height: 1.3;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      font-weight: 400;
+    }
+
+    h1 { font-size: 2.5rem; margin-top: 0; letter-spacing: -0.02em; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.4rem; }
+
+    p {
+      margin: 0 0 1.5rem 0;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+      border-bottom: 1px solid var(--border);
+      transition: border-color 0.3s ease;
+    }
+
+    a:hover {
+      border-bottom-color: var(--primary);
+    }
+
+    /* Code and Pre */
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.85em;
+      background: var(--bg-alt);
+      padding: 0.2em 0.4em;
+      border-radius: 3px;
+    }
+
+    pre {
+      background: var(--bg-alt);
+      padding: 1.5rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
+
+    pre code {
+      background: transparent;
+      padding: 0;
+      border: none;
+    }
+
+    /* Lists */
+    ul, ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    /* Blockquote */
+    blockquote {
+      margin: 2rem 0;
+      padding: 1rem 1.5rem;
+      border-left: 2px solid var(--primary);
+      background: var(--bg-alt);
+      font-style: italic;
+      color: var(--text-muted);
+    }
+
+    /* Hero / Intro specific styles */
+    .hero {
+      margin-bottom: 4rem;
+    }
+
+    .hero-subtitle {
+      font-size: 1.2rem;
+      color: var(--text-muted);
+      max-width: 600px;
+      line-height: 1.6;
+    }
+
+    /* Animations */
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      .site-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.5rem;
+      }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Work</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} Serenata. Powered by Hwaro.</p>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/serenata/templates/index.html
+++ b/serenata/templates/index.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="hero">
+  <h1>{{ page.title }}</h1>
+  {% if page.description %}
+    <p class="hero-subtitle">{{ page.description }}</p>
+  {% endif %}
+</div>
+
+<div class="content-body">
+  {{ content | safe }}
+</div>
+
+{% if site.pages %}
+  <div class="portfolio-grid">
+    <style>
+      .portfolio-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 2rem;
+        margin-top: 3rem;
+      }
+      .portfolio-item {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        overflow: hidden;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        background: var(--bg-alt);
+        text-decoration: none;
+        border-bottom: 1px solid var(--border);
+      }
+      .portfolio-item:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+        border-bottom: 1px solid var(--border);
+      }
+      .portfolio-image {
+        height: 200px;
+        background-color: var(--bg);
+        background-size: cover;
+        background-position: center;
+        border-bottom: 1px solid var(--border);
+      }
+      .portfolio-content {
+        padding: 1.5rem;
+      }
+      .portfolio-title {
+        font-size: 1.2rem;
+        margin: 0 0 0.5rem 0;
+        color: var(--primary);
+      }
+      .portfolio-desc {
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        margin: 0;
+        font-family: var(--font-sans);
+      }
+    </style>
+    {% for item in site.pages %}{% if item.section == "work" %}
+      <a href="{{ item.url }}" class="portfolio-item">
+        {% if item.image %}
+          <div class="portfolio-image" style="background-image: url('{{ item.image }}')"></div>
+        {% else %}
+          <div class="portfolio-image" style="background: linear-gradient(135deg, var(--bg-alt) 0%, var(--border) 100%);"></div>
+        {% endif %}
+        <div class="portfolio-content">
+          <h3 class="portfolio-title">{{ item.title }}</h3>
+          {% if item.description %}
+            <p class="portfolio-desc">{{ item.description }}</p>
+          {% elif item.summary %}
+            <p class="portfolio-desc">{{ item.summary | strip_html | truncate_words(15) }}</p>
+          {% endif %}
+        </div>
+      </a>
+    {% endif %}{% endfor %}
+  </div>
+{% endif %}
+{% endblock %}

--- a/serenata/templates/page.html
+++ b/serenata/templates/page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+  <header class="page-header">
+    <h1 class="page-title">{{ page.title }}</h1>
+  </header>
+
+  <div class="content-body">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/serenata/templates/section.html
+++ b/serenata/templates/section.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ section.title }}</h1>
+  {% if section.description %}
+    <p class="hero-subtitle">{{ section.description }}</p>
+  {% endif %}
+</header>
+
+<div class="section-content">
+  {{ section.list | safe }}
+</div>
+{% endblock %}

--- a/serenata/templates/shortcodes/alert.html
+++ b/serenata/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/serenata/templates/taxonomy.html
+++ b/serenata/templates/taxonomy.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ taxonomy_name | capitalize }}</h1>
+</header>
+
+<div class="taxonomy-terms">
+  <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 1rem;">
+    {% for term in taxonomy_terms %}
+      <li>
+        <a href="{{ base_url }}/{{ taxonomy_name }}/{{ term | slugify }}/" style="display: inline-block; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 4px; text-decoration: none;">
+          {{ term }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/serenata/templates/taxonomy_term.html
+++ b/serenata/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ taxonomy_term }}</h1>
+  <p class="hero-subtitle">Pages tagged with "{{ taxonomy_term }}" in {{ taxonomy_name }}</p>
+</header>
+
+<div class="taxonomy-pages">
+  <ul style="list-style: none; padding: 0;">
+    {% for p in taxonomy_pages %}
+      <li style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border);">
+        <h3 style="margin: 0 0 0.5rem 0;"><a href="{{ p.url }}" style="border: none;">{{ p.title }}</a></h3>
+        {% if p.description %}
+          <p style="margin: 0; color: var(--text-muted); font-size: 0.9rem;">{{ p.description }}</p>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -3995,6 +3995,13 @@
     "docs",
     "metrics"
   ],
+  "serenata": [
+    "elegant",
+    "minimal",
+    "portfolio",
+    "light",
+    "dark"
+  ],
   "sfumato": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR introduces a new example template for Hwaro named **Serenata**.

Serenata is an elegant, minimalistic portfolio and landing page theme. It focuses on clean typography (using Playfair Display and Inter) and spacious layouts.

### Changes Included:
- **Project Structure**: Initialized with `hwaro init serenata`.
- **Configuration**: Updated `config.toml` with the appropriate title, description, and base URL settings.
- **Templates**: Replaced default headers/footers with a `base.html` inheritance structure. Implemented responsive, elegant designs for `index.html`, `page.html`, `section.html`, `taxonomy.html`, `taxonomy_term.html`, and `404.html`.
- **Content**: Added sample projects in a `work/` section and an `about.md` page to demonstrate the layout.
- **Tags**: Registered the site in `tags.json` alphabetically.

Verified using Playwright and standard `hwaro build`/`serve` commands. No linting or build errors.

---
*PR created automatically by Jules for task [2543653441570795162](https://jules.google.com/task/2543653441570795162) started by @chei-l*