### PR TITLE
Add new example: intermission (#1511)

### DIFF
--- a/intermission/AGENTS.md
+++ b/intermission/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/intermission/config.toml
+++ b/intermission/config.toml
@@ -1,0 +1,35 @@
+# Intermission Configuration
+title = "Intermission"
+description = "Between Acts: A refined theater festival theme with elegant pause motifs."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[og.auto_image]
+enabled = true
+background = "#2E1A47"
+text_color = "#E0C9A6"
+accent_color = "#E0C9A6"
+font_size = 48
+show_title = true
+style = "minimal"
+format = "svg"
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/intermission/content/about.md
+++ b/intermission/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "The Stage"
+description = "Refined atmosphere and transitional moments."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="program-listing" style="text-align: center; border: none;">
+  <h2 class="show-title">The Grand Lyric</h2>
+  <p>Our theater is a space for quiet reflection and intense performance. We invite you to embrace the transitional moments — the intermissions where the story continues in the minds of the audience.</p>
+</div>
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-top: 2rem;">
+  <div style="border: 1px solid var(--gold); padding: 1.5rem;">
+    <h3 class="day-label" style="font-size: 14px; margin-bottom: 0.5rem;">The Foyer</h3>
+    <p style="font-size: 14px;">Serving artisan refreshments during all intermissions. Please return to your seat when the bell tolls.</p>
+  </div>
+  <div style="border: 1px solid var(--gold); padding: 1.5rem;">
+    <h3 class="day-label" style="font-size: 14px; margin-bottom: 0.5rem;">The Gallery</h3>
+    <p style="font-size: 14px;">Featuring original costume sketches and program notes from the 1926 inaugural season.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/intermission/content/index.md
+++ b/intermission/content/index.md
@@ -1,0 +1,62 @@
++++
+title = "The Program"
+description = "A multi-day theater festival schedule."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="program-listing">
+  <div class="show-time">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 2v10l4.5 4.5"/>
+      <circle cx="12" cy="12" r="10"/>
+    </svg>
+    18:30 — 20:15
+  </div>
+  <h2 class="show-title">The Glass Menagerie</h2>
+  <p>A refined production of Tennessee Williams' classic, exploring memory and fragility in a changing world.</p>
+  <div class="intermission-tag">
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor">
+      <rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>
+    </svg>
+    INTERMISSION: 15 MINUTES
+  </div>
+</div>
+
+<div class="hourglass-svg">
+  <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="1.5">
+    <path d="M5 2h14M5 22h14M6 2v6c0 3.31 2.69 6 6 6s6-2.69 6-6V2M6 22v-6c0-3.31 2.69-6 6-6s6 2.69 6 6v6" />
+    <path d="M12 12v4M10 19h4" opacity="0.5"/>
+  </svg>
+</div>
+
+<div class="program-listing">
+  <div class="show-time">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 2v10l4.5 4.5"/>
+      <circle cx="12" cy="12" r="10"/>
+    </svg>
+    20:45 — 22:30
+  </div>
+  <h2 class="show-title">Waiting for Godot</h2>
+  <p>Samuel Beckett's masterpiece of existential uncertainty, staged in total darkness with minimal set design.</p>
+  <div class="intermission-tag">
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor">
+      <rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>
+    </svg>
+    INTERMISSION: 10 MINUTES
+  </div>
+</div>
+
+<div style="text-align: center; margin-top: 4rem;">
+  <svg width="100" height="60" viewBox="0 0 100 60" fill="none" stroke="var(--gold)" stroke-width="1">
+    <path d="M10 50 Q 50 10 90 50" />
+    <path d="M20 50 Q 50 20 80 50" />
+    <path d="M30 50 Q 50 30 70 50" />
+  </svg>
+  <p class="day-label" style="font-size: 14px;">Curtain Call at 23:00</p>
+</div>
+
+{% endblock %}

--- a/intermission/templates/404.html
+++ b/intermission/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div style="text-align: center; padding: 4rem 0;">
+  <div class="intermission-tag" style="font-size: 24px; padding: 1rem 2rem;">LOST ACT (404)</div>
+  <p style="margin-top: 2rem;">The scene you are looking for has been cut from the final production.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; border: 1px solid var(--gold); padding: 0.5rem 1rem; color: var(--gold); text-decoration: none; font-feature-settings: 'smcp';">Return to the Program</a>
+</div>
+{% endblock %}

--- a/intermission/templates/base.html
+++ b/intermission/templates/base.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@900&family=Crimson+Pro:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --burgundy: #4A0E0E;
+      --cream: #F5F5DC;
+      --gold: #D4AF37;
+      --black: #1A1A1A;
+      --white: #FFFFFF;
+    }
+    
+    *, *::before, *::after { box-sizing: border-box; }
+    
+    body {
+      margin: 0;
+      background-color: var(--burgundy);
+      color: var(--cream);
+      font-family: 'Crimson Pro', serif;
+      line-height: 1.6;
+      font-variant-numeric: oldstyle-nums;
+    }
+
+    .seat-pattern {
+      height: 20px;
+      background-image: url("data:image/svg+xml,%3Csvg width='40' height='20' viewBox='0 0 40 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 20 L5 10 L35 10 L40 20' fill='none' stroke='%23D4AF37' stroke-width='1'/%3E%3C/svg%3E");
+      background-repeat: repeat-x;
+      opacity: 0.3;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      border-left: 1px solid var(--gold);
+      border-right: 1px solid var(--gold);
+      min-height: 100vh;
+      background-color: rgba(0,0,0,0.2);
+    }
+
+    header {
+      padding: 4rem 0;
+      text-align: center;
+      border-bottom: 2px double var(--gold);
+    }
+
+    .site-title {
+      font-family: 'Merriweather', serif;
+      font-weight: 900;
+      font-size: 100px;
+      color: var(--gold);
+      margin: 0;
+      line-height: 1;
+      text-transform: uppercase;
+    }
+
+    .day-label {
+      font-feature-settings: "smcp";
+      font-size: 18px;
+      letter-spacing: 0.2em;
+      color: var(--gold);
+      display: block;
+      margin-bottom: 1rem;
+    }
+
+    nav {
+      margin-top: 2rem;
+    }
+
+    nav a {
+      color: var(--cream);
+      text-decoration: none;
+      margin: 0 1rem;
+      font-feature-settings: "smcp";
+      letter-spacing: 0.1em;
+    }
+
+    nav a:hover {
+      color: var(--gold);
+    }
+
+    main {
+      padding: 4rem 0;
+    }
+
+    .program-listing {
+      margin-bottom: 3rem;
+      padding-bottom: 2rem;
+      border-bottom: 1px solid rgba(212, 175, 55, 0.2);
+    }
+
+    .show-time {
+      font-family: 'JetBrains+Mono', monospace;
+      font-size: 13px;
+      color: var(--gold);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .show-title {
+      font-size: 28px;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .intermission-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background-color: var(--gold);
+      color: var(--burgundy);
+      padding: 0.2rem 0.6rem;
+      font-family: 'JetBrains+Mono', monospace;
+      font-size: 11px;
+      font-weight: bold;
+      margin-top: 1rem;
+    }
+
+    .hourglass-svg {
+      width: 40px;
+      height: 40px;
+      margin: 2rem auto;
+      display: block;
+    }
+
+    footer {
+      text-align: center;
+      padding: 4rem 0;
+      border-top: 2px double var(--gold);
+      font-feature-settings: "smcp";
+      font-size: 14px;
+      color: var(--gold);
+    }
+
+    @media (max-width: 768px) {
+      .site-title { font-size: 50px; }
+      .container { border: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="seat-pattern"></div>
+  <div class="container">
+    <header>
+      <span class="day-label">Summer Season 2026</span>
+      <h1 class="site-title">{{ site.title }}</h1>
+      <nav>
+        <a href="{{ base_url }}/">The Program</a>
+        <a href="{{ base_url }}/about/">The Stage</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      <p>REFRAIN FROM PHOTOGRAPHY // NO EMOJIS // NO GRADIENTS</p>
+    </footer>
+  </div>
+  <div class="seat-pattern"></div>
+</body>
+</html>

--- a/intermission/templates/page.html
+++ b/intermission/templates/page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="program-listing" style="border: none;">
+  <h1 class="show-title" style="font-size: 48px; text-align: center; margin-bottom: 2rem;">{{ page.title }}</h1>
+  <div style="font-size: 18px; max-width: 700px; margin: 0 auto;">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/intermission/templates/section.html
+++ b/intermission/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="show-title" style="font-size: 48px; text-align: center; margin-bottom: 4rem;">{{ section.title }}</h1>
+<div style="display: grid; grid-template-columns: 1fr; gap: 2rem;">
+  {% for page in section.pages %}
+  <div class="program-listing">
+    <h2 class="show-title"><a href="{{ page.permalink }}" style="color: var(--cream); text-decoration: none;">{{ page.title }}</a></h2>
+    <p>{{ page.description }}</p>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/intermission/templates/shortcodes/alert.html
+++ b/intermission/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/intermission/templates/taxonomy.html
+++ b/intermission/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/intermission/templates/taxonomy_term.html
+++ b/intermission/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -2358,6 +2358,13 @@
     "interference",
     "optical"
   ],
+  "intermission": [
+    "event",
+    "theater",
+    "festival",
+    "multi-day",
+    "elegant"
+  ],
   "inventory": [
     "light",
     "dashboard",


### PR DESCRIPTION
This PR adds a new event-style example site: **intermission**.

### Design Overview
- **Concept:** Between Acts (Theater Festival).
- **Palette:** Burgundy, Cream, and Gold.
- **Typography:** Merriweather, Crimson Pro (Oldstyle numerals), JetBrains Mono.
- **Visuals:** SVG hourglass, pause button motifs, and theater seat patterns.

### Compliance
- [x] NO emojis used.
- [x] NO CSS gradients used.
- [x] Verified with `hwaro build`.

Closes #1511