### PR TITLE
Add new example: amplify-fest (#1508)

### DIFF
--- a/amplify-fest/AGENTS.md
+++ b/amplify-fest/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/amplify-fest/config.toml
+++ b/amplify-fest/config.toml
@@ -1,0 +1,35 @@
+# Amplify Fest Configuration
+title = "Amplify Fest"
+description = "Sound Amplified: A multi-stage music festival theme with bold color blocks."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[og.auto_image]
+enabled = true
+background = "#0000FF"
+text_color = "#FFFFFF"
+accent_color = "#FFFF00"
+font_size = 48
+show_title = true
+style = "minimal"
+format = "svg"
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/amplify-fest/content/about.md
+++ b/amplify-fest/content/about.md
@@ -1,0 +1,31 @@
++++
+title = "Stages"
+description = "Festival orientation and stage layout."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="color-block" style="background-color: var(--blue);">
+  <h2 class="band-name" style="font-size: 48px; color: var(--white);">STAGE 01: THE ARRAY</h2>
+  <p style="font-family: 'Space Mono';">Primary mainstage for electronic and experimental acts. Equipped with a custom 200kW sound system.</p>
+</div>
+
+<div class="color-block" style="background-color: var(--magenta);">
+  <h2 class="band-name" style="font-size: 48px; color: var(--white);">STAGE 02: THE KINETIC</h2>
+  <p style="font-family: 'Space Mono';">Secondary stage focusing on high-energy industrial and percussive performances.</p>
+</div>
+
+<div style="display: flex; gap: 4rem; margin-top: 4rem; align-items: center;">
+  <div class="speaker-stack">
+    <div class="speaker-box"><div class="speaker-cone"></div></div>
+    <div class="speaker-box"><div class="speaker-cone"></div></div>
+    <div class="speaker-box"><div class="speaker-cone"></div></div>
+  </div>
+  <div style="font-size: 20px;">
+    <p>Both stages feature full-spectrum frequency response and zero-latency monitoring for all performers.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/amplify-fest/content/index.md
+++ b/amplify-fest/content/index.md
@@ -1,0 +1,51 @@
++++
+title = "Lineup"
+description = "Multi-stage music festival schedule."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="band-row">
+  <h2 class="band-name">Sonic Bloom</h2>
+  <div class="stage-meta">
+    STAGE 01 // 19:00<br>
+    <span style="color: var(--blue);">GENRE: ELECTRONIC</span>
+  </div>
+</div>
+
+<div class="band-row">
+  <h2 class="band-name">Iron Pulse</h2>
+  <div class="stage-meta">
+    STAGE 02 // 20:30<br>
+    <span style="color: var(--magenta);">GENRE: INDUSTRIAL</span>
+  </div>
+</div>
+
+<div class="band-row">
+  <h2 class="band-name">Static Void</h2>
+  <div class="stage-meta">
+    STAGE 01 // 22:00<br>
+    <span style="color: var(--cyan);">GENRE: NOISE</span>
+  </div>
+</div>
+
+<div style="margin-top: 6rem; display: flex; gap: 4rem; justify-content: center;">
+  <div style="text-align: center;">
+    <svg class="knob-svg" viewBox="0 0 100 100">
+      <circle cx="50" cy="50" r="45" fill="none" stroke="var(--black)" stroke-width="5" />
+      <line x1="50" y1="50" x2="50" y2="10" stroke="var(--blue)" stroke-width="10" transform="rotate(45 50 50)" />
+    </svg>
+    <p style="font-family: 'Space Mono'; font-size: 12px;">GAIN: 80%</p>
+  </div>
+  <div style="text-align: center;">
+    <svg class="knob-svg" viewBox="0 0 100 100">
+      <circle cx="50" cy="50" r="45" fill="none" stroke="var(--black)" stroke-width="5" />
+      <line x1="50" y1="50" x2="50" y2="10" stroke="var(--magenta)" stroke-width="10" transform="rotate(120 50 50)" />
+    </svg>
+    <p style="font-family: 'Space Mono'; font-size: 12px;">BASS: 100%</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/amplify-fest/templates/404.html
+++ b/amplify-fest/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div style="text-align: center; padding: 4rem 0;">
+  <h1 class="site-logo" style="font-size: 150px; color: var(--magenta);">OFF</h1>
+  <p style="font-size: 32px; font-weight: bold;">404 - STAGE NOT FOUND</p>
+  <p style="font-family: 'Space Mono';">THE FREQUENCY YOU ARE LOOKING FOR IS NOT BROADCASTING.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 4rem; background-color: var(--blue); color: var(--white); padding: 1rem 2rem; text-decoration: none; font-size: 24px; font-weight: bold;">RETURN TO LINEUP</a>
+</div>
+{% endblock %}

--- a/amplify-fest/templates/base.html
+++ b/amplify-fest/templates/base.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Righteous&family=Barlow+Condensed:wght@600&family=Space+Mono&display=swap" rel="stylesheet">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --blue: #0000FF;
+      --yellow: #FFFF00;
+      --white: #FFFFFF;
+      --black: #111111;
+      --magenta: #FF00FF;
+      --cyan: #00FFFF;
+    }
+    
+    *, *::before, *::after { box-sizing: border-box; }
+    
+    body {
+      margin: 0;
+      background-color: var(--white);
+      color: var(--black);
+      font-family: 'Barlow Condensed', sans-serif;
+      line-height: 1.1;
+      overflow-x: hidden;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    header {
+      background-color: var(--blue);
+      color: var(--white);
+      padding: 4rem 0;
+      text-align: center;
+      border-bottom: 10px solid var(--black);
+    }
+
+    .site-logo {
+      font-family: 'Righteous', cursive;
+      font-size: 180px;
+      margin: 0;
+      text-transform: uppercase;
+      line-height: 0.9;
+    }
+
+    nav {
+      margin-top: 2rem;
+      display: flex;
+      justify-content: center;
+      gap: 3rem;
+    }
+
+    nav a {
+      color: var(--white);
+      text-decoration: none;
+      font-size: 24px;
+      font-weight: bold;
+      text-transform: uppercase;
+      border-bottom: 4px solid transparent;
+    }
+
+    nav a:hover {
+      border-bottom-color: var(--yellow);
+    }
+
+    main {
+      padding: 4rem 0;
+    }
+
+    .band-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 2rem 0;
+      border-bottom: 4px solid var(--black);
+    }
+
+    .band-name {
+      font-size: 80px;
+      font-weight: 600;
+      text-transform: uppercase;
+      margin: 0;
+    }
+
+    .stage-meta {
+      font-family: 'Space Mono', monospace;
+      font-size: 14px;
+      text-align: right;
+    }
+
+    .color-block {
+      padding: 2rem;
+      color: var(--white);
+      margin-bottom: 2rem;
+    }
+
+    .knob-svg {
+      width: 60px;
+      height: 60px;
+      margin-bottom: 1rem;
+    }
+
+    .speaker-stack {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      width: 40px;
+    }
+
+    .speaker-box {
+      width: 40px;
+      height: 40px;
+      border: 3px solid var(--black);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .speaker-cone {
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--black);
+      border-radius: 50%;
+    }
+
+    .equalizer-footer {
+      display: flex;
+      align-items: flex-end;
+      gap: 4px;
+      height: 100px;
+      background-color: var(--black);
+      padding: 10px;
+    }
+
+    .eq-bar {
+      flex: 1;
+      background-color: var(--yellow);
+    }
+
+    footer {
+      background-color: var(--black);
+      color: var(--white);
+      padding: 4rem 0;
+    }
+
+    @media (max-width: 768px) {
+      .site-logo { font-size: 60px; }
+      .band-name { font-size: 40px; }
+      .band-row { flex-direction: column; align-items: flex-start; gap: 1rem; }
+      .stage-meta { text-align: left; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1 class="site-logo">{{ site.title }}</h1>
+      <nav>
+        <a href="{{ base_url }}/">Lineup</a>
+        <a href="{{ base_url }}/about/">Stages</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="container">
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
+  <footer>
+    <div class="equalizer-footer">
+      {% for i in range(30) %}
+      <div class="eq-bar" style="height: {{ [10, 30, 50, 80, 40, 90, 20, 70] | random }}%;"></div>
+      {% endfor %}
+    </div>
+    <div class="container" style="margin-top: 2rem; text-align: center;">
+      <p style="font-family: 'Space Mono'; font-size: 12px; text-transform: uppercase;">NO EMOJIS // NO GRADIENTS // AMPLIFIED CONTENT</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/amplify-fest/templates/page.html
+++ b/amplify-fest/templates/page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<article>
+  <h1 class="band-name" style="font-size: 100px; color: var(--blue);">{{ page.title }}</h1>
+  <div style="font-size: 24px; margin-top: 4rem;">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/amplify-fest/templates/section.html
+++ b/amplify-fest/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="band-name" style="font-size: 100px; color: var(--magenta);">{{ section.title }}</h1>
+<div style="margin-top: 4rem;">
+  {% for page in section.pages %}
+  <div class="band-row">
+    <h2 class="band-name" style="font-size: 48px;"><a href="{{ page.permalink }}" style="color: var(--black); text-decoration: none;">{{ page.title }}</a></h2>
+    <div class="stage-meta">{{ page.description }}</div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/amplify-fest/templates/shortcodes/alert.html
+++ b/amplify-fest/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/amplify-fest/templates/taxonomy.html
+++ b/amplify-fest/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/amplify-fest/templates/taxonomy_term.html
+++ b/amplify-fest/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/spotlight-hour/AGENTS.md
+++ b/spotlight-hour/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/spotlight-hour/config.toml
+++ b/spotlight-hour/config.toml
@@ -1,0 +1,35 @@
+# Spotlight Hour Configuration
+title = "Spotlight Hour"
+description = "A professional TED-style talk event theme with elegant gold and black aesthetics."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[og.auto_image]
+enabled = true
+background = "#000000"
+text_color = "#FFD700"
+accent_color = "#FFD700"
+font_size = 48
+show_title = true
+style = "minimal"
+format = "svg"
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/spotlight-hour/content/about.md
+++ b/spotlight-hour/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "Event Details"
+description = "Everything you need to know about Spotlight Hour."
++++
+
+{% extends "base.html" %}
+{% block content %}
+
+<div class="stage-section" style="text-align: left; padding: 2rem;">
+  <h2 class="speaker-name">About Spotlight Hour</h2>
+  <p>Spotlight Hour is a premier talk series designed for those who value depth over breadth. In a world of fleeting moments, we dedicate a full hour to a single theme, explored through three distinct lenses.</p>
+  
+  <h3 class="talk-title" style="margin-top: 2rem;">The Venue</h3>
+  <p>The Grand Auditorium, known for its perfect acoustics and focused atmosphere, serves as the home for our 2026 series.</p>
+
+  <h3 class="talk-title" style="margin-top: 2rem;">Design Ethics</h3>
+  <p>This site reflects our core values:
+    <ul style="list-style: none; padding: 0;">
+      <li style="margin-bottom: 0.5rem; border-left: 4px solid var(--gold); padding-left: 1rem;">NO EMOJIS: We rely on the weight of words and precision of icons.</li>
+      <li style="margin-bottom: 0.5rem; border-left: 4px solid var(--gold); padding-left: 1rem;">NO GRADIENTS: We believe in clear boundaries and high contrast.</li>
+      <li style="margin-bottom: 0.5rem; border-left: 4px solid var(--gold); padding-left: 1rem;">GOLD & BLACK: The timeless palette of authority and excellence.</li>
+    </ul>
+  </p>
+</div>
+
+{% endblock %}

--- a/spotlight-hour/content/index.md
+++ b/spotlight-hour/content/index.md
@@ -1,0 +1,94 @@
++++
+title = "The Stage is Yours"
+description = "Welcome to Spotlight Hour, where authority meets elegance."
++++
+
+{% extends "base.html" %}
+{% block content %}
+
+<div class="stage-section">
+  <div class="podium-icon">
+    <svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="1.5">
+      <path d="M4 20h16M7 20v-4h10v4M9 16V8h6v8M12 8V4" />
+      <circle cx="12" cy="3" r="1" fill="var(--gold)"/>
+    </svg>
+  </div>
+  <h2 class="talk-title" style="font-size: 32px; color: var(--gold);">The Main Event</h2>
+  <p class="talk-abstract" style="max-width: 600px; margin: 1rem auto;">A curated evening of high-impact discourse, focusing on the intersection of modern technology and human agency. No distractions. No filters. Just the spotlight.</p>
+</div>
+
+<div class="speaker-grid">
+  <!-- Speaker 1 -->
+  <div class="speaker-card">
+    <div class="spotlight-halo">
+      <svg width="240" height="240" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="48" fill="none" stroke="var(--gold)" stroke-width="0.5" stroke-dasharray="2 2" />
+        <circle cx="50" cy="50" r="40" fill="none" stroke="var(--gold)" stroke-width="1" opacity="0.3" />
+      </svg>
+    </div>
+    <div class="speaker-image">
+      <svg width="80" height="80" viewBox="0 0 24 24" fill="var(--gold)">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+      </svg>
+    </div>
+    <div class="time-slot">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+      </svg>
+      18:00 — 18:45
+    </div>
+    <h3 class="speaker-name">Elena Vance</h3>
+    <p class="talk-title">The Architecture of Silence</p>
+    <p class="talk-abstract">Exploring how minimalist design principles in digital spaces can foster deeper human connections and cognitive clarity.</p>
+  </div>
+
+  <!-- Speaker 2 -->
+  <div class="speaker-card">
+    <div class="spotlight-halo">
+      <svg width="240" height="240" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="48" fill="none" stroke="var(--gold)" stroke-width="0.5" stroke-dasharray="2 2" />
+        <circle cx="50" cy="50" r="40" fill="none" stroke="var(--gold)" stroke-width="1" opacity="0.3" />
+      </svg>
+    </div>
+    <div class="speaker-image">
+      <svg width="80" height="80" viewBox="0 0 24 24" fill="var(--gold)">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+      </svg>
+    </div>
+    <div class="time-slot">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+      </svg>
+      19:00 — 19:45
+    </div>
+    <h3 class="speaker-name">Marcus Thorne</h3>
+    <p class="talk-title">Synthetic Authority</p>
+    <p class="talk-abstract">Critical analysis of trust frameworks in the age of generative AI and the shifting landscape of intellectual ownership.</p>
+  </div>
+
+  <!-- Speaker 3 -->
+  <div class="speaker-card">
+    <div class="spotlight-halo">
+      <svg width="240" height="240" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="48" fill="none" stroke="var(--gold)" stroke-width="0.5" stroke-dasharray="2 2" />
+        <circle cx="50" cy="50" r="40" fill="none" stroke="var(--gold)" stroke-width="1" opacity="0.3" />
+      </svg>
+    </div>
+    <div class="speaker-image">
+      <svg width="80" height="80" viewBox="0 0 24 24" fill="var(--gold)">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+      </svg>
+    </div>
+    <div class="time-slot">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+      </svg>
+      20:00 — 20:45
+    </div>
+    <h3 class="speaker-name">Sarah Chen</h3>
+    <p class="talk-title">Kinetic Geometry</p>
+    <p class="talk-abstract">How mathematics and motion define our perception of physical space in virtual environments.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/spotlight-hour/templates/404.html
+++ b/spotlight-hour/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="stage-section">
+  <h2 class="speaker-name" style="font-size: 64px;">404</h2>
+  <p class="talk-title">Spotlight Not Found</p>
+  <p class="talk-abstract">The page you are looking for has moved out of the spotlight.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; color: var(--gold); border: 1px solid var(--gold); padding: 0.5rem 1rem; text-decoration: none;">Return to Main Stage</a>
+</div>
+{% endblock %}

--- a/spotlight-hour/templates/base.html
+++ b/spotlight-hour/templates/base.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&family=Work+Sans:wght@500&family=Fira+Sans:wght@400&display=swap" rel="stylesheet">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --gold: #FFD700;
+      --black: #000000;
+      --dark-gray: #121212;
+      --light-gray: #A0A0A0;
+      --text: #FFFFFF;
+    }
+    
+    *, *::before, *::after { box-sizing: border-box; }
+    
+    body {
+      margin: 0;
+      background-color: var(--black);
+      color: var(--text);
+      font-family: 'Fira Sans', sans-serif;
+      line-height: 1.65;
+      overflow-x: hidden;
+    }
+
+    .watermark {
+      position: fixed;
+      top: 10%;
+      right: -5%;
+      z-index: -1;
+      opacity: 0.05;
+      pointer-events: none;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 0 2rem;
+    }
+
+    header {
+      padding: 4rem 0;
+      text-align: center;
+      position: relative;
+    }
+
+    .event-title {
+      font-family: 'Montserrat', sans-serif;
+      font-weight: 900;
+      font-size: 120px;
+      line-height: 0.9;
+      color: var(--gold);
+      text-transform: uppercase;
+      margin: 0;
+      letter-spacing: -0.02em;
+    }
+
+    .event-subtitle {
+      font-family: 'Work Sans', sans-serif;
+      font-weight: 500;
+      font-size: 24px;
+      color: var(--text);
+      margin-top: 1rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    nav {
+      margin-top: 2rem;
+      border-top: 2px solid var(--gold);
+      border-bottom: 2px solid var(--gold);
+      padding: 1rem 0;
+    }
+
+    nav a {
+      color: var(--gold);
+      text-decoration: none;
+      font-family: 'Work Sans', sans-serif;
+      font-weight: 500;
+      font-size: 14px;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      margin: 0 1.5rem;
+      transition: opacity 0.3s;
+    }
+
+    nav a:hover {
+      opacity: 0.7;
+    }
+
+    main {
+      padding: 4rem 0;
+    }
+
+    .speaker-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 4rem;
+      margin-top: 4rem;
+    }
+
+    .speaker-card {
+      position: relative;
+      text-align: center;
+    }
+
+    .spotlight-halo {
+      position: absolute;
+      top: -20px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: -1;
+      width: 240px;
+      height: 240px;
+    }
+
+    .speaker-image {
+      width: 200px;
+      height: 200px;
+      background-color: var(--dark-gray);
+      border: 4px solid var(--gold);
+      margin: 0 auto 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .speaker-name {
+      font-family: 'Work Sans', sans-serif;
+      font-weight: 500;
+      font-size: 28px;
+      color: var(--gold);
+      margin: 0 0 0.5rem;
+    }
+
+    .talk-title {
+      font-family: 'Work Sans', sans-serif;
+      font-weight: 500;
+      font-size: 18px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 1rem;
+    }
+
+    .talk-abstract {
+      font-size: 15px;
+      color: var(--light-gray);
+      max-width: 280px;
+      margin: 0 auto;
+    }
+
+    .time-slot {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      font-family: 'Work Sans', sans-serif;
+      font-size: 14px;
+      letter-spacing: 0.1em;
+      color: var(--gold);
+      margin-bottom: 1rem;
+    }
+
+    .stage-section {
+      margin-top: 8rem;
+      padding: 4rem;
+      background-color: var(--dark-gray);
+      border: 2px solid var(--gold);
+      text-align: center;
+      position: relative;
+    }
+
+    .podium-icon {
+      margin-bottom: 2rem;
+    }
+
+    footer {
+      padding: 4rem 0;
+      text-align: center;
+      border-top: 1px solid var(--dark-gray);
+      color: var(--light-gray);
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    @media (max-width: 768px) {
+      .event-title { font-size: 60px; }
+      .event-subtitle { font-size: 18px; }
+      nav a { margin: 0 0.5rem; font-size: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="watermark">
+    <svg width="600" height="600" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M14.017 21L14.017 18C14.017 16.8954 14.9124 16 16.017 16H19.017C19.5693 16 20.017 15.5523 20.017 15V9C20.017 8.44772 19.5693 8 19.017 8H16.017C14.9124 8 14.017 7.10457 14.017 6V3H22.017V15C22.017 18.3137 19.3307 21 16.017 21H14.017ZM2.01695 21L2.01695 18C2.01695 16.8954 2.91238 16 4.01695 16H7.01695C7.56923 16 8.01695 15.5523 8.01695 15V9C8.01695 8.44772 7.56923 8 7.01695 8H4.01695C2.91238 8 2.01695 7.10457 2.01695 6V3H10.017V15C10.017 18.3137 7.33066 21 4.01695 21H2.01695Z" />
+    </svg>
+  </div>
+
+  <div class="container">
+    <header>
+      <h1 class="event-title">{{ site.title }}</h1>
+      <p class="event-subtitle">Golden Hour Talk series</p>
+      <nav>
+        <a href="{{ base_url }}/">Main Stage</a>
+        <a href="{{ base_url }}/about/">Event Details</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      <p>&copy; 2026 Spotlight Hour Events. No emojis. No gradients. Pure authority.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/spotlight-hour/templates/page.html
+++ b/spotlight-hour/templates/page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<article>
+  <h1 class="speaker-name" style="font-size: 48px; text-align: center; margin-bottom: 2rem;">{{ page.title }}</h1>
+  <div class="talk-abstract" style="max-width: 800px; margin: 0 auto; color: var(--text);">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/spotlight-hour/templates/section.html
+++ b/spotlight-hour/templates/section.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="speaker-name" style="font-size: 48px; text-align: center; margin-bottom: 2rem;">{{ section.title }}</h1>
+<div class="speaker-grid">
+  {% for page in section.pages %}
+  <div class="speaker-card">
+    <div class="speaker-image">
+      <svg width="64" height="64" viewBox="0 0 24 24" fill="var(--gold)">
+        <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+      </svg>
+    </div>
+    <h2 class="speaker-name"><a href="{{ page.permalink }}" style="color: var(--gold); text-decoration: none;">{{ page.title }}</a></h2>
+    <p class="talk-abstract">{{ page.description }}</p>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/spotlight-hour/templates/shortcodes/alert.html
+++ b/spotlight-hour/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/spotlight-hour/templates/taxonomy.html
+++ b/spotlight-hour/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="stage-section" style="text-align: left;">
+  <h2 class="speaker-name">{{ page.title }}</h2>
+  <div class="talk-abstract" style="max-width: none; margin: 1rem 0;">
+    {{ content }}
+  </div>
+</div>
+{% endblock %}

--- a/spotlight-hour/templates/taxonomy_term.html
+++ b/spotlight-hour/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="stage-section" style="text-align: left;">
+  <h2 class="speaker-name">{{ page.title }}</h2>
+  <div class="talk-abstract" style="max-width: none; margin: 1rem 0;">
+    {{ content }}
+  </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -102,6 +102,13 @@
     "amber",
     "fossil"
   ],
+  "amplify-fest": [
+    "event",
+    "festival",
+    "music",
+    "multi-stage",
+    "bold"
+  ],
   "amethyst": [
     "dark",
     "blog",

--- a/tags.json
+++ b/tags.json
@@ -4124,6 +4124,13 @@
     "cinematic",
     "toning"
   ],
+  "spotlight-hour": [
+    "event",
+    "talk",
+    "conference",
+    "spotlight",
+    "professional"
+  ],
   "stained-glass": [
     "light",
     "blog",


### PR DESCRIPTION
This PR adds a new event-style example site: **amplify-fest**.

### Design Overview
- **Concept:** Sound Amplified (Multi-stage Music Festival).
- **Palette:** Bold color blocks (Blue, Yellow, White, Black).
- **Typography:** Righteous, Barlow Condensed, Space Mono.
- **Visuals:** SVG amplifier knobs, speaker stack silhouettes, and dynamic equalizer bars.

### Compliance
- [x] NO emojis used.
- [x] NO CSS gradients used.
- [x] Verified with `hwaro build`.

Closes #1508