### PR TITLE
Add Velvet Glow example site

### DIFF
--- a/velvet-glow/.gitignore
+++ b/velvet-glow/.gitignore
@@ -1,0 +1,1 @@
+server.log

--- a/velvet-glow/AGENTS.md
+++ b/velvet-glow/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/velvet-glow/config.toml
+++ b/velvet-glow/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Velvet Glow"
+description = "An elegant, luxurious dark theme for Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/velvet-glow/content/about.md
+++ b/velvet-glow/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About"
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/velvet-glow/content/archives.md
+++ b/velvet-glow/content/archives.md
@@ -1,0 +1,5 @@
++++
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/velvet-glow/content/index.md
+++ b/velvet-glow/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Experience Elegance"
+description = "Welcome to Velvet Glow, a luxurious dark theme for Hwaro."
++++
+
+Welcome to a space where simplicity meets luxury. The Velvet Glow theme is designed for writers and creators who appreciate the finer details.
+
+With deep, rich tones and soft, glowing accents, your content will shine. Typography is carefully selected—featuring *Playfair Display* for striking, elegant headings, paired with the highly legible *Inter* for body text.
+
+### The Art of Writing
+
+Every post is treated like a canvas. The glassmorphism header, subtle hover states, and smooth transitions create a reading experience that is both modern and timeless.
+
+> "Simplicity is the ultimate sophistication." — Leonardo da Vinci
+
+Explore the [blog](/posts/) to see the theme in action, or read [about the author](/about/).

--- a/velvet-glow/content/posts/_index.md
+++ b/velvet-glow/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/velvet-glow/content/posts/getting-started-with-hwaro.md
+++ b/velvet-glow/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,36 @@
++++
+title = "Getting Started with Hwaro"
+date = "2024-01-20"
+tags = ["tutorial", "getting-started", "hwaro"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "A beginner's guide to building websites with Hwaro."
++++
+
+In this post, I'll walk you through the basics of setting up and using Hwaro.
+
+## Installation
+
+First, make sure you have Crystal installed. Then:
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Creating Your First Site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+That's it! Your blog is now running at `http://localhost:3000`.
+
+## Next Steps
+
+- Customize your templates in the `templates/` directory
+- Add new posts in `content/posts/`
+- Configure your site in `config.toml`

--- a/velvet-glow/content/posts/hello-world.md
+++ b/velvet-glow/content/posts/hello-world.md
@@ -1,0 +1,32 @@
++++
+title = "The Allure of the Dark Mode"
+date = 2024-05-15
+description = "Exploring why dark themes with glowing accents are so captivating."
+[taxonomies]
+tags = ["design", "aesthetics", "ux"]
+categories = ["thoughts"]
++++
+
+There is something inherently captivating about a well-designed dark interface. It strips away the harshness of a bright screen, allowing the content itself to take center stage.
+
+When dark backgrounds are paired with soft, glowing accents—like the violet and pink hues in the **Velvet Glow** theme—the effect is reminiscent of a neon sign reflecting off a wet street at midnight. It's moody, atmospheric, and incredibly satisfying.
+
+### Typography Matters
+
+In a dark environment, the contrast of the text is paramount.
+
+Using a serif font like `Playfair Display` for headings adds a touch of classic elegance. It feels like reading a high-end magazine. For the body text, `Inter` provides the necessary clarity and modern touch.
+
+```css
+:root {
+  --bg-color: #0d0814;
+  --primary-glow: #ff2a85;
+  --font-serif: 'Playfair Display', serif;
+}
+```
+
+### Finding Balance
+
+The key to a luxurious design is balance. The glowing effects must be subtle—never overpowering. Borders should be barely there, giving a glass-like feel to the UI components.
+
+When these elements are combined, the result is an experience that feels both refined and effortlessly stylish.

--- a/velvet-glow/content/posts/markdown-tips.md
+++ b/velvet-glow/content/posts/markdown-tips.md
@@ -1,0 +1,48 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2024-01-25"
+tags = ["markdown", "writing", "tips"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "Learn useful Markdown formatting techniques for your blog posts."
++++
+
+Hwaro uses Markdown for content. Here are some useful formatting tips.
+
+## Text Formatting
+
+- **Bold text** using `**bold**`
+- *Italic text* using `*italic*`
+- `Inline code` using backticks
+
+## Code Blocks
+
+Use triple backticks for code blocks:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Lists
+
+Ordered lists:
+1. First item
+2. Second item
+3. Third item
+
+Unordered lists:
+- Item one
+- Item two
+- Item three
+
+## Links and Images
+
+- [Link text](https://example.com)
+- ![Alt text](/path/to/image.jpg)
+
+## Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.
+
+Happy writing!

--- a/velvet-glow/static/css/style.css
+++ b/velvet-glow/static/css/style.css
@@ -1,0 +1,467 @@
+/* Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap');
+
+/* CSS Variables for Velvet Glow */
+:root {
+  /* Colors */
+  --bg-color: #0d0814;
+  --bg-surface: #170f23;
+  --bg-glass: rgba(23, 15, 35, 0.6);
+  --text-main: #e8e3f2;
+  --text-muted: #a395ba;
+  --primary-glow: #ff2a85;
+  --secondary-glow: #8a2be2;
+  --accent: #d4af37; /* Gold accent */
+  --border-subtle: rgba(255, 42, 133, 0.2);
+  --border-strong: rgba(255, 42, 133, 0.4);
+
+  /* Typography */
+  --font-serif: 'Playfair Display', serif;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  /* Layout */
+  --max-width: 800px;
+  --header-height: 80px;
+  --border-radius: 12px;
+}
+
+/* Reset & Base */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-image:
+    radial-gradient(circle at 15% 50%, rgba(138, 43, 226, 0.1), transparent 25%),
+    radial-gradient(circle at 85% 30%, rgba(255, 42, 133, 0.08), transparent 25%);
+  background-attachment: fixed;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-serif);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
+}
+
+h1 {
+  font-size: 3rem;
+  line-height: 1.2;
+  text-shadow: 0 0 20px rgba(255, 42, 133, 0.3);
+}
+
+h2 {
+  font-size: 2.2rem;
+  margin-top: 3rem;
+}
+
+h3 {
+  font-size: 1.6rem;
+  margin-top: 2rem;
+}
+
+p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  color: var(--text-main);
+}
+
+a {
+  color: var(--primary-glow);
+  text-decoration: none;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+a:hover {
+  color: #fff;
+  text-shadow: 0 0 10px var(--primary-glow);
+}
+
+/* Header & Navigation */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--header-height);
+  background: var(--bg-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-subtle);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+}
+
+.header-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 2rem;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-shadow: 0 0 15px rgba(255, 42, 133, 0.5);
+}
+
+.site-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-nav a {
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.site-nav a:hover,
+.site-nav a.active {
+  color: #fff;
+  text-shadow: 0 0 15px var(--secondary-glow);
+}
+
+/* Main Content */
+.main-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: calc(var(--header-height) + 4rem) 2rem 4rem;
+  min-height: calc(100vh - 100px);
+}
+
+/* Post List */
+.post-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.post-item {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius);
+  padding: 2.5rem;
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.4s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.post-item::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--primary-glow), transparent);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.post-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.4), 0 0 20px rgba(138, 43, 226, 0.15);
+  border-color: var(--border-strong);
+}
+
+.post-item:hover::before {
+  opacity: 1;
+}
+
+.post-title {
+  font-size: 1.8rem;
+  margin-bottom: 0.8rem;
+}
+
+.post-title a {
+  color: #fff;
+}
+
+.post-title a:hover {
+  color: var(--primary-glow);
+  text-shadow: none;
+}
+
+.post-meta {
+  font-family: var(--font-sans);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.post-meta span {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.post-excerpt {
+  color: var(--text-muted);
+  margin-bottom: 0;
+}
+
+/* Post Detail */
+.post-header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.post-header h1 {
+  font-size: 3.5rem;
+  margin-bottom: 1rem;
+}
+
+.post-content {
+  font-size: 1.15rem;
+  line-height: 1.8;
+}
+
+/* Markdown Elements */
+blockquote {
+  border-left: 4px solid var(--primary-glow);
+  padding: 1.5rem;
+  margin: 2rem 0;
+  background: linear-gradient(90deg, rgba(255, 42, 133, 0.1), transparent);
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  color: #fff;
+  font-style: italic;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2rem 0;
+}
+
+code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.9em;
+  color: var(--accent);
+}
+
+pre code {
+  color: var(--text-main);
+}
+
+img {
+  max-width: 100%;
+  border-radius: var(--border-radius);
+  margin: 2rem 0;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border-subtle);
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border-strong), transparent);
+  margin: 3rem 0;
+}
+
+/* Tags */
+.tag-container {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.tag {
+  background: rgba(138, 43, 226, 0.15);
+  color: var(--secondary-glow);
+  padding: 0.4rem 1rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid rgba(138, 43, 226, 0.3);
+  transition: all 0.3s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tag:hover {
+  background: var(--secondary-glow);
+  color: #fff;
+  text-shadow: none;
+  box-shadow: 0 0 15px rgba(138, 43, 226, 0.4);
+}
+
+/* Footer */
+.site-footer {
+  text-align: center;
+  padding: 3rem 2rem;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background: var(--bg-surface);
+}
+
+/* Search */
+.search-container {
+  display: flex;
+  align-items: center;
+}
+
+.search-trigger {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: color 0.3s ease;
+}
+
+.search-trigger:hover {
+  color: #fff;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+}
+
+.search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(13, 8, 20, 0.95);
+  backdrop-filter: blur(20px);
+  z-index: 2000;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 15vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-modal {
+  width: 100%;
+  max-width: 600px;
+  padding: 0 2rem;
+}
+
+.search-input-wrap {
+  position: relative;
+  width: 100%;
+  margin-bottom: 2rem;
+}
+
+.search-input-wrap input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid var(--border-strong);
+  color: #fff;
+  font-size: 2rem;
+  padding: 1rem 0;
+  font-family: var(--font-serif);
+}
+
+.search-input-wrap input:focus {
+  outline: none;
+  border-color: var(--primary-glow);
+  box-shadow: 0 10px 20px -10px rgba(255, 42, 133, 0.3);
+}
+
+.search-results {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.search-result-item {
+  display: block;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.3s ease;
+}
+
+.search-result-item:hover {
+  background: rgba(255, 42, 133, 0.05);
+}
+
+.search-result-title {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  color: #fff;
+  margin-bottom: 0.5rem;
+}
+
+.search-result-snippet {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.close-search {
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.close-search:hover {
+  transform: rotate(90deg);
+  color: var(--primary-glow);
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-in {
+  animation: fadeIn 0.8s ease-out forwards;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  h1 { font-size: 2.2rem; }
+  .header-container { flex-direction: column; gap: 1rem; padding: 1rem; }
+  .site-header { height: auto; padding: 1rem 0; }
+  .main-content { padding-top: 140px; }
+}

--- a/velvet-glow/static/js/search.js
+++ b/velvet-glow/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/velvet-glow/templates/404.html
+++ b/velvet-glow/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/velvet-glow/templates/footer.html
+++ b/velvet-glow/templates/footer.html
@@ -1,0 +1,25 @@
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-container">
+      <p>&copy; {{ now | date(format="%Y") }} {{ site.title }}. All rights reserved.</p>
+      <p>Powered by <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">Hwaro</a>.</p>
+    </div>
+  </footer>
+
+  <!-- Search Overlay -->
+  <div id="searchOverlay" class="search-overlay">
+    <button class="close-search" onclick="closeSearch()" aria-label="Close Search">&times;</button>
+    <div class="search-modal">
+      <div class="search-input-wrap">
+        <input type="text" id="searchInput" placeholder="Search the elegance..." autocomplete="off">
+      </div>
+      <div id="searchResults" class="search-results"></div>
+    </div>
+  </div>
+
+  {{ highlight_js }}
+  <script src="{{ base_url }}/js/search.js"></script>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/velvet-glow/templates/header.html
+++ b/velvet-glow/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+
+  <header class="site-header">
+    <div class="header-container">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title | e }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/" class="{% if current_path == '/' %}active{% endif %}">Home</a>
+        <a href="{{ base_url }}/posts/" class="{% if current_path and current_path is starting_with('/posts/') %}active{% endif %}">Blog</a>
+        <a href="{{ base_url }}/archives/" class="{% if current_path == '/archives/' %}active{% endif %}">Archives</a>
+        <a href="{{ base_url }}/about/" class="{% if current_path == '/about/' %}active{% endif %}">About</a>
+        <button class="search-trigger" onclick="openSearch()" aria-label="Search">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          Search
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="main-content fade-in">

--- a/velvet-glow/templates/page.html
+++ b/velvet-glow/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<article class="page">
+  <header class="post-header">
+    <h1>{{ page.title | e }}</h1>
+  </header>
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+</article>
+{% include "footer.html" %}

--- a/velvet-glow/templates/post.html
+++ b/velvet-glow/templates/post.html
@@ -1,0 +1,39 @@
+{% include "header.html" %}
+<article class="post">
+  <header class="post-header">
+    <h1>{{ page.title | e }}</h1>
+    <div class="post-meta">
+      <span>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <time>{{ page.date }}</time>
+      </span>
+      {% if page.reading_time %}
+      <span>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <polyline points="12 6 12 12 16 14"></polyline>
+        </svg>
+        {{ page.reading_time }} min read
+      </span>
+      {% endif %}
+    </div>
+  </header>
+
+  <div class="post-content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.taxonomies.tags %}
+  <div class="tag-container">
+    {% for tag in page.taxonomies.tags %}
+    <a href="{{ base_url }}/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+</article>
+{% include "footer.html" %}

--- a/velvet-glow/templates/section.html
+++ b/velvet-glow/templates/section.html
@@ -1,0 +1,52 @@
+{% include "header.html" %}
+<header class="post-header">
+  <h1>{{ page.title | e }}</h1>
+</header>
+
+<div class="post-content">
+  {{ content | safe }}
+</div>
+
+<ul class="post-list">
+  {% for subpage in section.pages %}
+  <li class="post-item">
+    <h2 class="post-title"><a href="{{ subpage.permalink }}">{{ subpage.title }}</a></h2>
+    <div class="post-meta">
+      <span>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <time>{{ subpage.date }}</time>
+      </span>
+      {% if subpage.reading_time %}
+      <span>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <polyline points="12 6 12 12 16 14"></polyline>
+        </svg>
+        {{ subpage.reading_time }} min read
+      </span>
+      {% endif %}
+    </div>
+    {% if subpage.description %}
+    <p class="post-excerpt">{{ subpage.description }}</p>
+    {% endif %}
+    {% if subpage.taxonomies and subpage.taxonomies.tags %}
+    <div class="tag-container" style="margin-top: 1rem;">
+      {% for tag in subpage.taxonomies.tags %}
+      <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+
+{% if pagination %}
+  {{ pagination }}
+{% endif %}
+
+{% include "footer.html" %}

--- a/velvet-glow/templates/shortcodes/alert.html
+++ b/velvet-glow/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/velvet-glow/templates/taxonomy.html
+++ b/velvet-glow/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/velvet-glow/templates/taxonomy_term.html
+++ b/velvet-glow/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces the "Velvet Glow" example site to demonstrate an elegant, luxurious dark theme for Hwaro. It includes a custom CSS implementation utilizing CSS variables, glowing effects, and a glassmorphic header, paired with Playfair Display and Inter fonts. The basic `blog` scaffold templates have been updated to support the new aesthetic, and sample content has been provided.

---
*PR created automatically by Jules for task [8322502288804257622](https://jules.google.com/task/8322502288804257622) started by @hahwul*