### PR TITLE
feat: Add Synthwave Retro example template

### DIFF
--- a/examples/synthwave-retro/AGENTS.md
+++ b/examples/synthwave-retro/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/synthwave-retro/config.toml
+++ b/examples/synthwave-retro/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Synthwave Retro"
+description = "A neon-infused, 80s-inspired static site template."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/synthwave-retro/content/_index.md
+++ b/examples/synthwave-retro/content/_index.md
@@ -1,0 +1,28 @@
++++
+title = "Welcome to the Future"
+description = "A neon-infused, 80s-inspired static site template."
++++
+
+Welcome to the **Synthwave Retro** template for Hwaro. Let's travel back to the future on the neon grid.
+
+## System Initialized
+
+The grid is alive. The cyber-city lights up with endless possibilities. This is your blank canvas, illuminated by magenta and cyan glows.
+
+### Quick Start
+To boot up the mainframe:
+1. `hwaro serve`
+2. Access terminal at `http://localhost:3000`
+3. Hack the mainframe by editing `content/_index.md`
+
+```rust
+// Welcome to 1984
+fn initiate_sequence() {
+    println!("Neon lights fading in...");
+    connect_to_grid(true);
+}
+```
+
+> "The future is not a straight line. It is filled with many crossroads. There must be a future that we can choose for ourselves."
+
+Enjoy the ride!

--- a/examples/synthwave-retro/content/about.md
+++ b/examples/synthwave-retro/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/synthwave-retro/templates/404.html
+++ b/examples/synthwave-retro/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-retro/templates/footer.html
+++ b/examples/synthwave-retro/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer" style="margin-top: 3rem; padding: 2rem 0; border-top: 2px solid var(--magenta); color: var(--text-muted); font-size: 1.1rem; text-align: center; font-family: 'VT323', monospace; box-shadow: 0 -4px 10px rgba(255, 0, 255, 0.2);">
+      <p style="margin: 0;">Powered by <span style="color: var(--cyan); text-shadow: 0 0 5px var(--cyan);">Neon Grid</span></p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/synthwave-retro/templates/header.html
+++ b/examples/synthwave-retro/templates/header.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link href="https://fonts.googleapis.com/css2?family=VT323&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --magenta: #ff00ff;
+      --cyan: #00ffff;
+      --yellow: #ffff00;
+      --bg: #090014;
+      --grid-color: rgba(255, 0, 255, 0.3);
+      --text: #e0e0e0;
+      --text-muted: #a0a0a0;
+      --primary: var(--cyan);
+      --border: var(--magenta);
+    }
+
+    @keyframes scrollGrid {
+      0% { transform: perspective(500px) rotateX(60deg) translateY(0); }
+      100% { transform: perspective(500px) rotateX(60deg) translateY(40px); }
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: 'Orbitron', sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background-color: var(--bg);
+      position: relative;
+      overflow-x: hidden;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Synthwave Grid Background */
+    body::before {
+      content: "";
+      position: fixed;
+      bottom: -30vh;
+      left: -50vw;
+      width: 200vw;
+      height: 80vh;
+      background-image:
+        linear-gradient(var(--grid-color) 2px, transparent 2px),
+        linear-gradient(90deg, var(--grid-color) 2px, transparent 2px);
+      background-size: 40px 40px;
+      transform-origin: top center;
+      transform: perspective(500px) rotateX(60deg);
+      animation: scrollGrid 3s linear infinite;
+      z-index: -1;
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    body::after {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: linear-gradient(to bottom, rgba(9, 0, 20, 1) 0%, rgba(9, 0, 20, 0.4) 60%, rgba(255, 0, 255, 0.1) 100%);
+      z-index: -2;
+      pointer-events: none;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      flex-grow: 1;
+      width: 100%;
+      background: rgba(9, 0, 20, 0.85);
+      box-shadow: 0 0 20px rgba(255, 0, 255, 0.2);
+      border-left: 1px solid rgba(255, 0, 255, 0.3);
+      border-right: 1px solid rgba(255, 0, 255, 0.3);
+      backdrop-filter: blur(5px);
+    }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.5rem 0;
+      border-bottom: 2px solid var(--magenta);
+      margin-bottom: 2.5rem;
+      box-shadow: 0 4px 10px rgba(255, 0, 255, 0.2);
+    }
+
+    .site-logo {
+      font-weight: 700;
+      font-size: 1.8rem;
+      color: #fff;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 0 0 5px var(--magenta), 0 0 10px var(--magenta), 0 0 20px var(--magenta);
+      transition: all 0.3s ease;
+    }
+
+    .site-logo:hover {
+      color: var(--cyan);
+      text-shadow: 0 0 5px var(--cyan), 0 0 10px var(--cyan), 0 0 20px var(--cyan);
+    }
+
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      color: var(--text);
+      text-decoration: none;
+      font-size: 1.1rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: all 0.2s ease;
+    }
+    .site-header nav a:hover {
+      color: var(--cyan);
+      text-shadow: 0 0 8px var(--cyan);
+    }
+
+    .site-main { min-height: calc(100vh - 250px); padding-bottom: 3rem; }
+
+    /* Typography */
+    h1, h2, h3 {
+      line-height: 1.3;
+      margin-top: 1.5em;
+      margin-bottom: 0.5em;
+      font-weight: 700;
+      color: #fff;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    h1 {
+      font-size: 2.5rem;
+      margin-top: 0;
+      text-shadow: 0 0 10px var(--cyan), 0 0 20px var(--cyan);
+      color: var(--cyan);
+    }
+    h2 {
+      font-size: 1.8rem;
+      color: var(--yellow);
+      text-shadow: 0 0 8px rgba(255, 255, 0, 0.6);
+    }
+    h3 { font-size: 1.4rem; color: var(--magenta); text-shadow: 0 0 5px var(--magenta); }
+    p { margin: 1.2em 0; font-family: 'VT323', monospace; font-size: 1.4rem; letter-spacing: 0.5px; }
+
+    a {
+      color: var(--cyan);
+      text-decoration: none;
+      text-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+      border-bottom: 1px dashed var(--cyan);
+      transition: all 0.2s;
+    }
+    a:hover {
+      color: var(--magenta);
+      text-shadow: 0 0 8px var(--magenta);
+      border-bottom: 1px solid var(--magenta);
+    }
+
+    code {
+      background: rgba(255, 0, 255, 0.15);
+      padding: 0.15rem 0.4rem;
+      border-radius: 4px;
+      font-size: 1.1rem;
+      font-family: 'VT323', monospace;
+      color: var(--yellow);
+      border: 1px solid rgba(255, 255, 0, 0.3);
+    }
+    pre {
+      background: rgba(0, 0, 0, 0.6);
+      padding: 1.2rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      border: 1px solid var(--cyan);
+      box-shadow: 0 0 10px rgba(0, 255, 255, 0.2) inset;
+    }
+    pre code { background: none; padding: 0; border: none; color: var(--text); }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem;
+      padding: 1rem;
+      background: rgba(255, 0, 255, 0.05);
+      border-radius: 0px;
+      border-left: 4px solid var(--cyan);
+      transition: all 0.3s;
+    }
+    ul.section-list li:hover {
+      background: rgba(255, 0, 255, 0.1);
+      box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
+      transform: translateX(5px);
+    }
+    ul.section-list li a { font-weight: 700; border-bottom: none; font-size: 1.2rem; }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; font-family: 'VT323', monospace; font-size: 1.3rem; }
+
+    nav.pagination { margin: 2rem 0; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.8rem; flex-wrap: wrap; align-items: center; }
+    nav.pagination a {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border: 1px solid var(--cyan);
+      color: var(--cyan);
+      text-decoration: none;
+      text-shadow: none;
+      background: rgba(0, 255, 255, 0.1);
+    }
+    nav.pagination a:hover {
+      background: var(--cyan);
+      color: #000;
+      box-shadow: 0 0 10px var(--cyan);
+    }
+    .pagination-current span {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border: 1px solid var(--magenta);
+      background: rgba(255, 0, 255, 0.3);
+      color: #fff;
+      box-shadow: 0 0 10px var(--magenta);
+    }
+    .pagination-disabled span {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border: 1px solid #444;
+      color: #666;
+      opacity: 0.6;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; align-items: center; }
+      .site-wrapper { padding: 0 1rem; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/synthwave-retro/templates/page.html
+++ b/examples/synthwave-retro/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-retro/templates/section.html
+++ b/examples/synthwave-retro/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-retro/templates/shortcodes/alert.html
+++ b/examples/synthwave-retro/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/synthwave-retro/templates/taxonomy.html
+++ b/examples/synthwave-retro/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-retro/templates/taxonomy_term.html
+++ b/examples/synthwave-retro/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces a new example template for Hwaro named `synthwave-retro`. 

The design focuses on a stylized, 80s-inspired retro-futuristic aesthetic, often referred to as "Synthwave" or "Outrun". It features a dark background with vibrant neon cyan and magenta text and borders. A key visual element is the animated, perspective-shifted scrolling grid background implemented entirely in CSS, giving the illusion of traveling along a digital landscape. The typography uses 'Orbitron' for headings and 'VT323' for mono-spaced text and code snippets to complete the retro vibe.

The example includes customized `config.toml`, `header.html`, `footer.html`, and `_index.md` files.

---
*PR created automatically by Jules for task [16299060891595200302](https://jules.google.com/task/16299060891595200302) started by @hahwul*