### PR TITLE
feat: add luminescent-threads example site

### DIFF
--- a/luminescent-threads/AGENTS.md
+++ b/luminescent-threads/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/luminescent-threads/config.toml
+++ b/luminescent-threads/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminescent Threads"
+description = "A glowing, elegant dark theme for Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/luminescent-threads/content/about.md
+++ b/luminescent-threads/content/about.md
@@ -1,0 +1,13 @@
++++
+title = "About"
++++
+
+# About Luminescent Threads
+
+This is an elegant dark theme blending deep backgrounds with vibrant glowing accents. It was designed to showcase a modern, high-tech abstract aesthetic for the Hwaro static site generator.
+
+## Key Features
+
+- **Deep Dark Background**: Immerse yourself in the void.
+- **Neon Accents**: Cyan, Magenta, and Purple glows.
+- **Modern Typography**: JetBrains Mono for a technical edge.

--- a/luminescent-threads/content/index.md
+++ b/luminescent-threads/content/index.md
@@ -1,0 +1,10 @@
++++
+title = "Luminescent Threads"
+tags = ["aesthetic", "neon", "dark"]
++++
+
+# Enter the Glow
+
+Welcome to a high-tech abstract aesthetic. Let the glowing threads guide your way.
+
+Here you can explore beautiful glowing typography, neon colors, and deep dark backgrounds. Feel the warmth of the luminescent threads.

--- a/luminescent-threads/content/posts/_index.md
+++ b/luminescent-threads/content/posts/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Posts"
+page_template = "page"
++++

--- a/luminescent-threads/content/posts/first-post.md
+++ b/luminescent-threads/content/posts/first-post.md
@@ -1,0 +1,10 @@
++++
+title = "First Post"
+tags = ["neon"]
++++
+
+# Glowing Beginning
+
+This is the first glowing post in the luminescent threads realm.
+
+Look at how the text naturally shines when you read it.

--- a/luminescent-threads/templates/404.html
+++ b/luminescent-threads/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/luminescent-threads/templates/footer.html
+++ b/luminescent-threads/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer" style="margin-top: 4rem; padding: 2rem 0; text-align: center; color: var(--text-muted); font-family: var(--font-mono); font-size: 0.9rem;">
+      <div class="thread" style="height: 1px; width: 100%; background: var(--accent); box-shadow: 0 0 10px var(--accent); margin-bottom: 2rem; opacity: 0.5;"></div>
+      <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }} - Woven with Light.</p>
+    </footer>
+  </div>
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/luminescent-threads/templates/header.html
+++ b/luminescent-threads/templates/header.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #0A0A0E;
+      --bg-subtle: #12121A;
+      --border: #2A2A35;
+      --primary: #00F0FF;
+      --accent: #FF0055;
+      --accent2: #8A2BE2;
+      --text: #E0E0E0;
+      --text-muted: #888888;
+      --font-body: 'Inter', sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-body);
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      background-image: radial-gradient(circle at 50% 0%, rgba(138, 43, 226, 0.15) 0%, transparent 50%);
+      min-height: 100vh;
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 2rem 0;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 3rem;
+      position: relative;
+    }
+
+    .site-header::after {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      width: 100%;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--primary), transparent);
+      opacity: 0.5;
+    }
+
+    .site-logo {
+      font-family: var(--font-mono);
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: var(--text);
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      transition: all 0.3s ease;
+    }
+
+    .site-logo:hover {
+      color: var(--primary);
+      text-shadow: 0 0 15px rgba(0, 240, 255, 0.6);
+    }
+
+    .site-header nav { display: flex; gap: 2rem; }
+    .site-header nav a {
+      font-family: var(--font-mono);
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: all 0.3s ease;
+    }
+
+    .site-header nav a:hover {
+      color: var(--accent);
+      text-shadow: 0 0 10px rgba(255, 0, 85, 0.6);
+    }
+
+    .site-main { min-height: calc(100vh - 250px); }
+
+    /* Typography */
+    .prose h1, .prose h2, .prose h3 {
+      font-family: var(--font-mono);
+      line-height: 1.3;
+      margin-top: 2em;
+      margin-bottom: 1em;
+      font-weight: 700;
+      color: #fff;
+    }
+
+    .prose h1 {
+      font-size: 2.5rem;
+      margin-top: 0;
+      color: var(--primary);
+      text-shadow: 0 0 20px rgba(0, 240, 255, 0.3);
+      position: relative;
+      display: inline-block;
+    }
+
+    .prose h2 {
+      font-size: 1.8rem;
+      color: var(--text);
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 0.5rem;
+    }
+
+    .prose h3 { font-size: 1.3rem; color: var(--accent2); }
+
+    .prose p { margin: 1.5em 0; font-size: 1.1rem; color: var(--text); }
+
+    .prose a {
+      color: var(--primary);
+      text-decoration: none;
+      border-bottom: 1px solid rgba(0, 240, 255, 0.3);
+      transition: all 0.3s ease;
+    }
+
+    .prose a:hover {
+      border-bottom-color: var(--primary);
+      text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+    }
+
+    .prose code {
+      background: var(--bg-subtle);
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.9em;
+      font-family: var(--font-mono);
+      color: var(--accent);
+      border: 1px solid var(--border);
+    }
+
+    .prose pre {
+      background: var(--bg-subtle);
+      padding: 1.5rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+      position: relative;
+    }
+
+    .prose pre::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; width: 100%; height: 2px;
+      background: linear-gradient(90deg, var(--accent2), var(--primary));
+      opacity: 0.7;
+    }
+
+    .prose pre code {
+      background: none;
+      padding: 0;
+      color: var(--text);
+      border: none;
+    }
+
+    .prose ul, .prose ol {
+      font-size: 1.1rem;
+      padding-left: 1.5rem;
+    }
+
+    .prose li {
+      margin-bottom: 0.5rem;
+    }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; display: grid; gap: 1.5rem; }
+    ul.section-list li {
+      background: var(--bg-subtle);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      padding: 1.5rem;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    ul.section-list li::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; width: 3px; height: 100%;
+      background: var(--primary);
+      opacity: 0.5;
+      transition: opacity 0.3s ease;
+    }
+
+    ul.section-list li:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+      border-color: rgba(0, 240, 255, 0.3);
+    }
+
+    ul.section-list li:hover::before {
+      opacity: 1;
+      box-shadow: 0 0 10px var(--primary);
+    }
+
+    ul.section-list li a {
+      font-weight: 700;
+      font-family: var(--font-mono);
+      font-size: 1.3rem;
+      color: var(--text);
+      text-decoration: none;
+      display: block;
+      margin-bottom: 0.5rem;
+    }
+
+    ul.section-list li:hover a {
+      color: var(--primary);
+    }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 2rem; font-size: 1.1rem; }
+
+    /* Pagination */
+    nav.pagination { margin: 3rem 0; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.75rem; justify-content: center; }
+    nav.pagination a, .pagination-current span, .pagination-disabled span {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+      font-family: var(--font-mono);
+      background: var(--bg-subtle);
+      transition: all 0.3s ease;
+    }
+
+    nav.pagination a { color: var(--text); text-decoration: none; }
+    nav.pagination a:hover {
+      color: var(--primary);
+      border-color: var(--primary);
+      box-shadow: 0 0 15px rgba(0, 240, 255, 0.2);
+    }
+
+    .pagination-current span {
+      border-color: var(--primary);
+      color: var(--bg);
+      background: var(--primary);
+      box-shadow: 0 0 15px rgba(0, 240, 255, 0.4);
+    }
+
+    .pagination-disabled span { color: var(--text-muted); opacity: 0.5; }
+
+    /* Custom Thread Element */
+    .thread {
+      height: 1px;
+      width: 100%;
+      background: var(--accent);
+      box-shadow: 0 0 15px var(--accent);
+      margin-bottom: 2rem;
+      border-radius: 50%;
+    }
+
+    .glow-text {
+      text-shadow: 0 0 10px var(--primary);
+      color: var(--primary);
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1.5rem; text-align: center; }
+      .site-header nav { flex-wrap: wrap; justify-content: center; }
+      .site-wrapper { padding: 0 1rem; }
+      .prose h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/luminescent-threads/templates/page.html
+++ b/luminescent-threads/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/luminescent-threads/templates/section.html
+++ b/luminescent-threads/templates/section.html
@@ -1,0 +1,48 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="prose">
+      {{ content | safe }}
+    </div>
+
+    <ul class="section-list">
+      {% for page in section.pages %}
+      <li>
+        <a href="{{ base_url }}{{ page.permalink }}">{{ page.title }}</a>
+        {% if page.description %}
+          <p style="margin: 0.5rem 0 0; color: var(--text-muted); font-size: 0.95rem;">{{ page.description }}</p>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+
+    {% if paginator %}
+    <nav class="pagination">
+      <ul class="pagination-list">
+        {% if paginator.previous %}
+          <li><a href="{{ base_url }}{{ paginator.previous }}">Previous</a></li>
+        {% else %}
+          <li class="pagination-disabled"><span>Previous</span></li>
+        {% endif %}
+
+        {% for i in range(start=1, end=paginator.total_pages + 1) %}
+          {% if i == paginator.current_page %}
+            <li class="pagination-current"><span>{{ i }}</span></li>
+          {% else %}
+            {% if i == 1 %}
+              <li><a href="{{ base_url }}{{ section.permalink }}">{{ i }}</a></li>
+            {% else %}
+              <li><a href="{{ base_url }}{{ section.permalink }}page/{{ i }}/">{{ i }}</a></li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+
+        {% if paginator.next %}
+          <li><a href="{{ base_url }}{{ paginator.next }}">Next</a></li>
+        {% else %}
+          <li class="pagination-disabled"><span>Next</span></li>
+        {% endif %}
+      </ul>
+    </nav>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/luminescent-threads/templates/shortcodes/alert.html
+++ b/luminescent-threads/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/luminescent-threads/templates/taxonomy.html
+++ b/luminescent-threads/templates/taxonomy.html
@@ -1,0 +1,17 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="prose">
+      <h1 class="glow-text">{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Explore the glowing taxonomy: {{ page.title | e }}</p>
+    </div>
+
+    <ul class="section-list">
+      {% for term in taxonomy_terms %}
+      <li>
+        <a href="{{ term.url }}">{{ term.name }}</a>
+        <span style="font-family: var(--font-mono); color: var(--accent); font-size: 0.9rem;">{{ term.pages | length }} items</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/luminescent-threads/templates/taxonomy_term.html
+++ b/luminescent-threads/templates/taxonomy_term.html
@@ -1,0 +1,49 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="prose">
+      <h1 class="glow-text">{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">{{ taxonomy_pages | length }} items illuminated under {{ taxonomy_term }}.</p>
+    </div>
+
+    <ul class="section-list">
+      {% for page in taxonomy_pages %}
+      <li>
+        <a href="{{ page.url }}">{{ page.title }}</a>
+        {% if page.description %}
+          <p style="margin: 0.5rem 0 0; color: var(--text-muted); font-size: 0.95rem;">{{ page.description }}</p>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+
+    {% if paginator %}
+    <nav class="pagination">
+      <ul class="pagination-list">
+        {% if paginator.previous %}
+          <li><a href="{{ base_url }}{{ paginator.previous }}">Previous</a></li>
+        {% else %}
+          <li class="pagination-disabled"><span>Previous</span></li>
+        {% endif %}
+
+        {% for i in range(start=1, end=paginator.total_pages + 1) %}
+          {% if i == paginator.current_page %}
+            <li class="pagination-current"><span>{{ i }}</span></li>
+          {% else %}
+            {% if i == 1 %}
+              <li><a href="{{ page.url }}">{{ i }}</a></li>
+            {% else %}
+              <li><a href="{{ page.url }}page/{{ i }}/">{{ i }}</a></li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+
+        {% if paginator.next %}
+          <li><a href="{{ base_url }}{{ paginator.next }}">Next</a></li>
+        {% else %}
+          <li class="pagination-disabled"><span>Next</span></li>
+        {% endif %}
+      </ul>
+    </nav>
+    {% endif %}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Add a new Hwaro example site called "luminescent-threads". It features a high-tech abstract aesthetic with deep dark backgrounds and neon glowing accents. Typography relies on Inter and JetBrains Mono. All templates correctly handle Jinja/Crinja variables and pagination.

---
*PR created automatically by Jules for task [15997247575949612119](https://jules.google.com/task/15997247575949612119) started by @hahwul*