### PR TITLE
feat: add synthwave-nebula static site example

### DIFF
--- a/examples/synthwave-nebula/AGENTS.md
+++ b/examples/synthwave-nebula/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/synthwave-nebula/config.toml
+++ b/examples/synthwave-nebula/config.toml
@@ -1,0 +1,6 @@
+title = "Synthwave Nebula"
+base_url = "http://localhost:3000"
+
+[markdown]
+highlight_code = true
+highlight_theme = "dracula"

--- a/examples/synthwave-nebula/content/_index.md
+++ b/examples/synthwave-nebula/content/_index.md
@@ -1,0 +1,19 @@
++++
+title = "Home"
++++
+
+# Enter the Nebula
+
+Welcome to the retro-futuristic grid. Experience the neon lights and synth beats.
+
+This layout features:
+- Glowing text
+- Animated 3D CSS grid background
+- Dracula code highlights
+
+```javascript
+function bootSystem() {
+  console.log("System initialized. Welcome to 198X.");
+  return true;
+}
+```

--- a/examples/synthwave-nebula/content/about.md
+++ b/examples/synthwave-nebula/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About"
++++
+
+# The Outrun
+
+This is a Synthwave themed static site example built with Hwaro. High speed, high fidelity.
+
+Built using:
+* Hwaro Static Site Generator
+* Raw CSS and HTML
+* A whole lot of neon pink and cyan
+
+[Back to Home](/)

--- a/examples/synthwave-nebula/static/style.css
+++ b/examples/synthwave-nebula/static/style.css
@@ -1,0 +1,112 @@
+:root {
+  --neon-magenta: #ff00ff;
+  --neon-cyan: #00ffff;
+  --bg-dark: #0b001a;
+  --grid-color: rgba(255, 0, 255, 0.3);
+}
+
+body.synth-theme {
+  background-color: var(--bg-dark);
+  color: var(--neon-cyan);
+  font-family: "Courier New", Courier, monospace;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+body.synth-theme::before {
+  content: "";
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 50vh;
+  background-image:
+    linear-gradient(transparent 95%, var(--grid-color) 100%),
+    linear-gradient(90deg, transparent 95%, var(--grid-color) 100%);
+  background-size: 50px 50px;
+  transform: perspective(500px) rotateX(60deg) translateY(100px) translateZ(-200px);
+  z-index: -1;
+  animation: grid-move 5s linear infinite;
+}
+
+@keyframes grid-move {
+  0% { transform: perspective(500px) rotateX(60deg) translateY(0px) translateZ(-200px); }
+  100% { transform: perspective(500px) rotateX(60deg) translateY(50px) translateZ(-200px); }
+}
+
+header {
+  background-color: rgba(11, 0, 26, 0.8);
+  border-bottom: 2px solid var(--neon-cyan);
+  padding: 1rem 0;
+  box-shadow: 0 0 10px var(--neon-cyan);
+}
+
+.nav-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 2rem;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--neon-magenta);
+  text-decoration: none;
+  text-shadow: 0 0 10px var(--neon-magenta);
+}
+
+nav a {
+  color: var(--neon-cyan);
+  text-decoration: none;
+  margin-left: 1.5rem;
+  transition: color 0.3s, text-shadow 0.3s;
+}
+
+nav a:hover {
+  color: #fff;
+  text-shadow: 0 0 10px #fff;
+}
+
+main {
+  flex: 1;
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 2rem;
+}
+
+.prose {
+  background-color: rgba(11, 0, 26, 0.8);
+  padding: 2rem;
+  border: 1px solid var(--neon-magenta);
+  box-shadow: inset 0 0 20px rgba(255, 0, 255, 0.2), 0 0 15px rgba(255, 0, 255, 0.3);
+  border-radius: 5px;
+}
+
+.prose h1, .prose h2, .prose h3 {
+  color: var(--neon-magenta);
+  text-shadow: 0 0 10px var(--neon-magenta);
+  text-transform: uppercase;
+}
+
+.prose a {
+  color: var(--neon-cyan);
+  text-shadow: 0 0 5px var(--neon-cyan);
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  border-top: 2px solid var(--neon-magenta);
+  background-color: rgba(11, 0, 26, 0.8);
+  box-shadow: 0 0 10px var(--neon-magenta);
+  margin-top: auto;
+}
+.section-list a { color: var(--neon-cyan); text-shadow: 0 0 5px var(--neon-cyan); text-decoration: none; font-weight: bold; }
+.section-list a:hover { color: #fff; text-shadow: 0 0 10px #fff; }

--- a/examples/synthwave-nebula/templates/404.html
+++ b/examples/synthwave-nebula/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-nebula/templates/footer.html
+++ b/examples/synthwave-nebula/templates/footer.html
@@ -1,0 +1,6 @@
+    </main>
+    <footer>
+        <p>&copy; 2024 Synthwave Nebula. Welcome to the future.</p>
+    </footer>
+</body>
+</html>

--- a/examples/synthwave-nebula/templates/header.html
+++ b/examples/synthwave-nebula/templates/header.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ site.title }}</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body class="synth-theme">
+    <header>
+        <div class="nav-container">
+            <a href="/" class="logo">SYNTHWAVE</a>
+            <nav>
+                <a href="/">HOME</a>
+                <a href="/about/">ABOUT</a>
+            </nav>
+        </div>
+    </header>
+    <main>

--- a/examples/synthwave-nebula/templates/page.html
+++ b/examples/synthwave-nebula/templates/page.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<article class="prose">
+    {% if page.title %}
+        <h1>{{ page.title }}</h1>
+    {% endif %}
+    {{ page.content | safe }}
+</article>
+
+{% include "footer.html" %}

--- a/examples/synthwave-nebula/templates/section.html
+++ b/examples/synthwave-nebula/templates/section.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+
+<article class="prose">
+    {% if section.title %}
+        <h1>{{ section.title }}</h1>
+    {% endif %}
+    {{ content | safe }}
+    <ul class="section-list">
+        {{ section.list | safe }}
+    </ul>
+</article>
+
+{% include "footer.html" %}

--- a/examples/synthwave-nebula/templates/shortcodes/alert.html
+++ b/examples/synthwave-nebula/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/synthwave-nebula/templates/taxonomy.html
+++ b/examples/synthwave-nebula/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/synthwave-nebula/templates/taxonomy_term.html
+++ b/examples/synthwave-nebula/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces a new example site for the Hwaro static site generator named `synthwave-nebula`.

### Changes
- Scaffolds a new project directory `examples/synthwave-nebula`.
- Configures `config.toml` with the `dracula` syntax theme and appropriate titles.
- Provides a comprehensive `style.css` driving the synthwave aesthetic (neon glows, deep purple background).
- Uses CSS to generate an animated 3D grid effect spanning the lower half of the page.
- Re-architects `header.html`, `footer.html`, `page.html`, and `section.html` to leverage the custom styling.
- Creates dummy content (`_index.md`, `about.md`) demonstrating layout use cases.

---
*PR created automatically by Jules for task [7134848770309789622](https://jules.google.com/task/7134848770309789622) started by @hahwul*