### PR TITLE
Add Neon Prism Example Template

### DIFF
--- a/neon-prism/AGENTS.md
+++ b/neon-prism/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/neon-prism/config.toml
+++ b/neon-prism/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Neon Prism"
+description = "A modern neon-themed Hwaro template."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/neon-prism/content/about.md
+++ b/neon-prism/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About The Construct"
+description = "System architecture and framework overview."
+tags = ["about", "system", "info"]
++++
+
+# System Architecture
+
+The **Neon Prism** is a modular design concept intended to showcase the flexibility of Hwaro's template engine combined with modern CSS techniques.
+
+## Core Directives
+
+Our mission is to provide a visually striking interface for developers, researchers, and synthwave enthusiasts. The visual identity relies heavily on:
+
+- High-contrast typography.
+- Emissive CSS filters (`text-shadow`, `box-shadow`).
+- Subtractive background layers using backdrop filters.
+
+*End of transmission.*

--- a/neon-prism/content/index.md
+++ b/neon-prism/content/index.md
@@ -1,0 +1,31 @@
++++
+title = "Neon Prism Hub"
+description = "Welcome to the central network terminal."
+tags = ["cyber", "neon", "welcome"]
++++
+
+Access granted. Welcome to the **Neon Prism** framework.
+
+This construct is built on [Hwaro](https://github.com/hahwul/hwaro), generating lightning-fast static nodes across the network.
+
+## System Capabilities
+
+- **Lightweight Structure:** Minimal overhead, maximum performance.
+- **Cyber Aesthetic:** Dark mode by default, powered by vivid neon accents.
+- **Seamless Integration:** Built-in support for taxonomies and metadata.
+
+## Navigation Protocols
+
+1. Traverse the [About Module](/about/) for system history.
+2. Scan [Registered Tags](/tags/) to filter entities.
+3. Access terminal configurations via `config.toml`.
+
+> "The grid is a digital frontier. I tried to picture clusters of information as they moved through the computer."
+
+### Code Execution
+
+```python
+def initiate_sequence():
+    print("Initializing Neon Prism...")
+    return True
+```

--- a/neon-prism/static/css/style.css
+++ b/neon-prism/static/css/style.css
@@ -1,0 +1,313 @@
+:root {
+  /* Neon Palette */
+  --bg-color: #05050a;
+  --bg-panel: rgba(15, 15, 25, 0.7);
+  --text-main: #e0e0ff;
+  --text-muted: #8a8aab;
+  --neon-cyan: #00f3ff;
+  --neon-pink: #ff00ea;
+  --neon-purple: #9d00ff;
+
+  /* Typography */
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'Fira Code', ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  min-height: 100vh;
+  /* Subtle grid background */
+  background-image:
+    linear-gradient(rgba(0, 243, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 243, 255, 0.03) 1px, transparent 1px);
+  background-size: 30px 30px;
+}
+
+a {
+  color: var(--neon-cyan);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--neon-pink);
+  text-shadow: 0 0 8px rgba(255, 0, 234, 0.5);
+}
+
+.site-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Header & Nav */
+.site-header {
+  padding: 30px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(157, 0, 255, 0.2);
+  margin-bottom: 40px;
+}
+
+.site-logo {
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #fff;
+  text-decoration: none;
+  position: relative;
+}
+
+.logo-text {
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-pink));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 15px rgba(0, 243, 255, 0.3);
+}
+
+.site-nav {
+  display: flex;
+  gap: 25px;
+}
+
+.site-nav a {
+  color: var(--text-main);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+}
+
+.site-nav a:hover {
+  color: var(--neon-cyan);
+  text-shadow: 0 0 10px rgba(0, 243, 255, 0.5);
+}
+
+/* Main Content */
+.site-main {
+  flex: 1;
+}
+
+.neon-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 30px;
+  color: #fff;
+  text-shadow:
+    0 0 5px #fff,
+    0 0 10px #fff,
+    0 0 20px var(--neon-purple),
+    0 0 40px var(--neon-purple);
+}
+
+.content-body {
+  background: var(--bg-panel);
+  padding: 30px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 243, 255, 0.1);
+  box-shadow: 0 0 20px rgba(15, 15, 25, 0.8), inset 0 0 15px rgba(0, 243, 255, 0.05);
+  backdrop-filter: blur(10px);
+}
+
+.content-body h1,
+.content-body h2,
+.content-body h3 {
+  color: var(--text-main);
+  margin: 1.5em 0 0.5em 0;
+  font-weight: 600;
+}
+
+.content-body h1 { font-size: 2rem; color: var(--neon-pink); text-shadow: 0 0 10px rgba(255,0,234,0.3); }
+.content-body h2 { font-size: 1.5rem; color: var(--neon-cyan); }
+.content-body h3 { font-size: 1.25rem; color: var(--text-main); }
+
+.content-body p {
+  margin-bottom: 1.2em;
+  color: var(--text-muted);
+}
+
+.content-body ul, .content-body ol {
+  margin-bottom: 1.2em;
+  padding-left: 20px;
+  color: var(--text-muted);
+}
+
+.content-body li {
+  margin-bottom: 0.5em;
+}
+
+.content-body code {
+  font-family: var(--font-mono);
+  background: rgba(157, 0, 255, 0.1);
+  color: var(--neon-pink);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  border: 1px solid rgba(157, 0, 255, 0.2);
+}
+
+.content-body pre {
+  background: #0a0a10;
+  padding: 20px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(0, 243, 255, 0.2);
+  margin-bottom: 1.5em;
+  box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+}
+
+.content-body pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #a0a0c0;
+}
+
+.content-body blockquote {
+  border-left: 4px solid var(--neon-cyan);
+  padding-left: 15px;
+  margin-left: 0;
+  margin-right: 0;
+  font-style: italic;
+  color: var(--text-main);
+  background: linear-gradient(90deg, rgba(0, 243, 255, 0.05), transparent);
+  padding: 10px 15px;
+  border-radius: 0 8px 8px 0;
+}
+
+/* Lists and Components */
+ul.neon-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 30px;
+}
+
+ul.neon-list li {
+  background: var(--bg-panel);
+  margin-bottom: 15px;
+  padding: 20px;
+  border-radius: 8px;
+  border-left: 3px solid var(--neon-purple);
+  transition: all 0.3s ease;
+  border-top: 1px solid rgba(255,255,255,0.02);
+  border-right: 1px solid rgba(255,255,255,0.02);
+  border-bottom: 1px solid rgba(255,255,255,0.02);
+}
+
+ul.neon-list li:hover {
+  transform: translateX(5px);
+  border-left-color: var(--neon-pink);
+  box-shadow: -5px 0 15px rgba(255, 0, 234, 0.2);
+}
+
+ul.neon-list li a {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+ul.neon-list li a:hover {
+  color: var(--neon-pink);
+  text-shadow: none;
+}
+
+/* Taxonomy */
+.taxonomy-terms a {
+  display: inline-block;
+  background: rgba(0, 243, 255, 0.05);
+  border: 1px solid var(--neon-cyan);
+  padding: 8px 16px;
+  border-radius: 20px;
+  margin: 0 10px 10px 0;
+  color: var(--neon-cyan);
+  font-size: 0.9rem;
+  transition: all 0.3s;
+}
+
+.taxonomy-terms a:hover {
+  background: var(--neon-cyan);
+  color: var(--bg-color);
+  box-shadow: 0 0 15px rgba(0, 243, 255, 0.4);
+}
+
+/* 404 */
+.error-content {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.error-code {
+  font-size: 8rem;
+  line-height: 1;
+  margin-bottom: 10px;
+  color: transparent;
+  -webkit-text-stroke: 2px var(--neon-pink);
+  text-shadow: none;
+  animation: glitch 2s infinite alternate;
+}
+
+@keyframes glitch {
+  0% { text-shadow: 4px 4px var(--neon-cyan), -4px -4px var(--neon-purple); }
+  25% { text-shadow: -4px 4px var(--neon-cyan), 4px -4px var(--neon-purple); }
+  50% { text-shadow: 4px -4px var(--neon-cyan), -4px 4px var(--neon-purple); }
+  75% { text-shadow: -4px -4px var(--neon-cyan), 4px 4px var(--neon-purple); }
+  100% { text-shadow: 4px 4px var(--neon-cyan), -4px -4px var(--neon-purple); }
+}
+
+.neon-btn {
+  display: inline-block;
+  margin-top: 30px;
+  padding: 12px 30px;
+  border: 2px solid var(--neon-cyan);
+  border-radius: 4px;
+  color: var(--neon-cyan);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 1px;
+  background: rgba(0, 243, 255, 0.05);
+}
+
+.neon-btn:hover {
+  background: var(--neon-cyan);
+  color: var(--bg-color);
+  box-shadow: 0 0 20px rgba(0, 243, 255, 0.6);
+  text-shadow: none;
+}
+
+/* Footer */
+.site-footer {
+  margin-top: 60px;
+  padding: 30px 0;
+  border-top: 1px solid rgba(0, 243, 255, 0.1);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .site-header {
+    flex-direction: column;
+    gap: 20px;
+  }
+  .neon-title {
+    font-size: 2rem;
+  }
+  .content-body {
+    padding: 20px;
+  }
+}

--- a/neon-prism/templates/404.html
+++ b/neon-prism/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="error-content">
+    <h1 class="neon-title error-code">404</h1>
+    <h2>Signal Lost</h2>
+    <p>The transmission you are looking for has been interrupted or does not exist in this sector.</p>
+    <a href="{{ base_url }}/" class="neon-btn">Return to Hub</a>
+  </div>
+{% endblock %}

--- a/neon-prism/templates/base.html
+++ b/neon-prism/templates/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page and page.description %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page and page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body {% if page and page.section %}data-section="{{ page.section }}"{% endif %}>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">
+        <span class="logo-text">Neon Prism</span>
+      </a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <p>&copy; 2024 {{ site.title }}. Powered by <a href="https://hwaro.hahwul.com" target="_blank">Hwaro</a>.</p>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/neon-prism/templates/page.html
+++ b/neon-prism/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <article class="page-content">
+    <header class="page-header">
+      <h1 class="neon-title">{{ page.title | e }}</h1>
+    </header>
+    <div class="content-body">
+      {{ content | safe }}
+    </div>
+  </article>
+{% endblock %}

--- a/neon-prism/templates/section.html
+++ b/neon-prism/templates/section.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="section-content">
+    <header class="section-header">
+      <h1 class="neon-title">{{ page.title | e }}</h1>
+    </header>
+    <div class="content-body">
+      {{ content | safe }}
+    </div>
+
+    <div class="item-list">
+      <ul class="neon-list">
+        {{ section.list | safe }}
+      </ul>
+    </div>
+
+    <div class="pagination-container">
+      {{ pagination | safe }}
+    </div>
+  </div>
+{% endblock %}

--- a/neon-prism/templates/shortcodes/alert.html
+++ b/neon-prism/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/neon-prism/templates/taxonomy.html
+++ b/neon-prism/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="taxonomy-content">
+    <header class="taxonomy-header">
+      <h1 class="neon-title">{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Index of all registered terms:</p>
+    </header>
+
+    <div class="taxonomy-terms">
+      {{ content | safe }}
+    </div>
+  </div>
+{% endblock %}

--- a/neon-prism/templates/taxonomy_term.html
+++ b/neon-prism/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="taxonomy-term-content">
+    <header class="term-header">
+      <h1 class="neon-title">Term: {{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Entities mapped to this term:</p>
+    </header>
+
+    <div class="item-list">
+      {{ content | safe }}
+    </div>
+  </div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -40,12 +40,6 @@
     "admin",
     "sidebar"
   ],
-  "aetherial-echoes": [
-    "elegant",
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
   "aether": [
     "dark",
     "blog",
@@ -55,6 +49,12 @@
     "dark-mode",
     "elegant",
     "portfolio"
+  ],
+  "aetherial-echoes": [
+    "elegant",
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "after-dark": [
     "blog",
@@ -2974,6 +2974,13 @@
     "vintage",
     "retro"
   ],
+  "neon-prism": [
+    "cyber",
+    "dark",
+    "modern",
+    "neon",
+    "prism"
+  ],
   "neon-tokyo": [
     "dark",
     "blog",
@@ -3635,17 +3642,17 @@
     "bold",
     "minimal"
   ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
   "quire-fold": [
     "book",
     "light",
     "craft",
     "structure",
     "traditional"
-  ],
-  "quill": [
-    "light",
-    "blog",
-    "fiction"
   ],
   "radiolaria": [
     "dark",


### PR DESCRIPTION
This PR introduces the `neon-prism` example template to the repository. It focuses on showcasing an elegant, modern, and stylized "cyber" aesthetic utilizing dark backgrounds, CSS neon glow effects (`box-shadow` and `text-shadow`), and a clean layout using a centralized `base.html`. The changes involve generating the standard Hwaro scaffolding, redesigning the CSS and templates, writing thematic placeholder content, and correctly hooking it up to `tags.json`.

---
*PR created automatically by Jules for task [2534568039948393313](https://jules.google.com/task/2534568039948393313) started by @chei-l*