### PR TITLE
Add new example: stagelight (#1503)

### DIFF
--- a/stagelight/AGENTS.md
+++ b/stagelight/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/stagelight/config.toml
+++ b/stagelight/config.toml
@@ -1,0 +1,35 @@
+# Stagelight Configuration
+title = "Stagelight"
+description = "Illuminated Performance: A dramatic theater festival theme with beam visuals."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "monokai"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[og.auto_image]
+enabled = true
+background = "#000000"
+text_color = "#FFFFFF"
+accent_color = "#FFFFFF"
+font_size = 48
+show_title = true
+style = "minimal"
+format = "svg"
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = false

--- a/stagelight/content/about.md
+++ b/stagelight/content/about.md
@@ -1,0 +1,26 @@
++++
+title = "Auditorium"
+description = "A space of light and shadow."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div style="max-width: 700px; margin: 0 auto; text-align: center;">
+  <h2 style="font-family: 'DM Serif Display'; font-size: 48px; margin-bottom: 2rem;">The Architecture of Shadow</h2>
+  <p>Our auditorium is designed to disappear. When the lights go down, the only reality is the performance. Every line of sight, every acoustic reflection, is tuned for maximum dramatic impact.</p>
+</div>
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 4rem; margin-top: 6rem;">
+  <div style="border: 1px solid var(--gray); padding: 2rem;">
+    <span class="act-label">SEATING</span>
+    <p>Tiered galleries provide intimate views of the stage from every angle. Capacity: 450.</p>
+  </div>
+  <div style="border: 1px solid var(--gray); padding: 2rem;">
+    <span class="act-label">LIGHTING</span>
+    <p>A custom-built 48-channel spotlight array capable of precise beam shaping and intensity control.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/stagelight/content/index.md
+++ b/stagelight/content/index.md
@@ -1,0 +1,40 @@
++++
+title = "Program"
+description = "A dramatic theater festival lineup."
++++
+
+{% extends "base.html" %}
+
+{% block content %}
+
+<div style="text-align: center; margin-bottom: 6rem;">
+  <div class="mask-icon">
+    <svg viewBox="0 0 24 24">
+      <path d="M12 2c-4.97 0-9 4.03-9 9 0 4.17 2.84 7.67 6.69 8.69L12 22l2.31-2.31C18.16 18.67 21 15.17 21 11c0-4.97-4.03-9-9-9zm-3 9c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm6 0c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-3 5c-1.66 0-3-1.34-3-3h6c0 1.66-1.34 3-3 3z"/>
+    </svg>
+  </div>
+  <span class="act-label">ACT I: THE AWAKENING</span>
+  <h2 style="font-family: 'DM Serif Display'; font-size: 48px; margin: 1rem 0;">Echoes of the Void</h2>
+  <div style="margin-top: 2rem;">
+    <h3 class="cast-name">Julian Thorne</h3>
+    <p style="font-variant: small-caps; font-size: 14px; opacity: 0.7;">Lead Performer</p>
+  </div>
+</div>
+
+<div style="text-align: center; margin-bottom: 6rem;">
+  <span class="act-label">ACT II: THE REVELATION</span>
+  <h2 style="font-family: 'DM Serif Display'; font-size: 48px; margin: 1rem 0;">Shadows on the Wall</h2>
+  <div style="margin-top: 2rem;">
+    <h3 class="cast-name">Sarah Vance</h3>
+    <p style="font-variant: small-caps; font-size: 14px; opacity: 0.7;">Lead Performer</p>
+  </div>
+</div>
+
+<div style="text-align: center;">
+  <svg width="100" height="40" viewBox="0 0 100 40">
+    <path d="M10 20 L50 10 L90 20 L50 30 Z" fill="none" stroke="white" stroke-width="1" />
+  </svg>
+  <p class="act-label" style="margin-top: 1rem;">INTERVAL: 20 MINUTES</p>
+</div>
+
+{% endblock %}

--- a/stagelight/templates/404.html
+++ b/stagelight/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div style="text-align: center; padding: 4rem 0;">
+  <h1 style="font-family: 'DM Serif Display'; font-size: 150px; color: var(--white); margin: 0;">DARK</h1>
+  <p style="font-size: 32px; font-weight: 300;">404 - SCENE NOT FOUND</p>
+  <p style="font-variant: small-caps; letter-spacing: 0.2em;">THE SPOTLIGHT HAS SHIFTED. THE STAGE IS EMPTY.</p>
+  <a href="{{ base_url }}/" style="display: inline-block; margin-top: 4rem; border: 1px solid var(--white); padding: 1rem 2rem; color: var(--white); text-decoration: none; font-variant: small-caps; letter-spacing: 0.2em;">RETURN TO PROGRAM</a>
+</div>
+{% endblock %}

--- a/stagelight/templates/base.html
+++ b/stagelight/templates/base.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Nunito+Sans:wght@700&display=swap" rel="stylesheet">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --black: #000000;
+      --white: #FFFFFF;
+      --gray: #333333;
+    }
+    
+    *, *::before, *::after { box-sizing: border-box; }
+    
+    body {
+      margin: 0;
+      background-color: var(--black);
+      color: var(--white);
+      font-family: 'Nunito Sans', sans-serif;
+      line-height: 1.6;
+    }
+
+    .spotlight-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 10;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 0 2rem;
+      position: relative;
+      z-index: 5;
+    }
+
+    header {
+      padding: 8rem 0 4rem;
+      text-align: center;
+      position: relative;
+    }
+
+    .curtain-drape {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100px;
+      background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0 Q 25 0 25 50 Q 25 100 0 100 L100 100 Q 75 100 75 50 Q 75 0 100 0 Z' fill='%23333333'/%3E%3C/svg%3E");
+      background-repeat: repeat-x;
+      opacity: 0.5;
+    }
+
+    .site-title {
+      font-family: 'DM Serif Display', serif;
+      font-size: 130px;
+      margin: 0;
+      text-transform: uppercase;
+      line-height: 0.9;
+    }
+
+    nav {
+      margin-top: 4rem;
+      display: flex;
+      justify-content: center;
+      gap: 3rem;
+    }
+
+    nav a {
+      color: var(--white);
+      text-decoration: none;
+      text-transform: uppercase;
+      font-size: 14px;
+      letter-spacing: 0.3em;
+      border-bottom: 1px solid transparent;
+    }
+
+    nav a:hover {
+      border-bottom-color: var(--white);
+    }
+
+    main {
+      padding: 4rem 0;
+    }
+
+    .act-label {
+      font-size: 14px;
+      letter-spacing: 0.3em;
+      text-transform: uppercase;
+      color: var(--white);
+      opacity: 0.7;
+      margin-bottom: 1rem;
+      display: block;
+      font-variant: small-caps;
+    }
+
+    .cast-name {
+      font-size: 24px;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .mask-icon {
+      width: 40px;
+      height: 40px;
+      margin-bottom: 1rem;
+      fill: var(--white);
+    }
+
+    .stage-floor {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 200px;
+      z-index: -1;
+      opacity: 0.1;
+    }
+
+    footer {
+      padding: 6rem 0;
+      text-align: center;
+      border-top: 1px solid var(--gray);
+      font-variant: small-caps;
+      font-size: 14px;
+      letter-spacing: 0.2em;
+    }
+
+    @media (max-width: 768px) {
+      .site-title { font-size: 60px; }
+      nav { flex-direction: column; align-items: center; gap: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="spotlight-overlay">
+    <svg width="100%" height="100%" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+      <polygon points="450,0 550,0 1000,1000 0,1000" fill="white" opacity="0.03" />
+      <polygon points="100,0 200,0 500,1000 -200,1000" fill="white" opacity="0.02" />
+      <polygon points="800,0 900,0 1200,1000 500,1000" fill="white" opacity="0.02" />
+    </svg>
+  </div>
+
+  <div class="stage-floor">
+    <svg width="100%" height="100%" viewBox="0 0 1000 200" preserveAspectRatio="none">
+      <path d="M0 200 L450 0 M1000 200 L550 0 M200 200 L475 0 M800 200 L525 0" stroke="white" stroke-width="1" />
+    </svg>
+  </div>
+
+  <div class="container">
+    <header>
+      <div class="curtain-drape"></div>
+      <h1 class="site-title">{{ site.title }}</h1>
+      <nav>
+        <a href="{{ base_url }}/">Program</a>
+        <a href="{{ base_url }}/about/">Auditorium</a>
+      </nav>
+    </header>
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      <p>ILLUMINATED PERFORMANCE // NO EMOJIS // NO GRADIENTS</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/stagelight/templates/page.html
+++ b/stagelight/templates/page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<article style="max-width: 800px; margin: 0 auto; text-align: center;">
+  <h1 style="font-family: 'DM Serif Display'; font-size: 80px; margin-bottom: 4rem;">{{ page.title }}</h1>
+  <div style="font-size: 20px;">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock %}

--- a/stagelight/templates/section.html
+++ b/stagelight/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-family: 'DM Serif Display'; font-size: 80px; text-align: center; margin-bottom: 4rem;">{{ section.title }}</h1>
+<div style="display: grid; grid-template-columns: 1fr; gap: 4rem; text-align: center;">
+  {% for page in section.pages %}
+  <div style="border-bottom: 1px solid var(--gray); padding-bottom: 2rem;">
+    <h2 style="font-family: 'DM Serif Display'; font-size: 40px;"><a href="{{ page.permalink }}" style="color: var(--white); text-decoration: none;">{{ page.title }}</a></h2>
+    <p>{{ page.description }}</p>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/stagelight/templates/shortcodes/alert.html
+++ b/stagelight/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/stagelight/templates/taxonomy.html
+++ b/stagelight/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/stagelight/templates/taxonomy_term.html
+++ b/stagelight/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -4288,6 +4288,13 @@
     "spotlight",
     "professional"
   ],
+  "stagelight": [
+    "event",
+    "theater",
+    "performance",
+    "dramatic",
+    "spotlight"
+  ],
   "stained-glass": [
     "light",
     "blog",


### PR DESCRIPTION
This PR adds a new event-style example site: **stagelight**.

### Design Overview
- **Concept:** Illuminated Performance (Theater Festival).
- **Palette:** Dramatic High-Contrast (Black and White).
- **Typography:** DM Serif Display, Nunito Sans.
- **Visuals:** SVG spotlight beam shapes, theater mask icons, and stage floor perspective lines.

### Compliance
- [x] NO emojis used.
- [x] NO CSS gradients used.
- [x] Verified with `hwaro build`.

Closes #1503