### PR TITLE
Add Cobalt Engine example site

### DIFF
--- a/cobalt-engine/AGENTS.md
+++ b/cobalt-engine/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/cobalt-engine/config.toml
+++ b/cobalt-engine/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Cobalt Engine"
+description = "A sleek, high-performance static site powered by Cobalt."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/cobalt-engine/content/_index.md
+++ b/cobalt-engine/content/_index.md
@@ -1,0 +1,17 @@
++++
+title = "Cobalt Engine"
+description = "High-performance framework for building the future of the web."
+layout = "page"
++++
+
+# Welcome to Cobalt Engine
+
+The Cobalt Engine is designed for speed, security, and next-generation aesthetics. It combines a deep space aesthetic with neon accents to create visually stunning applications that perform flawlessly.
+
+## Core Features
+
+- **Hyper-Fast Builds**: Compiles your entire project in milliseconds.
+- **Glassmorphic Design**: Built-in support for stunning, blurred, and layered UI elements.
+- **Deep Space Palette**: Optimized dark-mode color scheme out-of-the-box.
+
+Get started by reading our [latest updates](/posts/).

--- a/cobalt-engine/content/about.md
+++ b/cobalt-engine/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About Cobalt"
+description = "Learn more about the vision behind the Cobalt Engine."
+layout = "page"
++++
+
+# About Cobalt
+
+Cobalt Engine was born from the need for a web framework that doesn't compromise on either aesthetics or performance.
+
+We believe that the web should be both lightning-fast and beautifully designed. Our engine leverages modern web standards and cutting-edge design principles to help you create unforgettable digital experiences.
+
+## Our Philosophy
+
+- **Performance First**: Every kilobyte matters.
+- **Design Driven**: Aesthetics are not an afterthought; they are central to the user experience.
+- **Developer Experience**: Tooling should be invisible and intuitive.
+
+Join us in building the future of the web.

--- a/cobalt-engine/content/posts/_index.md
+++ b/cobalt-engine/content/posts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Posts"
+description = "Latest news, updates, and articles about Cobalt Engine."
+layout = "section"
+page_template = "page"
++++
+
+# Cobalt Updates
+
+Stay up-to-date with the latest developments, release notes, and community highlights from the Cobalt Engine ecosystem.

--- a/cobalt-engine/content/posts/introducing-cobalt-v1.md
+++ b/cobalt-engine/content/posts/introducing-cobalt-v1.md
@@ -1,0 +1,28 @@
++++
+title = "Introducing Cobalt Engine v1.0"
+date = 2024-05-01
+description = "The first major release of Cobalt Engine is here, bringing massive performance improvements and a sleek new design system."
++++
+
+# Introducing Cobalt Engine v1.0
+
+We are thrilled to announce the official release of **Cobalt Engine v1.0**. After months of rigorous testing and refining, the engine is now ready for production use.
+
+## What's New?
+
+1. **New Glassmorphism Utilities**: Easily create stunning, frosted-glass effects across your UI components.
+2. **Neon Accent System**: A highly configurable accent color system that makes your content pop against deep dark backgrounds.
+3. **Sub-millisecond Compilation**: The core engine has been rewritten from the ground up for unprecedented speed.
+
+### Code Example
+
+Here is a quick look at how you can configure your new project:
+
+```toml
+[site]
+title = "My Cobalt Project"
+accent = "cyan"
+glass_blur = "10px"
+```
+
+We can't wait to see what you build with Cobalt Engine!

--- a/cobalt-engine/templates/404.html
+++ b/cobalt-engine/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main prose">
+    <h1>404: Not Found</h1>
+    <p>The page you requested could not be found.</p>
+    <p><a href="{{ base_url }}/">Return to Homepage</a></p>
+  </main>
+{% include "footer.html" %}

--- a/cobalt-engine/templates/footer.html
+++ b/cobalt-engine/templates/footer.html
@@ -1,0 +1,10 @@
+  </div>
+  <footer class="site-footer">
+    <div class="footer-content">
+      <p>Powered by <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener noreferrer">Hwaro</a> & Cobalt Engine</p>
+    </div>
+  </footer>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/cobalt-engine/templates/header.html
+++ b/cobalt-engine/templates/header.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg-base: #050810;
+      --bg-surface: #0a0f1c;
+      --bg-glass: rgba(10, 15, 28, 0.6);
+
+      --accent-cyan: #06B6D4;
+      --accent-cyan-glow: rgba(6, 182, 212, 0.3);
+      --accent-blue: #3B82F6;
+      --accent-blue-glow: rgba(59, 130, 246, 0.3);
+
+      --text-main: #E2E8F0;
+      --text-muted: #94A3B8;
+      --text-heading: #F8FAFC;
+
+      --border-color: rgba(255, 255, 255, 0.1);
+      --border-glow: rgba(6, 182, 212, 0.2);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-main);
+      background-color: var(--bg-base);
+      background-image:
+        radial-gradient(circle at 15% 50%, rgba(59, 130, 246, 0.08), transparent 25%),
+        radial-gradient(circle at 85% 30%, rgba(6, 182, 212, 0.08), transparent 25%);
+      background-attachment: fixed;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Glassmorphic Nav */
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      background: var(--bg-glass);
+      border-bottom: 1px solid var(--border-color);
+      box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    }
+
+    .header-content {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .site-logo {
+      font-weight: 700;
+      font-size: 1.25rem;
+      color: var(--text-heading);
+      text-decoration: none;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .site-logo::before {
+      content: '';
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      background: var(--accent-cyan);
+      border-radius: 50%;
+      box-shadow: 0 0 10px var(--accent-cyan-glow);
+    }
+
+    .site-logo:hover {
+      text-shadow: 0 0 8px var(--accent-cyan-glow);
+    }
+
+    .site-header nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s, text-shadow 0.2s;
+    }
+
+    .site-header nav a:hover {
+      color: var(--accent-cyan);
+      text-shadow: 0 0 8px var(--accent-cyan-glow);
+    }
+
+    /* Main Container */
+    .site-wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+      flex: 1;
+      width: 100%;
+    }
+
+    /* Content Typography */
+    .prose {
+      max-width: 100%;
+    }
+
+    .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+      color: var(--text-heading);
+      line-height: 1.3;
+      margin-top: 2em;
+      margin-bottom: 0.75em;
+      font-weight: 600;
+    }
+
+    .prose h1 {
+      font-size: 2.5rem;
+      margin-top: 0;
+      letter-spacing: -0.02em;
+      background: linear-gradient(to right, var(--text-heading), var(--accent-cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .prose h2 { font-size: 1.75rem; border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em; }
+    .prose h3 { font-size: 1.35rem; }
+
+    .prose p { margin: 1.2em 0; font-size: 1.05rem; }
+
+    .prose a {
+      color: var(--accent-cyan);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+    }
+
+    .prose a:hover {
+      border-color: var(--accent-cyan);
+    }
+
+    .prose blockquote {
+      margin: 1.5rem 0;
+      padding: 1rem 1.5rem;
+      border-left: 4px solid var(--accent-blue);
+      background: var(--bg-surface);
+      border-radius: 0 8px 8px 0;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .prose ul, .prose ol {
+      padding-left: 1.5rem;
+      margin: 1.2em 0;
+    }
+
+    .prose li {
+      margin-bottom: 0.5em;
+    }
+
+    /* Code Blocks */
+    .prose code {
+      background: var(--bg-surface);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: 'JetBrains Mono', monospace;
+      color: var(--accent-cyan);
+      border: 1px solid var(--border-color);
+    }
+
+    .prose pre {
+      background: var(--bg-surface);
+      padding: 1.25rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border-color);
+      box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+    }
+
+    .prose pre code {
+      background: none;
+      padding: 0;
+      border: none;
+      color: inherit;
+    }
+
+    /* Lists/Cards */
+    ul.section-list {
+      list-style: none;
+      padding: 0;
+      margin: 2rem 0;
+      display: grid;
+      gap: 1rem;
+    }
+
+    ul.section-list li {
+      background: var(--bg-surface);
+      border-radius: 8px;
+      border: 1px solid var(--border-color);
+      transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+    }
+
+    ul.section-list li a {
+      display: block;
+      padding: 1.25rem;
+      color: var(--text-heading);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 1.1rem;
+    }
+
+    ul.section-list li:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent-blue);
+      box-shadow: 0 4px 20px var(--accent-blue-glow);
+    }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; }
+
+    /* Pagination */
+    nav.pagination { margin: 2rem 0; }
+    nav.pagination .pagination-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+    }
+
+    nav.pagination a, .pagination-current span, .pagination-disabled span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2.5rem;
+      height: 2.5rem;
+      padding: 0 0.75rem;
+      border-radius: 6px;
+      border: 1px solid var(--border-color);
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      text-decoration: none;
+      font-weight: 500;
+      transition: all 0.2s;
+    }
+
+    nav.pagination a:hover {
+      color: var(--accent-cyan);
+      border-color: var(--accent-cyan);
+      background: rgba(6, 182, 212, 0.1);
+    }
+
+    .pagination-current span {
+      color: var(--accent-cyan);
+      border-color: var(--accent-cyan);
+      background: rgba(6, 182, 212, 0.1);
+      box-shadow: 0 0 10px var(--accent-cyan-glow);
+    }
+
+    .pagination-disabled span {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* Footer */
+    .site-footer {
+      margin-top: auto;
+      padding: 2rem 0;
+      border-top: 1px solid var(--border-color);
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .header-content { flex-direction: column; gap: 1rem; align-items: center; padding: 1rem; }
+      .site-wrapper { padding: 2rem 1rem; }
+      .prose h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section | default(value='') }}">
+  <header class="site-header">
+    <div class="header-content">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+      </nav>
+    </div>
+  </header>
+  <div class="site-wrapper">

--- a/cobalt-engine/templates/page.html
+++ b/cobalt-engine/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main prose">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/cobalt-engine/templates/section.html
+++ b/cobalt-engine/templates/section.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+  <main class="site-main prose">
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+
+    {% if section.list %}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {% endif %}
+
+    {{ pagination }}
+  </main>
+{% include "footer.html" %}

--- a/cobalt-engine/templates/shortcodes/alert.html
+++ b/cobalt-engine/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/cobalt-engine/templates/taxonomy.html
+++ b/cobalt-engine/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-main prose">
+    <h1>{{ taxonomy.name | capitalize }}</h1>
+    <p class="taxonomy-desc">All {{ taxonomy.name }} terms</p>
+
+    <ul class="section-list">
+      {% for term in taxonomy_terms %}
+        <li>
+          <a href="{{ base_url }}/{{ taxonomy.name }}/{{ term.name | slugify }}/">
+            {{ term.name }} ({{ term.count }})
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}

--- a/cobalt-engine/templates/taxonomy_term.html
+++ b/cobalt-engine/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% include "header.html" %}
+  <main class="site-main prose">
+    <h1>{{ term.name }}</h1>
+    <p class="taxonomy-desc">Pages tagged with "{{ term.name }}"</p>
+
+    <ul class="section-list">
+      {% for page in taxonomy_pages %}
+        <li>
+          <a href="{{ base_url }}{{ page.permalink }}">
+            {{ page.title }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a new Hwaro example site named `cobalt-engine`.

It was initialized using `hwaro init cobalt-engine` and features:
- A high-tech, deep space dark theme with neon accents (`#3B82F6`, `#06B6D4`).
- Glassmorphism navigation.
- Typography utilizing Inter and JetBrains Mono.
- Fully matching auxiliary templates (`404.html`, `taxonomy.html`).
- Sample data demonstrating basic page, section, and post functionality.

---
*PR created automatically by Jules for task [7301671030829169295](https://jules.google.com/task/7301671030829169295) started by @hahwul*