### PR TITLE
feat: add starlight-synth-glass example site

### DIFF
--- a/starlight-synth-glass/AGENTS.md
+++ b/starlight-synth-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/starlight-synth-glass/config.toml
+++ b/starlight-synth-glass/config.toml
@@ -1,0 +1,23 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Starlight Synth Glass"
+description = "A neon-infused glassmorphism theme for Hwaro"
+base_url = "/"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp", "css"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = true

--- a/starlight-synth-glass/content/_index.md
+++ b/starlight-synth-glass/content/_index.md
@@ -1,0 +1,21 @@
++++
+title = "Starlight Synth Glass"
++++
+
+Welcome to the **Starlight Synth Glass** theme. This Hwaro theme combines deep space neon aesthetics with elegant translucent glassmorphism panels.
+
+## Features
+
+- **Animated Backgrounds:** A breathing radial gradient illuminating the void.
+- **Glassmorphism Panels:** Frosted, translucent content containers using `backdrop-filter`.
+- **Neon Glows:** Text elements that glow in vibrant cyan and pink.
+- **Modern Typography:** Utilizing Space Grotesk and Inter for a futuristic feel.
+
+```crystal
+# Example code block
+def generate_glow(color)
+  puts "Glowing with #{color}!"
+end
+```
+
+> "In the vastness of the digital universe, a single glowing node can illuminate the darkest void."

--- a/starlight-synth-glass/content/about.md
+++ b/starlight-synth-glass/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About This Theme"
++++
+
+This theme was built as a demonstration of what is possible with Hwaro, showcasing an immersive, app-like visual experience with pure CSS.
+
+The layout emphasizes readability while wrapping content in luxurious, glowing, frosted glass containers.
+
+It is fully responsive and uses modern CSS variables for easy customization.

--- a/starlight-synth-glass/static/style.css
+++ b/starlight-synth-glass/static/style.css
@@ -1,0 +1,200 @@
+:root {
+  --bg-dark: #07080e;
+  --bg-color: #0b0c10;
+  --text-main: #e0e6ed;
+  --text-muted: #8b9bb4;
+  --accent-cyan: #05d9e8;
+  --accent-pink: #ff2a6d;
+  --accent-purple: #9d4edd;
+
+  --font-heading: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Animated Background Gradient */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: radial-gradient(circle at 50% 50%, rgba(5, 217, 232, 0.15) 0%, rgba(255, 42, 109, 0.15) 50%, var(--bg-dark) 100%);
+  z-index: -1;
+  animation: pulseGradient 15s ease infinite alternate;
+}
+
+@keyframes pulseGradient {
+  0% { transform: scale(1); }
+  100% { transform: scale(1.1); }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  margin-top: 0;
+  font-weight: 700;
+  color: #fff;
+}
+
+a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--accent-pink);
+  text-shadow: 0 0 8px rgba(255, 42, 109, 0.6);
+}
+
+.glow-text-cyan {
+  color: var(--accent-cyan);
+  text-shadow: 0 0 10px rgba(5, 217, 232, 0.8), 0 0 20px rgba(5, 217, 232, 0.4);
+}
+
+.glow-text-pink {
+  color: var(--accent-pink);
+  text-shadow: 0 0 10px rgba(255, 42, 109, 0.8), 0 0 20px rgba(255, 42, 109, 0.4);
+}
+
+/* Glassmorphism Panel */
+.glass-panel {
+  background: rgba(11, 12, 16, 0.4);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  padding: 2rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.glass-panel:hover {
+  transform: translateY(-2px);
+  border-color: rgba(5, 217, 232, 0.3);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6), 0 0 15px rgba(5, 217, 232, 0.2), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+/* Header/Nav */
+.site-header {
+  padding: 1.5rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.site-header .glass-panel {
+  margin-bottom: 0;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 20px;
+}
+
+.site-title {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.site-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  color: var(--text-main);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 0.9rem;
+}
+
+.site-nav a:hover {
+  color: var(--accent-cyan);
+}
+
+/* Layout Container */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.main-content {
+  padding: 3rem 0;
+}
+
+/* Footer */
+.site-footer {
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.site-footer .glass-panel {
+  padding: 1.5rem;
+  border-radius: 20px;
+}
+
+/* Prose/Content Formatting */
+.prose h1, .prose h2, .prose h3 {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose p {
+  margin-bottom: 1.5em;
+  font-size: 1.05rem;
+}
+
+.prose code {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-family: monospace;
+  color: var(--accent-pink);
+  border: 1px solid rgba(255, 42, 109, 0.2);
+}
+
+.prose pre {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.prose blockquote {
+  border-left: 4px solid var(--accent-purple);
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+  font-style: italic;
+  background: linear-gradient(90deg, rgba(157, 78, 221, 0.1) 0%, transparent 100%);
+  padding: 1rem;
+  border-radius: 0 8px 8px 0;
+}

--- a/starlight-synth-glass/templates/404.html
+++ b/starlight-synth-glass/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/starlight-synth-glass/templates/footer.html
+++ b/starlight-synth-glass/templates/footer.html
@@ -1,0 +1,10 @@
+<footer class="site-footer">
+    <div class="container">
+        <div class="glass-panel">
+            <p>&copy; 2024 {{ site.title }}. Built with <a href="https://hwaro.hahwul.com" class="glow-text-pink">Hwaro</a>.</p>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/starlight-synth-glass/templates/header.html
+++ b/starlight-synth-glass/templates/header.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="{{ base_url }}/style.css">
+</head>
+<body>
+
+<header class="site-header">
+    <div class="container">
+        <div class="glass-panel">
+            <div class="site-title">
+                <a href="{{ base_url }}/" class="glow-text-cyan">{{ site.title }}</a>
+            </div>
+            <nav class="site-nav">
+                <ul>
+                    <li><a href="{{ base_url }}/">Home</a></li>
+                    <li><a href="{{ base_url }}/about/">About</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</header>

--- a/starlight-synth-glass/templates/page.html
+++ b/starlight-synth-glass/templates/page.html
@@ -1,0 +1,14 @@
+{% include "header.html" %}
+
+<main class="main-content">
+    <div class="container">
+        <article class="glass-panel prose">
+            <h1>{{ page.title }}</h1>
+            <div class="page-content">
+                {{ content | safe }}
+            </div>
+        </article>
+    </div>
+</main>
+
+{% include "footer.html" %}

--- a/starlight-synth-glass/templates/section.html
+++ b/starlight-synth-glass/templates/section.html
@@ -1,0 +1,27 @@
+{% include "header.html" %}
+
+<main class="main-content">
+    <div class="container">
+        <div class="glass-panel prose">
+            <h1>{{ section.title }}</h1>
+            <div class="section-content">
+                {{ content | safe }}
+            </div>
+
+            {% if section.pages %}
+            <div class="page-list">
+                {% for page in section.pages %}
+                <article class="list-item" style="margin-top: 2rem; padding-top: 2rem; border-top: 1px solid rgba(255,255,255,0.1);">
+                    <h3><a href="{{ page.permalink }}">{{ page.title }}</a></h3>
+                    {% if page.description %}
+                    <p>{{ page.description }}</p>
+                    {% endif %}
+                </article>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</main>
+
+{% include "footer.html" %}

--- a/starlight-synth-glass/templates/shortcodes/alert.html
+++ b/starlight-synth-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/starlight-synth-glass/templates/taxonomy.html
+++ b/starlight-synth-glass/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/starlight-synth-glass/templates/taxonomy_term.html
+++ b/starlight-synth-glass/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -40,12 +40,6 @@
     "admin",
     "sidebar"
   ],
-  "aetherial-echoes": [
-    "elegant",
-    "dark",
-    "portfolio",
-    "minimal"
-  ],
   "aether": [
     "dark",
     "blog",
@@ -55,6 +49,12 @@
     "dark-mode",
     "elegant",
     "portfolio"
+  ],
+  "aetherial-echoes": [
+    "elegant",
+    "dark",
+    "portfolio",
+    "minimal"
   ],
   "after-dark": [
     "blog",
@@ -3635,17 +3635,17 @@
     "bold",
     "minimal"
   ],
+  "quill": [
+    "light",
+    "blog",
+    "fiction"
+  ],
   "quire-fold": [
     "book",
     "light",
     "craft",
     "structure",
     "traditional"
-  ],
-  "quill": [
-    "light",
-    "blog",
-    "fiction"
   ],
   "radiolaria": [
     "dark",
@@ -4143,6 +4143,13 @@
     "portfolio",
     "elegant",
     "minimal"
+  ],
+  "starlight-synth-glass": [
+    "dark",
+    "synthwave",
+    "glassmorphism",
+    "glowing",
+    "blog"
   ],
   "starting-gun": [
     "event",


### PR DESCRIPTION
Added a new example website showcasing a unique blend of synthwave
and glassmorphism aesthetics. This includes animated glowing
backgrounds, translucent glass panels, and modern typography
using Inter and Space Grotesk. Also registered the example in tags.json.

---
*PR created automatically by Jules for task [11898547152517803294](https://jules.google.com/task/11898547152517803294) started by @hahwul*