### PR TITLE
feat: add bento-portfolio example site

### DIFF
--- a/bento-portfolio/AGENTS.md
+++ b/bento-portfolio/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/bento-portfolio/config.toml
+++ b/bento-portfolio/config.toml
@@ -1,0 +1,13 @@
+title = "Alex Doe"
+base_url = "https://example.com"
+description = "Creative Developer & Designer"
+
+[author]
+name = "Alex Doe"
+
+[build]
+theme = ""
+
+[taxonomies]
+tags = "Tags"
+categories = "Categories"

--- a/bento-portfolio/content/_index.md
+++ b/bento-portfolio/content/_index.md
@@ -1,0 +1,60 @@
++++
+title = "Home"
++++
+
+<div class="bento-grid">
+
+  <div class="bento-item bento-large">
+    <h2>Hi, I'm Alex 👋</h2>
+    <p>I'm a creative developer and designer passionate about crafting beautiful, intuitive, and performant web experiences. I love bridging the gap between design and engineering.</p>
+    <div class="social-links" style="justify-content: flex-start; margin-top: 2rem;">
+      <a href="#">GitHub</a>
+      <a href="#">LinkedIn</a>
+      <a href="#">Twitter</a>
+    </div>
+  </div>
+
+  <div class="bento-item bento-image">
+    <img src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?q=80&w=800&auto=format&fit=crop" alt="Workspace">
+  </div>
+
+  <div class="bento-item bento-center">
+    <h2>10+</h2>
+    <p>Projects Completed</p>
+  </div>
+
+  <div class="bento-item bento-wide">
+    <h2>Selected Projects</h2>
+    <p>A collection of my recent work in web development and design.</p>
+    <ul style="list-style: none; margin-top: 1rem;">
+      <li style="margin-bottom: 0.5rem;"><strong><a href="#">Project Alpha</a></strong> - E-commerce Platform</li>
+      <li style="margin-bottom: 0.5rem;"><strong><a href="#">Project Beta</a></strong> - Mobile App Redesign</li>
+      <li><strong><a href="#">Project Gamma</a></strong> - Open Source Tool</li>
+    </ul>
+  </div>
+
+  <div class="bento-item">
+    <h2>Skills</h2>
+    <div class="tags">
+      <span class="tag">JavaScript</span>
+      <span class="tag">TypeScript</span>
+      <span class="tag">React</span>
+      <span class="tag">Node.js</span>
+      <span class="tag">CSS/SCSS</span>
+      <span class="tag">Figma</span>
+    </div>
+  </div>
+
+  <div class="bento-item bento-tall" style="background-color: var(--accent-color); color: white;">
+    <h2 style="color: white;">Let's work together</h2>
+    <p style="color: rgba(255,255,255,0.8); margin-bottom: 2rem;">I'm currently available for freelance projects and open to full-time opportunities.</p>
+    <a href="mailto:hello@example.com" style="color: white; font-weight: bold; font-size: 1.2rem; text-decoration: underline;">hello@example.com</a>
+  </div>
+
+  <div class="bento-item">
+    <h2>Writing</h2>
+    <p style="margin-bottom: 1rem;">Thoughts on design, development, and the web.</p>
+    <a href="#">Read my blog &rarr;</a>
+  </div>
+
+</div>

--- a/bento-portfolio/content/about.md
+++ b/bento-portfolio/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/bento-portfolio/static/style.css
+++ b/bento-portfolio/static/style.css
@@ -1,0 +1,195 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-color: #f0f2f5;
+  --bento-bg: #ffffff;
+  --text-primary: #1a1a1a;
+  --text-secondary: #666666;
+  --accent-color: #007bff;
+  --border-radius: 24px;
+  --grid-gap: 20px;
+  --shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #121212;
+    --bento-bg: #1e1e1e;
+    --text-primary: #ffffff;
+    --text-secondary: #a0a0a0;
+    --shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header {
+  padding: 2rem 5%;
+  text-align: center;
+}
+
+.site-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.site-header p {
+  color: var(--text-secondary);
+}
+
+.main-content {
+  flex: 1;
+  padding: 2rem 5%;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.bento-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-auto-rows: 250px;
+  gap: var(--grid-gap);
+  grid-auto-flow: dense;
+}
+
+.bento-item {
+  background-color: var(--bento-bg);
+  border-radius: var(--border-radius);
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  overflow: hidden;
+}
+
+.bento-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.1);
+}
+
+/* Different sizes for bento boxes */
+.bento-large {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+.bento-wide {
+  grid-column: span 2;
+}
+
+.bento-tall {
+  grid-row: span 2;
+}
+
+/* Media Query for responsiveness */
+@media (max-width: 768px) {
+  .bento-grid {
+    grid-template-columns: 1fr;
+  }
+  .bento-large, .bento-wide {
+    grid-column: span 1;
+  }
+  .bento-tall, .bento-large {
+    grid-row: span 1;
+    min-height: 250px;
+  }
+}
+
+.bento-item h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+}
+
+.bento-item p {
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+a {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Fun additions */
+.bento-image {
+  padding: 0;
+}
+
+.bento-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--border-radius);
+}
+
+.bento-center {
+  text-align: center;
+  align-items: center;
+}
+
+.social-links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.social-links a {
+  padding: 0.5rem 1rem;
+  background-color: var(--bg-color);
+  border-radius: 50px;
+  color: var(--text-primary);
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.social-links a:hover {
+  background-color: var(--accent-color);
+  color: white;
+  text-decoration: none;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tag {
+  background-color: var(--bg-color);
+  padding: 0.3rem 0.8rem;
+  border-radius: 50px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}

--- a/bento-portfolio/templates/404.html
+++ b/bento-portfolio/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+
+{% include "footer.html" %}

--- a/bento-portfolio/templates/footer.html
+++ b/bento-portfolio/templates/footer.html
@@ -1,0 +1,6 @@
+    </main>
+    <footer class="site-footer">
+        <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }}. Built with <a href="https://hwaro.hahwul.com" target="_blank">Hwaro</a>.</p>
+    </footer>
+</body>
+</html>

--- a/bento-portfolio/templates/header.html
+++ b/bento-portfolio/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>{{ site.title }}</h1>
+        <p>{{ site.description }}</p>
+    </header>
+    <main class="main-content">

--- a/bento-portfolio/templates/page.html
+++ b/bento-portfolio/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+<article>
+    {{ content | safe }}
+</article>
+
+{% include "footer.html" %}

--- a/bento-portfolio/templates/section.html
+++ b/bento-portfolio/templates/section.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    {{ content }}
+    <ul class="section-list">
+      {{ section.list }}
+    </ul>
+    {{ pagination }}
+
+{% include "footer.html" %}

--- a/bento-portfolio/templates/shortcodes/alert.html
+++ b/bento-portfolio/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/bento-portfolio/templates/taxonomy.html
+++ b/bento-portfolio/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+
+{% include "footer.html" %}

--- a/bento-portfolio/templates/taxonomy_term.html
+++ b/bento-portfolio/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+
+{% include "footer.html" %}


### PR DESCRIPTION
Added a new example site for Hwaro named `bento-portfolio`. This site features a modern "Bento Box" CSS Grid layout, clean typography (Inter), soft shadows, and dark mode support. Included templates, configuration, and sample content to demonstrate the aesthetic.

---
*PR created automatically by Jules for task [10974692029635752129](https://jules.google.com/task/10974692029635752129) started by @hahwul*