### PR TITLE
feat: add velvet-horizon example site

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -792,6 +792,12 @@
     "landing",
     "event"
   ],
+  "celestial-breeze": [
+    "elegant",
+    "light",
+    "blog",
+    "minimal"
+  ],
   "celestial-burst": [
     "dark",
     "glamorous",
@@ -5012,6 +5018,11 @@
     "landing",
     "luxury"
   ],
+  "velvet-horizon": [
+    "dark",
+    "blog",
+    "minimal"
+  ],
   "velvet-rope": [
     "event",
     "gala",
@@ -5249,11 +5260,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "celestial-breeze": [
-    "elegant",
-    "light",
-    "blog",
-    "minimal"
   ]
 }

--- a/velvet-horizon/AGENTS.md
+++ b/velvet-horizon/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/velvet-horizon/config.toml
+++ b/velvet-horizon/config.toml
@@ -1,0 +1,182 @@
+title = "Velvet Horizon"
+description = "A dark-themed elegant glassmorphism aesthetic blog template"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = true
+per_page = 5
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+filename = "rss.xml"
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/velvet-horizon/content/_index.md
+++ b/velvet-horizon/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "The Velvet Horizon"
+description = "A journey into elegant glassmorphism and subtle glows."
+template = "section"
++++
+
+Welcome to **Velvet Horizon**. This dark-themed blog template emphasizes a smooth reading experience with frosted glass elements floating over soft, warmly glowing gradient backdrops.
+
+Feel free to explore the elegant typography, subtle animations, and deep contrasting colors.

--- a/velvet-horizon/content/about.md
+++ b/velvet-horizon/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About the Horizon"
+description = "Discover the design philosophy behind Velvet Horizon."
+date = "2025-10-24"
++++
+
+**Velvet Horizon** was crafted with the idea of a serene digital space. Imagine watching a distant glowing horizon over a quiet, dark sea.
+
+## Design Philosophy
+
+The core of this aesthetic lies in **glassmorphism**:
+
+- Translucent panels that reveal the soft, animated gradients beneath.
+- A restrained color palette consisting of deep slate, space blacks, and warm corals.
+- Typography that pairs the refined strokes of `Playfair Display` with the crisp legibility of `Inter`.
+
+## Why Hwaro?
+
+Hwaro provides the speed and flexibility necessary to build these beautiful, highly-customized static sites effortlessly. Its powerful templating engine lets us weave complex layouts together seamlessly.

--- a/velvet-horizon/content/posts/_index.md
+++ b/velvet-horizon/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+description = "All blog posts from the Velvet Horizon."
+sort_by = "date"
+template = "section"
+transparent = true
++++

--- a/velvet-horizon/content/posts/embracing-shadows.md
+++ b/velvet-horizon/content/posts/embracing-shadows.md
@@ -1,0 +1,24 @@
++++
+title = "Embracing the Shadows"
+date = "2025-10-24"
+description = "A short post about the use of shadows and dark themes in UI."
+tags = ["design", "glassmorphism"]
++++
+
+Dark themes are more than just inverted colors. When combined with carefully considered shadows and glows, a dark UI can create depth and focus that light themes sometimes struggle to achieve.
+
+## The Glow
+
+By allowing warm and cool radial gradients to bleed through translucent background panels, we give the interface a sense of life—a gentle breathing rhythm.
+
+### Code Example
+
+```css
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+}
+```
+
+This simple combination of properties is what gives the "frosted glass" effect.

--- a/velvet-horizon/static/css/style.css
+++ b/velvet-horizon/static/css/style.css
@@ -1,0 +1,260 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+
+:root {
+  --color-bg-dark: #0a0512;
+  --color-bg-light: #160b24;
+  --color-glow-warm: #ff5e62;
+  --color-glow-cool: #ff9966;
+  --color-text-main: #f8fafc;
+  --color-text-muted: #94a3b8;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --glass-bg: rgba(22, 11, 36, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.05);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--color-bg-dark);
+  color: var(--color-text-main);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Background gradient / glow */
+body::before {
+  content: '';
+  position: fixed;
+  top: -20%;
+  left: -10%;
+  width: 50vw;
+  height: 50vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--color-glow-warm) 0%, transparent 60%);
+  opacity: 0.15;
+  filter: blur(100px);
+  z-index: -1;
+  animation: floatWarm 15s ease-in-out infinite alternate;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  bottom: -20%;
+  right: -10%;
+  width: 40vw;
+  height: 40vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--color-glow-cool) 0%, transparent 60%);
+  opacity: 0.15;
+  filter: blur(100px);
+  z-index: -1;
+  animation: floatCool 20s ease-in-out infinite alternate;
+}
+
+@keyframes floatWarm {
+  0% { transform: translate(0, 0); }
+  100% { transform: translate(5%, 10%); }
+}
+@keyframes floatCool {
+  0% { transform: translate(0, 0); }
+  100% { transform: translate(-5%, -10%); }
+}
+
+a {
+  color: var(--color-glow-cool);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+a:hover {
+  color: var(--color-glow-warm);
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  font-size: 3rem;
+  line-height: 1.2;
+}
+
+h2 {
+  font-size: 2rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.5rem;
+}
+
+p {
+  margin-bottom: 1.5rem;
+  color: var(--color-text-muted);
+}
+
+/* Layout */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* Header & Nav */
+header {
+  padding: 2rem 0;
+  margin-bottom: 3rem;
+  position: relative;
+  z-index: 10;
+}
+
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: 100px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+}
+
+.site-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text-main);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.nav-links a {
+  margin-left: 1.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 500;
+}
+
+.nav-links a:hover {
+  color: var(--color-glow-warm);
+}
+
+/* Content Area */
+main {
+  min-height: 60vh;
+}
+
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 2.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+/* Post Meta */
+.post-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: 2rem;
+  font-family: 'Inter', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Lists */
+.post-list {
+  list-style: none;
+}
+
+.post-item {
+  margin-bottom: 1.5rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.post-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+}
+
+.post-item h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+}
+
+.post-item h3 a {
+  color: var(--color-text-main);
+}
+
+.post-item h3 a:hover {
+  color: var(--color-glow-warm);
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 3rem 0;
+  margin-top: 4rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+/* Prose for content rendering */
+.prose h1, .prose h2, .prose h3 {
+  color: var(--color-text-main);
+  margin-top: 2rem;
+}
+
+.prose a {
+  color: var(--color-glow-cool);
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 153, 102, 0.3);
+  text-underline-offset: 4px;
+}
+
+.prose a:hover {
+  color: var(--color-glow-warm);
+  text-decoration-color: var(--color-glow-warm);
+}
+
+.prose code {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+  color: var(--color-glow-cool);
+}
+
+.prose pre {
+  background: rgba(0, 0, 0, 0.5) !important;
+  padding: 1.5rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid var(--glass-border);
+  margin-bottom: 1.5rem;
+}
+
+.prose pre code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}

--- a/velvet-horizon/templates/404.html
+++ b/velvet-horizon/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/velvet-horizon/templates/footer.html
+++ b/velvet-horizon/templates/footer.html
@@ -1,0 +1,8 @@
+    </main>
+    <footer>
+        <div class="container">
+            <p>&copy; {{ current_year }} {{ site.title }}. Built with <a href="https://hwaro.hahwul.com">Hwaro</a>.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/velvet-horizon/templates/header.html
+++ b/velvet-horizon/templates/header.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page is defined and page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+    {% if site.highlight is defined and site.highlight.enabled %}
+      {% if site.highlight.use_cdn %}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/{{ site.highlight.theme | default('atom-one-dark') }}.min.css">
+      {% endif %}
+    {% endif %}
+    {{ site.auto_includes | safe }}
+</head>
+<body>
+    <header>
+        <div class="container">
+            <nav>
+                <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+                <div class="nav-links">
+                    <a href="{{ base_url }}/">Home</a>
+                    <a href="{{ base_url }}/about/">About</a>
+                </div>
+            </nav>
+        </div>
+    </header>
+    <main class="container">

--- a/velvet-horizon/templates/page.html
+++ b/velvet-horizon/templates/page.html
@@ -1,0 +1,28 @@
+{% include "header.html" %}
+
+<article class="glass-panel prose">
+    <header>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="post-meta">
+            {{ page.date | date("%B %d, %Y") }}
+            {% if page.reading_time %}
+            &middot; {{ page.reading_time }} min read
+            {% endif %}
+        </div>
+        {% endif %}
+    </header>
+
+    {{ content | safe }}
+
+    {% if page.taxonomies is defined and page.taxonomies.tags %}
+    <div class="tags" style="margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--glass-border);">
+        <strong>Tags:</strong>
+        {% for tag in page.taxonomies.tags %}
+            <a href="{{ base_url }}/tags/{{ tag | slugify }}/" style="margin-right: 0.5rem; display: inline-block; padding: 0.2rem 0.6rem; background: rgba(255,255,255,0.05); border-radius: 4px; font-size: 0.8rem;">#{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+
+{% include "footer.html" %}

--- a/velvet-horizon/templates/section.html
+++ b/velvet-horizon/templates/section.html
@@ -1,0 +1,30 @@
+{% include "header.html" %}
+
+<div class="glass-panel prose">
+    {% if section.title %}
+        <h1>{{ section.title }}</h1>
+    {% elif page.title %}
+        <h1>{{ page.title }}</h1>
+    {% endif %}
+
+    {% if content %}
+        {{ content | safe }}
+    {% endif %}
+</div>
+
+{% if section.pages %}
+<div class="post-list">
+    {% for post in section.pages %}
+    <article class="glass-panel post-item">
+        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        <div class="post-meta">{{ post.date | date("%B %d, %Y") }}</div>
+        {% if post.summary %}
+        <p>{{ post.summary | strip_html | truncate_words(30) }}</p>
+        {% endif %}
+        <a href="{{ post.url }}" style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">Read More &rarr;</a>
+    </article>
+    {% endfor %}
+</div>
+{% endif %}
+
+{% include "footer.html" %}

--- a/velvet-horizon/templates/shortcodes/alert.html
+++ b/velvet-horizon/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/velvet-horizon/templates/taxonomy.html
+++ b/velvet-horizon/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/velvet-horizon/templates/taxonomy_term.html
+++ b/velvet-horizon/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces a new example site to showcase Hwaro's capabilities with elegant and sophisticated design aesthetics.

Key features of the `velvet-horizon` template:
- Dark-themed UI with `Playfair Display` headers and `Inter` body text.
- Glassmorphism design utilizing translucent panels (`backdrop-filter: blur()`).
- Warm and cool glowing ambient gradients running via CSS animations.
- Registered with the tags: `dark`, `blog`, and `minimal`.

All code review and visual verification checks have passed locally.

---
*PR created automatically by Jules for task [9231729750151057901](https://jules.google.com/task/9231729750151057901) started by @hahwul*