### PR TITLE
Fix broken links in helix-docs example

### DIFF
--- a/helix-docs/content/getting-started/configuration.md
+++ b/helix-docs/content/getting-started/configuration.md
@@ -33,4 +33,4 @@ enabled = true
 
 ## Full Reference
 
-See the [Configuration Reference](/reference/config.html) for all available options.
+See the [Configuration Reference](/reference/config/) for all available options.

--- a/helix-docs/content/getting-started/installation.md
+++ b/helix-docs/content/getting-started/installation.md
@@ -37,4 +37,4 @@ We recommend using a sterile virtual environment for all Helix projects.
 
 ## Next Steps
 
-Once your environment is isolated, proceed to [Rapid Prototyping]({{ base_url }}/getting-started/quick-start/) to begin building your first model.
+Once your environment is isolated, proceed to [Rapid Prototyping](/getting-started/quick-start/) to begin building your first model.

--- a/helix-docs/content/getting-started/quick-start.md
+++ b/helix-docs/content/getting-started/quick-start.md
@@ -42,5 +42,5 @@ Visit `http://localhost:3000` to see your site.
 
 ## Next Steps
 
-- Read about [Configuration](/getting-started/configuration.html)
-- Learn about [Content Management](/guide/content-management.html)
+- Read about [Configuration](/getting-started/configuration/)
+- Learn about [Content Management](/guide/content-management/)

--- a/helix-docs/content/guide/content-management.md
+++ b/helix-docs/content/guide/content-management.md
@@ -42,7 +42,7 @@ Sections are directories containing related content. Each section should have an
 Link to other pages using relative paths:
 
 ```markdown
-[Installation](/getting-started/installation.html)
+[Installation](/getting-started/installation/)
 ```
 
 ## Images

--- a/helix-docs/content/guide/templates.md
+++ b/helix-docs/content/guide/templates.md
@@ -34,4 +34,4 @@ For complex data models, use our built-in shortcodes to enhance clarity.
 - **DNA Patterns**: Inject subtle helix-themed decorations.
 - **Progressive Disclosure**: Reveal content based on user interaction.
 
-Proceed to the [Terminal Hub]({{ base_url }}/reference/cli/) for advanced command-line control over your visualization engine.
+Proceed to the [Terminal Hub](/reference/cli/) for advanced command-line control over your visualization engine.

--- a/helix-docs/content/index.md
+++ b/helix-docs/content/index.md
@@ -26,4 +26,4 @@ To initialize your research environment, follow our isolation protocols and rapi
 helix init my-research --scaffold science
 ```
 
-Next, analyze the [Structural Components]({{ base_url }}/guide/) to understand how data is synthesized within our environment.
+Next, analyze the [Structural Components](/guide/) to understand how data is synthesized within our environment.


### PR DESCRIPTION
Fix broken links in helix-docs example

Updated internal links in markdown files to use directory-based URLs rather than `.html` extensions. Replaced interpolation of `{{ base_url }}` inside markdown files, since it is not evaluated and results in literal strings, with proper relative/absolute paths.

---
*PR created automatically by Jules for task [4738828204605710130](https://jules.google.com/task/4738828204605710130) started by @chei-l*