### PR TITLE
Add new example: lumina-grid

### DIFF
--- a/lumina-grid/AGENTS.md
+++ b/lumina-grid/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/lumina-grid/config.toml
+++ b/lumina-grid/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lumina Grid"
+description = "A futuristic light-based grid theme"
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"      # Set explicitly to prevent warning
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/lumina-grid/content/about.md
+++ b/lumina-grid/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About"
+description = "Details about the Lumina Grid theme."
+date = 2026-04-18
++++
+
+## About Lumina Grid
+
+Lumina Grid is designed for projects that need a dark, highly technical, and futuristic look. It is perfect for tech blogs, portfolios, documentation for cutting-edge software, or anything cyberpunk-related.
+
+### Design Philosophy
+
+The design revolves around the concept of a digital matrix. We keep unnecessary styling to a minimum, letting the vivid colors and structured layout draw focus to the content.
+
+<div class="tech-specs">
+  <h3>Technical Specs</h3>
+  <ul>
+    <li>Dark mode by default</li>
+    <li>Lightweight CSS variables</li>
+    <li>No heavy frameworks</li>
+  </ul>
+</div>
+
+Return to the [Homepage](/).

--- a/lumina-grid/content/index.md
+++ b/lumina-grid/content/index.md
@@ -1,0 +1,20 @@
++++
+title = "Home"
+description = "Welcome to Lumina Grid, the neon-lit futuristic theme."
+date = 2026-04-18
++++
+
+<div class="hero">
+  <h1>Lumina Grid</h1>
+  <p class="subtitle">A light-based futuristic architecture</p>
+</div>
+
+Welcome to **Lumina Grid**, where neon lines intersect and data flows endlessly. This template uses striking contrast, geometric grid backgrounds, and bright accents to create a cyberpunk-inspired atmosphere.
+
+## Core Features
+
+- **Neon Aesthetics:** High contrast with `cyan` and `magenta` highlights against deep `#050505` backgrounds.
+- **Glowing Grid:** A CSS background grid that illuminates as you scroll.
+- **Futuristic Typography:** Clean, precise sans-serif styling with technical monospace accents.
+
+Check out the [About page](/about/) for more details.

--- a/lumina-grid/templates/404.html
+++ b/lumina-grid/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-404" style="text-align: center; padding: 4rem 0;">
+  <h1 style="font-size: 5rem; color: var(--magenta); text-shadow: 0 0 20px rgba(255,0,60,0.5); margin-bottom: 0;">404</h1>
+  <h2 style="border: none; color: var(--cyan);">SYSTEM_ERROR: PAGE_NOT_FOUND</h2>
+  <p style="color: var(--text-muted); margin: 2rem 0; font-family: ui-monospace, monospace;">The requested data sector does not exist or has been corrupted.</p>
+  <a href="{{ base_url }}" style="display: inline-block; padding: 0.8rem 1.5rem; background: rgba(0,240,255,0.1); border: 1px solid var(--cyan); text-transform: uppercase; letter-spacing: 1px; border-radius: 4px;">Return to Main Grid</a>
+</div>
+{% endblock %}

--- a/lumina-grid/templates/base.html
+++ b/lumina-grid/templates/base.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default('en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page and page.description is present %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page and page.title is present %}{{ page.title | e }} - {% elif section and section.title is present %}{{ section.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --bg-dark: #050508;
+      --grid-line: rgba(0, 255, 255, 0.08);
+      --text-main: #e0e0e0;
+      --text-muted: #8892b0;
+      --cyan: #00f0ff;
+      --magenta: #ff003c;
+      --accent: var(--cyan);
+      --border-color: rgba(0, 240, 255, 0.2);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-main);
+      background-color: var(--bg-dark);
+      /* Cyberpunk grid background using box-shadow and pseudo elements instead of gradients */
+      min-height: 100vh;
+      position: relative;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="none" stroke="rgba(0,255,255,0.08)" stroke-width="1"/></svg>');
+      z-index: -1;
+      pointer-events: none;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 2rem; flex: 1; display: flex; flex-direction: column; width: 100%; }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 2rem 0;
+      border-bottom: 2px solid var(--border-color);
+      margin-bottom: 3rem;
+      box-shadow: 0 4px 20px -10px rgba(0, 240, 255, 0.15);
+    }
+
+    .site-logo {
+      font-weight: 800;
+      font-size: 1.5rem;
+      color: var(--cyan);
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+    }
+
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      color: var(--text-main);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-family: ui-monospace, monospace;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: all 0.2s ease;
+    }
+    .site-header nav a:hover {
+      color: var(--magenta);
+      text-shadow: 0 0 8px rgba(255, 0, 60, 0.6);
+    }
+
+    .site-main { flex: 1; }
+
+    .site-footer {
+      margin-top: 4rem;
+      padding: 2rem 0;
+      border-top: 1px solid var(--border-color);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+      font-family: ui-monospace, monospace;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      line-height: 1.3;
+      margin-top: 2em;
+      margin-bottom: 0.8em;
+      font-weight: 700;
+      color: #fff;
+    }
+    h1 {
+      font-size: 2.5rem;
+      margin-top: 0;
+      color: var(--cyan);
+      text-shadow: 0 0 15px rgba(0, 240, 255, 0.4);
+    }
+    h2 { font-size: 1.8rem; border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em; }
+    h3 { font-size: 1.3rem; color: var(--magenta); }
+
+    p { margin: 1.2em 0; }
+
+    a {
+      color: var(--cyan);
+      text-decoration: none;
+      position: relative;
+    }
+    a:hover {
+      color: #fff;
+      text-shadow: 0 0 8px var(--cyan);
+    }
+    .site-main a {
+      border-bottom: 1px dashed var(--cyan);
+    }
+    .site-main a:hover {
+      border-bottom: 1px solid var(--cyan);
+    }
+
+    /* Elements */
+    code, pre {
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+    code {
+      background: rgba(0, 240, 255, 0.1);
+      color: var(--cyan);
+      padding: 0.2rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.85em;
+      border: 1px solid rgba(0, 240, 255, 0.2);
+    }
+    pre {
+      background: rgba(5, 5, 10, 0.8);
+      padding: 1.2rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      border: 1px solid var(--border-color);
+      border-left: 4px solid var(--magenta);
+    }
+    pre code { background: none; padding: 0; border: none; color: inherit; }
+
+    blockquote {
+      margin: 1.5rem 0;
+      padding: 1rem 1.5rem;
+      border-left: 4px solid var(--cyan);
+      background: rgba(0, 240, 255, 0.05);
+      color: var(--text-muted);
+    }
+
+    hr {
+      border: 0;
+      height: 1px;
+      background-color: var(--cyan);
+      margin: 3rem 0;
+      opacity: 0.2;
+    }
+
+    /* Custom classes used in content */
+    .hero {
+      text-align: center;
+      padding: 3rem 0 2rem;
+      margin-bottom: 2rem;
+    }
+    .hero h1 {
+      font-size: 3.5rem;
+      margin-bottom: 0.2em;
+    }
+    .hero .subtitle {
+      font-size: 1.2rem;
+      color: var(--text-muted);
+      font-family: ui-monospace, monospace;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+    .tech-specs {
+      background: rgba(255, 0, 60, 0.05);
+      border: 1px solid rgba(255, 0, 60, 0.3);
+      padding: 1.5rem;
+      border-radius: 4px;
+      margin: 2rem 0;
+    }
+    .tech-specs h3 {
+      margin-top: 0;
+      color: var(--magenta);
+    }
+    .tech-specs ul {
+      margin-bottom: 0;
+    }
+
+    /* Lists */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem;
+      padding: 1.5rem;
+      background: rgba(5, 5, 10, 0.7);
+      border-radius: 4px;
+      border: 1px solid var(--border-color);
+      position: relative;
+      transition: all 0.3s ease;
+    }
+    ul.section-list li:hover {
+      border-color: var(--cyan);
+      box-shadow: 0 0 15px rgba(0, 240, 255, 0.1);
+      transform: translateX(5px);
+    }
+    ul.section-list li a { font-weight: 600; font-size: 1.2rem; border-bottom: none; }
+
+    .meta { font-family: ui-monospace, monospace; font-size: 0.85rem; color: var(--text-muted); margin-bottom: 2rem; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; }
+      .site-wrapper { padding: 0 1.2rem; }
+      .hero h1 { font-size: 2.5rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{% if page and page.section %}{{ page.section }}{% endif %}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}">Home</a>
+        <a href="{{ base_url }}about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; 2026 {{ site.title }}. // SYSTEM ONLINE // <a href="{{ base_url }}rss.xml">DATA STREAM</a></p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/lumina-grid/templates/page.html
+++ b/lumina-grid/templates/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page">
+  <header>
+    <h1>{{ page.title | e }}</h1>
+    {% if page.date %}
+      <div class="meta">
+        <time datetime="{{ page.date | date(format='%Y-%m-%d') }}">{{ page.date | date(format="%B %d, %Y") }}</time>
+      </div>
+    {% endif %}
+  </header>
+
+  <div class="content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.tags and page.tags | length > 0 %}
+    <div class="tags" style="margin-top: 3rem; padding-top: 1rem; border-top: 1px dashed var(--border-color);">
+      <h3 style="font-size: 1rem; color: var(--text-muted); margin-top: 0;">CLASSIFICATION_TAGS:</h3>
+      {% for tag in page.tags %}
+        <a href="{{ base_url }}tags/{{ tag | lower | replace(pattern=' ', replace='-') }}/" style="display: inline-block; padding: 0.2rem 0.5rem; background: rgba(0,240,255,0.1); border: 1px solid var(--cyan); border-radius: 3px; font-family: ui-monospace, monospace; font-size: 0.8rem; margin-right: 0.5rem; text-decoration: none;">#{{ tag }}</a>
+      {% endfor %}
+    </div>
+  {% endif %}
+</article>
+{% endblock %}

--- a/lumina-grid/templates/section.html
+++ b/lumina-grid/templates/section.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section">
+  <h1>{{ section.title | default("Directory") | e }}</h1>
+
+  {% if content %}
+    <div class="content" style="margin-bottom: 2rem;">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+
+  {% if section.pages %}
+    <ul class="section-list">
+      {% for page in section.pages %}
+        <li>
+          <a href="{{ base_url }}{{ page.permalink }}">{{ page.title | e }}</a>
+          {% if page.description %}
+            <p style="margin: 0.5rem 0 0; color: var(--text-muted); font-size: 0.95rem;">{{ page.description | e }}</p>
+          {% endif %}
+          {% if page.date %}
+            <div style="margin-top: 0.5rem; font-family: ui-monospace, monospace; font-size: 0.8rem; color: var(--magenta);">
+              {{ page.date | date(format="%Y-%m-%d") }}
+            </div>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+
+    {% if pagination %}
+      <div class="pagination">
+        {{ pagination | safe }}
+      </div>
+    {% endif %}
+  {% else %}
+    <p style="color: var(--text-muted); font-style: italic;">// DIRECTORY_EMPTY //</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/lumina-grid/templates/shortcodes/alert.html
+++ b/lumina-grid/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/lumina-grid/templates/taxonomy.html
+++ b/lumina-grid/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy">
+  <h1>{{ page.title | e }}</h1>
+
+  {% if content %}
+    <div class="content" style="margin-bottom: 2rem;">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/lumina-grid/templates/taxonomy_term.html
+++ b/lumina-grid/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-term">
+  <h1>{{ page.title | e }}</h1>
+
+  {% if content %}
+    <div class="content" style="margin-bottom: 2rem;">
+      {{ content | safe }}
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2705,6 +2705,12 @@
     "elegant",
     "minimal"
   ],
+  "lumina-grid": [
+    "dark",
+    "grid",
+    "futuristic",
+    "neon"
+  ],
   "lumina-space": [
     "space",
     "dark",


### PR DESCRIPTION
Adds a uniquely designed neon/cyberpunk template called `lumina-grid`.
Includes fully responsive templates, basic markdown pages, and a unique CSS grid background made with an embedded SVG.

Tested locally with `hwaro build` and visually verified.

---
*PR created automatically by Jules for task [9260848200944934273](https://jules.google.com/task/9260848200944934273) started by @chei-l*