### PR TITLE
feat: add new Prismatica theme example

### DIFF
--- a/prismatica/AGENTS.md
+++ b/prismatica/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/prismatica/config.toml
+++ b/prismatica/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Prismatica"
+description = "A holographic, elegant portfolio and blog."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"      # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/prismatica/content/about.md
+++ b/prismatica/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About Prismatica"
+description = "Information about this glowing theme."
+date = "2024-05-01"
++++
+
+Prismatica is designed to make your content pop out of the darkness. By relying on CSS `backdrop-filter` and carefully placed radial gradients, it provides an immersive, elegant, and highly unique viewing experience.
+
+### Technical Details
+
+The background glow is created using a fixed pseudo-element (or div) with multiple layered `radial-gradient` backgrounds. These gradients are animated using a simple CSS `@keyframes` scale animation, causing the "light" to pulse softly behind the content.
+
+The cards use an RGBA background with very low opacity combined with a subtle white border, effectively creating the popular "glass" look.
+
+```css
+.glass-card {
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+```
+
+Enjoy building with Prismatica!

--- a/prismatica/content/index.md
+++ b/prismatica/content/index.md
@@ -1,0 +1,17 @@
++++
+title = "Experience the Spectrum"
+description = "Welcome to Prismatica, a holographic portfolio and blog theme."
+date = "2024-05-01"
++++
+
+Welcome to **Prismatica**, a visually striking template featuring a dark mode aesthetic, glassmorphism, and a luminous holographic glow.
+
+### Key Features
+* **Glassmorphism:** Elements mimic frosted glass, creating depth.
+* **Holographic Glow:** Subtle, animated background gradients that breathe life into the design.
+* **Modern Typography:** A crisp combination of Inter for reading and JetBrains Mono for a tech-forward feel.
+
+Get started by exploring the layout, customizing the CSS variables, and creating your own radiant content.
+
+<br>
+<a href="/about/" class="btn-primary">Learn More</a>

--- a/prismatica/static/style.css
+++ b/prismatica/static/style.css
@@ -1,0 +1,273 @@
+:root {
+  --bg-color: #0b0c10;
+  --text-primary: #e0e6ed;
+  --text-secondary: #8b9bb4;
+  --glass-bg: rgba(255, 255, 255, 0.03);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --gradient-1: #ff007f;
+  --gradient-2: #7928ca;
+  --gradient-3: #00f0ff;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --radius: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Prismatic Background Glow */
+.glow-bg {
+  position: fixed;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at 50% 50%, rgba(121, 40, 202, 0.15), transparent 40%),
+              radial-gradient(circle at 80% 20%, rgba(0, 240, 255, 0.1), transparent 30%),
+              radial-gradient(circle at 20% 80%, rgba(255, 0, 127, 0.1), transparent 30%);
+  z-index: -1;
+  animation: breathe 15s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+@keyframes breathe {
+  0% { transform: scale(1); }
+  100% { transform: scale(1.05); }
+}
+
+/* Glassmorphism Utilities */
+.glass-header, .glass-footer, .glass-card {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+}
+
+/* Layout */
+.nav-container, .main-content, .footer-content {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* Header & Nav */
+.glass-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid var(--glass-border);
+  border-left: none;
+  border-right: none;
+  border-top: none;
+}
+
+.nav-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 80px;
+}
+
+.logo {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: -0.5px;
+}
+
+.logo-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  background: linear-gradient(135deg, var(--gradient-1), var(--gradient-3));
+  box-shadow: 0 0 15px rgba(255,0,127,0.5);
+}
+
+.nav-links a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.3s ease;
+  margin-left: 1.5rem;
+}
+
+.nav-links a:hover {
+  color: #fff;
+}
+
+/* Main Content */
+.main-content {
+  flex: 1;
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+  width: 100%;
+}
+
+/* Typography & Gradients */
+.gradient-text {
+  background: linear-gradient(to right, var(--gradient-1), var(--gradient-2), var(--gradient-3));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  display: inline-block;
+}
+
+h1, h2, h3 {
+  color: #fff;
+  margin-bottom: 1rem;
+  line-height: 1.2;
+}
+
+h1 { font-size: 3rem; letter-spacing: -1px; }
+h2 { font-size: 2rem; }
+
+p { margin-bottom: 1.5rem; }
+
+a { color: var(--gradient-3); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Cards */
+.glass-card {
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+a.glass-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+a.glass-card:hover {
+  transform: translateY(-5px);
+  border-color: rgba(255,255,255,0.2);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.5), 0 0 20px rgba(121,40,202,0.2);
+}
+
+.card-title {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #fff;
+}
+
+.card-meta, .page-meta {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+.card-desc {
+  color: var(--text-secondary);
+  margin-bottom: 0;
+}
+
+/* Grid Layout for Sections */
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.content-grid .glass-card {
+  margin-bottom: 0;
+}
+
+/* Markdown Content Elements */
+.page-content h2 { margin-top: 2.5rem; }
+.page-content h3 { margin-top: 2rem; }
+.page-content ul, .page-content ol { margin-bottom: 1.5rem; padding-left: 1.5rem; }
+.page-content li { margin-bottom: 0.5rem; }
+
+/* Code Blocks */
+.page-content pre {
+  background: rgba(0, 0, 0, 0.4) !important;
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.page-content code {
+  font-family: var(--font-mono);
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.page-content pre code {
+  background: none;
+  padding: 0;
+}
+
+/* Footer */
+.glass-footer {
+  border-top: 1px solid var(--glass-border);
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  padding: 2rem 0;
+  margin-top: auto;
+}
+
+.footer-content p {
+  margin: 0;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+/* Button */
+.btn-primary {
+  display: inline-block;
+  background: linear-gradient(to right, var(--gradient-1), var(--gradient-2));
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 30px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  h1 { font-size: 2.2rem; }
+  .glass-card { padding: 1.5rem; }
+  .nav-container, .main-content, .footer-content { padding: 0 1.5rem; }
+}

--- a/prismatica/templates/404.html
+++ b/prismatica/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card error-page">
+  <h1 class="gradient-text text-xl">404</h1>
+  <p>The page you are looking for does not exist.</p>
+  <a href="{{ base_url }}" class="btn-primary">Return Home</a>
+</div>
+{% endblock content %}

--- a/prismatica/templates/base.html
+++ b/prismatica/templates/base.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <link rel="stylesheet" href="{{ base_url }}style.css" type="text/css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  {% if site.highlight is defined and site.highlight.enabled %}
+    {{ highlight_css | safe }}
+  {% endif %}
+</head>
+<body>
+  <div class="glow-bg"></div>
+
+  <header class="glass-header">
+    <nav class="nav-container">
+      <a href="{{ base_url }}" class="logo">
+        <span class="logo-icon"></span>
+        {{ site.title }}
+      </a>
+      <div class="nav-links">
+        <a href="{{ base_url }}about/">About</a>
+        <!-- Add more links if necessary -->
+      </div>
+    </nav>
+  </header>
+
+  <main class="main-content">
+    {% block content %}{% endblock content %}
+  </main>
+
+  <footer class="glass-footer">
+    <div class="footer-content">
+      <p>&copy; 2024 {{ site.title }}. Built with Hwaro.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/prismatica/templates/page.html
+++ b/prismatica/templates/page.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-card page-article">
+  <header class="page-header">
+    <h1 class="gradient-text">{{ page.title }}</h1>
+    {% if page.date %}
+    <p class="page-meta">
+      <time datetime="{{ page.date }}">{{ page.date | date(format="%B %d, %Y") }}</time>
+    </p>
+    {% endif %}
+  </header>
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock content %}

--- a/prismatica/templates/section.html
+++ b/prismatica/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section-container">
+  <header class="section-header">
+    <h1 class="gradient-text">{{ section.title }}</h1>
+    {% if section.description %}
+      <p class="section-desc">{{ section.description }}</p>
+    {% endif %}
+  </header>
+
+  <div class="content-grid">
+    {% for p in section.pages %}
+      <a href="{{ base_url }}{{ p.path | trim_start_matches(pat='/') }}" class="glass-card page-card">
+        <h2 class="card-title">{{ p.title }}</h2>
+        {% if p.date %}
+          <p class="card-meta">{{ p.date | date(format="%B %d, %Y") }}</p>
+        {% endif %}
+        {% if p.description %}
+          <p class="card-desc">{{ p.description }}</p>
+        {% endif %}
+      </a>
+    {% endfor %}
+  </div>
+</section>
+{% endblock content %}

--- a/prismatica/templates/shortcodes/alert.html
+++ b/prismatica/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/prismatica/templates/taxonomy.html
+++ b/prismatica/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section-container">
+  <header class="section-header">
+    <h1 class="gradient-text">{{ page.title }}</h1>
+  </header>
+  <div class="page-content taxonomy-content">
+    {{ content | safe }}
+  </div>
+</section>
+{% endblock content %}

--- a/prismatica/templates/taxonomy_term.html
+++ b/prismatica/templates/taxonomy_term.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section-container">
+  <header class="section-header">
+    <h1 class="gradient-text">{{ page.title }}</h1>
+  </header>
+  <div class="page-content taxonomy-term-content">
+    {{ content | safe }}
+  </div>
+</section>
+{% endblock content %}

--- a/tags.json
+++ b/tags.json
@@ -3589,6 +3589,12 @@
     "prism",
     "refraction"
   ],
+  "prismatica": [
+    "dark",
+    "prismatic",
+    "elegant",
+    "glassmorphism"
+  ],
   "prismify": [
     "glassmorphism",
     "landing",


### PR DESCRIPTION
Adds a new highly unique example theme called "Prismatica".
The theme features a modern, tech-forward aesthetic using a dark mode foundation combined with "glassmorphism" components (low-opacity backgrounds with backdrop blur) and a pulsing holographic background gradient. It serves as an elegant portfolio and blog template.

- Initializes `prismatica` project skeleton using standard `hwaro init`.
- Configures `config.toml` with the new theme name and correct absolute/relative `base_url`.
- Sets up standard template inheritance with `base.html`.
- Implements custom CSS styling `style.css` emphasizing gradients and glass cards.
- Provides sample Markdown content in `index.md` and `about.md`.
- Registers `"prismatica"` in `tags.json`.

---
*PR created automatically by Jules for task [4045141566070772269](https://jules.google.com/task/4045141566070772269) started by @chei-l*