### PR TITLE
feat: add prismatic-void example site

### DIFF
--- a/prismatic-void/AGENTS.md
+++ b/prismatic-void/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/prismatic-void/config.toml
+++ b/prismatic-void/config.toml
@@ -1,0 +1,174 @@
+title = "Prismatic Void"
+description = "A stunning, neon-infused glassmorphism portfolio site"
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = false
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = false
+
+[markdown]
+safe = false
+lazy_loading = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/prismatic-void/content/_index.md
+++ b/prismatic-void/content/_index.md
@@ -1,0 +1,17 @@
++++
+title = "Prismatic Void"
+description = "A striking, neon-infused glassmorphism portfolio aesthetic."
+template = "page"
++++
+
+# Welcome to the Void
+
+Where light bends through glass, shadows bloom, and geometry comes alive.
+
+<!-- more -->
+
+This is a space dedicated to the intersection of code, light, and motion. I explore the boundaries of digital aesthetics, creating fluid, iridescent, and interactive experiences.
+
+*   **Fluid Typography**
+*   **Iridescent Accents**
+*   **Deep Glassmorphism**

--- a/prismatic-void/content/about.md
+++ b/prismatic-void/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/prismatic-void/static/css/style.css
+++ b/prismatic-void/static/css/style.css
@@ -1,0 +1,299 @@
+:root {
+    --bg-deep: #05050A;
+    --glass-bg: rgba(20, 20, 35, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.08);
+    --glass-highlight: rgba(255, 255, 255, 0.15);
+
+    --neon-cyan: #00F0FF;
+    --neon-magenta: #FF0055;
+    --neon-purple: #8A2BE2;
+
+    --text-main: #E2E8F0;
+    --text-muted: #94A3B8;
+
+    --font-sans: 'Space Grotesk', system-ui, sans-serif;
+    --font-heading: 'Outfit', system-ui, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-deep);
+    color: var(--text-main);
+    font-family: var(--font-sans);
+    line-height: 1.6;
+    overflow-x: hidden;
+    min-height: 100vh;
+}
+
+/* Background Animation */
+.background-animation {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -2;
+    overflow: hidden;
+    background: var(--bg-deep);
+}
+
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.5;
+    animation: float 20s infinite ease-in-out;
+}
+
+.blob-1 {
+    top: -10%;
+    left: -10%;
+    width: 50vw;
+    height: 50vw;
+    background: radial-gradient(circle, var(--neon-purple) 0%, transparent 70%);
+    animation-delay: 0s;
+}
+
+.blob-2 {
+    bottom: -20%;
+    right: -10%;
+    width: 60vw;
+    height: 60vw;
+    background: radial-gradient(circle, var(--neon-cyan) 0%, transparent 70%);
+    animation-delay: -5s;
+    animation-direction: reverse;
+}
+
+.blob-3 {
+    top: 40%;
+    left: 50%;
+    width: 40vw;
+    height: 40vw;
+    background: radial-gradient(circle, var(--neon-magenta) 0%, transparent 70%);
+    animation-delay: -10s;
+    transform: translateX(-50%);
+}
+
+@keyframes float {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    33% { transform: translate(5%, 10%) scale(1.1); }
+    66% { transform: translate(-5%, -5%) scale(0.9); }
+}
+
+.noise-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    opacity: 0.04;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+}
+
+/* Layout */
+.layout {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+/* Glassmorphism Panel */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+/* Header/Nav */
+.nav-panel {
+    padding: 1rem 2rem;
+    margin-bottom: 3rem;
+    border-radius: 100px;
+}
+
+.nav-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.brand {
+    font-family: var(--font-heading);
+    font-weight: 800;
+    font-size: 1.5rem;
+    text-decoration: none;
+    color: #fff;
+    letter-spacing: -0.5px;
+    background: linear-gradient(to right, #fff, var(--neon-cyan));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.main-nav {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.nav-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: all 0.3s ease;
+}
+
+.nav-link:hover, .nav-link.active {
+    color: #fff;
+    text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+}
+
+/* Main Content */
+.content-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.main-article {
+    padding: 3rem;
+}
+
+.page-header {
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 2rem;
+}
+
+.gradient-text {
+    font-family: var(--font-heading);
+    font-size: 3.5rem;
+    font-weight: 800;
+    line-height: 1.1;
+    margin-bottom: 1rem;
+    background: linear-gradient(135deg, #fff 0%, var(--neon-cyan) 50%, var(--neon-purple) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    letter-spacing: -1px;
+}
+
+.subtitle {
+    font-size: 1.25rem;
+    color: var(--neon-cyan);
+    font-weight: 300;
+    opacity: 0.8;
+}
+
+.prose h1, .prose h2, .prose h3 {
+    font-family: var(--font-heading);
+    color: #fff;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.prose p {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+    color: var(--text-main);
+}
+
+.prose ul {
+    margin-bottom: 1.5rem;
+    padding-left: 1.5rem;
+}
+
+.prose li {
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+}
+
+.prose strong {
+    color: #fff;
+    font-weight: 700;
+}
+
+/* Cards Grid */
+.gallery-preview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1rem;
+}
+
+.card {
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    overflow: hidden;
+    position: relative;
+}
+
+.card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(135deg, rgba(255,255,255,0.1) 0%, transparent 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.4), 0 0 20px 0 rgba(0, 240, 255, 0.2);
+    border-color: var(--glass-highlight);
+}
+
+.card:hover::before {
+    opacity: 1;
+}
+
+.card-inner {
+    padding: 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+.card-inner h3 {
+    font-family: var(--font-heading);
+    color: #fff;
+    margin-bottom: 0.5rem;
+    font-size: 1.3rem;
+}
+
+.card-inner p {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+/* Footer */
+.site-footer {
+    margin-top: 4rem;
+    padding-top: 2rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    border-top: 1px solid var(--glass-border);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .layout { padding: 1rem; }
+    .main-article { padding: 2rem; }
+    .gradient-text { font-size: 2.5rem; }
+    .nav-panel {
+        padding: 1rem;
+        border-radius: 16px;
+    }
+}

--- a/prismatic-void/templates/404.html
+++ b/prismatic-void/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel main-article" style="text-align: center; padding: 5rem 2rem;">
+    <h1 class="gradient-text" style="font-size: 6rem; margin-bottom: 1rem;">404</h1>
+    <h2>Page Not Found</h2>
+    <p style="margin-top: 1rem; color: var(--text-muted);">The void has consumed this link.</p>
+    <a href="{{ base_url }}/" class="nav-link" style="display: inline-block; margin-top: 2rem; border: 1px solid var(--neon-cyan); padding: 0.5rem 1.5rem; border-radius: 50px;">Return Home</a>
+</div>
+{% endblock %}

--- a/prismatic-void/templates/base.html
+++ b/prismatic-void/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;600;700&family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="background-animation">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+        <div class="blob blob-3"></div>
+        <div class="noise-overlay"></div>
+    </div>
+
+    <div class="layout">
+        {% include "header.html" %}
+
+        <main class="content-wrapper">
+            {% block content %}{% endblock %}
+        </main>
+
+        {% include "footer.html" %}
+    </div>
+</body>
+</html>

--- a/prismatic-void/templates/footer.html
+++ b/prismatic-void/templates/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+    <p>&copy; {{ current_year }} {{ site.title }}. Designed with light and logic.</p>
+</footer>

--- a/prismatic-void/templates/header.html
+++ b/prismatic-void/templates/header.html
@@ -1,0 +1,9 @@
+<header class="site-header glass-panel nav-panel">
+    <div class="nav-content">
+        <a href="{{ base_url }}/" class="brand">{{ site.title }}</a>
+        <nav class="main-nav">
+            <a href="{{ base_url }}/" class="nav-link active">Home</a>
+            <a href="{{ base_url }}/about/" class="nav-link">About</a>
+        </nav>
+    </div>
+</header>

--- a/prismatic-void/templates/page.html
+++ b/prismatic-void/templates/page.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-panel main-article">
+    <header class="page-header">
+        <h1 class="gradient-text">{{ page.title }}</h1>
+        {% if page.description %}
+            <p class="subtitle">{{ page.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="prose">
+        {{ content | safe }}
+    </div>
+</article>
+
+<section class="gallery-preview">
+    <div class="glass-panel card">
+        <div class="card-inner">
+            <h3>Nebula Glow</h3>
+            <p>CSS volumetric lighting experiments.</p>
+        </div>
+    </div>
+    <div class="glass-panel card">
+        <div class="card-inner">
+            <h3>Cyber Geometry</h3>
+            <p>Interactive 3D primitives and arrays.</p>
+        </div>
+    </div>
+    <div class="glass-panel card">
+        <div class="card-inner">
+            <h3>Holographic UI</h3>
+            <p>Component library using backdrop filters.</p>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/prismatic-void/templates/section.html
+++ b/prismatic-void/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel main-article">
+    <header class="page-header">
+        <h1 class="gradient-text">{{ section.title }}</h1>
+        {% if section.description %}
+            <p class="subtitle">{{ section.description }}</p>
+        {% endif %}
+    </header>
+
+    <div class="gallery-preview" style="margin-top: 2rem;">
+        {% for page in section.pages %}
+        <a href="{{ page.url }}" style="text-decoration: none;">
+            <div class="glass-panel card">
+                <div class="card-inner">
+                    <h3>{{ page.title }}</h3>
+                    {% if page.description %}
+                        <p>{{ page.description }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        </a>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/prismatic-void/templates/shortcodes/alert.html
+++ b/prismatic-void/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/prismatic-void/templates/taxonomy.html
+++ b/prismatic-void/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel main-article">
+    <header class="page-header">
+        <h1 class="gradient-text">{% if page is defined %}{{ page.title }}{% else %}Tags{% endif %}</h1>
+    </header>
+    <div class="prose">
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 1rem;">
+            {% if taxonomy_terms is defined %}
+                {% for term in taxonomy_terms %}
+                <li>
+                    <a href="{{ base_url }}/tags/{{ term.name | slugify }}/" style="color: var(--neon-cyan); text-decoration: none; padding: 0.5rem 1rem; border: 1px solid var(--glass-border); border-radius: 50px; background: var(--glass-bg);">
+                        #{{ term.name }} ({{ term.pages | length }})
+                    </a>
+                </li>
+                {% endfor %}
+            {% endif %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/prismatic-void/templates/taxonomy_term.html
+++ b/prismatic-void/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="glass-panel main-article">
+    <header class="page-header">
+        <h1 class="gradient-text">{% if taxonomy_term is defined %}#{{ taxonomy_term.name }}{% endif %}</h1>
+    </header>
+    <div class="gallery-preview">
+        {% if taxonomy_pages is defined %}
+            {% for page in taxonomy_pages %}
+            <a href="{{ page.url }}" style="text-decoration: none;">
+                <div class="glass-panel card">
+                    <div class="card-inner">
+                        <h3>{{ page.title }}</h3>
+                    </div>
+                </div>
+            </a>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -3444,6 +3444,13 @@
     "wiki",
     "knowledge"
   ],
+  "obsidian-echoes": [
+    "dark",
+    "glassmorphism",
+    "portfolio",
+    "glowing",
+    "obsidian"
+  ],
   "obsidian-mirror": [
     "dark",
     "blog",
@@ -3896,6 +3903,11 @@
     "blog",
     "prism",
     "refraction"
+  ],
+  "prismatic-void": [
+    "dark",
+    "portfolio",
+    "cyberpunk"
   ],
   "prismatica": [
     "dark",
@@ -5337,12 +5349,5 @@
     "portfolio",
     "bold",
     "elegant"
-  ],
-  "obsidian-echoes": [
-    "dark",
-    "glassmorphism",
-    "portfolio",
-    "glowing",
-    "obsidian"
   ]
 }


### PR DESCRIPTION
This PR introduces a new example site to showcase Hwaro's capabilities. 

The `prismatic-void` example highlights a dark-themed, highly stylized "glassmorphism" aesthetic. Key features include:
- A custom `style.css` with CSS variables for a neon color palette and deep dark background.
- An animated, multi-layered background featuring glowing CSS radial gradients (`.blob`).
- Translucent, frosted glass UI components using `backdrop-filter`.
- A fully complete set of Jinja2 templates (`base.html`, `page.html`, `section.html`, `404.html`, etc.) that inherit properly to maintain the design across all page types.
- The example has been added to `tags.json` and `AGENTS.md` was generated for it.

---
*PR created automatically by Jules for task [17299045451176863330](https://jules.google.com/task/17299045451176863330) started by @hahwul*