### PR TITLE
feat: Add Luminous Echo template

### DIFF
--- a/luminous-echo/AGENTS.md
+++ b/luminous-echo/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/luminous-echo/config.toml
+++ b/luminous-echo/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminous Echo"
+description = "Signals from the glowing void."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"      # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/luminous-echo/content/_index.md
+++ b/luminous-echo/content/_index.md
@@ -1,0 +1,26 @@
++++
+title = "Home"
+description = "Welcome to Luminous Echo"
+template = "index"
++++
+
+<div class="hero-section">
+    <h1 class="hero-title">Signals from the Void</h1>
+    <p class="hero-subtitle">Exploring the dark corners of the web through radiant design and luminous typography.</p>
+    <a href="/about/" class="btn-glow">Enter the Nexus</a>
+</div>
+
+<div class="post-grid">
+    <article class="post-card">
+        <h2><a href="#">The Neon Paradox</a></h2>
+        <p>Why do we seek the brightest lights in the darkest rooms? A study on digital aesthetics and eye strain.</p>
+    </article>
+    <article class="post-card">
+        <h2><a href="#">Chromatic Aberration</a></h2>
+        <p>Harnessing the power of optical imperfections to create striking user interfaces in modern web design.</p>
+    </article>
+    <article class="post-card">
+        <h2><a href="#">Synthesizer Dreams</a></h2>
+        <p>When audio waveforms meet visual CSS: building interactive experiences that resonate with users.</p>
+    </article>
+</div>

--- a/luminous-echo/content/about.md
+++ b/luminous-echo/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About Luminous Echo"
+description = "The manifesto of our radiant journey"
++++
+
+Luminous Echo is an experimental digital space dedicated to the intersection of brutalist darkness and vibrant, glowing typography. We believe that true contrast is found not in black and white, but in the deepest voids and the most piercing neons.
+
+Here, we explore:
+
+- **Typography** that cuts through the noise.
+- **Layouts** that guide the eye with light.
+- **Interactions** that feel electric.
+
+Join us in illuminating the digital frontier.

--- a/luminous-echo/hwaro.log
+++ b/luminous-echo/hwaro.log
@@ -1,0 +1,23 @@
+Performing initial build...
+Building site...
+  Found 2 pages.
+  Generated sitemap with 2 URLs.
+  Generated robots.txt
+  Generated llms.txt
+  Generated search index with 2 pages.
+Build complete! Generated 2 pages in 4.21ms.
+Serving site at http://127.0.0.1:3000
+Press Ctrl+C to stop.
+Watching for changes in content/, templates/, static/ and config.toml...
+
+[Watch] Change detected (1 content file(s)). Strategy: incremental...
+Incremental build for 1 changed file(s)...
+  Generated sitemap with 2 URLs.
+  Generated robots.txt
+  Generated llms.txt
+  Generated search index with 2 pages.
+Incremental build complete! Rendered 2/2 pages in 2.45ms.
+
+[Watch] Change detected (1 template file(s)). Strategy: templates...
+Template change detected. Re-rendering all pages...
+Re-render complete! Rendered 2 pages in 2.1ms.

--- a/luminous-echo/static/style.css
+++ b/luminous-echo/static/style.css
@@ -1,0 +1,248 @@
+:root {
+    --bg-dark: #050510;
+    --bg-surface: #0a0a1a;
+    --text-main: #e0e0ff;
+    --text-muted: #8888aa;
+    --glow-primary: #00ffcc;
+    --glow-secondary: #cc00ff;
+    --glow-danger: #ff3366;
+    --font-family: 'Outfit', sans-serif;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-main);
+    font-family: var(--font-family);
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+}
+
+/* Background grid effect */
+body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-image:
+        linear-gradient(rgba(0, 255, 204, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 255, 204, 0.03) 1px, transparent 1px);
+    background-size: 50px 50px;
+    z-index: -1;
+    pointer-events: none;
+}
+
+a {
+    color: var(--glow-primary);
+    text-decoration: none;
+    transition: text-shadow 0.3s ease, color 0.3s ease;
+}
+
+a:hover {
+    color: #fff;
+    text-shadow: 0 0 10px var(--glow-primary);
+}
+
+.site-header {
+    padding: 2rem 4rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid rgba(0, 255, 204, 0.2);
+    background: rgba(5, 5, 16, 0.8);
+    backdrop-filter: blur(10px);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.site-title a {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #fff;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    text-shadow: 0 0 15px var(--glow-primary);
+}
+
+.site-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 2rem;
+}
+
+.site-nav a {
+    color: var(--text-main);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 1px;
+}
+
+.content-wrapper {
+    flex: 1;
+    padding: 4rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.glow-text {
+    color: #fff;
+    text-shadow: 0 0 20px var(--glow-secondary);
+    margin-bottom: 2rem;
+    font-size: 3rem;
+    font-weight: 800;
+}
+
+.glow-text-red {
+    color: #fff;
+    text-shadow: 0 0 20px var(--glow-danger);
+}
+
+.hero-section {
+    text-align: center;
+    padding: 6rem 0;
+}
+
+.hero-title {
+    font-size: 4.5rem;
+    font-weight: 800;
+    line-height: 1.1;
+    margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, var(--glow-primary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    filter: drop-shadow(0 0 20px rgba(0, 255, 204, 0.4));
+}
+
+.hero-subtitle {
+    font-size: 1.5rem;
+    color: var(--text-muted);
+    max-width: 600px;
+    margin: 0 auto 3rem auto;
+}
+
+.btn-glow {
+    display: inline-block;
+    padding: 1rem 2.5rem;
+    background: transparent;
+    color: var(--glow-primary);
+    border: 2px solid var(--glow-primary);
+    border-radius: 30px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 15px rgba(0, 255, 204, 0.2), inset 0 0 10px rgba(0, 255, 204, 0.1);
+}
+
+.btn-glow:hover {
+    background: var(--glow-primary);
+    color: var(--bg-dark);
+    box-shadow: 0 0 30px rgba(0, 255, 204, 0.6), inset 0 0 10px rgba(255, 255, 255, 0.5);
+    text-shadow: none;
+}
+
+.post-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-top: 3rem;
+}
+
+.post-card {
+    background: var(--bg-surface);
+    padding: 2rem;
+    border-radius: 12px;
+    border: 1px solid rgba(204, 0, 255, 0.2);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.post-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, var(--glow-primary), var(--glow-secondary));
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.post-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 30px rgba(204, 0, 255, 0.15);
+    border-color: rgba(204, 0, 255, 0.4);
+}
+
+.post-card:hover::before {
+    opacity: 1;
+}
+
+.post-card h2 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.post-card h2 a {
+    color: #fff;
+}
+
+.post-card p {
+    color: var(--text-muted);
+}
+
+.error-container {
+    text-align: center;
+    padding: 8rem 0;
+}
+
+.error-title {
+    font-size: 8rem;
+    margin-bottom: 1rem;
+    line-height: 1;
+}
+
+.error-message {
+    font-size: 1.5rem;
+    color: var(--text-muted);
+    margin-bottom: 3rem;
+}
+
+.site-footer {
+    padding: 3rem;
+    text-align: center;
+    border-top: 1px solid rgba(0, 255, 204, 0.2);
+    color: var(--text-muted);
+    background: var(--bg-surface);
+}
+
+@media (max-width: 768px) {
+    .site-header {
+        padding: 1.5rem;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .content-wrapper {
+        padding: 2rem;
+    }
+
+    .hero-title {
+        font-size: 3rem;
+    }
+}

--- a/luminous-echo/templates/404.html
+++ b/luminous-echo/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-container">
+    <h1 class="error-title glow-text-red">404</h1>
+    <p class="error-message">The light has faded from this path. Page not found.</p>
+    <a href="{{ base_url }}" class="btn-glow">Return to Nexus</a>
+</div>
+{% endblock %}

--- a/luminous-echo/templates/base.html
+++ b/luminous-echo/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
+</head>
+<body>
+    {% include "header.html" %}
+
+    <main class="content-wrapper">
+        {% block content %}{% endblock %}
+    </main>
+
+    {% include "footer.html" %}
+</body>
+</html>

--- a/luminous-echo/templates/footer.html
+++ b/luminous-echo/templates/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+    <p>&copy; 2026 {{ site.title }}. All signals transmitted.</p>
+</footer>

--- a/luminous-echo/templates/header.html
+++ b/luminous-echo/templates/header.html
@@ -1,0 +1,11 @@
+<header class="site-header">
+    <div class="site-title">
+        <a href="{{ base_url }}">{{ site.title }}</a>
+    </div>
+    <nav class="site-nav">
+        <ul>
+            <li><a href="{{ base_url }}">Nexus</a></li>
+            <li><a href="{{ base_url }}about/">Manifesto</a></li>
+        </ul>
+    </nav>
+</header>

--- a/luminous-echo/templates/index.html
+++ b/luminous-echo/templates/index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="content-body">
+    {{ content | safe }}
+</div>
+{% endblock %}

--- a/luminous-echo/templates/page.html
+++ b/luminous-echo/templates/page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+    {% if page.title and page.path != "/" %}
+        <h1 class="page-title glow-text">{{ page.title }}</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/luminous-echo/templates/section.html
+++ b/luminous-echo/templates/section.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="section-container">
+    <h1 class="section-title glow-text">{{ section.title }}</h1>
+    <div class="section-content">
+        {{ content | safe }}
+    </div>
+
+    <div class="post-grid">
+        {% for page in section.pages %}
+            <article class="post-card">
+                <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+                {% if page.description %}
+                    <p>{{ page.description }}</p>
+                {% endif %}
+            </article>
+        {% endfor %}
+    </div>
+</section>
+{% endblock %}

--- a/luminous-echo/templates/shortcodes/alert.html
+++ b/luminous-echo/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/luminous-echo/templates/taxonomy.html
+++ b/luminous-echo/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="taxonomy-container">
+    <h1 class="taxonomy-title glow-text">{{ page.title }}</h1>
+    <div class="taxonomy-list">
+        {{ content | safe }}
+    </div>
+</section>
+{% endblock %}

--- a/luminous-echo/templates/taxonomy_term.html
+++ b/luminous-echo/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="taxonomy-term-container">
+    <h1 class="term-title glow-text">{{ page.title }}</h1>
+    <div class="term-list">
+        {{ content | safe }}
+    </div>
+</section>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2929,6 +2929,12 @@
     "light",
     "minimal"
   ],
+  "luminous-echo": [
+    "dark",
+    "elegant",
+    "glow",
+    "portfolio"
+  ],
   "luminous-glass": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR adds the `luminous-echo` example to demonstrate a dark, elegant neon aesthetic.
Changes include:
- Generating the basic `hwaro init` scaffold
- Setting up a custom template inheritance hierarchy using `base.html`
- Building out an original CSS design (`style.css`) with neon glows and typographic styling
- Defining minimal placeholder content that adheres to the theme
- Fixing standard frontmatter properties in config and index.md
- Adding the entry to `tags.json`

---
*PR created automatically by Jules for task [8245758550494299922](https://jules.google.com/task/8245758550494299922) started by @chei-l*