### PR TITLE
feat: add nebula-weaver example site

### DIFF
--- a/nebula-weaver/AGENTS.md
+++ b/nebula-weaver/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/nebula-weaver/config.toml
+++ b/nebula-weaver/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Nebula Weaver"
+description = "A dark, space-themed cosmic exploration of thoughts and code."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"      # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/nebula-weaver/content/about.md
+++ b/nebula-weaver/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About the Weaver"
+description = "Information about the entity behind the Nebula Weaver."
+tags = ["about", "identity"]
++++
+
+## Cosmic Origin
+
+I am an explorer of the digital cosmos, weaving code and light into structure. My mission is to discover new paradigms and share the artifacts of my journey across the stellar network.
+
+### Skills
+- Navigating codebases
+- Synthesizing algorithms
+- Designing stellar interfaces
+
+> "The cosmos is within us. We are made of star-stuff. We are a way for the universe to know itself." — Carl Sagan

--- a/nebula-weaver/content/index.md
+++ b/nebula-weaver/content/index.md
@@ -1,0 +1,27 @@
++++
+title = "Nebula Weaver"
+description = "A cosmic exploration of thoughts and code, woven into the fabric of the web."
+tags = ["welcome", "cosmos", "exploration"]
++++
+
+# Welcome to the Nebula
+
+Embark on a journey through the stars. This is a space where code meets cosmic design, generating a unique static universe using [Hwaro](https://github.com/hahwul/hwaro).
+
+## The Cosmic Loom
+
+The universe is a vast tapestry, and here we weave threads of logic, design, and content into seamless web experiences.
+
+*   **Dark Matter Design:** Embrace the void with deep space colors.
+*   **Stardust Accents:** Let gradients and glowing elements light your path.
+*   **Glassmorphic Constellations:** Floating elements that reveal the cosmos behind them.
+
+## Initiate Sequence
+
+To navigate this system:
+
+1.  Warp to `content/` to write your starry logs.
+2.  Engage the hyperdrive with `hwaro build`.
+3.  Observe the phenomena using `hwaro serve`.
+
+May your code run faster than light.

--- a/nebula-weaver/templates/404.html
+++ b/nebula-weaver/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card" style="text-align: center; padding: 5rem 2rem;">
+  <h1 style="font-size: 5rem; margin: 0; background: linear-gradient(to right, var(--nebula-pink), var(--nebula-purple)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">404</h1>
+  <h2 style="border: none; margin-bottom: 2rem;">Lost in Space</h2>
+  <p style="color: var(--text-muted); font-size: 1.2rem; margin-bottom: 3rem;">The coordinates you entered lead to a void in the cosmic web.</p>
+  <a href="{{ base_url }}" style="display: inline-block; background: rgba(228, 66, 136, 0.2); border: 1px solid rgba(228, 66, 136, 0.5); padding: 0.8rem 2rem; border-radius: 30px; color: #fff; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">Return to Origin</a>
+</div>
+{% endblock %}

--- a/nebula-weaver/templates/base.html
+++ b/nebula-weaver/templates/base.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value='en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{% if page.description is present %}{{ page.description | e }}{% else %}{{ site.description | e }}{% endif %}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --space-dark: #070914;
+      --nebula-purple: #8134af;
+      --nebula-pink: #e44288;
+      --nebula-blue: #3f51b5;
+      --starlight: #e2e8f0;
+      --text-muted: #94a3b8;
+      --glass-bg: rgba(20, 24, 44, 0.6);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+    }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background-color: var(--space-dark);
+      color: var(--starlight);
+      margin: 0;
+      line-height: 1.7;
+      background-image:
+        radial-gradient(circle at 15% 50%, rgba(129, 52, 175, 0.15) 0%, transparent 50%),
+        radial-gradient(circle at 85% 30%, rgba(63, 81, 181, 0.15) 0%, transparent 50%),
+        radial-gradient(circle at 50% 80%, rgba(228, 66, 136, 0.1) 0%, transparent 50%);
+      background-attachment: fixed;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      color: #fff;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    h1 { font-size: 2.5rem; line-height: 1.2; margin-top: 0; }
+    h2 { font-size: 1.75rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 0.5rem; }
+
+    a {
+      color: var(--nebula-pink);
+      text-decoration: none;
+      transition: all 0.3s ease;
+      position: relative;
+    }
+
+    .site-main a:hover {
+      color: #fff;
+      text-shadow: 0 0 8px rgba(228, 66, 136, 0.6);
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      flex: 1;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    /* Header */
+    .site-header {
+      padding: 2rem 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 3rem;
+      border-bottom: 1px solid var(--glass-border);
+    }
+
+    .site-logo {
+      font-size: 1.5rem;
+      font-weight: 800;
+      background: linear-gradient(to right, var(--nebula-purple), var(--nebula-pink));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-decoration: none;
+      letter-spacing: -0.05em;
+    }
+
+    .site-nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-nav a {
+      color: var(--starlight);
+      font-size: 0.95rem;
+      font-weight: 500;
+    }
+
+    .site-nav a:hover {
+      color: #fff;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+    }
+
+    /* Glassmorphic Components */
+    .glass-card {
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      padding: 2rem;
+      box-shadow: var(--glass-shadow);
+      margin-bottom: 2rem;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    /* Code blocks */
+    pre {
+      background: rgba(0, 0, 0, 0.4);
+      border: 1px solid var(--glass-border);
+      padding: 1.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+    }
+
+    code {
+      font-family: 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 0.9em;
+      background: rgba(255, 255, 255, 0.05);
+      padding: 0.2em 0.4em;
+      border-radius: 4px;
+    }
+
+    pre code {
+      background: none;
+      padding: 0;
+    }
+
+    /* Footer */
+    .site-footer {
+      text-align: center;
+      padding: 3rem 0 2rem;
+      margin-top: auto;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      border-top: 1px solid var(--glass-border);
+    }
+
+    /* Lists */
+    .section-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    .section-list li {
+      margin-bottom: 1rem;
+    }
+
+    .section-list a {
+      display: block;
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      padding: 1.5rem;
+      border-radius: 12px;
+      color: var(--starlight);
+      transition: all 0.3s ease;
+    }
+
+    .section-list a:hover {
+      border-color: rgba(228, 66, 136, 0.5);
+      box-shadow: 0 0 15px rgba(228, 66, 136, 0.2);
+      transform: translateY(-2px);
+    }
+
+    .date-meta {
+      display: block;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 0.5rem;
+    }
+
+    /* Tags */
+    .tag {
+      display: inline-block;
+      background: rgba(63, 81, 181, 0.2);
+      border: 1px solid rgba(63, 81, 181, 0.5);
+      color: #a5b4fc;
+      padding: 0.2rem 0.6rem;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      margin-right: 0.5rem;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+    }
+
+    .tag:hover {
+      background: rgba(63, 81, 181, 0.4);
+      color: #fff;
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}" class="site-logo">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}">Home</a>
+        <a href="{{ base_url }}about/">About</a>
+        <a href="{{ base_url }}tags/">Tags</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ site.title }}. Weaving through the cosmos.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/nebula-weaver/templates/page.html
+++ b/nebula-weaver/templates/page.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-card">
+  <h1>{{ page.title }}</h1>
+  {% if page.date is present %}
+    <span class="date-meta">{{ page.date | date(format="%B %d, %Y") }}</span>
+  {% endif %}
+
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+
+  {% if page.tags and page.tags | length > 0 %}
+    <div class="page-tags" style="margin-top: 2rem; border-top: 1px solid var(--glass-border); padding-top: 1rem;">
+      {% for tag in page.tags %}
+        <a href="{{ base_url }}tags/{{ tag | slugify }}/" class="tag">#{{ tag }}</a>
+      {% endfor %}
+    </div>
+  {% endif %}
+</article>
+{% endblock %}

--- a/nebula-weaver/templates/section.html
+++ b/nebula-weaver/templates/section.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card">
+  <h1>{{ section.title | default(value="Section") }}</h1>
+  {% if section.description %}
+    <p style="color: var(--text-muted); font-size: 1.1rem; margin-bottom: 2rem;">{{ section.description }}</p>
+  {% endif %}
+
+  <div class="section-content">
+    {{ content | safe }}
+  </div>
+
+  <ul class="section-list">
+    {% for page in section.pages %}
+      <li>
+        <a href="{{ base_url }}{{ page.path }}">
+          {% if page.date is present %}
+            <span class="date-meta">{{ page.date | date(format="%B %d, %Y") }}</span>
+          {% endif %}
+          <span style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; display: block;">{{ page.title }}</span>
+          {% if page.description is present %}
+            <span style="color: var(--text-muted); font-weight: normal;">{{ page.description }}</span>
+          {% endif %}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+
+  {% if section.pages | length == 0 %}
+    <p style="color: var(--text-muted); font-style: italic;">No pages found in this section.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/nebula-weaver/templates/shortcodes/alert.html
+++ b/nebula-weaver/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/nebula-weaver/templates/taxonomy.html
+++ b/nebula-weaver/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card">
+  <h1>{{ page.title }}</h1>
+  <div class="taxonomy-desc">
+    {{ content | safe }}
+  </div>
+</div>
+{% endblock %}

--- a/nebula-weaver/templates/taxonomy_term.html
+++ b/nebula-weaver/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card">
+  <h1>{{ page.title }}</h1>
+  <div class="taxonomy-desc">
+    {{ content | safe }}
+  </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -3432,6 +3432,14 @@
     "portfolio",
     "elegant"
   ],
+  "nebula-weaver": [
+    "dark",
+    "space",
+    "glassmorphism",
+    "cosmos",
+    "purple",
+    "elegant"
+  ],
   "neo-deco": [
     "dark",
     "portfolio",


### PR DESCRIPTION
Adds a new Hwaro example site named `nebula-weaver` featuring a custom dark, space-themed design with glassmorphic elements and glowing accents.

- Initializes `nebula-weaver` with `hwaro init`.
- Refactors scaffold templates to use `base.html` for layout inheritance.
- Customizes CSS variables, typography, and card styles for the cosmic theme.
- Configures `config.toml` with `base_url = "/"` and `feeds.filename = "rss.xml"`.
- Adds `nebula-weaver` to `tags.json` with appropriate tags.

---
*PR created automatically by Jules for task [6088877324158601660](https://jules.google.com/task/6088877324158601660) started by @chei-l*