### PR TITLE
feat: add luminescent-glass example template

### DIFF
--- a/luminescent-glass/AGENTS.md
+++ b/luminescent-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/luminescent-glass/config.toml
+++ b/luminescent-glass/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminescent Glass"
+description = "A luminescent glassmorphism portfolio."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/luminescent-glass/content/about.md
+++ b/luminescent-glass/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About"
+description = "About the Luminescent Glass design."
++++
+
+# About This Design
+
+This template is built for creators who want their work to stand out in a dark, atmospheric environment.
+
+By combining the **Glassmorphism** trend (translucency and background blur) with **Cyberpunk/Neon** aesthetics (glowing colors and deep dark backgrounds), we create a unique visual identity that feels both physical and digital.
+
+### Features
+
+1.  **Fully Responsive Layout:** Built with flexbox and percentage-based sizing.
+2.  **Custom Code Highlighting:** The `pre code` block is specifically styled to fit the dark glass theme without clashing.
+3.  **Hwaro Native:** Utilizes Hwaro's template inheritance (`base.html`) for clean, maintainable code.
+
+[← Back Home](/)

--- a/luminescent-glass/content/index.md
+++ b/luminescent-glass/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "Luminescent Glass"
+description = "A luminescent glassmorphism portfolio."
++++
+
+# Designing with Light and Glass
+
+Welcome to **Luminescent Glass**. This portfolio demonstrates the power of modern CSS capabilities like `backdrop-filter`, neon text shadows, and ambient background blurs to create immersive, futuristic interfaces.
+
+## Core Principles
+
+*   **Transparency:** Utilizing `rgba` backgrounds with blur effects to create depth.
+*   **Illumination:** Neon accents (`#00f3ff` and `#ff00ff`) provide high contrast against the dark canvas.
+*   **Minimalism:** Keeping the structural elements simple so the lighting effects can take center stage.
+
+Check out the [About](/about/) page for more information on the structure.
+
+```css
+.glass-panel {
+  background: rgba(20, 20, 40, 0.4);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+```
+
+<a href="#" class="btn">Explore Gallery</a>

--- a/luminescent-glass/templates/404.html
+++ b/luminescent-glass/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="error-content" style="text-align: center; padding: 4rem 0;">
+  <h1>404</h1>
+  <p>Page Not Found</p>
+  <a href="{{ site.base_url | default(value="/") }}" class="btn">Return Home</a>
+</div>
+{% endblock %}

--- a/luminescent-glass/templates/base.html
+++ b/luminescent-glass/templates/base.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title | default(value=site.title) }}</title>
+  {% if page.description %}
+  <meta name="description" content="{{ page.description }}">
+  {% elif site.description %}
+  <meta name="description" content="{{ site.description }}">
+  {% endif %}
+  <style>
+    :root {
+      --bg-color: #05050f;
+      --glass-bg: rgba(20, 20, 40, 0.4);
+      --glass-border: rgba(255, 255, 255, 0.1);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+      --neon-cyan: #00f3ff;
+      --neon-magenta: #ff00ff;
+      --text-main: #e0e0f0;
+      --text-muted: #8888a0;
+      --glow-blur: 15px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background-color: var(--bg-color);
+      color: var(--text-main);
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    /* Ambient background glows */
+    body::before, body::after {
+      content: '';
+      position: absolute;
+      width: 400px;
+      height: 400px;
+      border-radius: 50%;
+      z-index: -1;
+      filter: blur(100px);
+      opacity: 0.5;
+    }
+
+    body::before {
+      top: -100px;
+      left: -100px;
+      background: var(--neon-cyan);
+    }
+
+    body::after {
+      bottom: 20%;
+      right: -100px;
+      background: var(--neon-magenta);
+    }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      border-radius: 16px;
+    }
+
+    header {
+      padding: 1.5rem;
+      margin: 2rem auto;
+      width: 90%;
+      max-width: 1200px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: relative;
+      z-index: 10;
+    }
+
+    .logo {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 0 0 10px var(--neon-cyan);
+    }
+
+    nav a {
+      color: var(--text-main);
+      text-decoration: none;
+      margin-left: 2rem;
+      font-weight: 500;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+
+    nav a:hover {
+      color: var(--neon-cyan);
+      text-shadow: 0 0 8px var(--neon-cyan);
+    }
+
+    main {
+      flex: 1;
+      width: 90%;
+      max-width: 1000px;
+      margin: 2rem auto;
+      padding: 3rem;
+      position: relative;
+      z-index: 5;
+    }
+
+    h1, h2, h3 {
+      color: #fff;
+      margin-bottom: 1.5rem;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+
+    h1 {
+      font-size: 3rem;
+      margin-bottom: 2rem;
+      background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-shadow: 0 0 20px rgba(0, 243, 255, 0.2);
+    }
+
+    p {
+      margin-bottom: 1.5rem;
+      font-size: 1.1rem;
+    }
+
+    a {
+      color: var(--neon-magenta);
+      text-decoration: none;
+      position: relative;
+    }
+
+    a:hover {
+      text-shadow: 0 0 8px var(--neon-magenta);
+    }
+
+    code {
+      background: rgba(0,0,0,0.5);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-family: monospace;
+      color: var(--neon-cyan);
+      border: 1px solid rgba(0, 243, 255, 0.2);
+    }
+
+    pre code {
+      display: block;
+      padding: 1.5rem;
+      overflow-x: auto;
+      background: rgba(10, 10, 20, 0.8);
+      border: 1px solid var(--glass-border);
+      border-radius: 12px;
+      box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+      color: var(--text-main);
+    }
+
+    .hljs {
+      background: transparent;
+    }
+
+    ul, ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 0.8rem 2rem;
+      margin-top: 1rem;
+      background: transparent;
+      color: #fff;
+      border: 1px solid var(--neon-cyan);
+      border-radius: 30px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: all 0.3s ease;
+      box-shadow: 0 0 10px rgba(0, 243, 255, 0.2), inset 0 0 10px rgba(0, 243, 255, 0.1);
+    }
+
+    .btn:hover {
+      background: var(--neon-cyan);
+      color: #000;
+      box-shadow: 0 0 20px var(--neon-cyan);
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem;
+      margin-top: 4rem;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      border-top: 1px solid var(--glass-border);
+      background: rgba(5, 5, 15, 0.8);
+      backdrop-filter: blur(8px);
+    }
+
+    /* Content styling specific */
+    .content-area img {
+      max-width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--glass-border);
+      box-shadow: 0 0 20px rgba(0,0,0,0.4);
+      margin: 2rem 0;
+    }
+  </style>
+</head>
+<body>
+
+  <header class="glass-panel">
+    <a href="{{ site.base_url | default(value="/") }}" class="logo">Lumiglass</a>
+    <nav>
+      <a href="{{ site.base_url | default(value="/") }}">Home</a>
+      <a href="{{ site.base_url | default(value="/") }}about/">About</a>
+    </nav>
+  </header>
+
+  <main class="glass-panel content-area">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer>
+    <p>&copy; {{ site.title }} - Powered by Hwaro</p>
+  </footer>
+
+</body>
+</html>

--- a/luminescent-glass/templates/page.html
+++ b/luminescent-glass/templates/page.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page-content">
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/luminescent-glass/templates/section.html
+++ b/luminescent-glass/templates/section.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="section-content">
+  {{ section.content | safe }}
+
+  <ul class="page-list">
+  {% for page in section.pages %}
+    <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+  {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/luminescent-glass/templates/shortcodes/alert.html
+++ b/luminescent-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/luminescent-glass/templates/taxonomy.html
+++ b/luminescent-glass/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="taxonomy-content">
+  <h1>{{ page.title }}</h1>
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/luminescent-glass/templates/taxonomy_term.html
+++ b/luminescent-glass/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="taxonomy-term-content">
+  <h1>{{ page.title }}</h1>
+  {{ content | safe }}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2524,6 +2524,13 @@
     "elegant",
     "portfolio"
   ],
+  "luminescent-glass": [
+    "dark",
+    "glassmorphism",
+    "elegant",
+    "neon",
+    "portfolio"
+  ],
   "luminescent-mesh": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR introduces a new example site template for Hwaro named `luminescent-glass`.

The template showcases a modern, dark-mode glassmorphism aesthetic featuring:
- Translucent "glass" panels with `backdrop-filter: blur`.
- Neon cyan and magenta glowing accents and text gradients.
- Ambient glowing background elements.
- Clean template inheritance structure (`base.html` extending to layout templates).
- Corrected taxonomy templates to avoid undefined variable build errors.

The template has been fully built, successfully passes `hwaro tool doctor` and `hwaro tool validate`, and has been visually verified. The new site is also registered in the repository's `tags.json`.

---
*PR created automatically by Jules for task [5802352367342609653](https://jules.google.com/task/5802352367342609653) started by @chei-l*