### PR TITLE
feat: add zephyr-glow example template

### DIFF
--- a/zephyr-glow/AGENTS.md
+++ b/zephyr-glow/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/zephyr-glow/config.toml
+++ b/zephyr-glow/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Zephyr Glow"
+description = "A glowing neon portfolio"
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/zephyr-glow/content/about.md
+++ b/zephyr-glow/content/about.md
@@ -1,0 +1,30 @@
++++
+title = "About the Glow"
+description = "Learn more about the design and the author"
+template = "page"
++++
+
+## The Vision
+
+The `zephyr-glow` theme was designed to break away from traditional flat design and embrace the vibrant energy of neon lights against a deep dark background.
+
+It draws inspiration from cyberpunk aesthetics and futuristic interfaces, combining deep blues and blacks with piercing cyan and electric pink accents.
+
+### Typography
+
+We use modern sans-serif typefaces to maintain readability while conveying a sleek, digital feel. The glowing effects are applied carefully to headers and interactive elements to draw the eye without overwhelming the reader.
+
+### Code Highlights
+
+```css
+:root {
+  --neon-primary: #66fcf1;
+  --neon-secondary: #45a29e;
+  --neon-accent: #ff007f;
+}
+```
+
+The syntax highlighter is also customized with a translucent dark background and a subtle neon border to perfectly integrate with the rest of the site.
+
+<br>
+<a href="/" class="btn">Back to Home</a>

--- a/zephyr-glow/content/index.md
+++ b/zephyr-glow/content/index.md
@@ -1,0 +1,28 @@
++++
+title = "Home"
+description = "A glowing neon portfolio"
+template = "page"
++++
+
+<div class="hero">
+    <h1>Illuminating the Web</h1>
+    <p>A highly original, elegant dark-mode template with glowing neon-like accents for your creative portfolio.</p>
+    <a href="/about/" class="btn">Discover the Glow</a>
+</div>
+
+<div style="display: flex; gap: 2rem; flex-wrap: wrap; justify-content: space-between; margin-top: 2rem;">
+    <div class="neon-box" style="flex: 1; min-width: 300px;">
+        <h2>Vibrant Styling</h2>
+        <p>Using CSS variables, text-shadow, and box-shadow to create a deeply immersive dark theme that truly shines.</p>
+    </div>
+
+    <div class="neon-box" style="flex: 1; min-width: 300px;">
+        <h2>Flexible Layout</h2>
+        <p>Built with modern Flexbox, ensuring responsive and fluid layouts that adapt to any screen size.</p>
+    </div>
+
+    <div class="neon-box" style="flex: 1; min-width: 300px;">
+        <h2>Simple Customization</h2>
+        <p>Easily change the primary, secondary, and accent colors to customize the mood and aesthetic to match your brand.</p>
+    </div>
+</div>

--- a/zephyr-glow/static/style.css
+++ b/zephyr-glow/static/style.css
@@ -1,0 +1,177 @@
+:root {
+  --bg-color: #0b0c10;
+  --text-color: #c5c6c7;
+  --neon-primary: #66fcf1;
+  --neon-secondary: #45a29e;
+  --neon-accent: #ff007f;
+  --font-main: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-main);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header {
+  padding: 2rem 5%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(102, 252, 241, 0.2);
+  box-shadow: 0 4px 15px rgba(102, 252, 241, 0.1);
+}
+
+.logo {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--neon-primary);
+  text-decoration: none;
+  text-shadow: 0 0 5px var(--neon-primary), 0 0 10px var(--neon-primary), 0 0 20px var(--neon-primary);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 2rem;
+}
+
+nav a {
+  color: var(--text-color);
+  text-decoration: none;
+  font-size: 1.1rem;
+  transition: all 0.3s ease;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+nav a:hover {
+  color: var(--neon-primary);
+  text-shadow: 0 0 8px var(--neon-primary);
+  background: rgba(102, 252, 241, 0.05);
+}
+
+main {
+  flex: 1;
+  padding: 4rem 5%;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+h1, h2, h3 {
+  color: #fff;
+  margin-bottom: 1.5rem;
+}
+
+.hero {
+  text-align: center;
+  padding: 6rem 0;
+}
+
+.hero h1 {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  color: var(--neon-primary);
+  text-shadow: 0 0 10px var(--neon-secondary), 0 0 20px var(--neon-secondary), 0 0 40px var(--neon-secondary);
+}
+
+.hero p {
+  font-size: 1.5rem;
+  color: var(--text-color);
+  max-width: 800px;
+  margin: 0 auto 3rem auto;
+}
+
+.neon-box {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--neon-primary);
+  padding: 2.5rem;
+  border-radius: 10px;
+  box-shadow: inset 0 0 15px rgba(102, 252, 241, 0.1), 0 0 15px rgba(102, 252, 241, 0.2);
+  transition: all 0.4s ease;
+  margin-bottom: 2rem;
+}
+
+.neon-box:hover {
+  box-shadow: inset 0 0 20px rgba(102, 252, 241, 0.2), 0 0 25px rgba(102, 252, 241, 0.4);
+  transform: translateY(-5px);
+}
+
+.neon-box h2 {
+  color: var(--neon-accent);
+  text-shadow: 0 0 5px var(--neon-accent), 0 0 10px var(--neon-accent);
+}
+
+.btn {
+  display: inline-block;
+  padding: 1rem 2.5rem;
+  font-size: 1.1rem;
+  color: var(--bg-color);
+  background-color: var(--neon-primary);
+  text-decoration: none;
+  border-radius: 30px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  box-shadow: 0 0 10px var(--neon-primary), 0 0 20px var(--neon-primary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.btn:hover {
+  background-color: #fff;
+  color: var(--bg-color);
+  box-shadow: 0 0 15px #fff, 0 0 30px var(--neon-primary);
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  border-top: 1px solid rgba(102, 252, 241, 0.1);
+  color: #888;
+  font-size: 0.9rem;
+}
+
+footer p {
+  text-shadow: 0 0 2px rgba(102, 252, 241, 0.3);
+}
+
+/* Markdown specific styles */
+main p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+}
+
+main a:not(.btn) {
+  color: var(--neon-secondary);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--neon-secondary);
+  transition: all 0.3s;
+}
+
+main a:not(.btn):hover {
+  color: var(--neon-primary);
+  border-bottom-color: var(--neon-primary);
+  text-shadow: 0 0 5px var(--neon-primary);
+}
+
+/* Syntax highlighting override */
+pre code.hljs, pre {
+  background: rgba(0, 0, 0, 0.5) !important;
+  border: 1px solid rgba(102, 252, 241, 0.3);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  border-radius: 8px;
+  padding: 1.5rem;
+}

--- a/zephyr-glow/templates/404.html
+++ b/zephyr-glow/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="hero">
+        <h1>404</h1>
+        <p>Page Not Found.</p>
+        <p>The signal was lost in the glow.</p>
+        <a href="/" class="btn">Return Home</a>
+    </div>
+{% endblock %}

--- a/zephyr-glow/templates/base.html
+++ b/zephyr-glow/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <link rel="stylesheet" href="/style.css">
+    {% if site.highlight is defined and site.highlight.enabled %}
+        {{ highlight_css | safe }}
+    {% endif %}
+</head>
+<body>
+    {% include "header.html" %}
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    {% include "footer.html" %}
+</body>
+</html>

--- a/zephyr-glow/templates/footer.html
+++ b/zephyr-glow/templates/footer.html
@@ -1,0 +1,3 @@
+<footer>
+    <p>&copy; {{ now() | date(format="%Y") }} {{ site.title }}. Designed with luminescent energy.</p>
+</footer>

--- a/zephyr-glow/templates/header.html
+++ b/zephyr-glow/templates/header.html
@@ -1,0 +1,9 @@
+<header>
+    <a href="/" class="logo">Zephyr Glow</a>
+    <nav>
+        <ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="/about/">About</a></li>
+        </ul>
+    </nav>
+</header>

--- a/zephyr-glow/templates/page.html
+++ b/zephyr-glow/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    {% if page.date %}
+        <p class="date"><em>{{ page.date | date(format="%Y-%m-%d") }}</em></p>
+    {% endif %}
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/zephyr-glow/templates/section.html
+++ b/zephyr-glow/templates/section.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ section.title }}</h1>
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+
+    {% if section.pages %}
+        <ul class="section-pages">
+        {% for page in section.pages %}
+            <li>
+                <a href="{{ page.permalink }}">{{ page.title }}</a>
+                {% if page.date %}
+                    - <span>{{ page.date | date(format="%Y-%m-%d") }}</span>
+                {% endif %}
+                {% if page.description %}
+                    <p>{{ page.description }}</p>
+                {% endif %}
+            </li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/zephyr-glow/templates/shortcodes/alert.html
+++ b/zephyr-glow/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/zephyr-glow/templates/taxonomy.html
+++ b/zephyr-glow/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/zephyr-glow/templates/taxonomy_term.html
+++ b/zephyr-glow/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}


### PR DESCRIPTION
Creates a new highly unique and elegant Hwaro template example called `zephyr-glow`.

The template avoids common naming collisions and implements a vibrant, cyberpunk-inspired glowing neon aesthetic against a deep dark background. 

- Initializes standard simple scaffold
- Refactors basic includes into `{% extends "base.html" %}` architecture
- Applies deeply custom CSS styling with neon lighting effects and flexible layouts
- Updates markdown contents to reflect the unique portfolio theme

---
*PR created automatically by Jules for task [9813119970157098652](https://jules.google.com/task/9813119970157098652) started by @chei-l*