### PR TITLE
feat: Add Apolo Nebula example site

### DIFF
--- a/apolo-nebula/AGENTS.md
+++ b/apolo-nebula/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/apolo-nebula/config.toml
+++ b/apolo-nebula/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Apolo Nebula"
+description = "A space-themed, dark mode glassmorphism Hwaro site."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/apolo-nebula/content/about.md
+++ b/apolo-nebula/content/about.md
@@ -1,0 +1,19 @@
++++
+title = "About the Nebula"
+description = "Information regarding the Apolo Nebula station and its mission in the vast digital universe."
++++
+
+# The Apolo Nebula Station
+
+The **Apolo Nebula** is a deep-space data relay designed to broadcast signals across the infinite void of the web. It embraces the dark, neon-lit aesthetics of deep space phenomena.
+
+Constructed upon the lightweight and highly performant architecture of **Hwaro**, this station ensures that your transmissions are delivered at lightspeed, without the heavy atmospheric drag of traditional dynamic frameworks.
+
+## Systems Log
+
+- **Engine:** Hwaro Static Site Generator
+- **Hull Plating:** Glassmorphism UI
+- **Reactor Core:** Dark Mode Energy
+- **Navigation:** Deep Indigo & Electric Cyan routing
+
+> "We are all made of star-stuff, and so is our code."

--- a/apolo-nebula/content/index.md
+++ b/apolo-nebula/content/index.md
@@ -1,0 +1,25 @@
++++
+title = "Apolo Nebula - The Cosmic Interface"
+description = "Welcome to the Apolo Nebula terminal. Your gateway to traversing the digital cosmos using Hwaro."
+tags = ["welcome", "cosmos", "exploration"]
++++
+
+# Welcome to Apolo Nebula
+
+Greetings, traveler. You have reached a secure terminal within the **Apolo Nebula**. This node is powered by the high-speed [Hwaro](https://github.com/hahwul/hwaro) static generation engine, built for deep space communication and blazing-fast delivery.
+
+## Mission Directives
+
+1. Edit your coordinates in `content/index.md` to alter this transmission.
+2. Generate new log entries in the `content/` directory.
+3. Execute `hwaro build` to compile the starmap.
+4. Run `hwaro serve` to preview the holographic projection locally.
+
+## Cosmic Archives
+
+Explore the known universe through our tagged data sectors:
+
+- [Explore all Sectors (Tags)](/tags/)
+- [View Mission Categories](/categories/)
+
+*Transmission ends.*

--- a/apolo-nebula/templates/404.html
+++ b/apolo-nebula/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>404 - Lost in Space</h1>
+      <p>The page you are looking for has drifted beyond the observable universe.</p>
+      <p><a href="{{ base_url }}/">Return to Base</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/apolo-nebula/templates/footer.html
+++ b/apolo-nebula/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer glass-container">
+      <p>&copy; {{ site.title }} - Exploring the Digital Frontier | Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a></p>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/apolo-nebula/templates/header.html
+++ b/apolo-nebula/templates/header.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --primary: #ff007f;
+      --secondary: #00f0ff;
+      --text: #e0e0ff;
+      --text-muted: #a0a0c0;
+      --bg-dark: #0a0a1a;
+      --glass-bg: rgba(255, 255, 255, 0.05);
+      --glass-border: rgba(255, 255, 255, 0.1);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    }
+
+    @keyframes starfield {
+      from { background-position: 0 0; }
+      to { background-position: -10000px 5000px; }
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background-color: var(--bg-dark);
+      background-image:
+        radial-gradient(1px 1px at 20px 30px, #ffffff, rgba(0,0,0,0)),
+        radial-gradient(1px 1px at 40px 70px, #ffffff, rgba(0,0,0,0)),
+        radial-gradient(1px 1px at 50px 160px, #ffffff, rgba(0,0,0,0)),
+        radial-gradient(1px 1px at 90px 40px, #ffffff, rgba(0,0,0,0)),
+        radial-gradient(1px 1px at 130px 80px, #ffffff, rgba(0,0,0,0)),
+        radial-gradient(1px 1px at 160px 120px, #ffffff, rgba(0,0,0,0));
+      background-repeat: repeat;
+      background-size: 200px 200px;
+      animation: starfield 200s linear infinite;
+      min-height: 100vh;
+    }
+
+    /* Glassmorphism Container */
+    .glass-container {
+      background: var(--glass-bg);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      box-shadow: var(--glass-shadow);
+      padding: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 2rem 1.5rem; }
+    .site-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1.5rem 2rem; margin-bottom: 3rem;
+    }
+    .site-logo {
+      font-weight: 800; font-size: 1.5rem;
+      color: var(--text); text-decoration: none;
+      text-transform: uppercase; letter-spacing: 2px;
+      background: linear-gradient(90deg, var(--primary), var(--secondary));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-shadow: 0 0 10px rgba(255, 0, 127, 0.3);
+    }
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      color: var(--text); text-decoration: none; font-size: 1rem; font-weight: 500;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+    .site-header nav a:hover {
+      color: var(--secondary);
+      text-shadow: 0 0 8px var(--secondary);
+    }
+
+    .site-main { min-height: calc(100vh - 300px); }
+    .site-footer {
+      padding: 1.5rem; text-align: center; color: var(--text-muted); font-size: 0.9rem;
+    }
+
+    /* Typography */
+    h1, h2, h3 {
+      line-height: 1.3; margin-top: 1.5em; margin-bottom: 0.5em; font-weight: 700;
+      color: #fff;
+    }
+    h1 { font-size: 2.5rem; margin-top: 0; text-shadow: 0 0 10px rgba(255, 255, 255, 0.2); }
+    h2 { font-size: 1.8rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 0.5rem; }
+    h3 { font-size: 1.4rem; }
+    p { margin: 1.2em 0; }
+
+    a {
+      color: var(--secondary); text-decoration: none;
+      transition: text-shadow 0.2s ease, color 0.2s ease;
+    }
+    a:hover {
+      color: var(--primary);
+      text-shadow: 0 0 8px var(--primary);
+      text-decoration: none;
+    }
+
+    code {
+      background: rgba(0, 0, 0, 0.4);
+      color: var(--secondary);
+      padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.85em;
+      font-family: 'Fira Code', 'Courier New', Courier, monospace;
+      border: 1px solid var(--glass-border);
+    }
+    pre {
+      background: rgba(0, 0, 0, 0.5);
+      padding: 1.5rem; border-radius: 12px; overflow-x: auto;
+      border: 1px solid var(--glass-border);
+      box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+    }
+    pre code {
+      background: none; padding: 0; border: none; color: inherit;
+      text-shadow: none;
+    }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem; padding: 1rem;
+      background: rgba(255, 255, 255, 0.02);
+      border-radius: 8px; border: 1px solid var(--glass-border);
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+    ul.section-list li:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+    ul.section-list li a { font-weight: 600; font-size: 1.2rem; display: block; margin-bottom: 0.5rem; }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; font-size: 1.1rem; }
+
+    nav.pagination { margin: 2.5rem 0 1rem 0; display: flex; justify-content: center; }
+    nav.pagination .pagination-list {
+      list-style: none; padding: 0; margin: 0; display: flex; gap: 0.75rem; flex-wrap: wrap;
+    }
+    nav.pagination a, .pagination-disabled span, .pagination-current span {
+      display: inline-flex; align-items: center; justify-content: center;
+      min-width: 2.5rem; height: 2.5rem; padding: 0 0.75rem;
+      border-radius: 8px; font-weight: 600;
+    }
+    nav.pagination a {
+      border: 1px solid var(--glass-border); color: var(--text); background: rgba(0,0,0,0.2);
+    }
+    nav.pagination a:hover {
+      color: var(--bg-dark); background: var(--secondary); border-color: var(--secondary);
+      text-shadow: none; box-shadow: 0 0 10px var(--secondary);
+    }
+    .pagination-current span {
+      border: 1px solid var(--primary); background: rgba(255, 0, 127, 0.2); color: var(--primary);
+      text-shadow: 0 0 5px var(--primary);
+    }
+    .pagination-disabled span {
+      border: 1px solid rgba(255,255,255,0.05); color: var(--text-muted); opacity: 0.4;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; align-items: center; text-align: center; }
+      .site-wrapper { padding: 1rem; }
+      .glass-container { padding: 1.5rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header glass-container">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+            <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/apolo-nebula/templates/page.html
+++ b/apolo-nebula/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/apolo-nebula/templates/section.html
+++ b/apolo-nebula/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+    </div>
+    {% if section.list %}
+    <div class="glass-container">
+      <ul class="section-list">
+        {{ section.list | safe }}
+      </ul>
+    </div>
+    {% endif %}
+    {% if pagination %}
+    <div class="glass-container">
+      {{ pagination | safe }}
+    </div>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/apolo-nebula/templates/shortcodes/alert.html
+++ b/apolo-nebula/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/apolo-nebula/templates/taxonomy.html
+++ b/apolo-nebula/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all cosmic sectors in this taxonomy:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/apolo-nebula/templates/taxonomy_term.html
+++ b/apolo-nebula/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Logs tagged with this cosmic anomaly:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
Adds the new `apolo-nebula` example to showcase a dark mode, space-themed glassmorphism UI for Hwaro static sites. This example avoids naming conflicts by using a distinct, original name and demonstrates extensive template customization including an animated CSS background, unique neon color palettes, and thematic sample content. Verified via local build and Playwright visual inspection.

---
*PR created automatically by Jules for task [12337681948493722003](https://jules.google.com/task/12337681948493722003) started by @chei-l*