### PR TITLE
feat: Add Scarlet Nexus example template

### DIFF
--- a/scarlet-nexus/AGENTS.md
+++ b/scarlet-nexus/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/scarlet-nexus/config.toml
+++ b/scarlet-nexus/config.toml
@@ -1,0 +1,11 @@
+title = "Scarlet Nexus"
+description = "A striking, crimson-infused dark template for elegant reading."
+base_url = "/"
+
+[highlight]
+enabled = true
+theme = "base16/monokai"
+
+[feeds]
+enabled = true
+filename = "rss.xml"

--- a/scarlet-nexus/content/about.md
+++ b/scarlet-nexus/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About the Nexus"
+description = "Information about this template."
++++
+
+Scarlet Nexus is a demonstration template for the Hwaro static site generator.
+
+### The Design Philosophy
+
+The goal was to create something that feels like a premium editorial experience in a dark environment. The crimson (`#dc143c`) provides a sharp contrast against the deep, off-black backgrounds (`#0f0a0c`).
+
+The pairing of *Playfair Display* with *Inter* creates a tension between classic editorial elegance and modern digital readability.

--- a/scarlet-nexus/content/index.md
+++ b/scarlet-nexus/content/index.md
@@ -1,0 +1,19 @@
++++
+title = "The Scarlet Nexus"
+description = "A sophisticated, crimson-infused dark template built for Hwaro."
++++
+
+Welcome to the Scarlet Nexus. This template provides a dark, elegant aesthetic with striking crimson accents, perfect for blogs, portfolios, and documentation.
+
+## Features
+
+- **Dark Mode Native**: Deep, rich backgrounds to reduce eye strain and look modern.
+- **Typography**: Uses Playfair Display for elegant headings and Inter for highly readable body text.
+- **Responsive**: Adapts perfectly to mobile, tablet, and desktop screens.
+- **Customizable**: Built with CSS variables for easy theme adjustments.
+
+> "Red is the color of extremes. It's the color of passionate love, seduction, violence, danger, anger, and adventure." - *Unknown*
+
+### Quick Start
+
+Check out the [Posts](/posts/) section to see how articles are styled.

--- a/scarlet-nexus/content/posts/_index.md
+++ b/scarlet-nexus/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Transmissions"
+description = "Latest entries from the Nexus."
+paginate = 10
++++

--- a/scarlet-nexus/content/posts/first-post.md
+++ b/scarlet-nexus/content/posts/first-post.md
@@ -1,0 +1,53 @@
++++
+title = "Syntax Highlighting in the Nexus"
+date = 2024-04-18
+description = "Demonstrating code blocks and syntax highlighting."
+
+[taxonomies]
+tags = ["code", "design", "hwaro"]
++++
+
+One of the essential features for any technical blog is syntax highlighting. The Scarlet Nexus template leverages Hwaro's built-in `highlight.enabled` configuration alongside custom CSS scoping to ensure code blocks integrate seamlessly into the dark theme.
+
+Here is an example in Crystal:
+
+```crystal
+require "http/server"
+
+server = HTTP::Server.new do |context|
+  context.response.content_type = "text/plain"
+  context.response.print "Hello from the Scarlet Nexus!"
+end
+
+address = server.bind_tcp 8080
+puts "Listening on http://#{address}"
+server.listen
+```
+
+And some Python:
+
+```python
+def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)
+
+print(fibonacci(10))
+```
+
+### Styling Approach
+
+To prevent the default highlighter themes from overriding the dark background with bright white boxes, the CSS specifically targets the `.hljs` class injected by Hwaro:
+
+```css
+pre {
+  background: var(--bg-alt) !important;
+  border: 1px solid var(--border);
+}
+
+.hljs {
+  background: transparent !important;
+}
+```
+
+This approach allows the rich syntax colors (like base16/monokai) to shine on a custom, controlled background.

--- a/scarlet-nexus/templates/404.html
+++ b/scarlet-nexus/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+  <h1>404 - Not Found</h1>
+  <p>The page you are looking for does not exist in the Nexus.</p>
+</div>
+<div style="text-align: center;">
+  <a href="{{ base_url }}/">&larr; Return Home</a>
+</div>
+{% endblock %}

--- a/scarlet-nexus/templates/base.html
+++ b/scarlet-nexus/templates/base.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Inter:wght@300;400;600&display=swap');
+
+    :root {
+      --bg: #0f0a0c;
+      --bg-alt: #1a1114;
+      --bg-hover: #26171b;
+      --text: #e6e0e2;
+      --text-muted: #a6989d;
+      --accent: #dc143c; /* Crimson */
+      --accent-hover: #ff335f;
+      --border: #3b2229;
+      --radius: 8px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background-color: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      margin: 0;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .site-header {
+      padding: 3rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 3rem;
+    }
+
+    .site-title {
+      font-family: 'Playfair Display', serif;
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: 0.5px;
+      transition: color 0.3s ease;
+    }
+
+    .site-title:hover {
+      color: var(--accent);
+    }
+
+    .site-nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition: color 0.3s ease;
+    }
+
+    .site-nav a:hover {
+      color: var(--accent);
+    }
+
+    .site-main {
+      flex-grow: 1;
+    }
+
+    .site-footer {
+      padding: 3rem 0;
+      margin-top: 4rem;
+      border-top: 1px solid var(--border);
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4 {
+      font-family: 'Playfair Display', serif;
+      color: var(--text);
+      line-height: 1.3;
+      margin-top: 2em;
+      margin-bottom: 0.8em;
+    }
+
+    h1 { font-size: 2.5rem; margin-top: 0; }
+    h2 { font-size: 1.8rem; }
+    h3 { font-size: 1.4rem; }
+
+    p { margin: 0 0 1.5em; }
+
+    a {
+      color: var(--accent);
+      text-decoration: none;
+      border-bottom: 1px dashed var(--accent);
+      transition: all 0.3s ease;
+    }
+
+    a:hover {
+      color: var(--accent-hover);
+      border-bottom-style: solid;
+    }
+
+    hr {
+      border: 0;
+      height: 1px;
+      background: var(--border);
+      margin: 3rem 0;
+    }
+
+    blockquote {
+      margin: 2rem 0;
+      padding: 1.5rem 2rem;
+      border-left: 4px solid var(--accent);
+      background: var(--bg-alt);
+      border-radius: 0 var(--radius) var(--radius) 0;
+      font-family: 'Playfair Display', serif;
+      font-style: italic;
+      font-size: 1.1rem;
+      color: var(--text-muted);
+    }
+
+    /* Code Blocks */
+    code {
+      font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--bg-alt);
+      padding: 0.2em 0.4em;
+      border-radius: 3px;
+      font-size: 0.85em;
+      color: var(--accent-hover);
+    }
+
+    pre {
+      background: var(--bg-alt) !important;
+      padding: 1.5rem;
+      border-radius: var(--radius);
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      margin: 2rem 0;
+    }
+
+    pre code {
+      background: transparent;
+      padding: 0;
+      color: inherit;
+    }
+
+    .hljs {
+      background: transparent !important;
+    }
+
+    /* Lists */
+    .article-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .article-item {
+      margin-bottom: 2.5rem;
+      padding-bottom: 2.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .article-item:last-child {
+      border-bottom: none;
+    }
+
+    .article-title {
+      margin: 0 0 0.5rem;
+      font-size: 1.6rem;
+    }
+
+    .article-title a {
+      color: var(--text);
+      border: none;
+    }
+
+    .article-title a:hover {
+      color: var(--accent);
+    }
+
+    .article-meta {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 1rem;
+      font-family: 'Playfair Display', serif;
+      font-style: italic;
+    }
+
+    .article-desc {
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    /* Taxonomy & Pagination */
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .tag {
+      font-size: 0.8rem;
+      padding: 0.2rem 0.6rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border); /* override default a */
+    }
+
+    .tag:hover {
+      background: var(--accent);
+      color: var(--bg);
+      border-color: var(--accent);
+    }
+
+    .pagination {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      margin-top: 3rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .pagination a {
+      padding: 0.5rem 1rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .pagination a:hover {
+      background: var(--bg-hover);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    /* Page Header */
+    .page-header {
+      margin-bottom: 3rem;
+      text-align: center;
+    }
+
+    .page-header h1 {
+      margin-bottom: 0.5rem;
+    }
+
+    .page-header p {
+      color: var(--text-muted);
+      font-size: 1.1rem;
+    }
+
+    @media (max-width: 600px) {
+      .site-header {
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+      }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-title">{{ site.title }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/posts/">Posts</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ site.title }} - Powered by Hwaro</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/scarlet-nexus/templates/page.html
+++ b/scarlet-nexus/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+  {% if page.title %}
+    <div class="page-header">
+      <h1>{{ page.title | e }}</h1>
+      {% if page.description %}
+        <p>{{ page.description | e }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+  {{ content | safe }}
+</article>
+{% endblock %}

--- a/scarlet-nexus/templates/section.html
+++ b/scarlet-nexus/templates/section.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{{ section.title | e }}</h1>
+  {% if section.description %}
+    <p>{{ section.description | e }}</p>
+  {% endif %}
+</div>
+
+{% if content %}
+  <div class="section-content">
+    {{ content | safe }}
+  </div>
+  <hr>
+{% endif %}
+
+<ul class="article-list">
+  {% for p in paginator.pages %}
+  <li class="article-item">
+    <h2 class="article-title"><a href="{{ base_url }}{{ p.permalink }}">{{ p.title | e }}</a></h2>
+    <div class="article-meta">
+      {% if p.date %}Published on {{ p.date | date(format="%B %d, %Y") }}{% endif %}
+    </div>
+    {% if p.description %}
+      <p class="article-desc">{{ p.description | e }}</p>
+    {% endif %}
+    {% if p.taxonomies is defined and p.taxonomies.tags is defined %}
+      <div class="tag-list">
+        {% for tag in p.taxonomies.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | urlencode }}/" class="tag">#{{ tag | e }}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+
+{% if paginator.total_pages > 1 %}
+  <nav class="pagination">
+    {% if paginator.previous %}
+      <a href="{{ base_url }}{{ paginator.previous }}">&larr; Previous</a>
+    {% endif %}
+    {% if paginator.next %}
+      <a href="{{ base_url }}{{ paginator.next }}">Next &rarr;</a>
+    {% endif %}
+  </nav>
+{% endif %}
+{% endblock %}

--- a/scarlet-nexus/templates/shortcodes/alert.html
+++ b/scarlet-nexus/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/scarlet-nexus/templates/taxonomy.html
+++ b/scarlet-nexus/templates/taxonomy.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{{ page.title | default("Tags") | e }}</h1>
+</div>
+{{ content | safe }}
+{% endblock %}

--- a/scarlet-nexus/templates/taxonomy_term.html
+++ b/scarlet-nexus/templates/taxonomy_term.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-header">
+  <h1>{{ page.title | e }}</h1>
+</div>
+{{ content | safe }}
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -4343,6 +4343,13 @@
     "docs",
     "scaffolding"
   ],
+  "scarlet-nexus": [
+    "dark",
+    "blog",
+    "elegant",
+    "crimson",
+    "portfolio"
+  ],
   "schematic": [
     "light",
     "docs",


### PR DESCRIPTION
This PR introduces a new example template named "Scarlet Nexus".

The template features a premium, crimson-infused dark mode editorial design, leveraging Playfair Display for headings and Inter for body text. It demonstrates Hwaro's template inheritance capabilities and provides custom CSS to beautifully integrate syntax highlighting within dark mode.

A new entry was added alphabetically to `tags.json` in the root repository.

---
*PR created automatically by Jules for task [3331677666738790958](https://jules.google.com/task/3331677666738790958) started by @chei-l*