### PR TITLE
feat: add crimson-velvet-glass example site

### DIFF
--- a/crimson-velvet-glass/AGENTS.md
+++ b/crimson-velvet-glass/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/crimson-velvet-glass/config.toml
+++ b/crimson-velvet-glass/config.toml
@@ -1,0 +1,354 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Crimson Velvet Glass"
+description = "Welcome to my personal blog powered by Hwaro."
+author = "Hwaro"
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github-dark"    # Dark theme for syntax highlighting
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"      # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/crimson-velvet-glass/content/about.md
+++ b/crimson-velvet-glass/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About"
+description = "Sample content"
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/crimson-velvet-glass/content/archives.md
+++ b/crimson-velvet-glass/content/archives.md
@@ -1,0 +1,6 @@
++++
+title = "Archives"
+description = "Sample content"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/crimson-velvet-glass/content/index.md
+++ b/crimson-velvet-glass/content/index.md
@@ -1,0 +1,13 @@
++++
+title = "Home"
+description = "Sample content"
+tags = ["home"]
++++
+
+This is a blog powered by [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator.
+
+Check out the latest posts in the [Posts](/posts/) section, or browse by:
+
+- [Tags](/tags/)
+- [Categories](/categories/)
+- [Authors](/authors/)

--- a/crimson-velvet-glass/content/posts/_index.md
+++ b/crimson-velvet-glass/content/posts/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Posts"
+description = "Sample content"
++++
+
+Browse all blog posts below.

--- a/crimson-velvet-glass/content/posts/getting-started-with-hwaro.md
+++ b/crimson-velvet-glass/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,35 @@
++++
+title = "Getting Started with Hwaro"
+date = "2024-01-20"
+tags = ["tutorial", "getting-started", "hwaro"]
+categories = ["tutorials"]
+description = "A beginner's guide to building websites with Hwaro."
++++
+
+In this post, I'll walk you through the basics of setting up and using Hwaro.
+
+## Installation
+
+First, make sure you have Crystal installed. Then:
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Creating Your First Site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+That's it! Your blog is now running at `http://localhost:3000`.
+
+## Next Steps
+
+- Customize your templates in the `templates/` directory
+- Add new posts in `content/posts/`
+- Configure your site in `config.toml`

--- a/crimson-velvet-glass/content/posts/hello-world.md
+++ b/crimson-velvet-glass/content/posts/hello-world.md
@@ -1,0 +1,19 @@
++++
+title = "Hello World"
+date = "2024-01-15"
+tags = ["introduction", "hello"]
+categories = ["general"]
+description = "My first blog post using Hwaro static site generator."
++++
+
+Welcome to my first blog post! This blog is powered by Hwaro, a fast and lightweight static site generator written in Crystal.
+
+## Why Hwaro?
+
+Hwaro offers a simple yet powerful way to create static websites:
+
+- **Fast**: Built with Crystal for blazing fast build times
+- **Simple**: Easy to understand directory structure
+- **Flexible**: Supports custom templates and shortcodes
+
+Stay tuned for more posts!

--- a/crimson-velvet-glass/content/posts/markdown-tips.md
+++ b/crimson-velvet-glass/content/posts/markdown-tips.md
@@ -1,0 +1,47 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2024-01-25"
+tags = ["markdown", "writing", "tips"]
+categories = ["tutorials"]
+description = "Learn useful Markdown formatting techniques for your blog posts."
++++
+
+Hwaro uses Markdown for content. Here are some useful formatting tips.
+
+## Text Formatting
+
+- **Bold text** using `**bold**`
+- *Italic text* using `*italic*`
+- `Inline code` using backticks
+
+## Code Blocks
+
+Use triple backticks for code blocks:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Lists
+
+Ordered lists:
+1. First item
+2. Second item
+3. Third item
+
+Unordered lists:
+- Item one
+- Item two
+- Item three
+
+## Links and Images
+
+- [Link text](https://example.com)
+- ![Alt text](/path/to/image.jpg)
+
+## Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.
+
+Happy writing!

--- a/crimson-velvet-glass/static/css/style.css
+++ b/crimson-velvet-glass/static/css/style.css
@@ -1,0 +1,270 @@
+:root {
+  --bg-color: #0b0507;
+  --text-color: #f2e1e4;
+  --glass-bg: rgba(138, 17, 39, 0.1);
+  --glass-border: rgba(138, 17, 39, 0.3);
+  --glass-hover: rgba(138, 17, 39, 0.2);
+  --accent: #d91c42;
+  --accent-light: #f73660;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-color);
+  background-image:
+    radial-gradient(circle at 15% 50%, rgba(138, 17, 39, 0.15), transparent 25%),
+    radial-gradient(circle at 85% 30%, rgba(138, 17, 39, 0.1), transparent 25%);
+  color: var(--text-color);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.glass-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Header */
+header {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  margin-bottom: 3rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+}
+
+.site-title {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+nav a {
+  color: var(--text-color);
+  text-decoration: none;
+  margin-left: 1.5rem;
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+nav a:hover {
+  color: var(--accent-light);
+}
+
+/* Main Content */
+main {
+  flex: 1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--text-color);
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  color: var(--accent-light);
+  margin-bottom: 1.5rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+a:hover {
+  color: var(--accent-light);
+}
+
+p {
+  margin-bottom: 1.5rem;
+}
+
+/* Post Item / Card */
+.post-item {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, background 0.3s ease;
+  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.2);
+}
+
+.post-item:hover {
+  transform: translateY(-5px);
+  background: var(--glass-hover);
+}
+
+.post-item-title {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.post-item-title a {
+  color: var(--text-color);
+}
+
+.post-item-title a:hover {
+  color: var(--accent);
+}
+
+.post-item-meta {
+  font-size: 0.9rem;
+  color: rgba(242, 225, 228, 0.6);
+  margin-bottom: 1rem;
+}
+
+.post-item-summary {
+  margin-bottom: 0;
+  color: rgba(242, 225, 228, 0.8);
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3rem;
+  padding: 1rem;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  backdrop-filter: blur(12px);
+}
+
+/* Footer */
+footer {
+  margin-top: 4rem;
+  padding: 2rem 0;
+  text-align: center;
+  color: rgba(242, 225, 228, 0.5);
+  font-size: 0.9rem;
+  border-top: 1px solid var(--glass-border);
+}
+
+/* Post details */
+.post-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.post-title {
+  margin-bottom: 0.5rem;
+}
+
+.post-meta {
+  color: rgba(242, 225, 228, 0.6);
+  font-size: 0.95rem;
+}
+
+.post-categories a {
+  color: var(--accent);
+}
+
+.post-tags {
+  margin-top: 3rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: rgba(138, 17, 39, 0.2);
+  color: var(--accent-light);
+  padding: 0.2rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  border: 1px solid var(--glass-border);
+}
+
+.tag:hover {
+  background: rgba(138, 17, 39, 0.4);
+}
+
+/* Code Highlight Overrides */
+pre code.hljs {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 1.5rem !important;
+}
+
+code {
+  background-color: rgba(138, 17, 39, 0.15);
+  color: var(--accent-light);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+pre code {
+  color: var(--text-color);
+  background-color: transparent;
+  padding: 0;
+}
+
+blockquote {
+  border-left: 4px solid var(--accent);
+  margin: 0;
+  padding-left: 1rem;
+  color: rgba(242, 225, 228, 0.8);
+  font-style: italic;
+  background: var(--glass-bg);
+  padding: 1rem;
+  border-radius: 0 8px 8px 0;
+}
+
+img {
+  max-width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+}
+
+/* 404 */
+.not-found {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.not-found h1 {
+  font-size: 6rem;
+  margin-bottom: 0;
+  color: var(--accent);
+  text-shadow: 0 0 20px rgba(217, 28, 66, 0.5);
+}
+
+.home-link {
+  display: inline-block;
+  margin-top: 2rem;
+  padding: 0.8rem 2rem;
+  background: var(--accent);
+  color: white;
+  border-radius: 30px;
+  transition: all 0.3s ease;
+}
+
+.home-link:hover {
+  background: var(--accent-light);
+  box-shadow: 0 0 15px rgba(247, 54, 96, 0.5);
+  color: white;
+}

--- a/crimson-velvet-glass/static/js/search.js
+++ b/crimson-velvet-glass/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/crimson-velvet-glass/templates/404.html
+++ b/crimson-velvet-glass/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}404 Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+<div class="not-found">
+    <h1>404</h1>
+    <p>Page Not Found</p>
+    <a href="/" class="home-link">Go back home</a>
+</div>
+{% endblock %}

--- a/crimson-velvet-glass/templates/base.html
+++ b/crimson-velvet-glass/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ site.title }}{% endblock %}</title>
+    {% if site.highlight is defined and site.highlight.enabled %}
+      {{ highlight_css | safe }}
+    {% endif %}
+    {% if auto_includes_css is defined %}
+      {{ auto_includes_css | safe }}
+    {% endif %}
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+    <div class="glass-container">
+        <header>
+            {% block header %}{% include "header.html" %}{% endblock %}
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            {% block footer %}{% include "footer.html" %}{% endblock %}
+        </footer>
+    </div>
+</body>
+</html>

--- a/crimson-velvet-glass/templates/footer.html
+++ b/crimson-velvet-glass/templates/footer.html
@@ -1,0 +1,10 @@
+    <footer class="blog-footer">
+      <p>Powered by Hwaro</p>
+    </footer>
+  </main>
+</div>
+{{ highlight_js }}
+<script src="{{ base_url }}/js/search.js"></script>
+{{ auto_includes_js }}
+</body>
+</html>

--- a/crimson-velvet-glass/templates/header.html
+++ b/crimson-velvet-glass/templates/header.html
@@ -1,0 +1,6 @@
+<a href="/" class="site-title">{{ site.title }}</a>
+<nav>
+    <a href="/">Home</a>
+    <a href="/about/">About</a>
+    <a href="/posts/">Blog</a>
+</nav>

--- a/crimson-velvet-glass/templates/page.html
+++ b/crimson-velvet-glass/templates/page.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if page.title %}
+    {{ page.title }} | {{ site.title }}
+  {% else %}
+    {{ site.title }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<article class="page">
+    {% if page.title %}
+        <h1>{{ page.title }}</h1>
+    {% endif %}
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/crimson-velvet-glass/templates/post.html
+++ b/crimson-velvet-glass/templates/post.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if page.title %}
+    {{ page.title }} | {{ site.title }}
+  {% else %}
+    {{ site.title }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<article class="post">
+    <header class="post-header">
+        {% if page.title %}
+            <h1 class="post-title">{{ page.title }}</h1>
+        {% endif %}
+
+        <div class="post-meta">
+            {% if page.date %}
+                <time datetime="{{ page.date | date(format="%Y-%m-%d") }}">
+                    {{ page.date | date(format="%B %d, %Y") }}
+                </time>
+            {% endif %}
+
+            {% if page.taxonomies is defined and page.taxonomies.categories is defined %}
+                <span class="post-categories">
+                    in
+                    {% for cat in page.taxonomies.categories %}
+                        <a href="/categories/{{ cat }}/">{{ cat }}</a>{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                </span>
+            {% endif %}
+        </div>
+    </header>
+
+    <div class="content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+        <footer class="post-footer">
+            <div class="post-tags">
+                {% for tag in page.taxonomies.tags %}
+                    <a href="/tags/{{ tag }}/" class="tag">#{{ tag }}</a>
+                {% endfor %}
+            </div>
+        </footer>
+    {% endif %}
+</article>
+{% endblock %}

--- a/crimson-velvet-glass/templates/section.html
+++ b/crimson-velvet-glass/templates/section.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if section.title %}
+    {{ section.title }} | {{ site.title }}
+  {% else %}
+    {{ site.title }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="section-container">
+    {% if section.title %}
+        <h1 class="section-title">{{ section.title }}</h1>
+    {% endif %}
+
+    {% if content %}
+        <div class="section-content">
+            {{ content | safe }}
+        </div>
+    {% endif %}
+
+    <div class="post-list">
+        {% if paginator %}
+            {% set pages = paginator.pages %}
+        {% else %}
+            {% set pages = section.pages %}
+        {% endif %}
+
+        {% for post in pages %}
+            <article class="post-item">
+                <h2 class="post-item-title"><a href="{{ post.permalink }}">{{ post.title }}</a></h2>
+                {% if post.date %}
+                    <div class="post-item-meta">
+                        <time datetime="{{ post.date | date(format="%Y-%m-%d") }}">{{ post.date | date(format="%B %d, %Y") }}</time>
+                    </div>
+                {% endif %}
+                {% if post.description %}
+                    <p class="post-item-summary">{{ post.description }}</p>
+                {% endif %}
+            </article>
+        {% endfor %}
+    </div>
+
+    {% if paginator and paginator.number_pagers > 1 %}
+        <nav class="pagination">
+            {% if paginator.previous %}
+                <a href="{{ paginator.previous }}" class="prev">← Newer</a>
+            {% endif %}
+            <span class="page-number">Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+            {% if paginator.next %}
+                <a href="{{ paginator.next }}" class="next">Older →</a>
+            {% endif %}
+        </nav>
+    {% endif %}
+</div>
+{% endblock %}

--- a/crimson-velvet-glass/templates/shortcodes/alert.html
+++ b/crimson-velvet-glass/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/crimson-velvet-glass/templates/taxonomy.html
+++ b/crimson-velvet-glass/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if page.title %}
+    {{ page.title }} | {{ site.title }}
+  {% else %}
+    Taxonomy | {{ site.title }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="taxonomy-container">
+    {% if page.title %}
+        <h1 class="taxonomy-title">{{ page.title }}</h1>
+    {% endif %}
+
+    <div class="taxonomy-list">
+        {{ content | safe }}
+    </div>
+</div>
+{% endblock %}

--- a/crimson-velvet-glass/templates/taxonomy_term.html
+++ b/crimson-velvet-glass/templates/taxonomy_term.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if page.title %}
+    {{ page.title }} | {{ site.title }}
+  {% else %}
+    Term | {{ site.title }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="taxonomy-term-container">
+    {% if page.title %}
+        <h1 class="taxonomy-term-title">{{ page.title }}</h1>
+    {% endif %}
+
+    <div class="taxonomy-term-list">
+        {{ content | safe }}
+    </div>
+
+    {% if paginator and paginator.number_pagers > 1 %}
+        <nav class="pagination">
+            {% if paginator.previous %}
+                <a href="{{ paginator.previous }}" class="prev">← Newer</a>
+            {% endif %}
+            <span class="page-number">Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+            {% if paginator.next %}
+                <a href="{{ paginator.next }}" class="next">Older →</a>
+            {% endif %}
+        </nav>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -1204,6 +1204,13 @@
     "agency",
     "bold"
   ],
+  "crimson-velvet-glass": [
+    "dark",
+    "elegant",
+    "glassmorphism",
+    "crimson",
+    "blog"
+  ],
   "cross-sectional": [
     "paper",
     "light",


### PR DESCRIPTION
This PR introduces a new example Hwaro site called "Crimson Velvet Glass".

- Initialized via `hwaro init crimson-velvet-glass --scaffold blog-dark`.
- Transformed scaffold templates to use Jinja2/Crinja template inheritance (`base.html`).
- Applied a distinct design focusing on:
  - Dark mode (`#0b0507`)
  - Glassmorphism effects (`backdrop-filter`)
  - Crimson accents (`#d91c42`)
  - Clean typography overrides
- Updated dummy content to ensure proper frontmatter metadata.
- Registered the new template in `tags.json` with appropriate tags (`dark`, `elegant`, `glassmorphism`, `crimson`, `blog`).

---
*PR created automatically by Jules for task [2967793702924713858](https://jules.google.com/task/2967793702924713858) started by @chei-l*