### PR TITLE
feat: add aetherial-glow example template

### DIFF
--- a/aetherial-glow/AGENTS.md
+++ b/aetherial-glow/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/aetherial-glow/config.toml
+++ b/aetherial-glow/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Aetherial Glow"
+description = "A glowing, aetherial portfolio template."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/aetherial-glow/content/_index.md
+++ b/aetherial-glow/content/_index.md
@@ -1,0 +1,27 @@
++++
+title = "Aetherial Glow"
+description = "Home"
+date = 2023-01-01
+tags = ["portfolio", "glassmorphism"]
++++
+
+<div class="hero">
+  <h1 class="glow-text">Aetherial Glow</h1>
+  <p>Welcome to the void.</p>
+</div>
+
+This is a fresh static site template powered by [Hwaro](https://github.com/hahwul/hwaro). It features an elegant dark glassmorphism design with neon glowing accents.
+
+## Features
+
+- **Glassmorphism UI:** Translucent containers that blur the dynamic background.
+- **Neon Glows:** Text shadows and borders that give an ethereal feel.
+- **Dynamic Background:** A subtle, slowly rotating radial gradient background.
+- **Responsive:** Looks great on desktops and mobile devices.
+
+## Taxonomies
+
+Hwaro supports taxonomies like tags and categories. Check out:
+
+- [All Tags](/tags/)
+- [All Categories](/categories/)

--- a/aetherial-glow/content/about.md
+++ b/aetherial-glow/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About"
+description = "About"
+date = 2023-01-01
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+<div class="content-box">
+  <h2 class="glow-text">About</h2>
+  <p>A minimal, glowing template.</p>
+</div>
+
+This is a demonstration of how inner pages look with the Aetherial Glow template.
+
+> "Elegance is achieved not when there is nothing more to add, but when there is nothing left to take away." - Antoine de Saint-Exupéry

--- a/aetherial-glow/templates/404.html
+++ b/aetherial-glow/templates/404.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>404 Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+      <p><a href="{{ base_url }}/">Return to Home</a></p>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aetherial-glow/templates/footer.html
+++ b/aetherial-glow/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>Aetherial Glow &copy; {{ site.time | date(format="%Y") }}. Powered by Hwaro.</p>
+    </footer>
+  </div>
+  {{ highlight_js | safe }}
+  {{ auto_includes_js | safe }}
+</body>
+</html>

--- a/aetherial-glow/templates/header.html
+++ b/aetherial-glow/templates/header.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags | safe }}
+  {{ hreflang_tags | safe }}
+  <style>
+    :root {
+      --primary: #b37acc;
+      --primary-glow: rgba(179, 122, 204, 0.4);
+      --text: #e0e0e0;
+      --text-muted: #8b8b99;
+      --border: rgba(255, 255, 255, 0.1);
+      --bg: #050508;
+      --bg-glass: rgba(15, 15, 20, 0.6);
+      --glass-blur: blur(16px);
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; margin: 0; color: var(--text); background: var(--bg); position: relative; }
+
+    body::before {
+      content: ""; position: fixed; top: -50%; left: -50%; width: 200%; height: 200%;
+      background: radial-gradient(circle at 50% 50%, rgba(179, 122, 204, 0.05) 0%, transparent 50%);
+      z-index: -1; animation: drift 30s linear infinite; pointer-events: none;
+    }
+    @keyframes drift {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; position: relative; z-index: 1; }
+    .site-header { display: flex; align-items: center; justify-content: space-between; padding: 1.5rem 0; margin-bottom: 3rem; }
+    .site-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); text-decoration: none; letter-spacing: 0.05em; text-transform: uppercase; text-shadow: 0 0 10px var(--primary-glow); transition: all 0.3s ease; }
+    .site-logo:hover { color: var(--primary); text-shadow: 0 0 20px var(--primary); }
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.95rem; font-weight: 500; transition: all 0.3s ease; }
+    .site-header nav a:hover { color: var(--primary); text-shadow: 0 0 10px var(--primary-glow); }
+    .site-main { min-height: calc(100vh - 200px); }
+    .site-footer { margin-top: 4rem; padding: 2rem 0; color: var(--text-muted); font-size: 0.85rem; text-align: center; border-top: 1px solid var(--border); }
+
+    /* Typography */
+    h1, h2, h3 { line-height: 1.2; margin-top: 1.5em; margin-bottom: 0.75em; font-weight: 600; letter-spacing: -0.02em; }
+    h1 { font-size: 2.5rem; margin-top: 0; }
+    h2 { font-size: 1.75rem; }
+    h3 { font-size: 1.25rem; }
+    p { margin: 1em 0; }
+    a { color: var(--primary); text-decoration: none; transition: all 0.2s ease; }
+    a:hover { color: #d0a3eb; text-shadow: 0 0 8px var(--primary-glow); }
+
+    .glow-text {
+      background: linear-gradient(90deg, #fff, var(--primary));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-shadow: 0 0 30px var(--primary-glow);
+    }
+
+    code { background: rgba(255,255,255,0.05); padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; color: #d0a3eb; }
+    pre { background: rgba(0,0,0,0.4); padding: 1.25rem; border-radius: 12px; overflow-x: auto; border: 1px solid var(--border); box-shadow: inset 0 0 10px rgba(0,0,0,0.5); }
+    pre code { background: none; padding: 0; color: inherit; }
+
+    /* Glassmorphism Container */
+    .glass-container {
+      background: var(--bg-glass);
+      backdrop-filter: var(--glass-blur);
+      -webkit-backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 2.5rem;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+      margin-bottom: 2rem;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+    .glass-container:hover {
+      box-shadow: 0 12px 40px rgba(179, 122, 204, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+      transform: translateY(-2px);
+    }
+
+    /* Components */
+    .hero { text-align: center; padding: 3rem 0; }
+    .hero p { font-size: 1.1rem; color: var(--text-muted); max-width: 600px; margin: 1rem auto; }
+
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; display: grid; gap: 1rem; }
+    ul.section-list li { padding: 1rem 1.25rem; background: rgba(255,255,255,0.03); border-radius: 8px; border: 1px solid var(--border); transition: all 0.2s ease; }
+    ul.section-list li:hover { background: rgba(255,255,255,0.05); border-color: rgba(179, 122, 204, 0.3); }
+    ul.section-list li a { font-weight: 500; font-size: 1.05rem; }
+
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; font-size: 1.1rem; }
+
+    nav.pagination { margin: 2rem 0; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; justify-content: center; align-items: center; }
+    nav.pagination a { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); text-decoration: none; background: rgba(255,255,255,0.02); transition: all 0.2s ease; }
+    nav.pagination a:hover { color: var(--text); border-color: var(--primary); background: rgba(179, 122, 204, 0.1); box-shadow: 0 0 10px var(--primary-glow); }
+    .pagination-current span { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 6px; border: 1px solid var(--primary); background: rgba(179, 122, 204, 0.2); color: #fff; box-shadow: 0 0 15px var(--primary-glow); }
+    .pagination-disabled span { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 6px; border: 1px solid transparent; color: var(--text-muted); opacity: 0.4; }
+
+    /* Markdown elements styling inside glass container */
+    .glass-container img { max-width: 100%; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.5); margin: 1.5rem 0; }
+    .glass-container blockquote { border-left: 3px solid var(--primary); margin: 1.5rem 0; padding: 1rem 1.5rem; background: linear-gradient(90deg, rgba(179, 122, 204, 0.1), transparent); border-radius: 0 8px 8px 0; color: #d0a3eb; font-style: italic; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; text-align: center; }
+      .glass-container { padding: 1.5rem; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css | safe }}
+  {{ auto_includes_css | safe }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+            <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/aetherial-glow/templates/page.html
+++ b/aetherial-glow/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aetherial-glow/templates/section.html
+++ b/aetherial-glow/templates/section.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      {{ content | safe }}
+      <ul class="section-list">
+        {{ section.list | safe }}
+      </ul>
+      {{ pagination | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aetherial-glow/templates/shortcodes/alert.html
+++ b/aetherial-glow/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/aetherial-glow/templates/taxonomy.html
+++ b/aetherial-glow/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/aetherial-glow/templates/taxonomy_term.html
+++ b/aetherial-glow/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-container">
+      <h1>{{ page.title | e }}</h1>
+      <p class="taxonomy-desc">Posts tagged with this term:</p>
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -68,6 +68,13 @@
     "portfolio",
     "minimal"
   ],
+  "aetherial-glow": [
+    "dark",
+    "elegant",
+    "glassmorphism",
+    "glow",
+    "portfolio"
+  ],
   "after-dark": [
     "blog",
     "dark",


### PR DESCRIPTION
Adds a new example site template named `aetherial-glow` featuring a modern, dark glassmorphism design with neon glowing accents. The site correctly utilizes Hwaro scaffolding, TOML frontmatter, and Crinja templating rules. It has been verified via Playwright visually and through `hwaro build` successfully.

---
*PR created automatically by Jules for task [3426057631641139195](https://jules.google.com/task/3426057631641139195) started by @chei-l*