### PR TITLE
feat: add synth-oasis example site

### DIFF
--- a/synth-oasis/AGENTS.md
+++ b/synth-oasis/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/synth-oasis/config.toml
+++ b/synth-oasis/config.toml
@@ -1,0 +1,212 @@
+# Hwaro Configuration File
+title = "Synth Oasis"
+base_url = "https://example.com"
+language_code = "en"
+description = "A dark-themed Hwaro example site featuring a retro-futuristic synthwave and glassmorphism aesthetic."
+theme = ""
+
+[taxonomies]
+tags = "Tags"
+categories = "Categories"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+# [highlight]
+# enabled = true
+# theme = "github"
+# use_cdn = true
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Markdown (Optional)
+# =============================================================================
+
+# [markdown]
+# safe = false
+# lazy_loading = false
+# emoji = false
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/synth-oasis/content/_index.md
+++ b/synth-oasis/content/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Welcome to Synth Oasis"
+date = "2023-10-27"
+description = "Enter the digital mirage of the Synth Oasis."
++++
+Welcome to **Synth Oasis**, a digital mirage where retro-futurism meets elegant glassmorphism. This Hwaro example site showcases a dark theme inspired by the neon glow of the 80s synthwave era, combined with modern frosted glass UI components.
+
+## Features
+
+*   **Deep Dark Void:** A background reminiscent of endless digital space.
+*   **Neon Aesthetics:** Glowing cyan, magenta, and purple accents that pulse with energy.
+*   **Glassmorphism:** Translucent UI panels with a frosted glass effect using `backdrop-filter`.
+*   **Retro Typography:** High-contrast, futuristic fonts to complete the vibe.

--- a/synth-oasis/content/about.md
+++ b/synth-oasis/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About Synth Oasis"
+date = "2023-10-27"
+description = "Learn more about the aesthetic and design of the Synth Oasis."
++++
+
+Synth Oasis is a demonstration of the flexibility and power of the Hwaro static site generator.
+
+This example was crafted to illustrate how you can combine modern CSS techniques—such as CSS grid, flexbox, CSS variables for theming, and the popular glassmorphism trend—with a specific, strong aesthetic like retro synthwave.
+
+Enjoy the neon glow and the smooth frosted glass as you explore the mirage.

--- a/synth-oasis/static/css/style.css
+++ b/synth-oasis/static/css/style.css
@@ -1,0 +1,246 @@
+:root {
+    --bg-dark: #030108;
+    --neon-cyan: #00f0ff;
+    --neon-magenta: #ff0055;
+    --neon-purple: #8a2be2;
+    --text-main: #e0e0ff;
+    --text-muted: #a0a0c0;
+    --glass-bg: rgba(20, 10, 40, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+
+    --font-heading: 'Space Grotesk', sans-serif;
+    --font-body: 'Outfit', sans-serif;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-main);
+    font-family: var(--font-body);
+    line-height: 1.6;
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
+}
+
+/* Retro Grid Background */
+.background-grid {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-image:
+        linear-gradient(rgba(0, 240, 255, 0.1) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 240, 255, 0.1) 1px, transparent 1px);
+    background-size: 40px 40px;
+    transform: perspective(500px) rotateX(60deg) translateY(-100px) translateZ(-200px);
+    z-index: -2;
+    animation: gridMove 20s linear infinite;
+    pointer-events: none;
+}
+
+@keyframes gridMove {
+    0% { background-position: 0 0; }
+    100% { background-position: 0 40px; }
+}
+
+/* Glowing Orbs */
+.glow-orb {
+    position: fixed;
+    border-radius: 50%;
+    filter: blur(80px);
+    z-index: -1;
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.orb-1 {
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, var(--neon-magenta), transparent 70%);
+    top: -100px;
+    left: -100px;
+    animation: float 15s ease-in-out infinite alternate;
+}
+
+.orb-2 {
+    width: 500px;
+    height: 500px;
+    background: radial-gradient(circle, var(--neon-cyan), transparent 70%);
+    bottom: -150px;
+    right: -100px;
+    animation: float 12s ease-in-out infinite alternate-reverse;
+}
+
+.orb-3 {
+    width: 300px;
+    height: 300px;
+    background: radial-gradient(circle, var(--neon-purple), transparent 70%);
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    animation: pulse 8s ease-in-out infinite;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0); }
+    100% { transform: translate(50px, 50px); }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.4; transform: translate(-50%, -50%) scale(1); }
+    50% { opacity: 0.7; transform: translate(-50%, -50%) scale(1.2); }
+}
+
+/* Layout */
+.container {
+    max-width: 900px;
+    margin: 100px auto 40px;
+    padding: 0 20px;
+}
+
+/* Glassmorphism Navigation */
+.glass-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--glass-border);
+    z-index: 100;
+}
+
+.nav-content {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 15px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.site-title {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--neon-cyan);
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+}
+
+.nav-links a {
+    color: var(--text-main);
+    text-decoration: none;
+    margin-left: 20px;
+    font-weight: 600;
+    transition: color 0.3s, text-shadow 0.3s;
+}
+
+.nav-links a:hover {
+    color: var(--neon-magenta);
+    text-shadow: 0 0 8px rgba(255, 0, 85, 0.6);
+}
+
+/* Glassmorphism Panels */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 40px;
+    box-shadow: var(--glass-shadow);
+    margin-bottom: 30px;
+    position: relative;
+    overflow: hidden;
+}
+
+.glass-panel::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 2px;
+    background: linear-gradient(90deg, transparent, var(--neon-cyan), transparent);
+    opacity: 0.5;
+}
+
+/* Typography */
+h1, h2, h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 20px;
+    font-weight: 700;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: transparent;
+    -webkit-text-stroke: 1px var(--neon-magenta);
+    background: linear-gradient(90deg, var(--neon-magenta), var(--neon-cyan));
+    -webkit-background-clip: text;
+    text-shadow: 0 0 20px rgba(255, 0, 85, 0.4);
+    letter-spacing: -1px;
+}
+
+.page-title {
+    font-size: 2.5rem;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 15px rgba(0, 240, 255, 0.4);
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 10px;
+}
+
+.content-body p {
+    margin-bottom: 15px;
+    font-size: 1.1rem;
+    color: var(--text-muted);
+}
+
+.content-body a {
+    color: var(--neon-cyan);
+    text-decoration: none;
+    border-bottom: 1px dashed var(--neon-cyan);
+    transition: all 0.3s;
+}
+
+.content-body a:hover {
+    color: var(--neon-magenta);
+    border-bottom-color: var(--neon-magenta);
+    text-shadow: 0 0 8px rgba(255, 0, 85, 0.6);
+}
+
+.content-body ul {
+    margin-bottom: 20px;
+    padding-left: 20px;
+}
+
+.content-body li {
+    margin-bottom: 10px;
+    color: var(--text-muted);
+}
+
+.content-body strong {
+    color: var(--text-main);
+}
+
+/* Footer */
+.glass-footer {
+    text-align: center;
+    padding: 20px;
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid var(--glass-border);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-top: 50px;
+}

--- a/synth-oasis/templates/404.html
+++ b/synth-oasis/templates/404.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-panel">
+    <h1 class="page-title neon-text" style="font-size: 4rem;">404</h1>
+    <h2>Page Not Found</h2>
+
+    <div class="content-body">
+        <p>The page you are looking for has faded into the digital void.</p>
+        <p><a href="/">Return to Home</a></p>
+    </div>
+</div>
+{% endblock %}

--- a/synth-oasis/templates/base.html
+++ b/synth-oasis/templates/base.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{% if page is defined and page.title %}{{ page.title }} | {% endif %}{% if site is defined and site.title %}{{ site.title }}{% endif %}{% endblock %}</title>
+    {% if page is defined and page.description %}
+    <meta name="description" content="{{ page.description }}">
+    {% elif site is defined and site.description %}
+    <meta name="description" content="{{ site.description }}">
+    {% endif %}
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+    <div class="background-grid"></div>
+    <div class="glow-orb orb-1"></div>
+    <div class="glow-orb orb-2"></div>
+    <div class="glow-orb orb-3"></div>
+
+    <nav class="glass-nav">
+        <div class="nav-content">
+            <a href="/" class="site-title">
+                {% if site is defined and site.title %}{{ site.title }}{% else %}Synth Oasis{% endif %}
+            </a>
+            <div class="nav-links">
+                <a href="/">Home</a>
+                <a href="/about/">About</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="glass-footer">
+        <p>&copy; 2023 {% if site is defined and site.title %}{{ site.title }}{% endif %}. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/synth-oasis/templates/index.html
+++ b/synth-oasis/templates/index.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel hero-panel">
+    {% if page is defined and page.title %}
+    <h1 class="neon-text">{{ page.title | default("Synth Oasis") }}</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {% if content is defined %}
+        {{ content | safe }}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/synth-oasis/templates/page.html
+++ b/synth-oasis/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-panel">
+    {% if page is defined and page.title %}
+    <h1 class="page-title">{{ page.title | default("Page") }}</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {% if content is defined %}
+        {{ content | safe }}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/synth-oasis/templates/section.html
+++ b/synth-oasis/templates/section.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel section-panel">
+    {% if page is defined and page.title %}
+    <h1 class="page-title">{{ page.title | default("Section") }}</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {% if content is defined %}
+        {{ content | safe }}
+        {% endif %}
+    </div>
+
+    {% if section is defined and section.pages %}
+    <ul class="section-list">
+        {% for child in section.pages %}
+        <li><a href="{{ child.permalink }}">{{ child.title }}</a></li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+{% endblock %}

--- a/synth-oasis/templates/shortcodes/alert.html
+++ b/synth-oasis/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/synth-oasis/templates/taxonomy.html
+++ b/synth-oasis/templates/taxonomy.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-panel">
+    {% if taxonomy is defined and taxonomy.name %}
+    <h1 class="page-title">{{ taxonomy.name | capitalize }}</h1>
+    {% else %}
+    <h1 class="page-title">Taxonomy</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {% if terms is defined %}
+        <ul>
+            {% for term in terms %}
+            <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/synth-oasis/templates/taxonomy_term.html
+++ b/synth-oasis/templates/taxonomy_term.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel page-panel">
+    {% if term is defined and term.name %}
+    <h1 class="page-title">{{ taxonomy.name | capitalize | default("Taxonomy") }}: {{ term.name }}</h1>
+    {% else %}
+    <h1 class="page-title">{{ taxonomy.name | capitalize | default("Taxonomy") }}</h1>
+    {% endif %}
+
+    <div class="content-body">
+        {% if term is defined and term.pages %}
+        <ul>
+            {% for term_page in term.pages %}
+            <li><a href="{{ term_page.permalink }}">{{ term_page.title }}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new example project named `synth-oasis` to the Hwaro examples repository. The project demonstrates a unique dark-themed, retro-futuristic synthwave aesthetic combined with elegant glassmorphism. It includes a complete setup with configuration, content, templates, and custom CSS.

---
*PR created automatically by Jules for task [4578086292787063462](https://jules.google.com/task/4578086292787063462) started by @hahwul*