### PR TITLE
feat: add aurora-nexus example site

### DIFF
--- a/aurora-nexus/AGENTS.md
+++ b/aurora-nexus/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/aurora-nexus/config.toml
+++ b/aurora-nexus/config.toml
@@ -1,0 +1,68 @@
+title = "Aurora Nexus"
+description = "A sophisticated dark-themed Hwaro example featuring an elegant glassmorphism and aurora gradient aesthetic."
+base_url = "https://aurora-nexus.hwaro.example.com"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[og]
+default_image = "/images/og-default.png"
+type = "website"
+twitter_card = "summary_large_image"
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content", "description"]
+filename = "search.json"
+exclude = []
+
+[pagination]
+enabled = false
+per_page = 10
+
+[taxonomies]
+name = "tags"
+feed = true
+sitemap = false
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] }
+]
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "A sample site for Hwaro demonstrating the aurora glassmorphism design."
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"
+truncate = 0
+full_content = true
+limit = 10
+sections = []
+
+[markdown]
+safe = false
+lazy_loading = true
+emoji = true

--- a/aurora-nexus/content/about.md
+++ b/aurora-nexus/content/about.md
@@ -1,0 +1,17 @@
++++
+title = "About Aurora Nexus"
+description = "Learn more about the design and architecture of the Aurora Nexus theme."
+date = "2024-04-18"
++++
+
+Aurora Nexus is an elegant design prototype crafted specifically for the Hwaro static site generator ecosystem.
+
+### The Aesthetic
+
+The core idea was to bring together the natural beauty of the aurora borealis with the sleek, structural look of glassmorphism. By layering heavily blurred, softly animating color orbs behind translucent, sharply-bordered panels, the design achieves a feeling of deep space luxury.
+
+### Technologies
+
+The theme relies purely on modern CSS and HTML. The background is a radial void gradient, accented by CSS keyframe-animated floating shapes. The glass panels rely on the `backdrop-filter: blur(16px)` property, complemented by subtle highlights and drop shadows to give a tactile feel.
+
+Feel free to break it apart and use it for your next cosmic project!

--- a/aurora-nexus/content/index.md
+++ b/aurora-nexus/content/index.md
@@ -1,0 +1,16 @@
++++
+title = "Experience the Nexus"
+description = "A sophisticated dark-themed glassmorphism experience."
+date = "2024-04-18"
++++
+
+Welcome to Aurora Nexus, where ethereal aurora gradients meet sleek glassmorphism. This Hwaro example showcases a unique, elegant dark-theme design suitable for a modern portfolio, landing page, or documentation site.
+
+## Features
+
+*   **Fluid Animations:** Ethereal aurora orbs gently floating in the background create a dynamic, atmospheric feel.
+*   **Frosted Glass:** Crisp, translucent `backdrop-filter` panels elevate content readability without obscuring the beautiful background.
+*   **Modern Typography:** A pairing of Space Grotesk for headings and Inter for body text ensures a clean, futuristic reading experience.
+*   **Built for Hwaro:** Extremely fast, minimal configuration, and easy to extend.
+
+You can modify the colors in the `:root` variables inside `static/css/style.css` to instantly change the vibe. Dive in and explore the possibilities!

--- a/aurora-nexus/static/css/style.css
+++ b/aurora-nexus/static/css/style.css
@@ -1,0 +1,264 @@
+:root {
+  --bg-color: #03040B; /* Deep void background */
+  --text-primary: #E2E8F0;
+  --text-secondary: #94A3B8;
+  --aurora-cyan: #00F0FF;
+  --aurora-magenta: #FF007F;
+  --aurora-purple: #9D00FF;
+  --glass-bg: rgba(15, 23, 42, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-highlight: rgba(255, 255, 255, 0.15);
+
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Animated Aurora Background */
+.aurora-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 50%, #03040B, #010205);
+}
+
+.aurora-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.5;
+  animation: float-orb 20s infinite ease-in-out alternate;
+}
+
+.aurora-orb.cyan {
+  top: -10%;
+  left: 10%;
+  width: 50vw;
+  height: 50vw;
+  background: var(--aurora-cyan);
+  animation-delay: 0s;
+}
+
+.aurora-orb.magenta {
+  bottom: -20%;
+  right: 10%;
+  width: 60vw;
+  height: 60vw;
+  background: var(--aurora-magenta);
+  animation-delay: -5s;
+}
+
+.aurora-orb.purple {
+  top: 30%;
+  left: 60%;
+  width: 40vw;
+  height: 40vw;
+  background: var(--aurora-purple);
+  animation-delay: -10s;
+}
+
+@keyframes float-orb {
+  0% {
+    transform: translate(0, 0) scale(1);
+  }
+  100% {
+    transform: translate(-50px, 50px) scale(1.1);
+  }
+}
+
+/* Glassmorphism Container */
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.glass-panel:hover {
+  border-color: var(--glass-highlight);
+  transform: translateY(-2px);
+}
+
+/* Layout */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem 0;
+  margin-bottom: 3rem;
+}
+
+.site-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: -0.05em;
+  background: linear-gradient(90deg, var(--aurora-cyan), var(--aurora-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  margin-left: 1.5rem;
+  font-family: var(--font-display);
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+nav a:hover,
+nav a.active {
+  color: #fff;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  color: #fff;
+  margin-bottom: 1rem;
+  margin-top: 2rem;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: 3rem;
+  letter-spacing: -0.02em;
+}
+
+p {
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+}
+
+a {
+  color: var(--aurora-cyan);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+a:hover {
+  color: var(--aurora-magenta);
+}
+
+/* Content specific */
+.content-area {
+  margin-bottom: 4rem;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 2rem;
+  margin-bottom: 3rem;
+}
+
+.hero h1 {
+  font-size: 4rem;
+  background: linear-gradient(to right, var(--aurora-cyan), var(--aurora-purple), var(--aurora-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 1.5rem;
+}
+
+.hero p {
+  font-size: 1.25rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Lists and sections */
+ul {
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+}
+
+li {
+  margin-bottom: 0.5rem;
+}
+
+.post-list {
+  list-style: none;
+  padding: 0;
+}
+
+.post-item {
+  margin-bottom: 1.5rem;
+}
+
+.post-item h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.post-item p {
+  margin-bottom: 0;
+}
+
+.post-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  border-top: 1px solid var(--glass-border);
+  margin-top: 4rem;
+}
+
+/* Code blocks */
+pre {
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+}
+
+code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9em;
+}
+
+p code, li code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}

--- a/aurora-nexus/templates/404.html
+++ b/aurora-nexus/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+
+<article class="glass-panel" style="text-align: center; padding: 5rem 2rem;">
+    <h1 style="font-size: 6rem; margin-bottom: 1rem; background: linear-gradient(to right, var(--aurora-cyan), var(--aurora-magenta)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">404</h1>
+    <h2>Lost in the Aurora</h2>
+    <p style="margin-bottom: 2rem;">The cosmic coordinates you provided lead to a void sector.</p>
+    <a href="/" style="display: inline-block; padding: 0.75rem 1.5rem; background: rgba(255,255,255,0.1); border: 1px solid var(--glass-border); border-radius: 8px; color: #fff; font-weight: 500;">Return to Base</a>
+</article>
+
+{% include "footer.html" %}

--- a/aurora-nexus/templates/footer.html
+++ b/aurora-nexus/templates/footer.html
@@ -1,0 +1,7 @@
+        </main>
+        <footer>
+            <p>&copy; 2024 {% if site is defined %}{{ site.title }}{% else %}Aurora Nexus{% endif %}. Built with Hwaro.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/aurora-nexus/templates/header.html
+++ b/aurora-nexus/templates/header.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page is defined and page.title %}{{ page.title }} | {% endif %}{% if site is defined %}{{ site.title }}{% endif %}</title>
+
+    {% if page is defined and page.description %}
+    <meta name="description" content="{{ page.description }}">
+    {% elif site is defined and site.description %}
+    <meta name="description" content="{{ site.description }}">
+    {% endif %}
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+    <!-- Animated Aurora Background -->
+    <div class="aurora-bg">
+        <div class="aurora-orb cyan"></div>
+        <div class="aurora-orb magenta"></div>
+        <div class="aurora-orb purple"></div>
+    </div>
+
+    <div class="container">
+        <header>
+            <a href="/" class="site-title">{% if site is defined %}{{ site.title }}{% else %}Aurora Nexus{% endif %}</a>
+            <nav>
+                <a href="/about/">About</a>
+            </nav>
+        </header>
+        <main class="content-area">

--- a/aurora-nexus/templates/page.html
+++ b/aurora-nexus/templates/page.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+
+<article class="glass-panel">
+    {% if page is defined and page.title %}
+    <header class="hero">
+        <h1>{{ page.title }}</h1>
+        {% if page.description is defined and page.description %}
+        <p>{{ page.description }}</p>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    <div class="content">
+        {% if content is defined and content %}
+            {{ content | safe }}
+        {% endif %}
+    </div>
+</article>
+
+{% include "footer.html" %}

--- a/aurora-nexus/templates/section.html
+++ b/aurora-nexus/templates/section.html
@@ -1,0 +1,35 @@
+{% include "header.html" %}
+
+<div class="glass-panel">
+    {% if section is defined and section.title %}
+    <header class="hero">
+        <h1>{{ section.title }}</h1>
+        {% if section.description is defined and section.description %}
+        <p>{{ section.description }}</p>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    <div class="content">
+        {% if content is defined and content %}
+            {{ content | safe }}
+        {% endif %}
+    </div>
+
+    {% if section is defined and section.pages %}
+    <ul class="post-list">
+        {% for p in section.pages %}
+        <li class="post-item">
+            <a href="{{ p.permalink }}" class="post-link glass-panel">
+                <h2>{{ p.title }}</h2>
+                {% if p.description is defined and p.description %}
+                <p>{{ p.description }}</p>
+                {% endif %}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+
+{% include "footer.html" %}

--- a/aurora-nexus/templates/shortcodes/alert.html
+++ b/aurora-nexus/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/aurora-nexus/templates/taxonomy.html
+++ b/aurora-nexus/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/aurora-nexus/templates/taxonomy_term.html
+++ b/aurora-nexus/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a new Hwaro example site named `aurora-nexus`. It showcases a dark-themed, sophisticated glassmorphism design featuring an animated aurora gradient background and translucent UI panels, illustrating how to build custom aesthetics using Hwaro's templating and static asset pipelines.

---
*PR created automatically by Jules for task [8885972108458656746](https://jules.google.com/task/8885972108458656746) started by @hahwul*