### PR TITLE
feat: add synth-glass-ui example site with synthwave glassmorphism design

### DIFF
--- a/synth-glass-ui/AGENTS.md
+++ b/synth-glass-ui/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/synth-glass-ui/config.toml
+++ b/synth-glass-ui/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "My Hwaro Site"
+description = "Welcome to my new Hwaro site."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/synth-glass-ui/content/about.md
+++ b/synth-glass-ui/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About Synth Glass UI"
+date = 2023-11-20
+description = "Information about the Synth Glass UI template and its design philosophy."
++++
+
+The **Synth Glass UI** theme was designed to explore the intersection of two popular design trends:
+
+1. **Synthwave (Outrun)**: Characterized by dark backgrounds, neon pinks, cyans, and grid landscapes reminiscent of 1980s retro-futurism.
+2. **Glassmorphism**: A UI trend featuring semi-transparent backgrounds with background blur, mimicking frosted glass.
+
+By merging these, the UI components appear to float above a vibrant, digital landscape.
+
+### Design Philosophy
+
+The goal is not just aesthetics, but also usability. The neon colors are used sparingly as accents (headers, links, hover states) to avoid overwhelming the user, while the primary text remains a readable off-white against the dark, translucent glass cards.
+
+[Return Home](/)

--- a/synth-glass-ui/content/index.md
+++ b/synth-glass-ui/content/index.md
@@ -1,0 +1,27 @@
++++
+title = "Synth Glass UI"
+date = 2023-11-20
+description = "A modern glassmorphism UI over a synthwave-inspired animated gradient background."
++++
+
+Welcome to **Synth Glass UI**. This theme combines the nostalgic retro-futurism of Synthwave aesthetics with modern Glassmorphism UI principles.
+
+### Features
+
+- 🌌 **Animated Grid**: A pure CSS animated synthwave grid background.
+- 🪟 **Glass Cards**: Translucent, blurred containers with subtle borders.
+- 💖 **Neon Typography**: Glowing accents using neon pink and cyan.
+- 📱 **Responsive**: Fully adaptable to any screen size.
+
+Here's an example of some code in this theme:
+
+```css
+.glass-element {
+  background: rgba(20, 21, 38, 0.4);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+}
+```
+
+Check out the [About](/about/) page to learn more.

--- a/synth-glass-ui/static/style.css
+++ b/synth-glass-ui/static/style.css
@@ -1,0 +1,313 @@
+/* Synthwave Glassmorphism UI */
+
+:root {
+  --neon-pink: #ff00ff;
+  --neon-blue: #00ffff;
+  --neon-purple: #b026ff;
+  --dark-bg: #090a0f;
+  --glass-bg: rgba(20, 21, 38, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  --text-primary: #e0e0e0;
+  --text-muted: #9ba1a6;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--dark-bg);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* Animated Synthwave Background */
+.glass-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  background:
+    linear-gradient(to bottom, #090a0f 0%, #1a0b2e 100%);
+  overflow: hidden;
+}
+
+.glass-bg::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    linear-gradient(90deg, rgba(255,0,255,0.03) 1px, transparent 1px),
+    linear-gradient(rgba(0,255,255,0.03) 1px, transparent 1px);
+  background-size: 40px 40px;
+  transform: perspective(500px) rotateX(60deg) translateY(-100px) scale(3);
+  animation: grid-move 20s linear infinite;
+  transform-origin: bottom;
+}
+
+.glass-bg::after {
+  content: '';
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, var(--neon-purple) 0%, transparent 60%);
+  opacity: 0.15;
+  filter: blur(40px);
+}
+
+@keyframes grid-move {
+  0% {
+    transform: perspective(500px) rotateX(60deg) translateY(0) scale(3);
+  }
+  100% {
+    transform: perspective(500px) rotateX(60deg) translateY(40px) scale(3);
+  }
+}
+
+/* Layout Container */
+.glass-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Glassmorphism Elements */
+.glass-header, .glass-footer, .glass-card {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  box-shadow: var(--glass-shadow);
+  padding: 1.5rem 2rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 40px 0 rgba(0, 0, 0, 0.45), 0 0 15px rgba(0, 255, 255, 0.1);
+  border-color: rgba(0, 255, 255, 0.2);
+}
+
+/* Header & Nav */
+.glass-header nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.site-title {
+  font-size: 1.8rem;
+  font-weight: 800;
+  text-decoration: none;
+  background: linear-gradient(45deg, var(--neon-blue), var(--neon-pink));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 20px rgba(255, 0, 255, 0.3);
+  letter-spacing: 1px;
+}
+
+.nav-links a {
+  color: var(--text-primary);
+  text-decoration: none;
+  margin-left: 1.5rem;
+  font-weight: 500;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+.nav-links a:hover {
+  color: var(--neon-blue);
+  text-shadow: 0 0 10px var(--neon-blue);
+}
+
+/* Typography & Prose */
+.page-header {
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 1rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  color: #fff;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 0 10px rgba(0, 255, 255, 0.4);
+}
+
+h2 {
+  font-size: 1.8rem;
+  color: var(--neon-blue);
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+h3 {
+  font-size: 1.4rem;
+  color: var(--neon-pink);
+  margin-top: 1.5rem;
+  margin-bottom: 0.8rem;
+}
+
+.meta-date, .meta-desc {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.prose p {
+  margin-bottom: 1.2rem;
+}
+
+.prose a {
+  color: var(--neon-pink);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--neon-pink);
+  transition: all 0.2s ease;
+}
+
+.prose a:hover {
+  color: #fff;
+  border-bottom: 1px solid #fff;
+  text-shadow: 0 0 8px var(--neon-pink);
+}
+
+/* Lists */
+.glass-list {
+  list-style: none;
+}
+
+.glass-list li {
+  margin-bottom: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+}
+
+.glass-list li:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 0, 255, 0.3);
+  transform: translateX(5px);
+}
+
+.glass-list a {
+  color: var(--neon-blue);
+  text-decoration: none;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.glass-list a:hover {
+  text-shadow: 0 0 10px rgba(0, 255, 255, 0.6);
+}
+
+/* Buttons */
+.glass-btn {
+  display: inline-block;
+  padding: 0.8rem 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 0, 255, 0.2), rgba(0, 255, 255, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.glass-btn:hover {
+  background: linear-gradient(135deg, rgba(255, 0, 255, 0.4), rgba(0, 255, 255, 0.4));
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+/* Error Page */
+.error-page {
+  padding: 4rem 2rem;
+}
+
+.error-code {
+  font-size: 6rem;
+  background: linear-gradient(to bottom, var(--neon-pink), var(--neon-purple));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 30px rgba(255, 0, 255, 0.4);
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.error-title {
+  margin-top: 0;
+  font-size: 2rem;
+  color: #fff;
+}
+
+.error-actions {
+  margin-top: 2rem;
+}
+
+/* Syntax Highlighting overrides */
+pre {
+  background: rgba(0, 0, 0, 0.6) !important;
+  border: 1px solid rgba(0, 255, 255, 0.2) !important;
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.8);
+}
+
+code {
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: var(--neon-blue);
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+/* Main & Footer */
+.glass-main {
+  flex: 1;
+}
+
+.glass-footer {
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-bottom: 0;
+}
+
+.glass-footer a {
+  color: var(--neon-blue);
+  text-decoration: none;
+}
+
+.glass-footer a:hover {
+  text-decoration: underline;
+}

--- a/synth-glass-ui/templates/404.html
+++ b/synth-glass-ui/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card error-page text-center">
+  <h1 class="error-code">404</h1>
+  <h2 class="error-title">Not Found</h2>
+  <p class="error-desc">The page you are looking for has drifted into the void.</p>
+  <div class="error-actions">
+    <a href="/" class="glass-btn">Return to Base</a>
+  </div>
+</div>
+{% endblock content %}

--- a/synth-glass-ui/templates/base.html
+++ b/synth-glass-ui/templates/base.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page is defined and page.title %}{{ page.title }} - {% elif section is defined and section.title %}{{ section.title }} - {% endif %}{{ site.title }}</title>
+  {% if page is defined and page.description %}
+  <meta name="description" content="{{ page.description }}">
+  {% elif site.description %}
+  <meta name="description" content="{{ site.description }}">
+  {% endif %}
+  <link rel="stylesheet" href="/style.css">
+  {% if site.highlight is defined and site.highlight.enabled %}
+  {{ highlight_css }}
+  {% endif %}
+</head>
+<body>
+  <div class="glass-bg"></div>
+  <div class="glass-container">
+    <header class="glass-header">
+      <nav>
+        <a href="/" class="site-title">{{ site.title }}</a>
+        <div class="nav-links">
+          {% if site.menus is defined and site.menus.main is defined %}
+            {% for item in site.menus.main %}
+            <a href="{{ item.url }}">{{ item.name }}</a>
+            {% endfor %}
+          {% else %}
+            <a href="/about/">About</a>
+          {% endif %}
+        </div>
+      </nav>
+    </header>
+
+    <main class="glass-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="glass-footer">
+      <p>&copy; 2024 {{ site.title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/synth-glass-ui/templates/page.html
+++ b/synth-glass-ui/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="glass-card page-content">
+  <header class="page-header">
+    <h1>{{ page.title | e }}</h1>
+    {% if page.date %}
+    <p class="meta-date">{{ page.date | date(format="%Y-%m-%d") }}</p>
+    {% endif %}
+  </header>
+  <div class="prose">
+    {{ content }}
+  </div>
+</article>
+{% endblock content %}

--- a/synth-glass-ui/templates/section.html
+++ b/synth-glass-ui/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-content">
+  <div class="glass-card page-content">
+    <h1>{{ page.title | e }}</h1>
+    {% if content %}
+    <div class="prose">
+      {{ content }}
+    </div>
+    {% endif %}
+  </div>
+
+  <div class="section-list-container">
+    <ul class="section-list glass-list">
+      {{ section.list }}
+    </ul>
+  </div>
+
+  <div class="pagination-container glass-card">
+    {{ pagination }}
+  </div>
+</div>
+{% endblock content %}

--- a/synth-glass-ui/templates/shortcodes/alert.html
+++ b/synth-glass-ui/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/synth-glass-ui/templates/taxonomy.html
+++ b/synth-glass-ui/templates/taxonomy.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card taxonomy-page">
+  <header class="page-header">
+    <h1>{{ page.title | e }}</h1>
+    <p class="meta-desc">Browse all terms in this taxonomy:</p>
+  </header>
+  <div class="prose taxonomy-terms">
+    {{ content }}
+  </div>
+</div>
+{% endblock content %}

--- a/synth-glass-ui/templates/taxonomy_term.html
+++ b/synth-glass-ui/templates/taxonomy_term.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-card taxonomy-term-page">
+  <header class="page-header">
+    <h1>{{ page.title | e }}</h1>
+    <p class="meta-desc">Posts tagged with this term:</p>
+  </header>
+  <div class="prose term-posts">
+    {{ content }}
+  </div>
+</div>
+{% endblock content %}

--- a/tags.json
+++ b/tags.json
@@ -4752,6 +4752,12 @@
     "creative",
     "neon"
   ],
+  "synth-glass-ui": [
+    "dark",
+    "glassmorphism",
+    "synthwave",
+    "ui"
+  ],
   "synthwave": [
     "dark",
     "retro",


### PR DESCRIPTION
This PR introduces `synth-glass-ui`, a new example site for Hwaro. It features a creative design combining a retro-futuristic synthwave animated gradient background with modern glassmorphism UI elements (translucent cards, blurred backgrounds, neon accents). It also demonstrates how to refactor the default Hwaro template scaffold to use a single base layout with template inheritance.

---
*PR created automatically by Jules for task [6496697261262053942](https://jules.google.com/task/6496697261262053942) started by @chei-l*