### PR TITLE
Add luminance-echo example site

### DIFF
--- a/luminance-echo/AGENTS.md
+++ b/luminance-echo/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/luminance-echo/config.toml
+++ b/luminance-echo/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminance Echo"
+description = "An elegant, futuristic dark theme exploring the luminant void."
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/luminance-echo/content/about.md
+++ b/luminance-echo/content/about.md
@@ -1,0 +1,12 @@
++++
+title = "About"
+description = "Learn more about the creator of Luminance Echo."
+tags = ["about"]
+categories = ["pages"]
++++
+
+Welcome to my blog! I write about technology, programming, and other interesting topics.
+
+## Contact
+
+Feel free to reach out through social media or email.

--- a/luminance-echo/content/archives.md
+++ b/luminance-echo/content/archives.md
@@ -1,0 +1,5 @@
++++
+title = "Archives"
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/luminance-echo/content/index.md
+++ b/luminance-echo/content/index.md
@@ -1,0 +1,13 @@
++++
+title = "Home"
+description = "Welcome to Luminance Echo, an exploration of elegant dark themes."
+tags = ["home"]
++++
+
+This is a blog powered by [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator.
+
+Check out the latest posts in the [Posts](/posts/) section, or browse by:
+
+- [Tags](/tags/)
+- [Categories](/categories/)
+- [Authors](/authors/)

--- a/luminance-echo/content/posts/_index.md
+++ b/luminance-echo/content/posts/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Posts"
++++
+
+Browse all blog posts below.

--- a/luminance-echo/content/posts/getting-started-with-hwaro.md
+++ b/luminance-echo/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,36 @@
++++
+title = "Getting Started with Hwaro"
+date = "2024-01-20"
+tags = ["tutorial", "getting-started", "hwaro"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "A beginner's guide to building websites with Hwaro."
++++
+
+In this post, I'll walk you through the basics of setting up and using Hwaro.
+
+## Installation
+
+First, make sure you have Crystal installed. Then:
+
+```bash
+git clone https://github.com/hahwul/hwaro
+cd hwaro
+shards build
+```
+
+## Creating Your First Site
+
+```bash
+hwaro init my-blog --scaffold blog
+cd my-blog
+hwaro serve
+```
+
+That's it! Your blog is now running at `http://localhost:3000`.
+
+## Next Steps
+
+- Customize your templates in the `templates/` directory
+- Add new posts in `content/posts/`
+- Configure your site in `config.toml`

--- a/luminance-echo/content/posts/hello-world.md
+++ b/luminance-echo/content/posts/hello-world.md
@@ -1,0 +1,20 @@
++++
+title = "Hello World"
+date = "2024-01-15"
+tags = ["introduction", "hello"]
+categories = ["general"]
+authors = ["admin"]
+description = "My first blog post using Hwaro static site generator."
++++
+
+Welcome to my first blog post! This blog is powered by Hwaro, a fast and lightweight static site generator written in Crystal.
+
+## Why Hwaro?
+
+Hwaro offers a simple yet powerful way to create static websites:
+
+- **Fast**: Built with Crystal for blazing fast build times
+- **Simple**: Easy to understand directory structure
+- **Flexible**: Supports custom templates and shortcodes
+
+Stay tuned for more posts!

--- a/luminance-echo/content/posts/markdown-tips.md
+++ b/luminance-echo/content/posts/markdown-tips.md
@@ -1,0 +1,48 @@
++++
+title = "Markdown Tips and Tricks"
+date = "2024-01-25"
+tags = ["markdown", "writing", "tips"]
+categories = ["tutorials"]
+authors = ["admin"]
+description = "Learn useful Markdown formatting techniques for your blog posts."
++++
+
+Hwaro uses Markdown for content. Here are some useful formatting tips.
+
+## Text Formatting
+
+- **Bold text** using `**bold**`
+- *Italic text* using `*italic*`
+- `Inline code` using backticks
+
+## Code Blocks
+
+Use triple backticks for code blocks:
+
+```crystal
+puts "Hello from Crystal!"
+```
+
+## Lists
+
+Ordered lists:
+1. First item
+2. Second item
+3. Third item
+
+Unordered lists:
+- Item one
+- Item two
+- Item three
+
+## Links and Images
+
+- [Link text](https://example.com)
+- ![Alt text](/path/to/image.jpg)
+
+## Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.
+
+Happy writing!

--- a/luminance-echo/static/css/style.css
+++ b/luminance-echo/static/css/style.css
@@ -1,0 +1,318 @@
+:root {
+  --bg-color: #0b0f19;
+  --bg-panel: #111827;
+  --accent: #00d2ff;
+  --accent-glow: rgba(0, 210, 255, 0.3);
+  --text-main: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border-color: #1e293b;
+  --font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  --content-width: 800px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: var(--font-family);
+  line-height: 1.7;
+  font-size: 1.1rem;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  text-shadow: 0 0 8px var(--accent-glow);
+  color: #fff;
+}
+
+.site-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* Header */
+.site-header {
+  background: rgba(11, 15, 25, 0.8);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 80px;
+}
+
+.site-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.site-title:hover {
+  text-shadow: 0 0 15px var(--accent-glow);
+}
+
+.site-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.site-nav a {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.5px;
+}
+
+.site-nav a:hover {
+  color: #fff;
+  text-shadow: 0 0 10px var(--accent-glow);
+}
+
+#search-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  transition: transform 0.2s ease;
+}
+
+#search-btn:hover {
+  transform: scale(1.1);
+  color: var(--accent);
+}
+
+/* Main Content */
+.site-content {
+  flex: 1;
+  padding: 4rem 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #fff;
+  margin-bottom: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+p {
+  margin-bottom: 1.5rem;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  margin: 2rem 0;
+}
+
+/* Components */
+.post-summary {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.post-summary:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4), 0 0 15px var(--accent-glow);
+  border-color: var(--accent);
+}
+
+.post-meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.tags a {
+  background: rgba(0, 210, 255, 0.1);
+  color: var(--accent);
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  margin-right: 0.5rem;
+  border: 1px solid rgba(0, 210, 255, 0.2);
+}
+
+.tags a:hover {
+  background: rgba(0, 210, 255, 0.2);
+  color: #fff;
+}
+
+/* Post Page */
+.post-header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.post-header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Typography and Markdown Elements */
+blockquote {
+  border-left: 4px solid var(--accent);
+  background: var(--bg-panel);
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  font-style: italic;
+  color: var(--text-muted);
+  border-radius: 0 8px 8px 0;
+}
+
+code {
+  background: var(--bg-panel);
+  color: #fff;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.9em;
+}
+
+pre {
+  background: var(--bg-panel) !important;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2rem 0;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+/* Overriding hljs classes for dark mode */
+.hljs {
+  background: #111827 !important;
+  color: #e2e8f0 !important;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  margin-top: auto;
+  background: var(--bg-panel);
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.footer-links a {
+  margin-left: 1rem;
+}
+
+/* Modal Search */
+.modal {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--bg-panel);
+  width: 90%;
+  max-width: 600px;
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 0 30px rgba(0, 210, 255, 0.1);
+  position: relative;
+}
+
+.close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+#search-input {
+  width: 100%;
+  padding: 1rem;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  color: #fff;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  margin-top: 1rem;
+  outline: none;
+}
+
+#search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 10px var(--accent-glow);
+}
+
+#search-results {
+  list-style: none;
+  margin-top: 1rem;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+#search-results li {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+#search-results li a {
+  font-size: 1.1rem;
+  color: #fff;
+}
+
+#search-results li:hover {
+  background: var(--bg-color);
+}

--- a/luminance-echo/static/js/search.js
+++ b/luminance-echo/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/luminance-echo/templates/404.html
+++ b/luminance-echo/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="not-found">
+  <h1>404</h1>
+  <p>Page not found</p>
+  <a href="{{ base_url }}" class="back-home">Back to Home</a>
+</div>
+{% endblock %}

--- a/luminance-echo/templates/base.html
+++ b/luminance-echo/templates/base.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default('en') }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <link rel="stylesheet" href="{{ base_url }}css/style.css">
+  {% if site.highlight is defined and site.highlight.enabled %}
+  {{ highlight_css }}
+  {% endif %}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section | default('') }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <div class="container header-inner">
+        <a href="{{ base_url }}" class="site-title">{{ site.title | e }}</a>
+        <nav class="site-nav">
+          <a href="{{ base_url }}about/">About</a>
+          <a href="{{ base_url }}posts/">Posts</a>
+          <a href="{{ base_url }}archives/">Archives</a>
+        </nav>
+        <div class="header-actions">
+          <button id="search-btn" aria-label="Search">🔍</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="site-content">
+      <div class="container">
+        {% block content %}{% endblock %}
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>&copy; {{ site.title | e }}. Crafted with Hwaro.</p>
+        <div class="footer-links">
+          <a href="{{ base_url }}rss.xml">RSS</a>
+          <a href="{{ base_url }}sitemap.xml">Sitemap</a>
+        </div>
+      </div>
+    </footer>
+  </div>
+
+  <div id="search-modal" class="modal hidden">
+    <div class="modal-content">
+      <span class="close-btn">&times;</span>
+      <input type="text" id="search-input" placeholder="Search...">
+      <ul id="search-results"></ul>
+    </div>
+  </div>
+
+  {% if site.search is defined and site.search.enabled %}
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js"></script>
+  <script src="{{ base_url }}js/search.js"></script>
+  {% endif %}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/luminance-echo/templates/page.html
+++ b/luminance-echo/templates/page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="page">
+  <h1>{{ page.title | e }}</h1>
+  <div class="page-content">
+    {{ content }}
+  </div>
+</article>
+{% endblock %}

--- a/luminance-echo/templates/post.html
+++ b/luminance-echo/templates/post.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="post">
+  <header class="post-header">
+    <h1>{{ page.title | e }}</h1>
+    <div class="post-meta">
+      <time datetime="{{ page.date | date('%Y-%m-%d') }}">{{ page.date | date("%B %d, %Y") }}</time>
+      {% if page.taxonomies is defined and page.taxonomies.tags is defined %}
+        <span class="tags">
+          {% for tag in page.taxonomies.tags %}
+            <a href="{{ base_url }}tags/{{ tag | replace(' ', '-') | lower }}/">#{{ tag }}</a>
+          {% endfor %}
+        </span>
+      {% endif %}
+    </div>
+  </header>
+  <div class="post-content">
+    {{ content }}
+  </div>
+</article>
+
+{% if site.related is defined and site.related.enabled and page.related_pages is defined and page.related_pages | length > 0 %}
+<div class="related-posts">
+  <h3>Related Posts</h3>
+  <ul>
+    {% for related in page.related_pages %}
+      <li><a href="{{ related.permalink }}">{{ related.title }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+{% endblock %}

--- a/luminance-echo/templates/section.html
+++ b/luminance-echo/templates/section.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="section">
+  {% if section.title %}
+    <h1>{{ section.title | e }}</h1>
+  {% endif %}
+  {% if section.content %}
+    <div class="section-content">
+      {{ section.content }}
+    </div>
+  {% endif %}
+
+  <div class="post-list">
+    {% for page in section.list %}
+      <article class="post-summary">
+        <h2><a href="{{ page.permalink }}">{{ page.title | e }}</a></h2>
+        <div class="post-meta">
+          <time datetime="{{ page.date | date('%Y-%m-%d') }}">{{ page.date | date("%b %d, %Y") }}</time>
+        </div>
+        {% if page.description %}
+          <p class="description">{{ page.description | e }}</p>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </div>
+
+  {% if pagination is defined %}
+    <nav class="pagination">
+      {% if pagination.prev %}
+        <a href="{{ pagination.prev }}" class="prev">← Newer</a>
+      {% endif %}
+      {% if pagination.next %}
+        <a href="{{ pagination.next }}" class="next">Older →</a>
+      {% endif %}
+    </nav>
+  {% endif %}
+</div>
+{% endblock %}

--- a/luminance-echo/templates/shortcodes/alert.html
+++ b/luminance-echo/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/luminance-echo/templates/taxonomy.html
+++ b/luminance-echo/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="taxonomy-page">
+  <h1>{{ page.title | default('Taxonomy') | e }}</h1>
+  {% if content %}
+    <div class="taxonomy-content">{{ content }}</div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/luminance-echo/templates/taxonomy_term.html
+++ b/luminance-echo/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="taxonomy-term-page">
+  <h1>{{ page.title | default('Taxonomy Term') | e }}</h1>
+  <div class="term-content">
+    {{ content }}
+  </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -2755,6 +2755,12 @@
     "neon",
     "gradient"
   ],
+  "luminance-echo": [
+    "dark",
+    "blog",
+    "elegant",
+    "future"
+  ],
   "luminance-stream": [
     "blog",
     "dark",


### PR DESCRIPTION
This PR introduces the `luminance-echo` example site, featuring an elegant dark theme design built with Hwaro. The templates have been refactored to use standard Jinja2 inheritance (`base.html`), and the frontmatter metadata/`tags.json` have been configured appropriately. Verified visual implementation locally using Playwright and Hwaro build commands.

---
*PR created automatically by Jules for task [14327227399334926624](https://jules.google.com/task/14327227399334926624) started by @chei-l*