### PR TITLE
Add new Sapphire Lumina example site

### DIFF
--- a/sapphire-lumina/AGENTS.md
+++ b/sapphire-lumina/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/sapphire-lumina/config.toml
+++ b/sapphire-lumina/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Sapphire Lumina"
+description = "A deep blue glassmorphic design"
+base_url = "/"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = ["posts"]   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/sapphire-lumina/content/about.md
+++ b/sapphire-lumina/content/about.md
@@ -1,0 +1,22 @@
++++
+title = "About"
+description = "About the Sapphire Lumina theme"
+date = 2024-01-01
+template = "page"
++++
+
+This is the About page. You can use it to introduce yourself, explain the purpose of your site, or share your portfolio.
+
+The Sapphire Lumina theme is designed to provide a modern, sleek reading experience with an emphasis on typography and visual hierarchy within a dark aesthetic.
+
+### Typography
+
+The theme uses standard sans-serif system fonts to maintain a clean and fast-loading experience, falling back to basic sans-serif if system fonts are unavailable.
+
+- **Headers**: Bold and clear for strong structure.
+- **Body Text**: Readable and well-spaced for long-form content.
+- **Code**: Monospace fonts optimized for code snippets.
+
+### Get in Touch
+
+Feel free to connect or drop a message if you like this theme!

--- a/sapphire-lumina/content/archives.md
+++ b/sapphire-lumina/content/archives.md
@@ -1,0 +1,6 @@
++++
+title = "Archives"
+description = "Browse all posts by date."
++++
+
+Browse all posts by date. Check the [Posts](/posts/) section for the complete list.

--- a/sapphire-lumina/content/index.md
+++ b/sapphire-lumina/content/index.md
@@ -1,0 +1,19 @@
++++
+title = "Home"
+description = "Welcome to Sapphire Lumina"
+date = 2024-01-01
+template = "page"
++++
+
+Welcome to **Sapphire Lumina**, an elegant dark glassmorphism theme designed for personal blogs and portfolios.
+
+This site demonstrates the capabilities of Hwaro combined with a visually striking aesthetic featuring deep blue hues, transparent panels, and subtle glows.
+
+## Features
+
+- **Glassmorphism Design**: Semi-transparent panels and blurred backdrops create depth.
+- **Deep Blue Color Palette**: Uses soothing `#0b1021` backgrounds with `#38bdf8` and `#818cf8` accents.
+- **Fully Responsive**: Adapts seamlessly to all screen sizes.
+- **Syntax Highlighting**: Beautiful code presentation tailored for the theme.
+
+Explore the [Posts](/posts/) section to see how different types of content are rendered in this theme.

--- a/sapphire-lumina/content/posts/_index.md
+++ b/sapphire-lumina/content/posts/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Posts"
+description = "Latest articles and updates"
+sort_by = "date"
+reverse = true
+paginate = 5
+template = "section"
+generate_feeds = true
++++

--- a/sapphire-lumina/content/posts/getting-started-with-hwaro.md
+++ b/sapphire-lumina/content/posts/getting-started-with-hwaro.md
@@ -1,0 +1,22 @@
++++
+title = "Getting Started with Hwaro"
+description = "Learn how to build static sites quickly."
+date = 2024-01-05
+tags = ["guide", "hwaro"]
+template = "post"
++++
+
+Hwaro makes generating static sites incredibly fast.
+
+Here's an example of some code in Ruby:
+
+```ruby
+def fibonacci(n)
+  return n if n <= 1
+  fibonacci(n - 1) + fibonacci(n - 2)
+end
+
+puts fibonacci(10)
+```
+
+The Sapphire Lumina theme includes special styling for code blocks, ensuring they fit perfectly within the dark glassmorphic design while overriding default highlight backgrounds that clash.

--- a/sapphire-lumina/content/posts/hello-world.md
+++ b/sapphire-lumina/content/posts/hello-world.md
@@ -1,0 +1,29 @@
++++
+title = "Hello World in Sapphire Lumina"
+description = "A warm welcome to the new theme."
+date = 2024-01-02
+tags = ["welcome", "theme"]
+template = "post"
++++
+
+This is a sample post demonstrating the styling of typical content elements in the Sapphire Lumina theme.
+
+## Headings
+
+You can use various levels of headings to structure your content.
+
+### A Level 3 Heading
+
+And paragraph text naturally flows below it. The spacing is carefully calculated to create a comfortable reading rhythm.
+
+> Blockquotes stand out beautifully with a gradient background and a glowing left border, perfect for highlighting important quotes or notes.
+
+Lists are styled cleanly:
+
+1. First item
+2. Second item
+   - A nested bullet point
+   - Another nested point
+3. Third item
+
+Enjoy the theme!

--- a/sapphire-lumina/content/posts/markdown-tips.md
+++ b/sapphire-lumina/content/posts/markdown-tips.md
@@ -1,0 +1,18 @@
++++
+title = "Markdown Tips & Tricks"
+description = "Improve your content formatting."
+date = 2024-01-10
+tags = ["markdown", "tips"]
+template = "post"
++++
+
+Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents.
+
+Here are a few quick tips:
+
+- Use `**` or `__` for **bold** text.
+- Use `*` or `_` for *italic* text.
+- Use `~~` for ~~strikethrough~~.
+- Use \` for `inline code`.
+
+You can also create links like [this one to the Hwaro site](https://hwaro.hahwul.com) and images using the `![alt](url)` syntax.

--- a/sapphire-lumina/static/css/style.css
+++ b/sapphire-lumina/static/css/style.css
@@ -1,0 +1,435 @@
+:root {
+    --color-bg-deep: #050b14;
+    --color-bg-base: #0b1021;
+    --color-panel-bg: rgba(30, 41, 59, 0.4);
+    --color-panel-border: rgba(255, 255, 255, 0.08);
+    --color-text-main: #e2e8f0;
+    --color-text-muted: #94a3b8;
+    --color-primary: #38bdf8;
+    --color-primary-glow: rgba(56, 189, 248, 0.5);
+    --color-accent: #818cf8;
+
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+
+    --glass-blur: blur(12px);
+    --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--color-bg-deep);
+    color: var(--color-text-main);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+}
+
+/* Background Mesh Gradient */
+.bg-mesh {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    background:
+        radial-gradient(circle at 15% 50%, rgba(30, 58, 138, 0.3) 0%, transparent 50%),
+        radial-gradient(circle at 85% 30%, rgba(14, 165, 233, 0.15) 0%, transparent 50%),
+        radial-gradient(circle at 50% 80%, rgba(56, 189, 248, 0.1) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+a {
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: var(--transition);
+}
+
+a:hover {
+    color: var(--color-accent);
+    text-shadow: 0 0 8px var(--color-primary-glow);
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+/* Glassmorphism Utilities */
+.glass-panel {
+    background: var(--color-panel-bg);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--color-panel-border);
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.glass-pill {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--color-panel-border);
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    transition: var(--transition);
+}
+
+.glass-pill:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Header */
+.glass-header {
+    padding: 1.5rem 0;
+    margin-bottom: 2rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(11, 16, 33, 0.7);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--color-panel-border);
+    padding: 1rem 1.5rem;
+    border-radius: 0 0 16px 16px;
+    margin: 0 -1.5rem;
+}
+
+.site-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text-main);
+    letter-spacing: -0.025em;
+    text-transform: uppercase;
+}
+
+.glass-nav {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.glass-nav a {
+    color: var(--color-text-muted);
+    font-weight: 500;
+}
+
+.glass-nav a:hover {
+    color: var(--color-text-main);
+}
+
+/* Main Content Area */
+.content-wrapper {
+    flex: 1;
+    padding: 2.5rem;
+    margin-bottom: 3rem;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+    color: var(--color-text-main);
+    margin-bottom: 1rem;
+    line-height: 1.3;
+    font-weight: 600;
+}
+
+h1 { font-size: 2.5rem; letter-spacing: -0.025em; }
+h2 { font-size: 2rem; margin-top: 2rem; }
+h3 { font-size: 1.5rem; margin-top: 1.5rem; }
+
+p { margin-bottom: 1.5rem; }
+
+ul, ol {
+    margin-bottom: 1.5rem;
+    padding-left: 1.5rem;
+}
+
+li { margin-bottom: 0.5rem; }
+
+/* Posts & Sections */
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-description {
+    color: var(--color-text-muted);
+    font-size: 1.125rem;
+}
+
+.post-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.post-card {
+    transition: var(--transition);
+}
+
+.hover-lift:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), 0 0 20px rgba(56, 189, 248, 0.1);
+    border-color: rgba(255, 255, 255, 0.15);
+}
+
+.post-card-content {
+    padding: 1.5rem;
+}
+
+.post-card h2 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1.5rem;
+}
+
+.post-card h2 a {
+    color: var(--color-text-main);
+}
+
+.post-card h2 a:hover {
+    color: var(--color-primary);
+    text-shadow: none;
+}
+
+.post-meta {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.post-summary {
+    color: var(--color-text-muted);
+    margin-bottom: 1.5rem;
+}
+
+.post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.tag {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+/* Post Page Specifics */
+.post-header {
+    margin-bottom: 3rem;
+    text-align: center;
+    border-bottom: 1px solid var(--color-panel-border);
+    padding-bottom: 2rem;
+}
+
+.post-header h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.post-header .post-meta {
+    justify-content: center;
+    font-size: 1rem;
+}
+
+.post-header .post-tags {
+    justify-content: center;
+    margin-top: 1.5rem;
+}
+
+.post-content {
+    font-size: 1.125rem;
+}
+
+/* Code Blocks */
+pre, code {
+    font-family: var(--font-mono);
+    border-radius: 8px;
+}
+
+code {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.2em 0.4em;
+    font-size: 0.9em;
+    color: #e2e8f0;
+}
+
+pre {
+    background: #0f172a !important; /* Override inline styles */
+    padding: 1.5rem;
+    overflow-x: auto;
+    border: 1px solid var(--color-panel-border);
+    margin-bottom: 1.5rem;
+}
+
+pre code {
+    background: transparent;
+    padding: 0;
+    color: inherit;
+}
+
+/* Blockquotes */
+blockquote {
+    border-left: 4px solid var(--color-primary);
+    padding-left: 1rem;
+    margin-left: 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.05) 0%, transparent 100%);
+    padding: 1rem;
+    border-radius: 0 8px 8px 0;
+}
+
+/* Images */
+img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    margin: 1.5rem 0;
+}
+
+/* TOC */
+.toc-container {
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    border-radius: 12px;
+}
+
+.toc-container summary {
+    font-weight: 600;
+    cursor: pointer;
+    outline: none;
+}
+
+.toc ul {
+    list-style: none;
+    padding-left: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 0;
+}
+
+.toc a {
+    color: var(--color-text-muted);
+    font-size: 0.95rem;
+}
+
+.toc a:hover {
+    color: var(--color-text-main);
+}
+
+/* Post Navigation */
+.post-nav {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--color-panel-border);
+}
+
+.post-nav a {
+    display: flex;
+    flex-direction: column;
+    max-width: 45%;
+}
+
+.post-nav .next {
+    text-align: right;
+    align-items: flex-end;
+}
+
+.nav-label {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.25rem;
+}
+
+.nav-title {
+    font-weight: 600;
+    color: var(--color-text-main);
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1.5rem;
+    margin-top: 3rem;
+}
+
+.pagination a {
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--color-panel-border);
+}
+
+.pagination a:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.page-number {
+    color: var(--color-text-muted);
+}
+
+/* Footer */
+.glass-footer {
+    text-align: center;
+    padding: 2rem 0;
+    border-top: 1px solid var(--color-panel-border);
+    margin-top: auto;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}
+
+/* 404 */
+.text-center {
+    text-align: center;
+}
+
+.error-code {
+    font-size: 6rem;
+    background: linear-gradient(to right, var(--color-primary), var(--color-accent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 0;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .content-wrapper {
+        padding: 1.5rem;
+    }
+
+    .post-header h1 {
+        font-size: 2rem;
+    }
+
+    .header-inner {
+        flex-direction: column;
+        gap: 1rem;
+    }
+}

--- a/sapphire-lumina/static/js/search.js
+++ b/sapphire-lumina/static/js/search.js
@@ -1,0 +1,146 @@
+(function () {
+  var searchData = null;
+  var activeIndex = -1;
+  var overlay = document.getElementById('searchOverlay');
+  var input = document.getElementById('searchInput');
+  var resultsEl = document.getElementById('searchResults');
+
+  function loadSearchData(cb) {
+    if (searchData) return cb(searchData);
+    var base = document.querySelector('link[rel="stylesheet"]').href;
+    var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+    fetch(searchUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { searchData = data; cb(data); })
+      .catch(function () { searchData = []; cb([]); });
+  }
+
+  window.openSearch = function () {
+    overlay.classList.add('active');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    activeIndex = -1;
+    input.focus();
+    loadSearchData(function () {});
+  };
+
+  window.closeSearch = function () {
+    overlay.classList.remove('active');
+    activeIndex = -1;
+  };
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      if (overlay.classList.contains('active')) {
+        closeSearch();
+      } else {
+        openSearch();
+      }
+    }
+    if (e.key === 'Escape' && overlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function highlightMatch(text, query) {
+    if (!query) return escapeHtml(text);
+    var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    var re = new RegExp('(' + escaped + ')', 'gi');
+    return escapeHtml(text).replace(re, '<mark>$1</mark>');
+  }
+
+  function getSnippet(content, query) {
+    var lower = content.toLowerCase();
+    var idx = lower.indexOf(query.toLowerCase());
+    var start = Math.max(0, idx - 60);
+    var end = Math.min(content.length, idx + query.length + 100);
+    var snippet = content.substring(start, end).replace(/\s+/g, ' ').trim();
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+    return snippet;
+  }
+
+  function search(query) {
+    if (!searchData || !query.trim()) {
+      resultsEl.innerHTML = '';
+      activeIndex = -1;
+      return;
+    }
+    var q = query.trim().toLowerCase();
+    var results = [];
+    for (var i = 0; i < searchData.length; i++) {
+      var item = searchData[i];
+      var titleIdx = item.title.toLowerCase().indexOf(q);
+      var contentIdx = item.content.toLowerCase().indexOf(q);
+      if (titleIdx !== -1 || contentIdx !== -1) {
+        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        results.push({ item: item, score: score });
+      }
+    }
+    results.sort(function (a, b) { return b.score - a.score; });
+    results = results.slice(0, 10);
+
+    if (results.length === 0) {
+      resultsEl.innerHTML = '<div class="search-no-results">No results for "' + escapeHtml(query) + '"</div>';
+      activeIndex = -1;
+      return;
+    }
+
+    var html = '';
+    for (var j = 0; j < results.length; j++) {
+      var r = results[j].item;
+      var snippet = getSnippet(r.content, query.trim());
+      html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+        + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
+        + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
+        + '</a>';
+    }
+    html += '<div class="search-hint"><span><kbd>&uarr;</kbd><kbd>&darr;</kbd> navigate</span><span><kbd>Enter</kbd> open</span><span><kbd>ESC</kbd> close</span></div>';
+    resultsEl.innerHTML = html;
+    activeIndex = -1;
+  }
+
+  function updateActive() {
+    var items = resultsEl.querySelectorAll('.search-result-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === activeIndex);
+    }
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  if (input) {
+    input.addEventListener('input', function () {
+      loadSearchData(function () { search(input.value); });
+    });
+
+    input.addEventListener('keydown', function (e) {
+      var items = resultsEl.querySelectorAll('.search-result-item');
+      var count = items.length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % count;
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + count) % count;
+        updateActive();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          window.location.href = items[activeIndex].href;
+        } else if (items.length > 0) {
+          window.location.href = items[0].href;
+        }
+      }
+    });
+  }
+})();

--- a/sapphire-lumina/templates/404.html
+++ b/sapphire-lumina/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="error-page text-center">
+    <h1 class="error-code">404</h1>
+    <h2>Page Not Found</h2>
+    <p>The page you are looking for does not exist or has been moved.</p>
+    <a href="{{ base_url }}" class="btn glass-pill">Return Home</a>
+</div>
+{% endblock %}

--- a/sapphire-lumina/templates/base.html
+++ b/sapphire-lumina/templates/base.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    {% if page.description %}
+    <meta name="description" content="{{ page.description }}">
+    {% elif site.description %}
+    <meta name="description" content="{{ site.description }}">
+    {% endif %}
+
+    <link rel="stylesheet" href="{{ base_url }}css/style.css">
+    {% if site.highlight is defined and site.highlight.enabled %}
+    {{ highlight_css | safe }}
+    {% endif %}
+</head>
+<body>
+    <div class="bg-mesh"></div>
+    <div class="container">
+        <header class="glass-header">
+            <div class="header-inner">
+                <a href="{{ base_url }}" class="site-title">{{ site.title }}</a>
+                <nav class="glass-nav">
+                    <a href="{{ base_url }}about/">About</a>
+                    <a href="{{ base_url }}posts/">Posts</a>
+                    <a href="{{ base_url }}archives/">Archives</a>
+                    <a href="{{ base_url }}tags/">Tags</a>
+                </nav>
+            </div>
+        </header>
+
+        <main class="content-wrapper glass-panel">
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer class="glass-footer">
+            <p>&copy; {{ current_year }} {{ site.title }}. Built with <a href="https://hwaro.hahwul.com" target="_blank">Hwaro</a>.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/sapphire-lumina/templates/page.html
+++ b/sapphire-lumina/templates/page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page">
+    <header class="page-header">
+        <h1>{{ page.title }}</h1>
+    </header>
+
+    <div class="page-content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/sapphire-lumina/templates/post.html
+++ b/sapphire-lumina/templates/post.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="post">
+    <header class="post-header">
+        <h1>{{ page.title }}</h1>
+        <div class="post-meta">
+            <time datetime="{{ page.date | date("%Y-%m-%d") }}">
+                {{ page.date | date("%B %d, %Y") }}
+            </time>
+            {% if page.reading_time %}
+            <span class="reading-time">· {{ page.reading_time }} min read</span>
+            {% endif %}
+        </div>
+        {% if page.taxonomies and page.taxonomies.tags %}
+        <div class="post-tags">
+            {% for tag in page.taxonomies.tags %}
+            <a href="{{ base_url }}tags/{{ tag | slugify }}/" class="tag glass-pill">#{{ tag }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </header>
+
+    {% if page.toc and page.toc | length > 0 %}
+    <details class="toc-container glass-panel">
+        <summary>Table of Contents</summary>
+        <nav class="toc">
+            <ul>
+            {% for header in page.toc %}
+                <li>
+                    <a href="{{ header.permalink }}">{{ header.title }}</a>
+                    {% if header.children %}
+                    <ul>
+                        {% for child in header.children %}
+                        <li><a href="{{ child.permalink }}">{{ child.title }}</a></li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
+                </li>
+            {% endfor %}
+            </ul>
+        </nav>
+    </details>
+    {% endif %}
+
+    <div class="post-content">
+        {{ content | safe }}
+    </div>
+
+    {% if page.lower or page.higher %}
+    <nav class="post-nav">
+        {% if page.higher %}
+        <a href="{{ page.higher.url }}" class="prev">
+            <span class="nav-label">&larr; Previous</span>
+            <span class="nav-title">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+        {% if page.lower %}
+        <a href="{{ page.lower.url }}" class="next">
+            <span class="nav-label">Next &rarr;</span>
+            <span class="nav-title">{{ page.lower.title }}</span>
+        </a>
+        {% endif %}
+    </nav>
+    {% endif %}
+</article>
+{% endblock %}

--- a/sapphire-lumina/templates/section.html
+++ b/sapphire-lumina/templates/section.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section-header">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}
+    <p class="section-description">{{ section.description }}</p>
+    {% endif %}
+</div>
+
+{% if content %}
+<div class="section-content">
+    {{ content | safe }}
+</div>
+{% endif %}
+
+<div class="post-list">
+    {% for post in section.pages %}
+    <article class="post-card glass-panel hover-lift">
+        <div class="post-card-content">
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <div class="post-meta">
+                <time datetime="{{ post.date | date("%Y-%m-%d") }}">{{ post.date | date("%b %d, %Y") }}</time>
+            </div>
+            {% if post.summary %}
+            <div class="post-summary">
+                {{ post.summary | safe }}
+            </div>
+            {% endif %}
+            {% if post.taxonomies and post.taxonomies.tags %}
+            <div class="post-tags">
+                {% for tag in post.taxonomies.tags %}
+                <span class="tag glass-pill">#{{ tag }}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </article>
+    {% endfor %}
+</div>
+
+{% if pagination is defined and pagination.total_pages is defined %}
+    {% if pagination.total_pages > 1 %}
+    <nav class="pagination">
+        {% if pagination.previous_page %}
+        <a href="{{ pagination.previous_page.url }}" class="prev">&larr; Newer</a>
+        {% endif %}
+
+        <span class="page-number">Page {{ pagination.current_page.number }} of {{ pagination.total_pages }}</span>
+
+        {% if pagination.next_page %}
+        <a href="{{ pagination.next_page.url }}" class="next">Older &rarr;</a>
+        {% endif %}
+    </nav>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/sapphire-lumina/templates/shortcodes/alert.html
+++ b/sapphire-lumina/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/sapphire-lumina/templates/taxonomy.html
+++ b/sapphire-lumina/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-header">
+    <h1>{{ page.title }}</h1>
+</div>
+
+<div class="taxonomy-content">
+    {{ content | safe }}
+</div>
+{% endblock %}

--- a/sapphire-lumina/templates/taxonomy_term.html
+++ b/sapphire-lumina/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="taxonomy-term-header">
+    <h1>{{ page.title }}</h1>
+</div>
+
+<div class="taxonomy-term-content">
+    {{ content | safe }}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -4323,6 +4323,11 @@
     "blog",
     "glamorous"
   ],
+  "sapphire-lumina": [
+    "blog",
+    "dark",
+    "glassmorphism"
+  ],
   "savanna": [
     "light",
     "blog",


### PR DESCRIPTION
This PR introduces a new example Hwaro site called "Sapphire Lumina". It features a creative and elegant dark "glassmorphism" design with a custom template structure utilizing inheritance via `base.html`. The site includes placeholder content and is fully integrated into the example repository by being listed in `tags.json`.

---
*PR created automatically by Jules for task [847144631635941920](https://jules.google.com/task/847144631635941920) started by @chei-l*