### PR TITLE
feat: add 4 Seoul-inspired examples

### DIFF
--- a/examples/clean-seoul/config.toml
+++ b/examples/clean-seoul/config.toml
@@ -1,0 +1,47 @@
+title = "Clean Seoul"
+description = "Typography first. Pure white, pure black, generous space, and a whisper of Seoul's skyline as a single line."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+[seo]
+llms_txt = true

--- a/examples/clean-seoul/content/about.md
+++ b/examples/clean-seoul/content/about.md
@@ -1,0 +1,48 @@
++++
+title = "About"
+template = "page"
++++
+
+## Clean Seoul
+
+Clean Seoul is the reduction of a blog theme to its load-bearing elements: black type, white paper, a single line for the skyline, and nothing else. It shares a family with Ink Seoul, but removes even the brush-stroke gestures. There is no ornament here. The typography carries the entire site.
+
+### Design Philosophy
+
+Everything on the page is either a word or the space around a word. No cards. No colored accents. No illustrations. The only decoration on the entire site is a single one-pixel line drawing of a skyline, rendered once in the hero and once in the footer.
+
+### The Palette
+
+| Tone | Hex | Role |
+|---|---|---|
+| White | #FFFFFF | Page surface |
+| Near-white | #FAFAFA | Code blocks |
+| Line | #ECECEC | Borders |
+| Rule | #D6D6D6 | Quiet dividers |
+| Mute | #8A8A8A | Metadata |
+| Text | #333333 | Body |
+| Heading | #0A0A0A | Headings, links |
+
+### Typography
+
+- **우아한 세리프 (ElegantSerif)** for the Hangul display mark — the 서울 signature
+- **Inter** at weights 200–800 for Latin display, body, and UI
+- **Noto Sans KR** for small Korean metadata and supporting text
+- **JetBrains Mono** for dates, coordinates, and ordinals
+- A serif Hangul face against a sans Latin face — the core typographic tension of the theme
+
+### Features
+
+- Giant 서 + 울(outline) Hangul mark as the hero signature
+- Vertical 깨끗한 서울 rail running down the left edge
+- 자모 (ㅅㅓㅇㅜㄹ) decomposition grid as a subtle typographic detail
+- Magazine-style 글 01 / 글 02 ordinals on every post, via CSS counters
+- 서울 signature wordmark in the footer — solid + outline pair
+- "없음" Korean treatment on the 404 page
+- Editorial list layout — posts as rows with Hangul ordinal, date, title, arrow
+- One-pixel line skyline as the only drawn illustration
+- Radically restrained palette: white, black, and the grays between
+
+### Built With
+
+This theme was built with [Hwaro](https://github.com/hahwul/hwaro), a fast and flexible static site generator.

--- a/examples/clean-seoul/content/index.md
+++ b/examples/clean-seoul/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Clean Seoul"
+template = "home"
++++

--- a/examples/clean-seoul/content/posts/_index.md
+++ b/examples/clean-seoul/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
+generate_feeds = true
++++

--- a/examples/clean-seoul/content/posts/one-line-skyline.md
+++ b/examples/clean-seoul/content/posts/one-line-skyline.md
@@ -1,0 +1,35 @@
++++
+title = "A Skyline in One Line"
+date = "2025-04-18"
+description = "Why the only illustration on this site is a single-pixel profile of a skyline, and what that decision costs."
+tags = ["design", "illustration", "restraint"]
+template = "page"
++++
+
+## One Mark
+
+Clean Seoul has exactly one drawn element: a one-pixel line that traces an imaginary skyline. It appears once in the hero, once in the footer, and nowhere else.
+
+The line is not Seoul's actual skyline. It is an abstract profile — rectangular blocks, a couple of antennas, one slightly taller tower. Enough to read as *a city*, not enough to read as *this city*. That distinction is the whole point.
+
+## What It Earns
+
+A site with no imagery feels anonymous. It also feels cold, in the worst cases. The single line does three things to counter that:
+
+- **Locates the theme.** You know this is about a city before you read a word.
+- **Gives the eye one rest point.** Between the logo at the top and the skyline below, the eye has something to settle on.
+- **Provides a signature.** When a reader remembers the site, they remember the line.
+
+A full illustration would do those same three jobs — and then also start demanding to be updated, restyled, and redrawn over the next ten years. A one-pixel line does not need to be updated.
+
+## What It Costs
+
+The restraint costs one thing: novelty. A site with elaborate illustration has something to show off. A site with a single line does not. If your audience wants to be impressed, you will lose them to the more decorated competitor.
+
+If your audience wants to read, you will keep them. The tradeoff is not subtle.
+
+## A Rule of Thumb
+
+If you must add a decorative element, ask: **would I be willing to have this element on every page I ever publish, for the next decade, unchanged?**
+
+If yes, use it. If no, leave it out. That is how Clean Seoul was built.

--- a/examples/clean-seoul/content/posts/type-as-the-whole-system.md
+++ b/examples/clean-seoul/content/posts/type-as-the-whole-system.md
@@ -1,0 +1,44 @@
++++
+title = "Type as the Whole System"
+date = "2025-04-30"
+description = "When the only design tool you allow yourself is typography, what does the resulting system look like?"
+tags = ["typography", "design", "system"]
+template = "page"
++++
+
+## A Single Tool
+
+Most design systems are four systems held together with tape: a type scale, a color palette, a spacing unit, and a component library. Each one brings its own decisions and its own entropy.
+
+Clean Seoul tries the opposite experiment: one tool, typography, asked to do everything.
+
+## How Type Replaces Color
+
+In a typical system, **color** is how you say "this is more important than that." In a type-only system, the same job falls to **weight and size**.
+
+A heading is not dark blue — it is simply bigger and heavier than body text. A caption is not gray — it is smaller and in a quieter face. The hierarchy reads at a glance, and without the baggage of color branding.
+
+## How Type Replaces Layout
+
+**Layout** normally handles grouping: "these items belong together because they sit in the same card." In a type-only system, the grouping comes from **vertical rhythm**. Items with the same top margin belong to the same beat.
+
+```
+Metadata · 0.6rem gap · Heading · 0.4rem gap · Description
+```
+
+No borders, no background color, no divider — just three typed rows whose spacing tells the eye what is associated with what.
+
+## How Type Replaces Interaction
+
+**Color change** on hover is the default way to signal interactivity. A type-only system has two alternatives:
+
+1. **Underline movement.** The underline's color or distance shifts on hover.
+2. **Position shift.** The whole row slides a few pixels to signal it is clickable.
+
+Both are subtle. Both are enough, if the user already understands that text is readable and links are readable.
+
+## The Tradeoff
+
+A type-only system demands more from the writer. If the words are weak, the page has nothing else to offer. That is the honest version of the tradeoff. Decoration hides thin content. Typography exposes it.
+
+For the right kind of site, that exposure is exactly what you want.

--- a/examples/clean-seoul/content/posts/welcome-to-clean-seoul.md
+++ b/examples/clean-seoul/content/posts/welcome-to-clean-seoul.md
@@ -1,0 +1,39 @@
++++
+title = "Welcome to Clean Seoul"
+date = "2025-05-12"
+description = "Typography, whitespace, and a single skyline line. A blog theme that has been stripped down to only what earns its place."
+tags = ["clean-seoul", "design", "introduction"]
+template = "page"
++++
+
+## The Hardest Version
+
+Clean Seoul is the hardest version of the brief to get right. When there is no color, no texture, and no decoration, every decision that remains has to do the work of three. Font weight, spacing, and scale become the only tools available.
+
+That is also the reward. When a stripped-down layout works, it holds up against every style that tries to age it. Typography doesn't go out of fashion.
+
+## What Stays
+
+Only five things survive the reduction:
+
+1. **Type scale.** From 0.72rem monospace labels to a 6rem display heading.
+2. **Vertical rhythm.** Lines, paragraphs, and sections all sit on a consistent space grid.
+3. **One line of skyline.** The only image on the site. It appears twice.
+4. **Dates in monospace.** So the eye can scan them without reading them.
+5. **Generous margins.** Because every element needs room to assert itself.
+
+## What Goes
+
+Cards, colored buttons, card shadows, hover backgrounds, icons, dividers, decorative borders, drop-caps, underline flourishes, fancy cursors, animated gradients, and every variant of "visual interest" are all gone.
+
+> Visual interest is a symptom of a layout that doesn't believe in its content.
+
+## When To Use It
+
+Clean Seoul is suited to:
+
+- Writing that wants to be read, not skimmed
+- Portfolios where the work already provides the visual weight
+- Documentation that needs to stay legible for a decade
+
+Pair it with strong writing and let the type carry the page.

--- a/examples/clean-seoul/static/css/style.css
+++ b/examples/clean-seoul/static/css/style.css
@@ -1,0 +1,1303 @@
+/* ========================================
+   Clean Seoul — Signature edition
+   Pure white, pure black, and 서울 as the mark.
+   Korean display: 우아한 세리프 (Grace Serif) via noonnu.cc
+   ======================================== */
+
+@font-face {
+  font-family: 'ElegantSerif';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/2604-1@1.0/GraceSerif-Regular.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'ElegantSerif';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/2604-1@1.0/GraceSerif-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-display: swap;
+}
+
+:root {
+  --white: #FFFFFF;
+  --near-white: #FAFAFA;
+  --line: #ECECEC;
+  --rule: #D6D6D6;
+  --mute: #8A8A8A;
+  --text: #2A2A2A;
+  --heading: #0A0A0A;
+  --black: #000000;
+
+  --font-sans: 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-kr: 'ElegantSerif', 'Noto Sans KR', 'Nanum Myeongjo', Georgia, serif;
+  --font-kr-body: 'Noto Sans KR', 'Inter', -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+
+  --max-w: 720px;
+  --max-w-wide: 1160px;
+  --header-h: 64px;
+
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.2s var(--ease);
+  --transition-slow: 0.4s var(--ease);
+  --transition-xslow: 0.6s var(--ease);
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--white);
+  color: var(--text);
+  line-height: 1.7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+}
+
+main { flex: 1; }
+
+a {
+  color: var(--heading);
+  text-decoration: underline;
+  text-decoration-color: var(--line);
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color var(--transition);
+}
+
+a:hover { text-decoration-color: var(--heading); }
+
+img { max-width: 100%; height: auto; display: block; }
+
+::selection { background: var(--heading); color: var(--white); }
+
+::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar-track { background: var(--white); }
+::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--mute); }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes markReveal {
+  from { opacity: 0; letter-spacing: 0.04em; }
+  to   { opacity: 1; letter-spacing: -0.05em; }
+}
+
+@keyframes railFadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.hero-inner, .post-grid, .post-list, .article-inner, .section-page-head {
+  animation: fadeUp 0.55s var(--ease);
+}
+
+/* ========================================
+   Header
+   ======================================== */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--line);
+  height: var(--header-h);
+}
+
+.header-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--heading);
+}
+
+.logo:hover { text-decoration: none; }
+.logo:hover .logo-kr { color: var(--mute); }
+
+.logo-kr {
+  font-family: var(--font-kr);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.01em;
+  transition: color var(--transition);
+}
+
+.logo-en {
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.site-nav { display: flex; align-items: center; }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  list-style: none;
+}
+
+.nav-links a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--mute);
+  text-decoration: none;
+  padding: 0.2rem 0;
+  transition: color var(--transition);
+}
+
+.nav-links a:hover { color: var(--heading); }
+
+.nav-toggle {
+  display: none;
+  background: none; border: none; cursor: pointer;
+  width: 24px; height: 18px; position: relative; z-index: 110;
+}
+
+.nav-toggle span {
+  display: block; width: 100%; height: 1.5px;
+  background: var(--heading);
+  position: absolute; left: 0;
+  transition: all var(--transition);
+}
+
+.nav-toggle span:nth-child(1) { top: 0; }
+.nav-toggle span:nth-child(2) { top: 50%; transform: translateY(-50%); }
+.nav-toggle span:nth-child(3) { bottom: 0; }
+
+.nav-toggle.active span:nth-child(1) { top: 50%; transform: translateY(-50%) rotate(45deg); }
+.nav-toggle.active span:nth-child(2) { opacity: 0; }
+.nav-toggle.active span:nth-child(3) { bottom: 50%; transform: translateY(50%) rotate(-45deg); }
+
+/* ========================================
+   Hero — signature block
+   ======================================== */
+.hero {
+  position: relative;
+  padding: 7rem 2rem 7rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* Vertical rail on the left edge */
+.hero-rail {
+  position: absolute;
+  top: 7rem;
+  left: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  color: var(--mute);
+  animation: railFadeIn 0.7s var(--ease) 0.1s backwards;
+}
+
+.hero-rail::before {
+  content: '';
+  display: block;
+  width: 1px;
+  height: 48px;
+  background: var(--heading);
+}
+
+.hero-rail::after {
+  content: '';
+  display: block;
+  width: 1px;
+  height: 48px;
+  background: var(--line);
+}
+
+.hero-rail .rail-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  color: var(--heading);
+}
+
+.hero-rail .rail-kr {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-family: var(--font-kr-body);
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--heading);
+  letter-spacing: 0;
+}
+
+.hero-rail .rail-kr span {
+  display: block;
+  line-height: 1;
+}
+
+.hero-rail .rail-dot {
+  width: 3px; height: 3px;
+  background: var(--rule);
+  border-radius: 50%;
+  color: transparent;
+  font-size: 0;
+  line-height: 0;
+}
+
+.hero-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding-left: 4.5rem;
+  position: relative;
+}
+
+.hero-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2em;
+}
+
+.hero-kicker::before {
+  content: '';
+  display: inline-block;
+  width: 32px;
+  height: 1px;
+  background: var(--heading);
+  margin-right: 1rem;
+  vertical-align: middle;
+}
+
+/* The 서울 mark — the centerpiece, Grace Serif display */
+.hero-mark {
+  font-family: var(--font-kr);
+  font-size: clamp(7rem, 22vw, 19rem);
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  color: var(--heading);
+  margin: 0 0 1.25rem -0.02em;
+  display: inline-flex;
+  align-items: baseline;
+  animation: markReveal 0.9s var(--ease) 0.05s backwards;
+}
+
+.hero-mark .mark-a {
+  color: var(--heading);
+}
+
+.hero-mark .mark-b {
+  color: transparent;
+  -webkit-text-stroke: 1.5px var(--heading);
+  text-stroke: 1.5px var(--heading);
+  transition: color var(--transition-xslow);
+}
+
+.hero:hover .hero-mark .mark-b,
+.hero-mark:hover .mark-b {
+  color: var(--heading);
+}
+
+/* Wordmark row with Clean + Seoul + jamo */
+.hero-wordmark {
+  display: flex;
+  align-items: baseline;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  margin-bottom: 3.25rem;
+  flex-wrap: wrap;
+}
+
+.word-thin {
+  font-family: var(--font-sans);
+  font-size: clamp(1.8rem, 3.8vw, 2.6rem);
+  font-weight: 200;
+  font-style: italic;
+  color: var(--mute);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.word-bold {
+  font-family: var(--font-sans);
+  font-size: clamp(1.8rem, 3.8vw, 2.6rem);
+  font-weight: 800;
+  color: var(--heading);
+  letter-spacing: -0.035em;
+  line-height: 1;
+}
+
+.word-divider {
+  width: 1px;
+  height: 1.6em;
+  background: var(--line);
+  align-self: center;
+  margin: 0 0.4rem;
+}
+
+.word-jamo {
+  display: grid;
+  grid-template-columns: repeat(2, 1.35em);
+  grid-auto-rows: 1em;
+  column-gap: 0.4em;
+  row-gap: 0.25em;
+  font-family: var(--font-kr-body);
+  font-size: 1.05rem;
+  font-weight: 400;
+  color: var(--mute);
+  line-height: 1;
+  align-self: center;
+  padding: 0.4rem 0 0.4rem 0.9rem;
+  border-left: 1px solid var(--line);
+  letter-spacing: 0;
+}
+
+.word-jamo span {
+  display: inline-block;
+  text-align: center;
+}
+
+.word-jamo .jamo-blank {
+  visibility: hidden;
+}
+
+.hero-desc {
+  font-size: 1.08rem;
+  color: var(--text);
+  line-height: 1.7;
+  max-width: 560px;
+  margin-bottom: 2.25rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* ========================================
+   Buttons
+   ======================================== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.8rem 1.6rem;
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all var(--transition);
+  cursor: pointer;
+  border-radius: 0;
+  letter-spacing: -0.005em;
+}
+
+.btn-primary {
+  background: var(--heading);
+  color: var(--white);
+  border: 1px solid var(--heading);
+}
+
+.btn-primary:hover {
+  background: var(--white);
+  color: var(--heading);
+  text-decoration: none;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--heading);
+  padding: 0.8rem 0.5rem;
+  text-decoration: none;
+}
+
+.btn-ghost .btn-arrow {
+  display: inline-block;
+  transition: transform var(--transition);
+}
+
+.btn-ghost:hover {
+  text-decoration: none;
+}
+
+.btn-ghost:hover .btn-arrow { transform: translateX(4px); }
+
+/* ========================================
+   Section header
+   ======================================== */
+.section-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.section-num {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: 0.14em;
+}
+
+.section-title-group {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.section-label {
+  font-family: var(--font-kr);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.section-en {
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  font-weight: 400;
+  color: var(--mute);
+  letter-spacing: 0.02em;
+  font-style: italic;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+  align-self: center;
+  min-width: 2rem;
+}
+
+.latest-posts { padding: 4rem 0 8rem; }
+
+/* ========================================
+   Post grid — magazine ordinal layout
+   ======================================== */
+.post-grid {
+  display: flex;
+  flex-direction: column;
+  counter-reset: postnum;
+}
+
+.post-card {
+  border-bottom: 1px solid var(--line);
+  counter-increment: postnum;
+  transition: background var(--transition);
+}
+
+.post-card:first-child { border-top: 1px solid var(--line); }
+
+.post-card a {
+  display: grid;
+  grid-template-columns: 140px 1fr 60px;
+  gap: 2.5rem;
+  align-items: baseline;
+  padding: 2.25rem 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: padding var(--transition), background var(--transition);
+}
+
+.post-card:hover a {
+  padding-left: 2rem;
+  background: var(--near-white);
+}
+
+.card-index {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  line-height: 1;
+}
+
+.idx-kr {
+  font-family: var(--font-kr);
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: 0;
+  transition: color var(--transition);
+}
+
+.idx-num {
+  font-family: var(--font-sans);
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: var(--heading);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  transition: color var(--transition);
+}
+
+.idx-num::before {
+  content: counter(postnum, decimal-leading-zero);
+}
+
+.post-card:hover .idx-num { color: var(--black); }
+.post-card:hover .idx-kr { color: var(--heading); }
+
+.card-body time {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--mute);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.card-body h3 {
+  font-family: var(--font-sans);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.028em;
+  line-height: 1.3;
+  margin-bottom: 0.45rem;
+}
+
+.card-body p {
+  font-size: 0.92rem;
+  color: var(--mute);
+  line-height: 1.65;
+  max-width: 560px;
+}
+
+.card-arrow {
+  font-family: var(--font-sans);
+  font-size: 1.1rem;
+  color: var(--rule);
+  text-align: right;
+  line-height: 1;
+  align-self: center;
+  transition: all var(--transition);
+}
+
+.post-card:hover .card-arrow {
+  color: var(--heading);
+  transform: translateX(6px);
+}
+
+/* ========================================
+   Section page (archive)
+   ======================================== */
+.section-page { padding: 5rem 0 6rem; }
+
+.section-page-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2.5rem;
+  align-items: baseline;
+  margin-bottom: 4rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.page-mark {
+  font-family: var(--font-kr);
+  font-size: clamp(5rem, 12vw, 9rem);
+  font-weight: 700;
+  color: var(--heading);
+  line-height: 0.85;
+  letter-spacing: -0.02em;
+  user-select: none;
+}
+
+.page-head-text { display: flex; flex-direction: column; gap: 0.4rem; }
+
+.page-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--mute);
+  letter-spacing: 0.16em;
+}
+
+.section-title {
+  font-family: var(--font-sans);
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 800;
+  color: var(--heading);
+  letter-spacing: -0.035em;
+  line-height: 1;
+}
+
+.page-sub {
+  font-family: var(--font-kr-body);
+  font-size: 0.95rem;
+  color: var(--mute);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.post-list {
+  display: flex;
+  flex-direction: column;
+  counter-reset: rownum;
+}
+
+.post-row {
+  border-bottom: 1px solid var(--line);
+  counter-increment: rownum;
+}
+
+.post-row:first-child { border-top: 1px solid var(--line); }
+
+.post-row a {
+  display: grid;
+  grid-template-columns: 120px 1fr 40px;
+  gap: 2rem;
+  align-items: baseline;
+  padding: 2rem 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: padding var(--transition), background var(--transition);
+}
+
+.post-row a:hover {
+  padding-left: 2rem;
+  background: var(--near-white);
+}
+
+.row-index {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  line-height: 1;
+}
+
+.row-index .idx-kr {
+  font-size: 0.9rem;
+}
+
+.row-index .idx-num {
+  font-size: 2rem;
+}
+
+.row-index .idx-num::before {
+  content: counter(rownum, decimal-leading-zero);
+}
+
+.row-body time {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--mute);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.45rem;
+}
+
+.row-body h2 {
+  font-family: var(--font-sans);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.028em;
+  line-height: 1.3;
+  margin-bottom: 0.4rem;
+}
+
+.row-body p {
+  font-size: 0.92rem;
+  color: var(--mute);
+  line-height: 1.65;
+  max-width: 620px;
+}
+
+.row-arrow {
+  font-family: var(--font-sans);
+  font-size: 1.05rem;
+  color: var(--rule);
+  text-align: right;
+  line-height: 1;
+  align-self: center;
+  transition: all var(--transition);
+}
+
+.post-row:hover .row-arrow {
+  color: var(--heading);
+  transform: translateX(6px);
+}
+
+/* ========================================
+   Article
+   ======================================== */
+.article { padding: 4.5rem 0 6rem; }
+
+.article-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.article-header {
+  margin-bottom: 3.5rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.article-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.article-kicker span {
+  font-family: var(--font-kr);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: 0;
+}
+
+.article-header h1 {
+  font-family: var(--font-sans);
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 800;
+  color: var(--heading);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+  margin-bottom: 1.5rem;
+}
+
+.article-meta {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--mute);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  letter-spacing: 0.02em;
+}
+
+.dot { color: var(--rule); }
+
+.article-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.article-tags a {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--text);
+  padding: 0.22rem 0;
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 4px;
+}
+
+.article-tags a:hover { text-decoration-color: var(--heading); }
+
+.article-body {
+  font-size: 1.06rem;
+  line-height: 1.85;
+  color: var(--text);
+}
+
+.article-body h2 {
+  font-family: var(--font-sans);
+  font-size: 1.7rem;
+  font-weight: 700;
+  color: var(--heading);
+  margin: 3rem 0 1rem;
+  letter-spacing: -0.022em;
+  line-height: 1.25;
+}
+
+.article-body h3 {
+  font-family: var(--font-sans);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--heading);
+  margin: 2.5rem 0 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+.article-body h4 {
+  font-size: 1.08rem;
+  font-weight: 600;
+  color: var(--heading);
+  margin: 2rem 0 0.5rem;
+}
+
+.article-body p { margin-bottom: 1.3rem; }
+
+.article-body strong {
+  font-weight: 600;
+  color: var(--heading);
+}
+
+.article-body ul, .article-body ol {
+  margin-bottom: 1.3rem;
+  padding-left: 1.5rem;
+}
+
+.article-body li { margin-bottom: 0.45rem; }
+.article-body li::marker { color: var(--mute); }
+
+.article-body blockquote {
+  margin: 2rem 0;
+  padding: 0.25rem 0 0.25rem 1.5rem;
+  border-left: 2px solid var(--heading);
+  color: var(--heading);
+  font-size: 1.18rem;
+  font-weight: 400;
+  line-height: 1.55;
+  font-style: normal;
+}
+
+.article-body blockquote p:last-child { margin-bottom: 0; }
+
+.article-body hr {
+  border: none;
+  height: 1px;
+  background: var(--line);
+  margin: 3rem 0;
+}
+
+.article-body code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--near-white);
+  padding: 0.12em 0.4em;
+  color: var(--heading);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.article-body pre {
+  margin: 1.75rem 0;
+  padding: 1.3rem 1.4rem;
+  background: var(--near-white);
+  border: 1px solid var(--line);
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+.article-body pre code {
+  background: none;
+  padding: 0;
+  border: none;
+  font-size: inherit;
+}
+
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.75rem 0;
+  font-size: 0.9rem;
+}
+
+.article-body thead { border-bottom: 2px solid var(--heading); }
+
+.article-body th {
+  font-weight: 600;
+  text-align: left;
+  padding: 0.8rem 0.85rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--heading);
+}
+
+.article-body td {
+  padding: 0.8rem 0.85rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.article-body img {
+  margin: 2rem 0;
+}
+
+/* ========================================
+   Article nav
+   ======================================== */
+.article-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--line);
+}
+
+.article-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem 0;
+  text-decoration: none;
+  transition: padding var(--transition);
+}
+
+.article-nav a:hover { padding-left: 0.5rem; }
+
+.nav-prev { text-align: left; }
+.nav-next { text-align: right; grid-column: 2; }
+.nav-next:hover { padding-left: 0; padding-right: 0.5rem; }
+
+.nav-dir {
+  font-family: var(--font-kr-body);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: var(--mute);
+}
+
+.nav-title {
+  font-family: var(--font-sans);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.02em;
+  line-height: 1.4;
+}
+
+/* ========================================
+   Footer — 서울 signature wordmark
+   ======================================== */
+.site-footer {
+  border-top: 1px solid var(--line);
+  padding: 4rem 2rem 3rem;
+  text-align: center;
+  overflow: hidden;
+}
+
+.footer-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+
+.footer-sig {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-bottom: 2.25rem;
+  line-height: 1;
+  user-select: none;
+}
+
+.sig-pre {
+  font-family: var(--font-kr-body);
+  font-size: 0.92rem;
+  font-weight: 400;
+  color: var(--mute);
+  letter-spacing: -0.005em;
+}
+
+.sig-mark {
+  font-family: var(--font-kr);
+  font-size: clamp(2.6rem, 5.2vw, 3.8rem);
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.025em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.sig-mark .sig-a { color: var(--heading); }
+.sig-mark .sig-b {
+  color: transparent;
+  -webkit-text-stroke: 1px var(--heading);
+  text-stroke: 1px var(--heading);
+}
+
+.footer-skyline {
+  display: block;
+  width: 100%;
+  max-width: 420px;
+  height: 36px;
+  margin: 0 auto 1.75rem;
+  color: var(--rule);
+  opacity: 0.9;
+}
+
+.footer-copy {
+  font-size: 0.82rem;
+  color: var(--mute);
+  margin-bottom: 0.5rem;
+}
+
+.footer-copy a {
+  color: var(--mute);
+  text-decoration-color: var(--rule);
+}
+
+.footer-copy a:hover {
+  color: var(--heading);
+  text-decoration-color: var(--heading);
+}
+
+.footer-feed {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+}
+
+.footer-feed a {
+  color: var(--rule);
+  text-decoration: none;
+}
+
+.footer-feed a:hover { color: var(--heading); }
+
+/* ========================================
+   404
+   ======================================== */
+.error-page {
+  padding: 8rem 2rem 7rem;
+  text-align: center;
+}
+
+.error-code {
+  font-family: var(--font-sans);
+  font-size: clamp(7rem, 20vw, 14rem);
+  font-weight: 900;
+  color: var(--heading);
+  line-height: 0.9;
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.06em;
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.error-code .code-o {
+  color: transparent;
+  -webkit-text-stroke: 3px var(--heading);
+  text-stroke: 3px var(--heading);
+}
+
+.error-han {
+  font-family: var(--font-kr);
+  font-size: clamp(1.8rem, 4.4vw, 2.6rem);
+  font-weight: 500;
+  color: var(--mute);
+  letter-spacing: -0.01em;
+  line-height: 1;
+  margin-bottom: 2rem;
+}
+
+.error-msg {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--heading);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.error-sub {
+  font-size: 0.9rem;
+  color: var(--mute);
+  margin-bottom: 2.5rem;
+}
+
+/* ========================================
+   Alerts
+   ======================================== */
+.alert {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  border-left: 2px solid var(--heading);
+  background: var(--near-white);
+  color: var(--text);
+}
+
+/* ========================================
+   Responsive
+   ======================================== */
+@media (max-width: 900px) {
+  .hero-inner { padding-left: 3rem; }
+  .hero-rail { left: 1.25rem; gap: 0.3rem; }
+  .hero-rail::before, .hero-rail::after { height: 32px; }
+
+  .section-page-head {
+    grid-template-columns: auto 1fr;
+    gap: 1.5rem;
+  }
+
+  .post-card a {
+    grid-template-columns: 100px 1fr 40px;
+    gap: 1.5rem;
+  }
+  .card-index .idx-num { font-size: 2rem; }
+
+  .post-row a {
+    grid-template-columns: 90px 1fr 32px;
+    gap: 1.25rem;
+  }
+  .row-index .idx-num { font-size: 1.7rem; }
+}
+
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .nav-links {
+    position: fixed;
+    top: 0; right: -100%;
+    width: 240px; height: 100vh;
+    background: var(--white);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2.5rem;
+    transition: right var(--transition-slow);
+    box-shadow: -4px 0 24px rgba(10, 10, 10, 0.06);
+    z-index: 105;
+  }
+  .nav-links.active { right: 0; }
+  .nav-links a { font-size: 1.1rem; }
+
+  .hero { padding: 5rem 1.5rem 5rem; }
+  .hero-inner { padding-left: 2.75rem; }
+  .hero-rail { top: 5rem; left: 1rem; gap: 0.25rem; }
+  .hero-rail::before, .hero-rail::after { height: 24px; }
+  .hero-rail .rail-label { font-size: 0.62rem; }
+  .hero-rail .rail-kr { font-size: 0.76rem; }
+
+  .hero-mark { letter-spacing: -0.05em; }
+  .hero-wordmark { gap: 0.6rem; }
+  .word-divider { display: none; }
+  .word-jamo { font-size: 0.9rem; padding-left: 0.6rem; }
+
+  .hero-kicker::before { width: 20px; margin-right: 0.75rem; }
+
+  .post-card a {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    padding: 1.75rem 0;
+  }
+  .post-card:hover a { padding-left: 0; }
+  .card-index { align-items: baseline; }
+  .card-arrow { display: none; }
+
+  .post-row a {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    padding: 1.75rem 0;
+  }
+  .post-row a:hover { padding-left: 0; }
+  .row-index { display: none; }
+  .row-arrow { display: none; }
+
+  .section-page-head {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .section-header { flex-wrap: wrap; gap: 0.75rem 1rem; }
+  .section-inner { padding: 0 1.5rem; }
+  .article-inner { padding: 0 1.5rem; }
+  .article-header h1 { font-size: 2rem; }
+
+  .article-nav { grid-template-columns: 1fr; }
+  .nav-next { grid-column: 1; text-align: left; }
+  .nav-next:hover { padding-left: 0.5rem; padding-right: 0; }
+
+  .error-page { padding: 6rem 1.5rem 5rem; }
+}
+
+@media (max-width: 480px) {
+  :root { --header-h: 56px; }
+  .header-inner { padding: 0 1.25rem; }
+  .logo-en { display: none; }
+
+  .hero { padding: 4rem 1.25rem 4rem; }
+  .hero-inner { padding-left: 2.25rem; }
+  .hero-rail { top: 4rem; left: 0.75rem; }
+  .hero-rail::before, .hero-rail::after { height: 18px; }
+
+  .hero-kicker { margin-bottom: 1.75rem; }
+  .hero-kicker::before { width: 14px; margin-right: 0.5rem; }
+  .hero-wordmark { margin-bottom: 2.25rem; }
+  .hero-desc { font-size: 1rem; }
+
+  .hero-actions { flex-direction: column; align-items: stretch; }
+  .btn { width: 100%; }
+
+  .section-inner { padding: 0 1.25rem; }
+  .article-inner { padding: 0 1.25rem; }
+  .section-header { margin-bottom: 2.25rem; }
+
+  .page-mark { font-size: 4.5rem; }
+  .section-title { font-size: 2rem; }
+
+  .article-header h1 { font-size: 1.65rem; }
+  .article-body { font-size: 1rem; line-height: 1.8; }
+  .article-body h2 { font-size: 1.4rem; }
+  .article-body h3 { font-size: 1.15rem; }
+
+  .footer-sig { margin-bottom: 1.75rem; }
+}
+
+@media print {
+  .site-header, .site-footer, .hero-actions, .article-nav, .nav-toggle,
+  .hero-rail, .footer-skyline, .footer-sig { display: none; }
+  body { background: #fff; color: #000; }
+  .hero-mark .mark-b { color: #000; -webkit-text-stroke: 0; }
+}

--- a/examples/clean-seoul/templates/404.html
+++ b/examples/clean-seoul/templates/404.html
@@ -1,0 +1,13 @@
+{% include "header.html" %}
+<main>
+  <section class="error-page">
+    <h1 class="error-code" aria-label="404">
+      <span>4</span><span class="code-o">0</span><span>4</span>
+    </h1>
+    <p class="error-han" aria-hidden="true">없음</p>
+    <p class="error-msg">Page not found.</p>
+    <p class="error-sub">Nothing at this address.</p>
+    <a href="{{ base_url }}/" class="btn btn-primary">Back to Home</a>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/clean-seoul/templates/footer.html
+++ b/examples/clean-seoul/templates/footer.html
@@ -1,0 +1,25 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-sig" aria-hidden="true">
+        <span class="sig-pre">깨끗한</span>
+        <span class="sig-mark"><span class="sig-a">서</span><span class="sig-b">울</span></span>
+      </div>
+      <svg class="footer-skyline" viewBox="0 0 400 40" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
+        <path d="M0 38 L40 38 L40 26 L70 26 L70 38 L110 38 L110 18 L115 18 L115 8 L118 8 L118 18 L123 18 L123 38 L160 38 L160 22 L180 22 L180 12 L200 12 L200 22 L220 22 L220 38 L260 38 L260 28 L290 28 L290 38 L320 38 L320 20 L325 20 L325 4 L328 4 L328 20 L333 20 L333 38 L400 38" stroke="currentColor" stroke-width="1" fill="none"/>
+      </svg>
+      <p class="footer-copy">Clean Seoul &copy; {{ site_title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+      {% if site.feeds %}
+      <p class="footer-feed"><a href="{{ base_url }}/rss.xml">RSS</a></p>
+      {% endif %}
+    </div>
+  </footer>
+  <script>
+    document.querySelector('.nav-toggle').addEventListener('click', function() {
+      document.querySelector('.nav-links').classList.toggle('active');
+      this.classList.toggle('active');
+    });
+  </script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/clean-seoul/templates/header.html
+++ b/examples/clean-seoul/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} | {{ site_title }}{% else %}{{ site_title }}{% endif %}</title>
+  <meta name="description" content="{{ page.description | default(site_description) }}">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700;800;900&family=Noto+Sans+KR:wght@300;400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="logo">
+        <span class="logo-kr" aria-hidden="true">서울</span>
+        <span class="logo-en">Clean Seoul</span>
+      </a>
+      <nav class="site-nav">
+        <button class="nav-toggle" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="{{ base_url }}/">Home</a></li>
+          <li><a href="{{ base_url }}/posts/">Posts</a></li>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>

--- a/examples/clean-seoul/templates/home.html
+++ b/examples/clean-seoul/templates/home.html
@@ -1,0 +1,74 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <aside class="hero-rail" aria-hidden="true">
+      <span class="rail-label">CLEAN SEOUL</span>
+      <span class="rail-dot">·</span>
+      <span class="rail-kr"><span>깨</span><span>끗</span><span>한</span></span>
+      <span class="rail-dot">·</span>
+      <span class="rail-kr"><span>서</span><span>울</span></span>
+    </aside>
+
+    <div class="hero-inner">
+      <p class="hero-kicker">01 · SEOUL &nbsp;/&nbsp; 37.56°N · 126.98°E</p>
+
+      <h1 class="hero-mark" aria-label="서울 · Clean Seoul">
+        <span class="mark-a">서</span><span class="mark-b">울</span>
+      </h1>
+
+      <div class="hero-wordmark">
+        <span class="word-thin">Clean</span>
+        <span class="word-bold">Seoul</span>
+        <span class="word-divider" aria-hidden="true"></span>
+        <span class="word-jamo" aria-hidden="true">
+          <span>ㅅ</span><span>ㅓ</span>
+          <span>ㅇ</span><span>ㅜ</span>
+          <span class="jamo-blank"></span><span>ㄹ</span>
+        </span>
+      </div>
+
+      <p class="hero-desc">{{ site_description }}</p>
+
+      <div class="hero-actions">
+        <a href="{{ base_url }}/posts/" class="btn btn-primary">Read Posts</a>
+        <a href="{{ base_url }}/about/" class="btn btn-ghost">About <span class="btn-arrow">→</span></a>
+      </div>
+    </div>
+  </section>
+
+  <section class="latest-posts">
+    <div class="section-inner">
+      <header class="section-header">
+        <span class="section-num">02.</span>
+        <div class="section-title-group">
+          <h2 class="section-label">최근 글</h2>
+          <span class="section-en">Recent Writing</span>
+        </div>
+        <span class="section-rule"></span>
+      </header>
+      <div class="post-grid">
+        {% for post in site.pages %}
+        {% if post.date %}
+        <article class="post-card">
+          <a href="{{ base_url }}{{ post.url }}">
+            <div class="card-index" aria-hidden="true">
+              <span class="idx-kr">글</span>
+              <span class="idx-num"></span>
+            </div>
+            <div class="card-body">
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+              <h3>{{ post.title }}</h3>
+              {% if post.description %}
+              <p>{{ post.description }}</p>
+              {% endif %}
+            </div>
+            <span class="card-arrow" aria-hidden="true">→</span>
+          </a>
+        </article>
+        {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/clean-seoul/templates/page.html
+++ b/examples/clean-seoul/templates/page.html
@@ -1,0 +1,45 @@
+{% include "header.html" %}
+<main>
+  <article class="article">
+    <div class="article-inner">
+      <header class="article-header">
+        <p class="article-kicker"><span aria-hidden="true">글</span> · Entry</p>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="article-meta">
+          <time>{{ page.date | date("%Y.%m.%d") }}</time>
+          {% if page.reading_time %}
+          <span class="dot">·</span>
+          <span>{{ page.reading_time }} min read</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.tags %}
+        <div class="article-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </header>
+      <div class="article-body">
+        {{ content | safe }}
+      </div>
+      <nav class="article-nav">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">
+          <span class="nav-dir"><span aria-hidden="true">←</span> 이전 글 · Previous</span>
+          <span class="nav-title">{{ page.lower.title }}</span>
+        </a>
+        {% endif %}
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">
+          <span class="nav-dir">다음 글 · Next <span aria-hidden="true">→</span></span>
+          <span class="nav-title">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+      </nav>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/clean-seoul/templates/section.html
+++ b/examples/clean-seoul/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <header class="section-page-head">
+        <span class="page-mark" aria-hidden="true">글</span>
+        <div class="page-head-text">
+          <p class="page-kicker">03 · ARCHIVE</p>
+          <h1 class="section-title">{{ page.title }}</h1>
+          <p class="page-sub">전체 글 · All Writing</p>
+        </div>
+      </header>
+      <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-row">
+          <a href="{{ base_url }}{{ post.url }}">
+            <div class="row-index" aria-hidden="true">
+              <span class="idx-kr">글</span>
+              <span class="idx-num"></span>
+            </div>
+            <div class="row-body">
+              <time>{{ post.date | date("%Y.%m.%d") }}</time>
+              <h2>{{ post.title }}</h2>
+              {% if post.description %}
+              <p>{{ post.description }}</p>
+              {% endif %}
+            </div>
+            <span class="row-arrow" aria-hidden="true">→</span>
+          </a>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/clean-seoul/templates/shortcodes/alert.html
+++ b/examples/clean-seoul/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default: "info" }}">
+  {{ message }}
+</div>

--- a/examples/clean-seoul/templates/taxonomy.html
+++ b/examples/clean-seoul/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/clean-seoul/templates/taxonomy_term.html
+++ b/examples/clean-seoul/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/config.toml
+++ b/examples/hanji-paper/config.toml
@@ -1,0 +1,47 @@
+title = "Hanji Paper"
+description = "A warm, light blog theme inspired by Korean hanji — handmade mulberry paper with the texture of centuries."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+[seo]
+llms_txt = true

--- a/examples/hanji-paper/content/about.md
+++ b/examples/hanji-paper/content/about.md
@@ -1,0 +1,43 @@
++++
+title = "About"
+template = "page"
++++
+
+## Hanji Paper
+
+Hanji is Korean handmade paper, pressed from the inner bark of the mulberry tree and dried against heated stone. It is said to last a thousand years. This theme borrows its warmth — the cream, the grain, the quiet breath between lines — and pairs it with deep walnut ink for a reading surface that feels like a letter rather than a screen.
+
+### Design Philosophy
+
+Where Ink Seoul stakes its claim on pure black and white, Hanji Paper lives in the warm middle. The page is not paper-white but mulberry-cream, softly textured. Text sits in walnut, not ink, so it reads with warmth even under bright light. The result is a quieter, gentler editorial voice.
+
+### The Palette
+
+| Tone | Hex | Role |
+|---|---|---|
+| Cream | #F6F0E2 | Paper ground |
+| Ivory | #EFE7D3 | Surface accent |
+| Wheat | #E7DCC2 | Borders |
+| Straw | #D9CBA7 | Decoration |
+| Tea | #B8A67C | Muted lines |
+| Bark | #6D5E42 | Secondary text |
+| Walnut | #4A3F2B | Primary text |
+| Rust | #8C3A2E | Hover accent |
+
+### Typography
+
+- **Noto Serif KR** for Korean and English headings
+- **Inter** for body and metadata
+- Generous line-height to let the paper breathe
+
+### Features
+
+- Warm cream background with a subtle hanji grain overlay
+- Walnut ink tones instead of pure black
+- Understated rust accents for links on hover
+- Generous white space and editorial typography
+- Responsive from mobile to desktop
+
+### Built With
+
+This theme was built with [Hwaro](https://github.com/hahwul/hwaro), a fast and flexible static site generator.

--- a/examples/hanji-paper/content/index.md
+++ b/examples/hanji-paper/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Hanji Paper"
+template = "home"
++++

--- a/examples/hanji-paper/content/posts/_index.md
+++ b/examples/hanji-paper/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
+generate_feeds = true
++++

--- a/examples/hanji-paper/content/posts/the-craft-of-mulberry.md
+++ b/examples/hanji-paper/content/posts/the-craft-of-mulberry.md
@@ -1,0 +1,27 @@
++++
+title = "The Craft of Mulberry"
+date = "2025-04-22"
+description = "How hanji is made — from stripped bark to a sheet that lasts a thousand years — and what that teaches about slow design."
+tags = ["hanji", "craft", "history"]
+template = "page"
++++
+
+## From Bark to Sheet
+
+Hanji begins with the paper mulberry tree, called *dak* in Korean. The outer bark is stripped and discarded; only the white inner bark is kept. That inner bark is boiled in ash, pounded to release its fibers, and suspended in cold water.
+
+A bamboo screen is dipped into the slurry, drawn up with a careful rocking motion, and pressed against a heated plate to dry. The resulting sheet is thin, almost translucent, but astonishingly strong.
+
+## Why Cold Water
+
+Cold water keeps the fibers long. Long fibers are what give hanji its characteristic strength and resistance to tearing. It is also why hanji can be dyed, folded, waxed, stitched, and used for everything from royal documents to winter coats.
+
+## Slow Design
+
+The craft takes days. The paper takes minutes to use. And yet, a letter written on hanji in 1400 can still be read today.
+
+There is a lesson there for anyone who makes things on the web. The systems that last are rarely the ones that shipped fastest — they are the ones that were made with patience, honoring their materials, and with a clear idea of whom they were for.
+
+## In This Theme
+
+Hanji Paper uses a layered SVG grain to mimic the texture of a real sheet. It is subtle on purpose. You should not see it so much as feel it underneath the words.

--- a/examples/hanji-paper/content/posts/warm-neutrals.md
+++ b/examples/hanji-paper/content/posts/warm-neutrals.md
@@ -1,0 +1,39 @@
++++
+title = "The Quiet Power of Warm Neutrals"
+date = "2025-04-10"
+description = "Why cream, wheat, and walnut read differently from white, gray, and black — and when to reach for each."
+tags = ["color", "design", "typography"]
+template = "page"
++++
+
+## Temperature Matters
+
+Designers often talk about contrast and hierarchy without talking about **temperature**. But a page made of pure white and pure black feels different from a page made of cream and walnut, even when the contrast ratio is identical.
+
+Cold palettes feel clinical and alert. Warm palettes feel slower, more forgiving. Neither is better — they simply call the reader to different postures.
+
+## A Small Table
+
+| Cool Light | Warm Light |
+|---|---|
+| `#FFFFFF` + `#000000` | `#F6F0E2` + `#4A3F2B` |
+| Alert, precise, public | Calm, personal, private |
+| Good for dashboards | Good for essays |
+
+## When to Choose Warm
+
+Reach for a warm palette when you want the reader to:
+
+- Stay on the page longer than they planned
+- Read something personal or introspective
+- Feel the writer's hand rather than a corporate voice
+
+Reach for cool white when you want:
+
+- Maximum clarity at a glance
+- Data, code, or reference material
+- A sense of distance and neutrality
+
+## The Middle Path
+
+Hanji Paper sits firmly in the warm camp, but it borrows the editorial discipline of the cool — strong hierarchy, generous space, minimal ornament. You can have warmth without sacrificing clarity. You just have to treat the paper as if it were made by hand.

--- a/examples/hanji-paper/content/posts/welcome-to-hanji.md
+++ b/examples/hanji-paper/content/posts/welcome-to-hanji.md
@@ -1,0 +1,23 @@
++++
+title = "Welcome to Hanji Paper"
+date = "2025-05-04"
+description = "A warm, paper-textured theme inspired by Korean mulberry paper — where the page is not white, but cream."
+tags = ["hanji", "design", "introduction"]
+template = "page"
++++
+
+## Paper that Breathes
+
+For more than a thousand years, Korean craftspeople have pressed mulberry bark into sheets of hanji. The surface is never completely flat, never completely white. Light catches fibers running against the grain, and the paper seems to breathe.
+
+Hanji Paper is a web theme that tries to remember that feeling.
+
+## Warm, not Bright
+
+Screen-white is useful, but it is also relentless. Hanji Paper replaces it with a warm cream that forgives the eye. Text is set in walnut instead of black, so lines read softly even at large sizes. The overall effect is less "inbox", more "letter from a friend".
+
+> Paper does not need to shout. It only needs to hold the words steady.
+
+## Where It Sits
+
+This theme is a cousin of [Ink Seoul](https://github.com/hahwul/hwaro-examples). Same editorial discipline, same generous margins — but tuned for readers who like to linger. Use it for essays, diaries, quiet publications, and anything that benefits from the feeling of turning a page.

--- a/examples/hanji-paper/static/css/style.css
+++ b/examples/hanji-paper/static/css/style.css
@@ -1,0 +1,895 @@
+/* ========================================
+   Hanji Paper — Warm mulberry-paper theme
+   Cream/ivory ground, deep charcoal ink.
+   ======================================== */
+
+:root {
+  --cream: #F6F0E2;
+  --ivory: #EFE7D3;
+  --wheat: #E7DCC2;
+  --straw: #D9CBA7;
+  --tea: #B8A67C;
+  --bark: #6D5E42;
+  --walnut: #4A3F2B;
+  --charcoal: #2C2A24;
+  --ink: #1A1814;
+  --rust: #8C3A2E;
+
+  --font-serif: 'Noto Serif KR', 'Cormorant Garamond', Georgia, serif;
+  --font-sans: 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+
+  --max-w: 720px;
+  --max-w-wide: 1080px;
+  --header-h: 72px;
+
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.2s var(--ease);
+  --transition-slow: 0.4s var(--ease);
+
+  --shadow-sm: 0 1px 3px rgba(74, 63, 43, 0.08);
+  --shadow-md: 0 4px 16px rgba(74, 63, 43, 0.10);
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--cream);
+  color: var(--ink);
+  line-height: 1.75;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+main { flex: 1; position: relative; z-index: 1; }
+
+/* Hanji paper grain — layered SVG noise at low opacity */
+.paper-grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.55;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.29 0 0 0 0 0.25 0 0 0 0 0.17 0 0 0 0.14 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>"),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='600' height='600'><filter id='f'><feTurbulence type='turbulence' baseFrequency='0.012' numOctaves='2'/><feColorMatrix values='0 0 0 0 0.42 0 0 0 0 0.36 0 0 0 0 0.24 0 0 0 0.10 0'/></filter><rect width='100%' height='100%' filter='url(%23f)'/></svg>");
+  background-size: 320px 320px, 600px 600px;
+  mix-blend-mode: multiply;
+}
+
+a {
+  color: var(--walnut);
+  text-decoration-line: underline;
+  text-decoration-color: var(--straw);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color var(--transition), color var(--transition);
+}
+
+a:hover {
+  color: var(--rust);
+  text-decoration-color: var(--rust);
+}
+
+img { max-width: 100%; height: auto; display: block; }
+
+::selection { background: var(--walnut); color: var(--cream); }
+
+::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar-track { background: var(--ivory); }
+::-webkit-scrollbar-thumb { background: var(--straw); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--tea); }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.hero-inner, .post-grid, .post-list, .article-inner {
+  animation: fadeUp 0.5s var(--ease);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(246, 240, 226, 0.92);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--wheat);
+  height: var(--header-h);
+}
+
+.header-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo { display: flex; align-items: baseline; gap: 0.55rem; text-decoration: none; }
+.logo:hover { text-decoration: none; opacity: 0.7; }
+
+.logo-kr {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--walnut);
+  letter-spacing: -0.01em;
+}
+
+.logo-en {
+  font-family: var(--font-serif);
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--bark);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.site-nav { display: flex; align-items: center; }
+
+.nav-links { display: flex; align-items: center; gap: 2rem; list-style: none; }
+
+.nav-links a {
+  font-size: 0.84rem;
+  font-weight: 500;
+  color: var(--bark);
+  text-decoration: none;
+  padding: 0.2rem 0;
+  position: relative;
+  transition: color var(--transition);
+}
+
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  bottom: -1px; left: 0;
+  width: 0; height: 1px;
+  background: var(--walnut);
+  transition: width var(--transition);
+}
+
+.nav-links a:hover { color: var(--walnut); }
+.nav-links a:hover::after { width: 100%; }
+
+.nav-toggle {
+  display: none;
+  background: none; border: none; cursor: pointer;
+  width: 24px; height: 18px; position: relative; z-index: 110;
+}
+
+.nav-toggle span {
+  display: block; width: 100%; height: 1.5px;
+  background: var(--walnut);
+  position: absolute; left: 0;
+  transition: all var(--transition);
+}
+
+.nav-toggle span:nth-child(1) { top: 0; }
+.nav-toggle span:nth-child(2) { top: 50%; transform: translateY(-50%); }
+.nav-toggle span:nth-child(3) { bottom: 0; }
+
+.nav-toggle.active span:nth-child(1) { top: 50%; transform: translateY(-50%) rotate(45deg); }
+.nav-toggle.active span:nth-child(2) { opacity: 0; }
+.nav-toggle.active span:nth-child(3) { bottom: 50%; transform: translateY(50%) rotate(-45deg); }
+
+/* Hero */
+.hero {
+  padding: 8.5rem 2rem 6.5rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1.5px;
+  height: 64px;
+  background: var(--bark);
+  opacity: 0.45;
+}
+
+.hero-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-label {
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  color: var(--tea);
+  margin-bottom: 2.5rem;
+}
+
+.hero-title {
+  margin-bottom: 2rem;
+  position: relative;
+}
+
+.hero-kr {
+  font-family: var(--font-serif);
+  font-size: 4.4rem;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  color: var(--walnut);
+  display: block;
+  line-height: 1.05;
+}
+
+.hero-rule {
+  display: block;
+  width: 52px;
+  height: 1.5px;
+  background: var(--bark);
+  margin: 1.6rem auto;
+  opacity: 0.7;
+}
+
+.hero-en {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 400;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: var(--bark);
+  display: block;
+}
+
+.hero-desc {
+  font-size: 0.98rem;
+  color: var(--walnut);
+  line-height: 1.85;
+  max-width: 460px;
+  margin: 0 auto 3rem;
+}
+
+.hero-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.9rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  border-radius: 0;
+  text-decoration: none;
+  transition: all var(--transition);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--walnut);
+  color: var(--cream);
+  border: 1px solid var(--walnut);
+}
+
+.btn-primary:hover {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--cream);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--walnut);
+  border: 1px solid var(--tea);
+}
+
+.btn-outline:hover {
+  border-color: var(--walnut);
+  color: var(--walnut);
+}
+
+/* Sections */
+.section-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-label {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--walnut);
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--straw);
+}
+
+.latest-posts { padding: 0 0 6rem; }
+
+/* Post grid */
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+
+.post-card {
+  border: 1px solid var(--wheat);
+  background: rgba(255, 251, 240, 0.5);
+  transition: all var(--transition);
+  position: relative;
+}
+
+.post-card::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--walnut);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition-slow);
+}
+
+.post-card:hover {
+  border-color: var(--tea);
+  background: rgba(255, 251, 240, 0.85);
+  box-shadow: var(--shadow-md);
+}
+
+.post-card:hover::after { transform: scaleX(1); }
+
+.post-card a {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.5rem 1.35rem;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+}
+
+.post-card time {
+  font-size: 0.7rem;
+  color: var(--tea);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.65rem;
+}
+
+.post-card h3 {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.35;
+  margin-bottom: 0.55rem;
+  transition: color var(--transition);
+}
+
+.post-card:hover h3 { color: var(--ink); }
+
+.post-card p {
+  font-size: 0.83rem;
+  color: var(--bark);
+  line-height: 1.65;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 1rem;
+}
+
+.card-tags span {
+  font-size: 0.63rem;
+  color: var(--bark);
+  background: var(--wheat);
+  padding: 0.18rem 0.48rem;
+  letter-spacing: 0.04em;
+}
+
+/* Section page */
+.section-page { padding: 4rem 0 6rem; }
+
+.section-title {
+  font-family: var(--font-serif);
+  font-size: 2.2rem;
+  font-weight: 600;
+  color: var(--walnut);
+  letter-spacing: -0.01em;
+  margin-bottom: 3rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 2px solid var(--walnut);
+}
+
+.post-list { display: flex; flex-direction: column; }
+
+.post-row { border-bottom: 1px solid var(--wheat); }
+.post-row:first-child { border-top: 1px solid var(--wheat); }
+
+.post-row a {
+  display: block;
+  padding: 1.8rem 0;
+  text-decoration: none;
+  color: inherit;
+  transition: padding-left var(--transition);
+}
+
+.post-row a:hover { padding-left: 1rem; }
+
+.post-row time {
+  font-size: 0.7rem;
+  color: var(--tea);
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.post-row h2 {
+  font-family: var(--font-serif);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.3;
+  margin-bottom: 0.35rem;
+  transition: color var(--transition);
+}
+
+.post-row:hover h2 { color: var(--ink); }
+
+.post-row p {
+  font-size: 0.87rem;
+  color: var(--bark);
+  line-height: 1.65;
+}
+
+/* Article */
+.article { padding: 4rem 0 6rem; }
+
+.article-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.article-header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+.article-header h1 {
+  font-family: var(--font-serif);
+  font-size: 2.6rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.18;
+  letter-spacing: -0.01em;
+  margin-bottom: 1.25rem;
+}
+
+.article-meta {
+  font-size: 0.82rem;
+  color: var(--bark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.dot { color: var(--tea); }
+
+.article-tags {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.article-tags a {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--walnut);
+  background: var(--wheat);
+  padding: 0.22rem 0.7rem;
+  text-decoration: none;
+  transition: all var(--transition);
+}
+
+.article-tags a:hover {
+  background: var(--walnut);
+  color: var(--cream);
+}
+
+.article-body {
+  font-size: 1.05rem;
+  line-height: 1.9;
+  color: var(--charcoal);
+}
+
+.article-body h2 {
+  font-family: var(--font-serif);
+  font-size: 1.7rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 3rem 0 1rem;
+  line-height: 1.3;
+}
+
+.article-body h3 {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 2.5rem 0 0.75rem;
+  line-height: 1.35;
+}
+
+.article-body h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 2rem 0 0.5rem;
+}
+
+.article-body p { margin-bottom: 1.3rem; }
+
+.article-body strong {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.article-body a {
+  color: var(--walnut);
+  text-decoration-color: var(--tea);
+}
+
+.article-body a:hover {
+  color: var(--rust);
+  text-decoration-color: var(--rust);
+}
+
+.article-body ul, .article-body ol {
+  margin-bottom: 1.3rem;
+  padding-left: 1.4rem;
+}
+
+.article-body li { margin-bottom: 0.35rem; }
+.article-body li::marker { color: var(--tea); }
+
+.article-body blockquote {
+  margin: 2rem 0;
+  padding: 1.25rem 1.5rem;
+  border-left: 3px solid var(--walnut);
+  background: var(--ivory);
+  font-style: italic;
+  color: var(--walnut);
+}
+
+.article-body blockquote p:last-child { margin-bottom: 0; }
+
+.article-body hr {
+  border: none;
+  height: 1.5px;
+  background: var(--straw);
+  margin: 3rem auto;
+  max-width: 56px;
+  opacity: 0.8;
+}
+
+.article-body code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--ivory);
+  padding: 0.12em 0.4em;
+  color: var(--walnut);
+  border: 1px solid var(--wheat);
+}
+
+.article-body pre {
+  margin: 1.75rem 0;
+  padding: 1.25rem 1.4rem;
+  background: var(--ivory);
+  border: 1px solid var(--wheat);
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+.article-body pre code {
+  background: none;
+  padding: 0;
+  border: none;
+  font-size: inherit;
+}
+
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.75rem 0;
+  font-size: 0.88rem;
+}
+
+.article-body thead { border-bottom: 2px solid var(--walnut); }
+
+.article-body th {
+  font-weight: 600;
+  text-align: left;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--walnut);
+}
+
+.article-body td {
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--wheat);
+  color: var(--charcoal);
+}
+
+.article-body tbody tr:hover { background: var(--ivory); }
+
+.article-body img {
+  margin: 2rem 0;
+  box-shadow: var(--shadow-md);
+}
+
+/* Article nav */
+.article-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--walnut);
+}
+
+.article-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.15rem 1.25rem;
+  border: 1px solid var(--wheat);
+  text-decoration: none;
+  transition: all var(--transition);
+}
+
+.article-nav a:hover {
+  border-color: var(--walnut);
+  background: var(--ivory);
+}
+
+.nav-prev { text-align: left; }
+.nav-next { text-align: right; grid-column: 2; }
+
+.nav-dir {
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--tea);
+}
+
+.nav-title {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--walnut);
+  line-height: 1.4;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--wheat);
+  padding: 3rem 2rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.footer-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
+.footer-logo {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--walnut);
+}
+
+.footer-sep { color: var(--tea); font-weight: 300; }
+
+.footer-en {
+  font-family: var(--font-serif);
+  font-size: 0.72rem;
+  color: var(--bark);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footer-copy {
+  font-size: 0.76rem;
+  color: var(--bark);
+  margin-bottom: 0.3rem;
+}
+
+.footer-copy a {
+  color: var(--bark);
+  text-decoration-color: var(--straw);
+}
+
+.footer-copy a:hover {
+  color: var(--walnut);
+  text-decoration-color: var(--walnut);
+}
+
+.footer-feed { font-size: 0.72rem; }
+.footer-feed a { color: var(--tea); }
+.footer-feed a:hover { color: var(--walnut); }
+
+/* 404 */
+.error-page {
+  padding: 10rem 2rem;
+  text-align: center;
+}
+
+.error-page h1 {
+  font-family: var(--font-serif);
+  font-size: 10rem;
+  font-weight: 300;
+  color: var(--wheat);
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.error-msg {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 500;
+  color: var(--walnut);
+  margin-bottom: 0.5rem;
+}
+
+.error-sub {
+  font-size: 0.9rem;
+  color: var(--bark);
+  margin-bottom: 2.5rem;
+}
+
+/* Alerts */
+.alert {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  border-left: 3px solid var(--walnut);
+  background: var(--ivory);
+  color: var(--walnut);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .nav-links {
+    position: fixed;
+    top: 0; right: -100%;
+    width: 240px; height: 100vh;
+    background: var(--cream);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2.5rem;
+    transition: right var(--transition-slow);
+    box-shadow: -4px 0 20px rgba(74, 63, 43, 0.08);
+    z-index: 105;
+  }
+  .nav-links.active { right: 0; }
+  .nav-links a { font-size: 1.1rem; }
+
+  .hero { padding: 6rem 1.5rem 5rem; }
+  .hero::before { height: 44px; }
+  .hero-kr { font-size: 3rem; }
+  .hero-en { font-size: 0.9rem; letter-spacing: 0.28em; }
+
+  .post-grid { grid-template-columns: 1fr; }
+  .section-inner { padding: 0 1.5rem; }
+  .article-inner { padding: 0 1.5rem; }
+  .article-header h1 { font-size: 2rem; }
+
+  .article-nav { grid-template-columns: 1fr; }
+  .nav-next { grid-column: 1; text-align: left; }
+
+  .error-page h1 { font-size: 6rem; }
+}
+
+@media (max-width: 480px) {
+  :root { --header-h: 60px; }
+  .header-inner { padding: 0 1.25rem; }
+  .logo-en { display: none; }
+
+  .hero { padding: 4.5rem 1.25rem 3.5rem; }
+  .hero-kr { font-size: 2.4rem; }
+  .hero-rule { width: 36px; margin: 1rem auto; }
+  .hero-en { font-size: 0.78rem; letter-spacing: 0.22em; }
+  .hero-desc { font-size: 0.88rem; margin-bottom: 2rem; }
+
+  .hero-actions { flex-direction: column; align-items: center; }
+  .btn { width: 100%; max-width: 200px; }
+
+  .section-inner { padding: 0 1.25rem; }
+  .article-inner { padding: 0 1.25rem; }
+
+  .article-header h1 { font-size: 1.6rem; }
+  .article-body { font-size: 1rem; line-height: 1.8; }
+  .article-body h2 { font-size: 1.4rem; }
+  .article-body h3 { font-size: 1.15rem; }
+
+  .section-title { font-size: 1.6rem; }
+  .post-row h2 { font-size: 1.2rem; }
+  .post-card h3 { font-size: 1.05rem; }
+
+  .error-page h1 { font-size: 4rem; }
+  .error-page { padding: 6rem 1.25rem; }
+
+  .footer-brand { flex-direction: column; gap: 0.15rem; }
+  .footer-sep { display: none; }
+}
+
+@media print {
+  .paper-grain, .site-header, .site-footer, .hero-actions, .article-nav, .nav-toggle { display: none; }
+  body { background: #fff; color: #000; }
+}

--- a/examples/hanji-paper/templates/404.html
+++ b/examples/hanji-paper/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="error-page">
+    <h1>404</h1>
+    <p class="error-msg">Page not found.</p>
+    <p class="error-sub">This sheet of paper is blank.</p>
+    <a href="{{ base_url }}/" class="btn btn-primary">Back to Home</a>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/templates/footer.html
+++ b/examples/hanji-paper/templates/footer.html
@@ -1,0 +1,23 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <span class="footer-logo">한지</span>
+        <span class="footer-sep">·</span>
+        <span class="footer-en">Hanji Paper</span>
+      </div>
+      <p class="footer-copy">&copy; {{ site_title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+      {% if site.feeds %}
+      <p class="footer-feed"><a href="{{ base_url }}/rss.xml">RSS</a></p>
+      {% endif %}
+    </div>
+  </footer>
+  <script>
+    document.querySelector('.nav-toggle').addEventListener('click', function() {
+      document.querySelector('.nav-links').classList.toggle('active');
+      this.classList.toggle('active');
+    });
+  </script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/hanji-paper/templates/header.html
+++ b/examples/hanji-paper/templates/header.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} | {{ site_title }}{% else %}{{ site_title }}{% endif %}</title>
+  <meta name="description" content="{{ page.description | default(site_description) }}">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@300;400;500;600;700&family=Cormorant+Garamond:wght@400;500;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+  <div class="paper-grain" aria-hidden="true"></div>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="logo">
+        <span class="logo-kr">한지</span>
+        <span class="logo-en">Hanji</span>
+      </a>
+      <nav class="site-nav">
+        <button class="nav-toggle" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="{{ base_url }}/">Home</a></li>
+          <li><a href="{{ base_url }}/posts/">Posts</a></li>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>

--- a/examples/hanji-paper/templates/home.html
+++ b/examples/hanji-paper/templates/home.html
@@ -1,0 +1,50 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="hero-inner">
+      <p class="hero-label">Seoul · Handmade Paper</p>
+      <h1 class="hero-title">
+        <span class="hero-kr">한지</span>
+        <span class="hero-rule"></span>
+        <span class="hero-en">Hanji Paper</span>
+      </h1>
+      <p class="hero-desc">{{ site_description }}</p>
+      <div class="hero-actions">
+        <a href="{{ base_url }}/posts/" class="btn btn-primary">Read Posts</a>
+        <a href="{{ base_url }}/about/" class="btn btn-outline">About</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="latest-posts">
+    <div class="section-inner">
+      <div class="section-header">
+        <h2 class="section-label">Latest</h2>
+        <span class="section-rule"></span>
+      </div>
+      <div class="post-grid">
+        {% for post in site.pages %}
+        {% if post.date %}
+        <article class="post-card">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h3>{{ post.title }}</h3>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+            {% if post.tags %}
+            <div class="card-tags">
+              {% for tag in post.tags %}
+              <span>{{ tag }}</span>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </a>
+        </article>
+        {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/templates/page.html
+++ b/examples/hanji-paper/templates/page.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<main>
+  <article class="article">
+    <div class="article-inner">
+      <header class="article-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="article-meta">
+          <time>{{ page.date | date("%B %d, %Y") }}</time>
+          {% if page.reading_time %}
+          <span class="dot">&middot;</span>
+          <span>{{ page.reading_time }} min read</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.tags %}
+        <div class="article-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </header>
+      <div class="article-body">
+        {{ content | safe }}
+      </div>
+      <nav class="article-nav">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">
+          <span class="nav-dir">Previous</span>
+          <span class="nav-title">{{ page.lower.title }}</span>
+        </a>
+        {% endif %}
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">
+          <span class="nav-dir">Next</span>
+          <span class="nav-title">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+      </nav>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/templates/section.html
+++ b/examples/hanji-paper/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-row">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h2>{{ post.title }}</h2>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+          </a>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/templates/shortcodes/alert.html
+++ b/examples/hanji-paper/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default: "info" }}">
+  {{ message }}
+</div>

--- a/examples/hanji-paper/templates/taxonomy.html
+++ b/examples/hanji-paper/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/hanji-paper/templates/taxonomy_term.html
+++ b/examples/hanji-paper/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/config.toml
+++ b/examples/seoul-modern-minimal/config.toml
@@ -1,0 +1,47 @@
+title = "Seoul Modern"
+description = "A light, concrete-and-neon theme for a modern Seoul — clean sans-serif type with a single electric accent."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+[seo]
+llms_txt = true

--- a/examples/seoul-modern-minimal/content/about.md
+++ b/examples/seoul-modern-minimal/content/about.md
@@ -1,0 +1,44 @@
++++
+title = "About"
+template = "page"
++++
+
+## Seoul Modern
+
+Seoul Modern is a light, contemporary theme for writers who want a clean editorial voice with one sharp point of emphasis. The palette is borrowed from the city's concrete-and-glass afternoon: cool grays, soft fog, and a single electric blue that appears only where attention is needed.
+
+### Design Philosophy
+
+Minimalism without coldness. The page is a neutral surface — pale grays with a light concrete wash — and all the energy is saved for a single neon accent. Links, hover states, markers, and section rules pull the eye with that one color. Everywhere else, typography does the work.
+
+### The Palette
+
+| Tone | Hex | Role |
+|---|---|---|
+| White | #FCFCFD | Page surface |
+| Cloud | #F4F5F7 | Secondary surface |
+| Fog | #EAECEF | Borders |
+| Steel | #B9BEC6 | Muted iconography |
+| Graphite | #6E747C | Metadata |
+| Slate | #3F454D | Body text |
+| Onyx | #1C1F23 | Headings |
+| Neon | #1D6BFF | Accent |
+
+### Typography
+
+- **Inter** / **Pretendard** for display and body
+- **Noto Sans KR** for Korean
+- **JetBrains Mono** for metadata and eyebrow labels
+- Tight tracking on display sizes, relaxed tracking on labels
+
+### Features
+
+- Electric blue accent applied sparingly for maximum impact
+- Monospace metadata and geographic coordinates in the hero
+- Rounded card grid with subtle hover lift
+- Concrete-wash background for depth without noise
+- Responsive grid from single-column mobile to three-column desktop
+
+### Built With
+
+This theme was built with [Hwaro](https://github.com/hahwul/hwaro), a fast and flexible static site generator.

--- a/examples/seoul-modern-minimal/content/index.md
+++ b/examples/seoul-modern-minimal/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Seoul Modern"
+template = "home"
++++

--- a/examples/seoul-modern-minimal/content/posts/_index.md
+++ b/examples/seoul-modern-minimal/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
+generate_feeds = true
++++

--- a/examples/seoul-modern-minimal/content/posts/concrete-and-neon.md
+++ b/examples/seoul-modern-minimal/content/posts/concrete-and-neon.md
@@ -1,0 +1,41 @@
++++
+title = "Concrete and Neon"
+date = "2025-04-25"
+description = "On the aesthetic tension between Seoul's raw concrete and its late-night electric glow, and how to translate that contrast into UI."
+tags = ["seoul", "color", "design"]
+template = "page"
++++
+
+## Two Cities in One Street
+
+If you walk from Euljiro to Seongsu at dusk, you pass through two cities. The daytime city is concrete: unpainted walls, exposed rebar, tungsten-gray metal shutters. The nighttime city is neon: signage, screens, and the peculiar cold blue of late subway platforms.
+
+Seoul's contemporary design identity lives in the tension between those two registers. Clean industrial surfaces as the base layer. A single saturated color as the voice.
+
+## Translating It to Screens
+
+You don't need a neon sign to get the effect. You need:
+
+1. **A cool base.** Not pure white — pure white reads as sterile. Something like `#FCFCFD` with a gray undertone.
+2. **One saturated accent.** Blue works. Pink works. Green can work. Yellow is harder. The accent must be bright enough that any element wearing it immediately draws the eye.
+3. **Restraint.** The accent applies to interactive states, a single brand mark, and one structural element (a rule, a marker). Nowhere else.
+
+## An Example
+
+```css
+:root {
+  --base: #FCFCFD;
+  --text: #1C1F23;
+  --mute: #6E747C;
+  --accent: #1D6BFF;
+}
+
+a:hover { color: var(--accent); }
+.mark  { background: var(--accent); }
+```
+
+That's the entire system. Everything else — cards, buttons, metadata, tags — is rendered in the base and text colors with light borders. The accent does not appear until something is active or interactive.
+
+## Why It Works
+
+The eye is wired to notice color change. When a page only has one place where color appears, that place becomes load-bearing. The user does not need to be trained where to look. They look because the design tells them to.

--- a/examples/seoul-modern-minimal/content/posts/pretendard-on-the-web.md
+++ b/examples/seoul-modern-minimal/content/posts/pretendard-on-the-web.md
@@ -1,0 +1,48 @@
++++
+title = "Pretendard on the Web"
+date = "2025-04-14"
+description = "Why Pretendard has become the default sans for modern Korean sites, and what it does better than Noto Sans KR alone."
+tags = ["typography", "korean", "pretendard"]
+template = "page"
++++
+
+## The Missing Sans
+
+For years, the default answer to "what sans serif should I use for a mixed Korean/English site?" was Noto Sans KR. It works. It renders well. But it was never designed to feel like a *system font* — the sort of type that disappears into the interface.
+
+Pretendard, by designer Kilhyung Lee, fills that gap. It borrows the vertical proportions of Apple System Font and Inter, then maps them onto a full set of Hangul glyphs. The result is a Korean sans that sits comfortably next to Latin type without ever announcing itself as a separate face.
+
+## What Changes
+
+When you swap Noto Sans KR for Pretendard on the same layout:
+
+- **Vertical alignment improves.** Hangul and Latin sit on the same baseline without visible drift.
+- **Weights feel consistent.** 400, 500, and 600 all look like siblings.
+- **Mixed-script lines read more evenly.** No sudden visual weight change where the language switches.
+
+## Loading It
+
+Pretendard ships as a variable font. On the web, the simplest path is the dynamic subset CDN:
+
+```html
+<link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css" />
+```
+
+Then use it like any other sans:
+
+```css
+body {
+  font-family: 'Pretendard Variable', 'Inter', sans-serif;
+}
+```
+
+## When Not To Use It
+
+Pretendard is excellent for UI, documentation, and editorial web. It is less suited to:
+
+- Formal or traditional contexts (use Noto Serif KR)
+- Display sizes where you want a distinctive voice (use a headline face)
+- Heritage brands where Hangul should feel explicitly Korean rather than system-neutral
+
+For everything else — and especially for a modern, minimal Seoul site — Pretendard is the safest and most considered choice available today.

--- a/examples/seoul-modern-minimal/content/posts/welcome-to-seoul-modern.md
+++ b/examples/seoul-modern-minimal/content/posts/welcome-to-seoul-modern.md
@@ -1,0 +1,29 @@
++++
+title = "Welcome to Seoul Modern"
+date = "2025-05-06"
+description = "A light editorial theme built for the contemporary city — cool grays, clean sans, and a single line of electric blue."
+tags = ["seoul", "design", "introduction"]
+template = "page"
++++
+
+## One Accent Is Enough
+
+The fastest way to make a modern interface feel noisy is to give every element its own color. The opposite discipline — picking one accent and defending it — is how the best contemporary Korean design studios produce work that still looks fresh five years later.
+
+Seoul Modern is built around that discipline. The accent color is a single electric blue, `#1D6BFF`. It appears on the logo mark, link hovers, the section rule, and nothing else of consequence.
+
+## What the Palette Doesn't Say
+
+A reader should never *think* about the palette. The grays here are calibrated to stay invisible — just enough tonal separation to make borders legible, not enough to attract attention. The accent exists because a well-placed spark of color can guide the eye more effectively than any amount of bold text.
+
+> Modernism is not the absence of decoration. It is decoration used with extreme restraint.
+
+## Pairings
+
+Seoul Modern pairs well with:
+
+- Product documentation that needs to feel current
+- Studio or agency blogs with a strong editorial voice
+- Personal sites for designers, developers, or writers who like monospace details
+
+It is a direct contrast to Hanji Paper, which chooses warmth over precision. Pick whichever better matches what you want the reader to feel when they land.

--- a/examples/seoul-modern-minimal/static/css/style.css
+++ b/examples/seoul-modern-minimal/static/css/style.css
@@ -1,0 +1,953 @@
+/* ========================================
+   Seoul Modern — Concrete + Electric Accent
+   Light gray-white, single neon-blue highlight.
+   ======================================== */
+
+:root {
+  --white: #FCFCFD;
+  --cloud: #F4F5F7;
+  --fog: #EAECEF;
+  --concrete: #DDE0E4;
+  --steel: #B9BEC6;
+  --graphite: #6E747C;
+  --slate: #3F454D;
+  --onyx: #1C1F23;
+  --black: #0A0B0D;
+
+  --neon: #1D6BFF;
+  --neon-soft: rgba(29, 107, 255, 0.14);
+  --neon-line: rgba(29, 107, 255, 0.35);
+
+  --font-sans: 'Inter', 'Pretendard', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Inter', 'Pretendard', 'Noto Sans KR', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+
+  --max-w: 720px;
+  --max-w-wide: 1120px;
+  --header-h: 68px;
+
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.18s var(--ease);
+  --transition-slow: 0.35s var(--ease);
+
+  --shadow-sm: 0 1px 2px rgba(28, 31, 35, 0.04);
+  --shadow-md: 0 6px 20px rgba(28, 31, 35, 0.06);
+  --shadow-neon: 0 0 0 1px var(--neon-line), 0 4px 18px rgba(29, 107, 255, 0.12);
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--white);
+  color: var(--onyx);
+  line-height: 1.65;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+main { flex: 1; position: relative; z-index: 1; }
+
+/* Concrete wash — subtle micro-texture, flat color (no gradients) */
+.concrete-wash {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-color: var(--white);
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><filter id='c'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.12 0 0 0 0 0.13 0 0 0 0 0.14 0 0 0 0.06 0'/></filter><rect width='100%' height='100%' filter='url(%23c)'/></svg>");
+  background-size: 400px 400px;
+  opacity: 0.9;
+  mix-blend-mode: multiply;
+}
+
+a {
+  color: var(--onyx);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover { color: var(--neon); }
+
+img { max-width: 100%; height: auto; display: block; }
+
+::selection { background: var(--neon-soft); color: var(--onyx); }
+
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: var(--cloud); }
+::-webkit-scrollbar-thumb { background: var(--steel); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--graphite); }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulseDot {
+  0%, 100% { box-shadow: 0 0 0 0 var(--neon-soft); }
+  50%      { box-shadow: 0 0 0 6px rgba(29, 107, 255, 0); }
+}
+
+.hero-inner, .post-grid, .post-list, .article-inner {
+  animation: fadeUp 0.5s var(--ease);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(252, 252, 253, 0.88);
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  border-bottom: 1px solid var(--fog);
+  height: var(--header-h);
+}
+
+.header-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--onyx);
+}
+
+.logo:hover { color: var(--onyx); }
+
+.logo-mark {
+  width: 10px;
+  height: 10px;
+  background: var(--neon);
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.logo-kr {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--onyx);
+  letter-spacing: -0.01em;
+}
+
+.logo-en {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--graphite);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.site-nav { display: flex; align-items: center; }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+}
+
+.nav-links a {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--slate);
+  padding: 0.35rem 0;
+  position: relative;
+}
+
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  bottom: -2px; left: 0;
+  width: 0; height: 2px;
+  background: var(--neon);
+  transition: width var(--transition);
+}
+
+.nav-links a:hover { color: var(--onyx); }
+.nav-links a:hover::after { width: 100%; }
+
+.nav-toggle {
+  display: none;
+  background: none; border: none; cursor: pointer;
+  width: 24px; height: 18px; position: relative; z-index: 110;
+}
+
+.nav-toggle span {
+  display: block; width: 100%; height: 1.5px;
+  background: var(--onyx);
+  position: absolute; left: 0;
+  transition: all var(--transition);
+}
+
+.nav-toggle span:nth-child(1) { top: 0; }
+.nav-toggle span:nth-child(2) { top: 50%; transform: translateY(-50%); }
+.nav-toggle span:nth-child(3) { bottom: 0; }
+
+.nav-toggle.active span:nth-child(1) { top: 50%; transform: translateY(-50%) rotate(45deg); }
+.nav-toggle.active span:nth-child(2) { opacity: 0; }
+.nav-toggle.active span:nth-child(3) { bottom: 50%; transform: translateY(50%) rotate(-45deg); }
+
+/* Hero */
+.hero {
+  padding: 8rem 2rem 6rem;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--graphite);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--fog);
+  background: var(--cloud);
+  border-radius: 999px;
+}
+
+.eyebrow-dot {
+  width: 6px; height: 6px;
+  background: var(--neon);
+  border-radius: 50%;
+  animation: pulseDot 2.5s infinite;
+}
+
+.hero-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.75rem;
+  max-width: 760px;
+}
+
+.hero-kr {
+  font-family: var(--font-display);
+  font-size: 5.6rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: var(--onyx);
+  line-height: 0.95;
+}
+
+.hero-en {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+  color: var(--graphite);
+}
+
+.hero-desc {
+  font-size: 1.02rem;
+  color: var(--slate);
+  line-height: 1.65;
+  max-width: 560px;
+  margin-bottom: 2.25rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero-grid {
+  position: absolute;
+  top: 2rem; right: 2rem;
+  display: grid;
+  grid-template-columns: repeat(2, 20px);
+  gap: 6px;
+  z-index: 1;
+  opacity: 0.9;
+}
+
+.hero-grid span {
+  width: 20px; height: 20px;
+  border: 1px solid var(--concrete);
+  background: var(--cloud);
+}
+
+.hero-grid span:nth-child(2) { background: var(--neon); border-color: var(--neon); }
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  font-weight: 500;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: all var(--transition);
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--onyx);
+  color: var(--white);
+  border: 1px solid var(--onyx);
+}
+
+.btn-primary:hover {
+  background: var(--neon);
+  border-color: var(--neon);
+  color: #fff;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--onyx);
+  border: 1px solid var(--concrete);
+}
+
+.btn-outline:hover {
+  border-color: var(--neon);
+  color: var(--neon);
+  background: var(--neon-soft);
+}
+
+/* Sections */
+.section-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-index {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--neon);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+}
+
+.section-label {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--onyx);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--fog);
+}
+
+.latest-posts { padding: 2rem 0 6rem; }
+
+/* Post grid */
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.post-card {
+  border: 1px solid var(--fog);
+  background: var(--white);
+  border-radius: 10px;
+  transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.post-card:hover {
+  border-color: var(--neon-line);
+  box-shadow: var(--shadow-neon);
+  transform: translateY(-2px);
+}
+
+.post-card a {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.5rem 1.35rem;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+  position: relative;
+}
+
+.post-card time {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--graphite);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.post-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--onyx);
+  line-height: 1.35;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+  transition: color var(--transition);
+}
+
+.post-card:hover h3 { color: var(--neon); }
+
+.post-card p {
+  font-size: 0.83rem;
+  color: var(--slate);
+  line-height: 1.6;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 1rem;
+}
+
+.card-tags span {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--graphite);
+  background: var(--cloud);
+  padding: 0.16rem 0.5rem;
+  border-radius: 4px;
+}
+
+.card-arrow {
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1rem;
+  font-size: 1rem;
+  color: var(--steel);
+  transition: all var(--transition);
+}
+
+.post-card:hover .card-arrow {
+  color: var(--neon);
+  transform: translate(3px, -3px);
+}
+
+/* Section page */
+.section-page { padding: 4rem 0 6rem; }
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--onyx);
+  letter-spacing: -0.03em;
+  margin-bottom: 3rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--fog);
+  position: relative;
+}
+
+.section-title::after {
+  content: '';
+  position: absolute;
+  bottom: -1px; left: 0;
+  width: 48px; height: 2px;
+  background: var(--neon);
+}
+
+.post-list { display: flex; flex-direction: column; }
+
+.post-row { border-bottom: 1px solid var(--fog); }
+.post-row:first-child { border-top: 1px solid var(--fog); }
+
+.post-row a {
+  display: block;
+  padding: 1.6rem 0;
+  color: inherit;
+  transition: padding-left var(--transition), background var(--transition);
+}
+
+.post-row a:hover {
+  padding-left: 1rem;
+  background: var(--cloud);
+}
+
+.post-row time {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--graphite);
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.post-row h2 {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--onyx);
+  line-height: 1.3;
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.02em;
+  transition: color var(--transition);
+}
+
+.post-row:hover h2 { color: var(--neon); }
+
+.post-row p {
+  font-size: 0.88rem;
+  color: var(--slate);
+  line-height: 1.6;
+}
+
+/* Article */
+.article { padding: 4rem 0 6rem; }
+
+.article-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.article-header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--fog);
+}
+
+.article-header h1 {
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--onyx);
+  line-height: 1.18;
+  letter-spacing: -0.03em;
+  margin-bottom: 1.1rem;
+}
+
+.article-meta {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--graphite);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.dot { color: var(--steel); }
+
+.article-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.article-tags a {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--slate);
+  background: var(--cloud);
+  padding: 0.22rem 0.6rem;
+  border-radius: 4px;
+  transition: all var(--transition);
+}
+
+.article-tags a:hover {
+  background: var(--neon);
+  color: #fff;
+}
+
+.article-body {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: var(--slate);
+}
+
+.article-body h2 {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--onyx);
+  margin: 3rem 0 1rem;
+  letter-spacing: -0.02em;
+}
+
+.article-body h3 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--onyx);
+  margin: 2.3rem 0 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+.article-body h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--onyx);
+  margin: 2rem 0 0.5rem;
+}
+
+.article-body p { margin-bottom: 1.25rem; }
+
+.article-body strong {
+  font-weight: 600;
+  color: var(--onyx);
+}
+
+.article-body a {
+  color: var(--neon);
+  text-decoration: underline;
+  text-decoration-color: var(--neon-line);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.article-body a:hover { text-decoration-color: var(--neon); }
+
+.article-body ul, .article-body ol {
+  margin-bottom: 1.25rem;
+  padding-left: 1.4rem;
+}
+
+.article-body li { margin-bottom: 0.4rem; }
+.article-body li::marker { color: var(--neon); }
+
+.article-body blockquote {
+  margin: 2rem 0;
+  padding: 1rem 1.4rem;
+  border-left: 3px solid var(--neon);
+  background: var(--cloud);
+  color: var(--slate);
+}
+
+.article-body blockquote p:last-child { margin-bottom: 0; }
+
+.article-body hr {
+  border: none;
+  height: 1px;
+  background: var(--fog);
+  margin: 3rem 0;
+}
+
+.article-body code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--cloud);
+  padding: 0.14em 0.4em;
+  color: var(--onyx);
+  border-radius: 3px;
+}
+
+.article-body pre {
+  margin: 1.75rem 0;
+  padding: 1.25rem 1.4rem;
+  background: var(--onyx);
+  color: var(--cloud);
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+.article-body pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.75rem 0;
+  font-size: 0.88rem;
+}
+
+.article-body thead {
+  border-bottom: 2px solid var(--onyx);
+}
+
+.article-body th {
+  font-weight: 600;
+  text-align: left;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--onyx);
+}
+
+.article-body td {
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--fog);
+}
+
+.article-body tbody tr:hover { background: var(--cloud); }
+
+.article-body img {
+  margin: 2rem 0;
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+}
+
+/* Article nav */
+.article-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--fog);
+}
+
+.article-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.15rem 1.25rem;
+  border: 1px solid var(--fog);
+  border-radius: 8px;
+  background: var(--white);
+  transition: all var(--transition);
+}
+
+.article-nav a:hover {
+  border-color: var(--neon-line);
+  box-shadow: var(--shadow-neon);
+}
+
+.nav-prev { text-align: left; }
+.nav-next { text-align: right; grid-column: 2; }
+
+.nav-dir {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--neon);
+}
+
+.nav-title {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--onyx);
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--fog);
+  padding: 3rem 2rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.footer-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+
+.footer-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.6rem;
+}
+
+.footer-mark {
+  width: 10px; height: 10px;
+  background: var(--neon);
+  border-radius: 2px;
+}
+
+.footer-logo {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--onyx);
+  letter-spacing: -0.01em;
+}
+
+.footer-copy {
+  font-size: 0.78rem;
+  color: var(--graphite);
+  margin-bottom: 0.3rem;
+}
+
+.footer-copy a { color: var(--graphite); }
+.footer-copy a:hover { color: var(--neon); }
+
+.footer-feed {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.footer-feed a { color: var(--steel); }
+.footer-feed a:hover { color: var(--neon); }
+
+/* 404 */
+.error-page {
+  padding: 10rem 2rem;
+  text-align: center;
+}
+
+.error-page h1 {
+  font-family: var(--font-display);
+  font-size: 9rem;
+  font-weight: 800;
+  color: var(--onyx);
+  line-height: 1;
+  margin-bottom: 1rem;
+  letter-spacing: -0.05em;
+}
+
+.error-msg {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--onyx);
+  margin-bottom: 0.5rem;
+}
+
+.error-sub {
+  font-size: 0.9rem;
+  color: var(--graphite);
+  margin-bottom: 2.5rem;
+}
+
+/* Alerts */
+.alert {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  border-left: 3px solid var(--neon);
+  background: var(--cloud);
+  color: var(--slate);
+  border-radius: 0 6px 6px 0;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .post-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .nav-links {
+    position: fixed;
+    top: 0; right: -100%;
+    width: 260px; height: 100vh;
+    background: var(--white);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2.5rem;
+    transition: right var(--transition-slow);
+    box-shadow: -4px 0 24px rgba(28, 31, 35, 0.06);
+    z-index: 105;
+  }
+  .nav-links.active { right: 0; }
+  .nav-links a { font-size: 1.1rem; }
+
+  .hero { padding: 6rem 1.5rem 4.5rem; }
+  .hero-kr { font-size: 3.6rem; }
+  .hero-en { font-size: 1.2rem; }
+  .hero-grid { display: none; }
+
+  .post-grid { grid-template-columns: 1fr; }
+  .section-inner { padding: 0 1.5rem; }
+  .article-inner { padding: 0 1.5rem; }
+  .article-header h1 { font-size: 1.9rem; }
+
+  .article-nav { grid-template-columns: 1fr; }
+  .nav-next { grid-column: 1; text-align: left; }
+
+  .error-page h1 { font-size: 6rem; }
+}
+
+@media (max-width: 480px) {
+  :root { --header-h: 58px; }
+  .header-inner { padding: 0 1.25rem; }
+  .logo-en { display: none; }
+
+  .hero { padding: 4rem 1.25rem 3rem; }
+  .hero-kr { font-size: 2.8rem; }
+  .hero-en { font-size: 1rem; }
+
+  .hero-actions { flex-direction: column; align-items: stretch; }
+  .btn { width: 100%; }
+
+  .section-inner { padding: 0 1.25rem; }
+  .article-inner { padding: 0 1.25rem; }
+
+  .article-header h1 { font-size: 1.5rem; }
+  .article-body { font-size: 0.95rem; line-height: 1.75; }
+  .article-body h2 { font-size: 1.35rem; }
+  .article-body h3 { font-size: 1.1rem; }
+
+  .section-title { font-size: 1.6rem; }
+
+  .error-page h1 { font-size: 4.5rem; }
+  .error-page { padding: 6rem 1.25rem; }
+}
+
+@media print {
+  .concrete-wash, .site-header, .site-footer, .hero-actions, .article-nav, .nav-toggle, .hero-grid { display: none; }
+  body { background: #fff; color: #000; }
+}

--- a/examples/seoul-modern-minimal/templates/404.html
+++ b/examples/seoul-modern-minimal/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="error-page">
+    <h1>404</h1>
+    <p class="error-msg">Page not found.</p>
+    <p class="error-sub">This address does not exist in our city grid.</p>
+    <a href="{{ base_url }}/" class="btn btn-primary">Back to Home</a>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/templates/footer.html
+++ b/examples/seoul-modern-minimal/templates/footer.html
@@ -1,0 +1,22 @@
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <span class="footer-mark"></span>
+        <span class="footer-logo">서울 Modern</span>
+      </div>
+      <p class="footer-copy">&copy; {{ site_title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+      {% if site.feeds %}
+      <p class="footer-feed"><a href="{{ base_url }}/rss.xml">RSS</a></p>
+      {% endif %}
+    </div>
+  </footer>
+  <script>
+    document.querySelector('.nav-toggle').addEventListener('click', function() {
+      document.querySelector('.nav-links').classList.toggle('active');
+      this.classList.toggle('active');
+    });
+  </script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/seoul-modern-minimal/templates/header.html
+++ b/examples/seoul-modern-minimal/templates/header.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} | {{ site_title }}{% else %}{{ site_title }}{% endif %}</title>
+  <meta name="description" content="{{ page.description | default(site_description) }}">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+  <div class="concrete-wash" aria-hidden="true"></div>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="logo">
+        <span class="logo-mark"></span>
+        <span class="logo-kr">서울</span>
+        <span class="logo-en">Seoul Modern</span>
+      </a>
+      <nav class="site-nav">
+        <button class="nav-toggle" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="{{ base_url }}/">Home</a></li>
+          <li><a href="{{ base_url }}/posts/">Posts</a></li>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>

--- a/examples/seoul-modern-minimal/templates/home.html
+++ b/examples/seoul-modern-minimal/templates/home.html
@@ -1,0 +1,54 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <div class="hero-inner">
+      <p class="hero-eyebrow"><span class="eyebrow-dot"></span> Seoul · 37.56°N 126.98°E</p>
+      <h1 class="hero-title">
+        <span class="hero-kr">서울</span>
+        <span class="hero-en">Modern Minimal</span>
+      </h1>
+      <p class="hero-desc">{{ site_description }}</p>
+      <div class="hero-actions">
+        <a href="{{ base_url }}/posts/" class="btn btn-primary">Read Posts</a>
+        <a href="{{ base_url }}/about/" class="btn btn-outline">About</a>
+      </div>
+      <div class="hero-grid" aria-hidden="true">
+        <span></span><span></span><span></span><span></span>
+      </div>
+    </div>
+  </section>
+
+  <section class="latest-posts">
+    <div class="section-inner">
+      <div class="section-header">
+        <span class="section-index">01</span>
+        <h2 class="section-label">Latest Posts</h2>
+        <span class="section-rule"></span>
+      </div>
+      <div class="post-grid">
+        {% for post in site.pages %}
+        {% if post.date %}
+        <article class="post-card">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h3>{{ post.title }}</h3>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+            {% if post.tags %}
+            <div class="card-tags">
+              {% for tag in post.tags %}
+              <span>{{ tag }}</span>
+              {% endfor %}
+            </div>
+            {% endif %}
+            <span class="card-arrow" aria-hidden="true">→</span>
+          </a>
+        </article>
+        {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/templates/page.html
+++ b/examples/seoul-modern-minimal/templates/page.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<main>
+  <article class="article">
+    <div class="article-inner">
+      <header class="article-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="article-meta">
+          <time>{{ page.date | date("%B %d, %Y") }}</time>
+          {% if page.reading_time %}
+          <span class="dot">·</span>
+          <span>{{ page.reading_time }} min read</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.tags %}
+        <div class="article-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/">#{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </header>
+      <div class="article-body">
+        {{ content | safe }}
+      </div>
+      <nav class="article-nav">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">
+          <span class="nav-dir">← Previous</span>
+          <span class="nav-title">{{ page.lower.title }}</span>
+        </a>
+        {% endif %}
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">
+          <span class="nav-dir">Next →</span>
+          <span class="nav-title">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+      </nav>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/templates/section.html
+++ b/examples/seoul-modern-minimal/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-row">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h2>{{ post.title }}</h2>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+          </a>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/templates/shortcodes/alert.html
+++ b/examples/seoul-modern-minimal/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default: "info" }}">
+  {{ message }}
+</div>

--- a/examples/seoul-modern-minimal/templates/taxonomy.html
+++ b/examples/seoul-modern-minimal/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/seoul-modern-minimal/templates/taxonomy_term.html
+++ b/examples/seoul-modern-minimal/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/config.toml
+++ b/examples/soft-hanok-modern/config.toml
@@ -1,0 +1,47 @@
+title = "Soft Hanok"
+description = "A warm, airy theme inspired by the lines of Korean hanok — wood and lattice, softened for the screen."
+base_url = "http://localhost:3000"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "github"
+use_cdn = true
+
+[search]
+enabled = true
+format = "fuse_json"
+
+[pagination]
+enabled = false
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[sitemap]
+enabled = true
+
+[robots]
+enabled = true
+
+[feeds]
+enabled = true
+type = "rss"
+limit = 10
+sections = ["posts"]
+
+[markdown]
+safe = false
+lazy_loading = true
+
+[seo]
+llms_txt = true

--- a/examples/soft-hanok-modern/content/about.md
+++ b/examples/soft-hanok-modern/content/about.md
@@ -1,0 +1,44 @@
++++
+title = "About"
+template = "page"
++++
+
+## Soft Hanok Modern
+
+Hanok are the traditional wooden houses of Korea — timber-framed, clay-walled, roofed in curved dark tiles. Soft Hanok Modern takes the most quiet parts of a hanok — the roof line, the wooden post, the lattice window — and reduces them to marks subtle enough to live on a screen.
+
+### Design Philosophy
+
+The hanok's defining feature is not the tile or the wood itself, but the way it holds empty space. A room is defined by what is left out. This theme borrows that attitude: generous whitespace, restrained color, and a few quiet gestures — a roof curve in the hero, a lattice band at the footer, a wood-tone line beside every heading.
+
+### The Palette
+
+| Tone | Hex | Role |
+|---|---|---|
+| White | #FDFBF6 | Page surface |
+| Rice | #F7F2E7 | Warm neutral |
+| Linen | #EFE8D6 | Borders |
+| Sand | #E2D6B8 | Subtle accents |
+| Bamboo | #C9B98E | Muted lines |
+| Pine | #8E7B54 | Metadata |
+| Oak | #6B5A3A | Links |
+| Walnut | #4A3E28 | Body text |
+| Roof | #3D3222 | Hover, emphasis |
+
+### Typography
+
+- **Noto Serif KR** for headings and Hangul display
+- **Inter** for body and metadata
+- Left-bordered headings echo the vertical post (gi-dung) of a hanok
+
+### Features
+
+- Hanok roof silhouette above the hero
+- Lattice-window detail between sections and at footer
+- Warm wood-tone palette with no bright accent
+- Quiet serif typography throughout
+- Responsive from mobile to desktop
+
+### Built With
+
+This theme was built with [Hwaro](https://github.com/hahwul/hwaro), a fast and flexible static site generator.

--- a/examples/soft-hanok-modern/content/index.md
+++ b/examples/soft-hanok-modern/content/index.md
@@ -1,0 +1,4 @@
++++
+title = "Soft Hanok"
+template = "home"
++++

--- a/examples/soft-hanok-modern/content/posts/_index.md
+++ b/examples/soft-hanok-modern/content/posts/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Posts"
+sort_by = "date"
+reverse = true
+template = "section"
+generate_feeds = true
++++

--- a/examples/soft-hanok-modern/content/posts/reading-the-roof.md
+++ b/examples/soft-hanok-modern/content/posts/reading-the-roof.md
@@ -1,0 +1,33 @@
++++
+title = "Reading the Roof"
+date = "2025-04-28"
+description = "Why the hanok's curved eaves look the way they do, and what they tell us about designing for the real world."
+tags = ["hanok", "architecture", "design"]
+template = "page"
++++
+
+## Not Decoration
+
+The curve of a hanok roof is not added for beauty. It is shaped that way because of three practical constraints:
+
+1. **Weather.** Long eaves shade the interior in summer and let in the low winter sun.
+2. **Rain.** An upward curve at the end throws water clear of the wooden structure below.
+3. **Snow load.** The curve sheds snow instead of holding it.
+
+Every aesthetic decision has a structural origin. The beauty is a by-product, not a goal.
+
+## Designing the Same Way
+
+The lesson transfers cleanly to design work. The most durable visual decisions are the ones whose purpose you could defend if asked — "this border exists because otherwise the two sections merge" — rather than "this looks nice here".
+
+When you later need to change the system, purposeful decisions survive the edit. Decorative ones do not, because there is nothing beneath them to hold them up.
+
+## In This Theme
+
+The roof SVG in the hero of this site is not asking for admiration. It is doing three jobs:
+
+- Anchoring the top of the page so the hero does not feel like it is floating
+- Signaling that this is a Korean theme without writing the word "Korean" anywhere
+- Providing a dark horizontal mass against which the light cream below can read
+
+Remove the curve and the hero collapses. Which is the test of any structural element.

--- a/examples/soft-hanok-modern/content/posts/welcome-to-hanok.md
+++ b/examples/soft-hanok-modern/content/posts/welcome-to-hanok.md
@@ -1,0 +1,29 @@
++++
+title = "Welcome to Soft Hanok"
+date = "2025-05-10"
+description = "A theme that borrows the quiet geometry of the Korean hanok — roof curves, wooden posts, lattice windows."
+tags = ["hanok", "design", "introduction"]
+template = "page"
++++
+
+## A House, Simplified
+
+Stand in the courtyard of a hanok in Bukchon and look up. Between the gray tiles and the pale sky, a curve holds the whole building together. It is not ornamental. It is structural — the eaves are long to keep rain off the earthen walls — and yet it is one of the most recognizable silhouettes in Korean architecture.
+
+Soft Hanok takes that silhouette and two or three of its companions (the lattice window, the dark vertical post) and uses them sparingly as structural marks on the page.
+
+## Quiet Geometry
+
+Most themes that invoke "tradition" over-decorate. Soft Hanok tries the opposite: one curve at the top of the hero, one band of lattice at the footer, one short vertical line beside each heading. That is the entire vocabulary. Everything else is type and space.
+
+> A hanok is mostly empty. The wood and the tile are there only to frame the emptiness.
+
+## When to Use It
+
+Reach for Soft Hanok when you are writing:
+
+- Personal essays that want warmth without nostalgia
+- Content about Korean culture, food, or architecture
+- Anything where a calm reading experience matters more than visual density
+
+It is a warmer, more textured sibling to Clean Seoul, and a more structured sibling to Hanji Paper. Pick the mood that fits what you want to say.

--- a/examples/soft-hanok-modern/content/posts/wood-tones-on-screen.md
+++ b/examples/soft-hanok-modern/content/posts/wood-tones-on-screen.md
@@ -1,0 +1,49 @@
++++
+title = "Wood Tones on Screen"
+date = "2025-04-16"
+description = "Choosing a warm neutral palette that reads as 'wooden' without actually putting wood grain anywhere."
+tags = ["color", "palette", "design"]
+template = "page"
++++
+
+## Wood Without the Wood
+
+The lazy way to make a site feel wooden is to add a wood-grain background. It always looks worse than you hoped. The better approach is to pick a palette the eye already associates with timber and let the association do the work.
+
+Three tones are usually enough:
+
+- A pale cream, for the page surface
+- A muted mid-brown, for borders and low-emphasis text
+- A deep walnut, for body text and emphasis
+
+That is basically the Soft Hanok palette. No textures, no images, just a controlled range of warm neutrals.
+
+## The Key Trick
+
+The single most important move is to **keep the body text warm**. A common mistake is to pair a warm background with near-black text. The result is a page that feels like it cannot decide what temperature to be.
+
+```css
+/* Avoid */
+body { background: #F7F2E7; color: #111; }
+
+/* Prefer */
+body { background: #F7F2E7; color: #4A3E28; }
+```
+
+Walnut body text on a rice-cream background reads as a single warm system. Black body text on the same background reads as a warm background with a cool foreground stapled to it.
+
+## A Range That Works
+
+If you want to extend the three-tone system, add intermediate steps:
+
+| Step | Hex | Use |
+|---|---|---|
+| Rice | `#F7F2E7` | Section surface |
+| Linen | `#EFE8D6` | Borders |
+| Sand | `#E2D6B8` | Tags, decoration |
+| Bamboo | `#C9B98E` | Muted lines |
+| Pine | `#8E7B54` | Metadata |
+| Oak | `#6B5A3A` | Links |
+| Walnut | `#4A3E28` | Body text |
+
+Seven steps is more than you need for any individual page, but the range lets you move between intimate prose and structured documentation without ever leaving the wood-tone family.

--- a/examples/soft-hanok-modern/static/css/style.css
+++ b/examples/soft-hanok-modern/static/css/style.css
@@ -1,0 +1,971 @@
+/* ========================================
+   Soft Hanok Modern — Wood, Lattice, Light
+   White base · warm wood accents · hanok lines
+   ======================================== */
+
+:root {
+  --white: #FDFBF6;
+  --rice: #F7F2E7;
+  --linen: #EFE8D6;
+  --sand: #E2D6B8;
+  --bamboo: #C9B98E;
+  --pine: #8E7B54;
+  --oak: #6B5A3A;
+  --walnut: #4A3E28;
+  --ebony: #2A2318;
+  --roof: #3D3222;
+
+  --font-serif: 'Noto Serif KR', Georgia, serif;
+  --font-sans: 'Inter', 'Noto Sans KR', -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+
+  --max-w: 720px;
+  --max-w-wide: 1100px;
+  --header-h: 72px;
+
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.2s var(--ease);
+  --transition-slow: 0.4s var(--ease);
+
+  --shadow-sm: 0 1px 3px rgba(61, 50, 34, 0.08);
+  --shadow-md: 0 6px 22px rgba(61, 50, 34, 0.10);
+}
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--white);
+  color: var(--walnut);
+  line-height: 1.75;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main { flex: 1; }
+
+a {
+  color: var(--oak);
+  text-decoration: none;
+  border-bottom: 1px solid var(--sand);
+  transition: all var(--transition);
+}
+
+a:hover {
+  color: var(--roof);
+  border-bottom-color: var(--roof);
+}
+
+img { max-width: 100%; height: auto; display: block; }
+
+::selection { background: var(--sand); color: var(--ebony); }
+
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: var(--rice); }
+::-webkit-scrollbar-thumb { background: var(--bamboo); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--pine); }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.hero-inner, .post-grid, .post-list, .article-inner {
+  animation: fadeUp 0.5s var(--ease);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(253, 251, 246, 0.94);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--linen);
+  height: var(--header-h);
+}
+
+.header-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--walnut);
+  border-bottom: none;
+}
+
+.logo:hover {
+  color: var(--roof);
+  border-bottom: none;
+}
+
+.logo-roof {
+  color: var(--oak);
+  flex-shrink: 0;
+}
+
+.logo-kr {
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--walnut);
+  letter-spacing: -0.01em;
+}
+
+.logo-en {
+  font-family: var(--font-serif);
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--pine);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.site-nav { display: flex; align-items: center; }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  list-style: none;
+}
+
+.nav-links a {
+  font-size: 0.84rem;
+  font-weight: 500;
+  color: var(--pine);
+  padding: 0.2rem 0;
+  position: relative;
+  border-bottom: none;
+  transition: color var(--transition);
+}
+
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  bottom: -2px; left: 0;
+  width: 0; height: 1.5px;
+  background: var(--oak);
+  transition: width var(--transition);
+}
+
+.nav-links a:hover {
+  color: var(--walnut);
+  border-bottom: none;
+}
+.nav-links a:hover::after { width: 100%; }
+
+.nav-toggle {
+  display: none;
+  background: none; border: none; cursor: pointer;
+  width: 24px; height: 18px; position: relative; z-index: 110;
+}
+
+.nav-toggle span {
+  display: block; width: 100%; height: 1.5px;
+  background: var(--walnut);
+  position: absolute; left: 0;
+  transition: all var(--transition);
+}
+
+.nav-toggle span:nth-child(1) { top: 0; }
+.nav-toggle span:nth-child(2) { top: 50%; transform: translateY(-50%); }
+.nav-toggle span:nth-child(3) { bottom: 0; }
+
+.nav-toggle.active span:nth-child(1) { top: 50%; transform: translateY(-50%) rotate(45deg); }
+.nav-toggle.active span:nth-child(2) { opacity: 0; }
+.nav-toggle.active span:nth-child(3) { bottom: 50%; transform: translateY(50%) rotate(-45deg); }
+
+/* Hero */
+.hero {
+  padding: 8.5rem 2rem 7rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background: var(--rice);
+  border-bottom: 1px solid var(--linen);
+}
+
+/* Hanok roof silhouette */
+.hero-roof {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 80px;
+  color: var(--roof);
+  opacity: 0.88;
+  pointer-events: none;
+}
+
+/* Lattice window decoration (flat, no gradient) */
+.hero-lattice {
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  height: 28px;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 3px;
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.hero-lattice::before,
+.hero-lattice::after {
+  content: '';
+  grid-column: 1 / -1;
+  height: 100%;
+  background-image:
+    linear-gradient(to right, var(--pine) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--pine) 1px, transparent 1px);
+  background-size: 28px 14px;
+  background-repeat: repeat;
+}
+
+.hero-lattice::after { display: none; }
+
+.hero-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.hero-label {
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--pine);
+  margin-bottom: 2.5rem;
+}
+
+.hero-title {
+  margin-bottom: 2rem;
+}
+
+.hero-kr {
+  font-family: var(--font-serif);
+  font-size: 4.2rem;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  color: var(--walnut);
+  display: block;
+  line-height: 1.1;
+}
+
+.hero-rule {
+  display: block;
+  width: 48px;
+  height: 1.5px;
+  background: var(--pine);
+  margin: 1.5rem auto;
+  opacity: 0.7;
+}
+
+.hero-en {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 400;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  color: var(--pine);
+  display: block;
+}
+
+.hero-desc {
+  font-size: 0.98rem;
+  color: var(--oak);
+  line-height: 1.85;
+  max-width: 460px;
+  margin: 0 auto 3rem;
+}
+
+.hero-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.72rem 1.9rem;
+  font-size: 0.84rem;
+  font-weight: 500;
+  border-radius: 2px;
+  text-decoration: none;
+  transition: all var(--transition);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  border-bottom: none;
+}
+
+.btn-primary {
+  background: var(--walnut);
+  color: var(--white);
+  border: 1px solid var(--walnut);
+}
+
+.btn-primary:hover {
+  background: var(--roof);
+  border-color: var(--roof);
+  color: var(--white);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--walnut);
+  border: 1px solid var(--bamboo);
+}
+
+.btn-outline:hover {
+  border-color: var(--walnut);
+  color: var(--walnut);
+  background: var(--rice);
+}
+
+/* Sections */
+.section-inner {
+  max-width: var(--max-w-wide);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-label {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--walnut);
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--linen);
+}
+
+.latest-posts { padding: 4rem 0 6rem; }
+
+/* Post grid */
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+
+.post-card {
+  background: var(--white);
+  border: 1px solid var(--linen);
+  border-radius: 2px;
+  transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Subtle roof line on top of each card */
+.post-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: var(--sand);
+  transform: scaleX(0.2);
+  transform-origin: left;
+  transition: transform var(--transition-slow);
+}
+
+.post-card:hover {
+  border-color: var(--bamboo);
+  background: var(--rice);
+  box-shadow: var(--shadow-md);
+}
+
+.post-card:hover::before {
+  transform: scaleX(1);
+  background: var(--oak);
+}
+
+.post-card a {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.5rem 1.35rem;
+  color: inherit;
+  height: 100%;
+  border-bottom: none;
+}
+
+.post-card a:hover { border-bottom: none; }
+
+.post-card time {
+  font-size: 0.7rem;
+  color: var(--bamboo);
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+}
+
+.post-card h3 {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.35;
+  margin-bottom: 0.55rem;
+  transition: color var(--transition);
+}
+
+.post-card:hover h3 { color: var(--roof); }
+
+.post-card p {
+  font-size: 0.83rem;
+  color: var(--pine);
+  line-height: 1.65;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 1rem;
+}
+
+.card-tags span {
+  font-size: 0.64rem;
+  color: var(--oak);
+  background: var(--linen);
+  padding: 0.18rem 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+/* Section page */
+.section-page { padding: 4rem 0 6rem; }
+
+.section-title {
+  font-family: var(--font-serif);
+  font-size: 2.2rem;
+  font-weight: 600;
+  color: var(--walnut);
+  letter-spacing: -0.01em;
+  margin-bottom: 3rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 2px solid var(--oak);
+  position: relative;
+}
+
+.post-list { display: flex; flex-direction: column; }
+
+.post-row { border-bottom: 1px solid var(--linen); }
+.post-row:first-child { border-top: 1px solid var(--linen); }
+
+.post-row a {
+  display: block;
+  padding: 1.8rem 0;
+  color: inherit;
+  transition: padding-left var(--transition);
+  border-bottom: none;
+}
+
+.post-row a:hover {
+  padding-left: 1rem;
+  border-bottom: none;
+}
+
+.post-row time {
+  font-size: 0.7rem;
+  color: var(--bamboo);
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.post-row h2 {
+  font-family: var(--font-serif);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.3;
+  margin-bottom: 0.35rem;
+  transition: color var(--transition);
+}
+
+.post-row:hover h2 { color: var(--roof); }
+
+.post-row p {
+  font-size: 0.88rem;
+  color: var(--pine);
+  line-height: 1.65;
+}
+
+/* Article */
+.article { padding: 4rem 0 6rem; }
+
+.article-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.article-header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+.article-header h1 {
+  font-family: var(--font-serif);
+  font-size: 2.6rem;
+  font-weight: 600;
+  color: var(--walnut);
+  line-height: 1.18;
+  letter-spacing: -0.01em;
+  margin-bottom: 1.25rem;
+}
+
+.article-meta {
+  font-size: 0.82rem;
+  color: var(--pine);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.dot { color: var(--bamboo); }
+
+.article-tags {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.article-tags a {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--walnut);
+  background: var(--linen);
+  padding: 0.22rem 0.7rem;
+  border-bottom: none;
+  transition: all var(--transition);
+}
+
+.article-tags a:hover {
+  background: var(--walnut);
+  color: var(--white);
+  border-bottom: none;
+}
+
+.article-body {
+  font-size: 1.05rem;
+  line-height: 1.9;
+  color: var(--walnut);
+}
+
+.article-body h2 {
+  font-family: var(--font-serif);
+  font-size: 1.7rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 3rem 0 1rem;
+  line-height: 1.3;
+  padding-left: 1rem;
+  border-left: 3px solid var(--sand);
+}
+
+.article-body h3 {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 2.5rem 0 0.75rem;
+  line-height: 1.35;
+}
+
+.article-body h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--walnut);
+  margin: 2rem 0 0.5rem;
+}
+
+.article-body p { margin-bottom: 1.3rem; }
+
+.article-body strong {
+  font-weight: 600;
+  color: var(--ebony);
+}
+
+.article-body a {
+  color: var(--oak);
+  border-bottom: 1px solid var(--sand);
+}
+
+.article-body a:hover {
+  color: var(--roof);
+  border-bottom-color: var(--roof);
+}
+
+.article-body ul, .article-body ol {
+  margin-bottom: 1.3rem;
+  padding-left: 1.4rem;
+}
+
+.article-body li { margin-bottom: 0.35rem; }
+.article-body li::marker { color: var(--bamboo); }
+
+.article-body blockquote {
+  margin: 2rem 0;
+  padding: 1.25rem 1.5rem;
+  border-left: 3px solid var(--oak);
+  background: var(--rice);
+  font-style: italic;
+  color: var(--walnut);
+}
+
+.article-body blockquote p:last-child { margin-bottom: 0; }
+
+.article-body hr {
+  border: none;
+  height: 1px;
+  background: var(--sand);
+  margin: 3rem auto;
+  max-width: 64px;
+}
+
+.article-body code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--rice);
+  padding: 0.14em 0.4em;
+  color: var(--walnut);
+  border: 1px solid var(--linen);
+  border-radius: 2px;
+}
+
+.article-body pre {
+  margin: 1.75rem 0;
+  padding: 1.25rem 1.4rem;
+  background: var(--rice);
+  border: 1px solid var(--linen);
+  border-left: 3px solid var(--oak);
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+.article-body pre code {
+  background: none;
+  padding: 0;
+  border: none;
+  font-size: inherit;
+}
+
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.75rem 0;
+  font-size: 0.88rem;
+}
+
+.article-body thead { border-bottom: 2px solid var(--walnut); }
+
+.article-body th {
+  font-weight: 600;
+  text-align: left;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--walnut);
+}
+
+.article-body td {
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--linen);
+}
+
+.article-body tbody tr:hover { background: var(--rice); }
+
+.article-body img {
+  margin: 2rem 0;
+  border-radius: 2px;
+  box-shadow: var(--shadow-md);
+}
+
+/* Article nav */
+.article-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--oak);
+}
+
+.article-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.15rem 1.25rem;
+  border: 1px solid var(--linen);
+  background: var(--white);
+  transition: all var(--transition);
+  border-bottom: 1px solid var(--linen);
+}
+
+.article-nav a:hover {
+  border-color: var(--walnut);
+  background: var(--rice);
+}
+
+.nav-prev { text-align: left; }
+.nav-next { text-align: right; grid-column: 2; }
+
+.nav-dir {
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--bamboo);
+}
+
+.nav-title {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--walnut);
+  line-height: 1.4;
+}
+
+/* Footer */
+.site-footer {
+  position: relative;
+  border-top: 1px solid var(--linen);
+  padding: 3rem 2rem;
+  text-align: center;
+  background: var(--rice);
+  overflow: hidden;
+}
+
+/* Lattice band at top of footer */
+.footer-lattice {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 12px;
+  background-image:
+    linear-gradient(to right, var(--bamboo) 1px, transparent 1px);
+  background-size: 28px 12px;
+  opacity: 0.5;
+}
+
+.footer-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
+.footer-logo {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--walnut);
+}
+
+.footer-sep { color: var(--bamboo); font-weight: 300; }
+
+.footer-en {
+  font-family: var(--font-serif);
+  font-size: 0.72rem;
+  color: var(--pine);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footer-copy {
+  font-size: 0.78rem;
+  color: var(--pine);
+  margin-bottom: 0.3rem;
+}
+
+.footer-copy a {
+  color: var(--pine);
+  border-bottom-color: var(--sand);
+}
+
+.footer-copy a:hover {
+  color: var(--walnut);
+  border-bottom-color: var(--walnut);
+}
+
+.footer-feed { font-size: 0.74rem; }
+
+.footer-feed a {
+  color: var(--bamboo);
+  border-bottom: none;
+}
+
+.footer-feed a:hover { color: var(--walnut); border-bottom: none; }
+
+/* 404 */
+.error-page {
+  padding: 10rem 2rem;
+  text-align: center;
+}
+
+.error-page h1 {
+  font-family: var(--font-serif);
+  font-size: 10rem;
+  font-weight: 300;
+  color: var(--linen);
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.error-msg {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 500;
+  color: var(--walnut);
+  margin-bottom: 0.5rem;
+}
+
+.error-sub {
+  font-size: 0.9rem;
+  color: var(--pine);
+  margin-bottom: 2.5rem;
+}
+
+/* Alerts */
+.alert {
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  border-left: 3px solid var(--oak);
+  background: var(--rice);
+  color: var(--walnut);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .nav-links {
+    position: fixed;
+    top: 0; right: -100%;
+    width: 240px; height: 100vh;
+    background: var(--white);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2.5rem;
+    transition: right var(--transition-slow);
+    box-shadow: -4px 0 20px rgba(61, 50, 34, 0.08);
+    z-index: 105;
+  }
+  .nav-links.active { right: 0; }
+  .nav-links a { font-size: 1.1rem; }
+
+  .hero { padding: 7rem 1.5rem 5.5rem; }
+  .hero-roof { height: 56px; }
+  .hero-kr { font-size: 3rem; }
+  .hero-en { font-size: 0.88rem; letter-spacing: 0.28em; }
+
+  .post-grid { grid-template-columns: 1fr; }
+  .section-inner { padding: 0 1.5rem; }
+  .article-inner { padding: 0 1.5rem; }
+  .article-header h1 { font-size: 2rem; }
+
+  .article-nav { grid-template-columns: 1fr; }
+  .nav-next { grid-column: 1; text-align: left; }
+
+  .error-page h1 { font-size: 6rem; }
+}
+
+@media (max-width: 480px) {
+  :root { --header-h: 60px; }
+  .header-inner { padding: 0 1.25rem; }
+  .logo-en { display: none; }
+
+  .hero { padding: 5rem 1.25rem 4rem; }
+  .hero-roof { height: 40px; }
+  .hero-kr { font-size: 2.4rem; }
+  .hero-rule { width: 36px; margin: 1rem auto; }
+  .hero-en { font-size: 0.76rem; letter-spacing: 0.22em; }
+  .hero-desc { font-size: 0.88rem; margin-bottom: 2rem; }
+
+  .hero-actions { flex-direction: column; align-items: center; }
+  .btn { width: 100%; max-width: 200px; }
+
+  .section-inner { padding: 0 1.25rem; }
+  .article-inner { padding: 0 1.25rem; }
+
+  .article-header h1 { font-size: 1.65rem; }
+  .article-body { font-size: 1rem; line-height: 1.8; }
+  .article-body h2 { font-size: 1.4rem; }
+  .article-body h3 { font-size: 1.15rem; }
+
+  .section-title { font-size: 1.6rem; }
+  .post-row h2 { font-size: 1.2rem; }
+  .post-card h3 { font-size: 1.05rem; }
+
+  .error-page h1 { font-size: 4rem; }
+  .error-page { padding: 6rem 1.25rem; }
+
+  .footer-brand { flex-direction: column; gap: 0.15rem; }
+  .footer-sep { display: none; }
+}
+
+@media print {
+  .site-header, .site-footer, .hero-actions, .article-nav, .nav-toggle,
+  .hero-roof, .hero-lattice, .footer-lattice { display: none; }
+  body { background: #fff; color: #000; }
+}

--- a/examples/soft-hanok-modern/templates/404.html
+++ b/examples/soft-hanok-modern/templates/404.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="error-page">
+    <h1>404</h1>
+    <p class="error-msg">Page not found.</p>
+    <p class="error-sub">The gate you tried is closed today.</p>
+    <a href="{{ base_url }}/" class="btn btn-primary">Back to Home</a>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/templates/footer.html
+++ b/examples/soft-hanok-modern/templates/footer.html
@@ -1,0 +1,24 @@
+  <footer class="site-footer">
+    <div class="footer-lattice" aria-hidden="true"></div>
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <span class="footer-logo">한옥</span>
+        <span class="footer-sep">·</span>
+        <span class="footer-en">Soft Hanok Modern</span>
+      </div>
+      <p class="footer-copy">&copy; {{ site_title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+      {% if site.feeds %}
+      <p class="footer-feed"><a href="{{ base_url }}/rss.xml">RSS</a></p>
+      {% endif %}
+    </div>
+  </footer>
+  <script>
+    document.querySelector('.nav-toggle').addEventListener('click', function() {
+      document.querySelector('.nav-links').classList.toggle('active');
+      this.classList.toggle('active');
+    });
+  </script>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/soft-hanok-modern/templates/header.html
+++ b/examples/soft-hanok-modern/templates/header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page_title %}{{ page_title }} | {{ site_title }}{% else %}{{ site_title }}{% endif %}</title>
+  <meta name="description" content="{{ page.description | default(site_description) }}">
+  {{ og_all_tags }}
+  {{ canonical_tag }}
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a href="{{ base_url }}/" class="logo">
+        <svg class="logo-roof" width="28" height="14" viewBox="0 0 28 14" aria-hidden="true">
+          <path d="M1 13 Q 14 0, 27 13" stroke="currentColor" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+          <line x1="4" y1="13" x2="24" y2="13" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+        </svg>
+        <span class="logo-kr">한옥</span>
+        <span class="logo-en">Soft Hanok</span>
+      </a>
+      <nav class="site-nav">
+        <button class="nav-toggle" aria-label="Toggle navigation">
+          <span></span><span></span><span></span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="{{ base_url }}/">Home</a></li>
+          <li><a href="{{ base_url }}/posts/">Posts</a></li>
+          <li><a href="{{ base_url }}/about/">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>

--- a/examples/soft-hanok-modern/templates/home.html
+++ b/examples/soft-hanok-modern/templates/home.html
@@ -1,0 +1,54 @@
+{% include "header.html" %}
+<main>
+  <section class="hero">
+    <svg class="hero-roof" viewBox="0 0 1200 120" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M0 120 Q 600 0, 1200 120 L 1200 120 L 0 120 Z" fill="currentColor"/>
+    </svg>
+    <div class="hero-inner">
+      <p class="hero-label">Seoul · Hanok Living</p>
+      <h1 class="hero-title">
+        <span class="hero-kr">한옥</span>
+        <span class="hero-rule"></span>
+        <span class="hero-en">Soft Hanok Modern</span>
+      </h1>
+      <p class="hero-desc">{{ site_description }}</p>
+      <div class="hero-actions">
+        <a href="{{ base_url }}/posts/" class="btn btn-primary">Read Posts</a>
+        <a href="{{ base_url }}/about/" class="btn btn-outline">About</a>
+      </div>
+    </div>
+    <div class="hero-lattice" aria-hidden="true"></div>
+  </section>
+
+  <section class="latest-posts">
+    <div class="section-inner">
+      <div class="section-header">
+        <h2 class="section-label">Latest</h2>
+        <span class="section-rule"></span>
+      </div>
+      <div class="post-grid">
+        {% for post in site.pages %}
+        {% if post.date %}
+        <article class="post-card">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h3>{{ post.title }}</h3>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+            {% if post.tags %}
+            <div class="card-tags">
+              {% for tag in post.tags %}
+              <span>{{ tag }}</span>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </a>
+        </article>
+        {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/templates/page.html
+++ b/examples/soft-hanok-modern/templates/page.html
@@ -1,0 +1,44 @@
+{% include "header.html" %}
+<main>
+  <article class="article">
+    <div class="article-inner">
+      <header class="article-header">
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <div class="article-meta">
+          <time>{{ page.date | date("%B %d, %Y") }}</time>
+          {% if page.reading_time %}
+          <span class="dot">·</span>
+          <span>{{ page.reading_time }} min read</span>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if page.tags %}
+        <div class="article-tags">
+          {% for tag in page.tags %}
+          <a href="{{ base_url }}/tags/{{ tag | slugify }}/">{{ tag }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </header>
+      <div class="article-body">
+        {{ content | safe }}
+      </div>
+      <nav class="article-nav">
+        {% if page.lower %}
+        <a href="{{ base_url }}{{ page.lower.url }}" class="nav-prev">
+          <span class="nav-dir">Previous</span>
+          <span class="nav-title">{{ page.lower.title }}</span>
+        </a>
+        {% endif %}
+        {% if page.higher %}
+        <a href="{{ base_url }}{{ page.higher.url }}" class="nav-next">
+          <span class="nav-dir">Next</span>
+          <span class="nav-title">{{ page.higher.title }}</span>
+        </a>
+        {% endif %}
+      </nav>
+    </div>
+  </article>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/templates/section.html
+++ b/examples/soft-hanok-modern/templates/section.html
@@ -1,0 +1,22 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      <div class="post-list">
+        {% for post in section.pages %}
+        <article class="post-row">
+          <a href="{{ base_url }}{{ post.url }}">
+            <time>{{ post.date | date("%Y.%m.%d") }}</time>
+            <h2>{{ post.title }}</h2>
+            {% if post.description %}
+            <p>{{ post.description }}</p>
+            {% endif %}
+          </a>
+        </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/templates/shortcodes/alert.html
+++ b/examples/soft-hanok-modern/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{ type | default: "info" }}">
+  {{ message }}
+</div>

--- a/examples/soft-hanok-modern/templates/taxonomy.html
+++ b/examples/soft-hanok-modern/templates/taxonomy.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/examples/soft-hanok-modern/templates/taxonomy_term.html
+++ b/examples/soft-hanok-modern/templates/taxonomy_term.html
@@ -1,0 +1,10 @@
+{% include "header.html" %}
+<main>
+  <section class="section-page">
+    <div class="section-inner">
+      <h1 class="section-title">{{ page.title }}</h1>
+      {{ content | safe }}
+    </div>
+  </section>
+</main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -1110,6 +1110,13 @@
     "minimal",
     "typography"
   ],
+  "clean-seoul": [
+    "light",
+    "blog",
+    "minimal",
+    "seoul",
+    "typography"
+  ],
   "clocktower": [
     "dark",
     "landing",
@@ -2415,6 +2422,14 @@
     "dark",
     "blog",
     "aviation"
+  ],
+  "hanji-paper": [
+    "light",
+    "blog",
+    "paper",
+    "seoul",
+    "warm",
+    "serif"
   ],
   "hardcore-pit": [
     "event",
@@ -4910,6 +4925,13 @@
     "docs",
     "monitoring"
   ],
+  "seoul-modern-minimal": [
+    "light",
+    "blog",
+    "seoul",
+    "minimal",
+    "modern"
+  ],
   "seraph": [
     "minimal",
     "elegant",
@@ -5024,6 +5046,14 @@
     "community",
     "neon",
     "creative"
+  ],
+  "soft-hanok-modern": [
+    "light",
+    "blog",
+    "seoul",
+    "hanok",
+    "warm",
+    "serif"
   ],
   "solar-punk": [
     "light",


### PR DESCRIPTION
## Summary

Adds four light blog themes exploring different facets of Seoul design language, all sharing a restrained monochrome / warm-neutral direction.

- **hanji-paper** — cream + walnut ink with a subtle SVG hanji grain overlay; serif-driven editorial tone
- **seoul-modern-minimal** — cool grays with a single electric-blue accent; Inter/Pretendard sans + JetBrains Mono micro-details
- **soft-hanok-modern** — wood-tone palette with hanok roof curve and lattice band motifs; warm serif headings
- **clean-seoul** — typography-first signature. Giant `서울` display mark in **우아한 세리프 (Grace Serif via [noonnu.cc/1800](https://noonnu.cc/font_page/1800))**, vertical `깨끗한 서울` rail, `ㅅㅓㅇㅜㄹ` jamo decomposition grid, CSS-counter `글 01 / 글 02` magazine-style post ordinals, `서울` footer wordmark, `없음` 404 treatment

`tags.json` has an entry for each new example. No gradients, no emojis.

## Test plan

- [x] `hwaro build` succeeds locally for each of the four examples
- [x] CI `check-new-examples` workflow trial-build passes
- [x] `tags.json` entry check passes for all four
- [x] Home, posts list, post, 404, and about pages render as expected for each theme
- [x] Responsive behavior verified at 1200px / 768px / 480px