### PR TITLE
Fix 404 for /about in archipelago example

### DIFF
--- a/examples/archipelago/content/_index.md
+++ b/examples/archipelago/content/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Archipelago"
+description = "Archipelago"
 template = "index"
 +++

--- a/examples/archipelago/content/about.md
+++ b/examples/archipelago/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About"
+description = "About Archipelago"
++++
+
+# About
+
+Archipelago is an ecosystem of projects.

--- a/examples/archipelago/content/projects/_index.md
+++ b/examples/archipelago/content/projects/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Projects"
+description = "Projects"
 sort_by = "weight"
 +++
 Explore our ecosystem of tools and platforms.


### PR DESCRIPTION
Resolves the 404 error for the `/about` link in the `archipelago` example. Added the missing `about.md` and added descriptions to the `_index.md` files to pass validation.

---
*PR created automatically by Jules for task [11997398200499967795](https://jules.google.com/task/11997398200499967795) started by @chei-l*