### PR TITLE
Fix broken /about/ link in aether-shard example

### DIFF
--- a/examples/aether-shard/content/about.md
+++ b/examples/aether-shard/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About Aether Shard"
++++
+
+This is the about page for the Aether Shard example.


### PR DESCRIPTION
Fixes a broken link in the `aether-shard` example.

- Scanned examples for 404 links.
- Found that `examples/aether-shard` had a broken `/about/` link.
- Created `examples/aether-shard/content/about.md` to resolve the 404.

---
*PR created automatically by Jules for task [5802379754105134982](https://jules.google.com/task/5802379754105134982) started by @hahwul*