### PR TITLE
Add luminescent-glass-prism example

### DIFF
--- a/examples/luminescent-glass-prism/AGENTS.md
+++ b/examples/luminescent-glass-prism/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/luminescent-glass-prism/config.toml
+++ b/examples/luminescent-glass-prism/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Luminescent Glass Prism"
+description = "A luminescent glassmorphism portfolio site"
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/luminescent-glass-prism/content/about.md
+++ b/examples/luminescent-glass-prism/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
+description = "About this design"
++++
+# About
+This is a showcase of dark glassmorphism.

--- a/examples/luminescent-glass-prism/content/index.md
+++ b/examples/luminescent-glass-prism/content/index.md
@@ -1,0 +1,7 @@
++++
+title = "Welcome"
+description = "Homepage of Luminescent Glass Prism"
+tags = ["portfolio"]
++++
+# Enter the Prism
+Welcome to a luminous space.

--- a/examples/luminescent-glass-prism/templates/404.html
+++ b/examples/luminescent-glass-prism/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminescent-glass-prism/templates/footer.html
+++ b/examples/luminescent-glass-prism/templates/footer.html
@@ -1,0 +1,6 @@
+    <footer class="site-footer">
+      <p>&copy; {{ current_year }} {{ site.title }}. Built with <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/luminescent-glass-prism/templates/header.html
+++ b/examples/luminescent-glass-prism/templates/header.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      --primary: #00e5ff;
+      --primary-glow: rgba(0, 229, 255, 0.6);
+      --text: #e0e0e0;
+      --text-muted: #9e9e9e;
+      --border: rgba(255, 255, 255, 0.1);
+      --bg-glass: rgba(255, 255, 255, 0.05);
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text);
+      background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
+      background-attachment: fixed;
+      min-height: 100vh;
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 1.5rem; }
+
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.25rem 2rem;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      border-radius: 12px;
+      background: var(--bg-glass);
+      backdrop-filter: blur(15px);
+      -webkit-backdrop-filter: blur(15px);
+      border: 1px solid var(--border);
+      box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    }
+
+    .site-logo {
+      font-weight: 700;
+      font-size: 1.3rem;
+      color: #fff;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 0 0 10px var(--primary-glow);
+    }
+    .site-logo:hover { color: var(--primary); }
+
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+    .site-header nav a:hover {
+      color: var(--primary);
+      text-shadow: 0 0 8px var(--primary-glow);
+    }
+
+    .site-main { min-height: calc(100vh - 250px); }
+
+    .site-footer {
+      margin-top: 3rem;
+      margin-bottom: 2rem;
+      padding: 1.5rem 2rem;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-align: center;
+      background: var(--bg-glass);
+      backdrop-filter: blur(15px);
+      -webkit-backdrop-filter: blur(15px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    }
+
+    /* Glass Panel Component */
+    .glass-panel {
+      background: var(--bg-glass);
+      backdrop-filter: blur(15px);
+      -webkit-backdrop-filter: blur(15px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2.5rem;
+      box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+      margin-bottom: 2rem;
+    }
+
+    /* Typography */
+    h1, h2, h3 {
+      line-height: 1.3;
+      margin-top: 0;
+      margin-bottom: 1em;
+      font-weight: 600;
+      color: #fff;
+    }
+    h1 { font-size: 2.2rem; text-shadow: 0 0 15px rgba(255,255,255,0.2); }
+    h2 { font-size: 1.6rem; }
+    h3 { font-size: 1.3rem; }
+    p { margin: 1em 0; }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+      transition: text-shadow 0.3s ease;
+    }
+    a:hover {
+      text-decoration: underline;
+      text-shadow: 0 0 8px var(--primary-glow);
+    }
+
+    code {
+      background: rgba(0,0,0,0.3);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      border: 1px solid rgba(255,255,255,0.05);
+    }
+
+    pre {
+      background: rgba(0,0,0,0.4);
+      padding: 1.2rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
+    }
+    pre code { background: none; padding: 0; border: none; }
+
+    /* Lists */
+    ul.section-list, ul {
+      list-style: none;
+      padding: 0;
+      margin: 1.5rem 0;
+    }
+    ul li {
+      margin-bottom: 0.8rem;
+      padding: 0.8rem 1rem;
+      background: rgba(255,255,255,0.03);
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.05);
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+    ul li:hover {
+      background: rgba(255,255,255,0.08);
+      transform: translateX(5px);
+      border-color: rgba(255,255,255,0.15);
+    }
+    ul li a { font-weight: 500; display: block; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; align-items: center; padding: 1.5rem; }
+      .site-wrapper { padding: 0 1rem; }
+      .glass-panel { padding: 1.5rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/luminescent-glass-prism/templates/page.html
+++ b/examples/luminescent-glass-prism/templates/page.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      {{ content | safe }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminescent-glass-prism/templates/section.html
+++ b/examples/luminescent-glass-prism/templates/section.html
@@ -1,0 +1,36 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ section.title | e }}</h1>
+      {% if section.description %}
+      <p class="taxonomy-desc">{{ section.description | e }}</p>
+      {% endif %}
+
+      <ul class="section-list">
+      {% for p in pages %}
+        <li><a href="{{ p.url }}">{{ p.title | e }}</a> <span style="font-size: 0.85em; color: var(--text-muted); float: right;">{{ p.date | date("%Y-%m-%d") }}</span></li>
+      {% endfor %}
+      </ul>
+
+      {% if pagination is defined and pagination.total_pages is defined and pagination.total_pages > 1 %}
+      <nav class="pagination">
+        <ul class="pagination-list">
+          {% if pagination.previous_url %}
+            <li><a href="{{ pagination.previous_url }}">&larr; Prev</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>&larr; Prev</span></li>
+          {% endif %}
+
+          <li class="pagination-current"><span>Page {{ pagination.current_page }} of {{ pagination.total_pages }}</span></li>
+
+          {% if pagination.next_url %}
+            <li><a href="{{ pagination.next_url }}">Next &rarr;</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>Next &rarr;</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+      {% endif %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminescent-glass-prism/templates/shortcodes/alert.html
+++ b/examples/luminescent-glass-prism/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/luminescent-glass-prism/templates/taxonomy.html
+++ b/examples/luminescent-glass-prism/templates/taxonomy.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ page.title | e }}</h1>
+      <ul class="section-list">
+      {% for term in taxonomy_terms %}
+        <li><a href="{{ term.url }}">{{ term.name | e }}</a> ({{ term.pages_count }})</li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/luminescent-glass-prism/templates/taxonomy_term.html
+++ b/examples/luminescent-glass-prism/templates/taxonomy_term.html
@@ -1,0 +1,34 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel">
+      <h1>{{ taxonomy_term.name | e }}</h1>
+      <p class="taxonomy-desc">Pages tagged with "{{ taxonomy_term.name | e }}"</p>
+
+      <ul class="section-list">
+      {% for p in taxonomy_pages %}
+        <li><a href="{{ p.url }}">{{ p.title | e }}</a></li>
+      {% endfor %}
+      </ul>
+
+      {% if pagination is defined and pagination.total_pages is defined and pagination.total_pages > 1 %}
+      <nav class="pagination">
+        <ul class="pagination-list">
+          {% if pagination.previous_url %}
+            <li><a href="{{ pagination.previous_url }}">&larr; Prev</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>&larr; Prev</span></li>
+          {% endif %}
+
+          <li class="pagination-current"><span>Page {{ pagination.current_page }} of {{ pagination.total_pages }}</span></li>
+
+          {% if pagination.next_url %}
+            <li><a href="{{ pagination.next_url }}">Next &rarr;</a></li>
+          {% else %}
+            <li class="pagination-disabled"><span>Next &rarr;</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+      {% endif %}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/tags.json
+++ b/tags.json
@@ -3108,6 +3108,11 @@
     "neon",
     "portfolio"
   ],
+  "luminescent-glass-prism": [
+    "dark",
+    "portfolio",
+    "glassmorphism"
+  ],
   "luminescent-mesh": [
     "dark",
     "blog",


### PR DESCRIPTION
This PR introduces a new example site to the hwaro-examples repository named `luminescent-glass-prism`. It focuses on demonstrating a "dark glassmorphism" aesthetic with neon accents.

Changes:
- Generated initial directory structure using `hwaro init`.
- Updated `config.toml` with the new site title and description.
- Restyled `header.html` with a custom CSS layout utilizing CSS variables, linear gradients, and `backdrop-filter: blur()`.
- Updated `page.html`, `section.html`, `taxonomy.html`, and `taxonomy_term.html` to align with the new layout by wrapping content in the `.glass-panel` component class.
- Replaced the generated `{% if page.title is present %}` with `{% if page.title %}` in `header.html` to fix false positive flags in syntax linting.
- Ensured default values in taxonomy term templates to fix potential undefined warnings during build.
- Updated `tags.json` securely to categorize the new design as `"dark", "portfolio", "glassmorphism"`.
- Verified changes visually and via the CLI.

---
*PR created automatically by Jules for task [3348066306482093183](https://jules.google.com/task/3348066306482093183) started by @chei-l*