### PR TITLE
Add lumina-synth-void example project

### DIFF
--- a/examples/lumina-synth-void/AGENTS.md
+++ b/examples/lumina-synth-void/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/lumina-synth-void/config.toml
+++ b/examples/lumina-synth-void/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Lumina Synth Void"
+description = "A futuristic synth void themed glassmorphism site."
+base_url = "https://example.com"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/lumina-synth-void/content/about.md
+++ b/examples/lumina-synth-void/content/about.md
@@ -1,0 +1,18 @@
++++
+title = "About the Void Architects"
+description = "Discover the minds behind the Lumina Synth Void."
+tags = ["about", "creators", "lore"]
+categories = ["pages"]
++++
+
+We are the **Void Architects**, creators of digital realms that bridge the gap between human perception and raw data streams.
+
+The **Lumina Synth Void** was engineered to provide a sanctuary in the vast, chaotic sea of information. By fusing glassmorphism with cyberpunk aesthetics, we offer an interface that is both ethereal and profoundly grounded in deep cyber mechanics.
+
+## Our Philosophy
+
+*   **Transparency:** Clear, translucent structures revealing the hidden depth.
+*   **Illumination:** Neon accents illuminating the dark corners of the web.
+*   **Infinite Depth:** An immersive experience simulating the vastness of the digital universe.
+
+Return to the [Nexus](/).

--- a/examples/lumina-synth-void/content/index.md
+++ b/examples/lumina-synth-void/content/index.md
@@ -1,0 +1,26 @@
++++
+title = "Enter the Lumina Synth Void"
+description = "A futuristic journey through the cyber void."
+tags = ["cyberpunk", "synth", "void", "glassmorphism"]
+categories = ["design", "future"]
++++
+
+Welcome to the **Lumina Synth Void**, a designated sector where retro-futurism meets deep space glassmorphism.
+
+## The Grid
+
+Navigate the neon-lit pathways and translucent architectures built entirely in the Hwaro framework. Our cybernetic glass panels reflect the glowing essence of the digital frontier.
+
+> "In the void, light and glass are the only constants. The grid shapes our reality."
+>
+> — Unknown Architect
+
+## Key Features
+
+1. **Neon Accents:** Bright cyan, magenta, and purple glows guiding the way.
+2. **Glassmorphism:** Frosted translucent panels that float above the infinite background.
+3. **Deep Void:** A backdrop darker than space itself.
+
+Explore the cyber constructs and dive deeper into the code.
+
+[Learn more about us](/about/) or browse our [Taxonomies](/tags/).

--- a/examples/lumina-synth-void/static/css/style.css
+++ b/examples/lumina-synth-void/static/css/style.css
@@ -1,0 +1,499 @@
+/*
+  Lumina Synth Void Theme
+  A futuristic, deep space synth void themed glassmorphism design.
+*/
+
+:root {
+  /* Core Colors */
+  --bg-deep-void: #020108;
+  --bg-space: #070514;
+
+  /* Neon Accents */
+  --neon-cyan: #00f0ff;
+  --neon-magenta: #ff0055;
+  --neon-purple: #8a2be2;
+
+  /* Text */
+  --text-main: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-dark: #0f172a;
+
+  /* Glassmorphism */
+  --glass-bg: rgba(10, 15, 30, 0.4);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-border-hover: rgba(0, 240, 255, 0.3);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+
+  /* Fonts */
+  --font-body: 'Inter', sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  color: var(--text-main);
+  background-color: var(--bg-deep-void);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Background Effects */
+.synth-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  background: radial-gradient(circle at 50% 50%, var(--bg-space) 0%, var(--bg-deep-void) 100%);
+  overflow: hidden;
+}
+
+.grid-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 200%;
+  height: 200%;
+  background-image:
+    linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 50px 50px;
+  transform: perspective(500px) rotateX(60deg) translateY(-100px) translateZ(-200px);
+  animation: grid-move 20s linear infinite;
+  z-index: 1;
+}
+
+@keyframes grid-move {
+  0% { transform: perspective(500px) rotateX(60deg) translateY(0) translateZ(-200px); }
+  100% { transform: perspective(500px) rotateX(60deg) translateY(50px) translateZ(-200px); }
+}
+
+.glow-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.5;
+  z-index: 0;
+  animation: float 10s ease-in-out infinite alternate;
+}
+
+.glow-orb.cyan {
+  width: 40vw;
+  height: 40vw;
+  background: var(--neon-cyan);
+  top: -10%;
+  left: -10%;
+  animation-delay: 0s;
+}
+
+.glow-orb.magenta {
+  width: 30vw;
+  height: 30vw;
+  background: var(--neon-magenta);
+  bottom: 10%;
+  right: -5%;
+  animation-delay: -3s;
+}
+
+.glow-orb.purple {
+  width: 35vw;
+  height: 35vw;
+  background: var(--neon-purple);
+  top: 40%;
+  left: 30%;
+  animation-delay: -6s;
+  opacity: 0.3;
+}
+
+@keyframes float {
+  0% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(5%, 5%) scale(1.1); }
+  100% { transform: translate(-5%, 10%) scale(0.9); }
+}
+
+/* Layout */
+.site-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  line-height: 1.2;
+}
+
+a {
+  color: var(--neon-cyan);
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+a:hover {
+  color: var(--neon-magenta);
+  text-shadow: 0 0 8px rgba(255, 0, 85, 0.5);
+}
+
+p {
+  margin-bottom: 1.5rem;
+}
+
+/* Glassmorphism Classes */
+.glass-panel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  box-shadow: var(--glass-shadow);
+  padding: 2.5rem;
+  margin-bottom: 2rem;
+  transition: border-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.glass-panel:hover {
+  border-color: rgba(0, 240, 255, 0.2);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.6), 0 0 20px rgba(0, 240, 255, 0.1);
+}
+
+/* Header */
+.glass-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  margin: 2rem 0;
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: 100px;
+  box-shadow: var(--glass-shadow);
+  position: sticky;
+  top: 1rem;
+  z-index: 100;
+}
+
+.logo-text {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  background: linear-gradient(to right, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 20px rgba(0, 240, 255, 0.3);
+}
+
+.main-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: var(--text-main);
+  font-weight: 600;
+  font-size: 0.95rem;
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 2px;
+  bottom: -4px;
+  left: 0;
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+  transition: width 0.3s ease;
+}
+
+.nav-link:hover::after {
+  width: 100%;
+}
+
+.nav-link:hover {
+  color: #fff;
+}
+
+/* Main Content Area */
+.site-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-title {
+  font-size: 3rem;
+  margin-top: 0;
+  margin-bottom: 2rem;
+  background: linear-gradient(to right, #fff, var(--text-muted));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Content Body Typography */
+.content-body h2 {
+  font-size: 2rem;
+  color: #fff;
+  border-bottom: 1px solid var(--glass-border);
+  padding-bottom: 0.5rem;
+}
+
+.content-body h3 {
+  font-size: 1.5rem;
+  color: var(--text-main);
+}
+
+.content-body img {
+  max-width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--glass-border);
+}
+
+.content-body code {
+  background: rgba(0, 0, 0, 0.5);
+  color: var(--neon-cyan);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9em;
+  border: 1px solid rgba(0, 240, 255, 0.2);
+}
+
+.content-body pre {
+  background: rgba(5, 5, 10, 0.8);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--glass-border);
+  overflow-x: auto;
+}
+
+.content-body pre code {
+  background: transparent;
+  border: none;
+  color: #e2e8f0;
+  padding: 0;
+}
+
+.content-body blockquote {
+  margin: 2rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 4px solid var(--neon-magenta);
+  background: linear-gradient(90deg, rgba(255, 0, 85, 0.1) 0%, transparent 100%);
+  border-radius: 0 8px 8px 0;
+  font-style: italic;
+}
+
+/* Section Lists */
+ul.section-list, .section-items ul {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+ul.section-list li, .section-items li {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+ul.section-list li:hover, .section-items li:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(0, 240, 255, 0.3);
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3), 0 0 15px rgba(0, 240, 255, 0.1);
+}
+
+ul.section-list li a, .section-items li a {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* Pagination */
+nav.pagination {
+  margin: 3rem 0;
+}
+
+.pagination-list {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+}
+
+.pagination-list a, .pagination-list span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--text-main);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.pagination-list a:hover {
+  border-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+}
+
+.pagination-current span {
+  background: rgba(0, 240, 255, 0.1);
+  border-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+}
+
+.pagination-disabled span {
+  opacity: 0.3;
+}
+
+/* Footer */
+.glass-footer {
+  margin-top: auto;
+  padding: 2rem;
+  background: rgba(10, 15, 30, 0.2);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-top: 1px solid var(--glass-border);
+  margin-bottom: 2rem;
+  border-radius: 24px;
+}
+
+.footer-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer-content p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.glow-text {
+  color: var(--neon-cyan);
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.4);
+}
+
+.social-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.social-links a {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.social-links a:hover {
+  color: var(--neon-magenta);
+}
+
+/* Special Components */
+.glitch-text {
+  font-size: 6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  position: relative;
+  text-shadow: 0.05em 0 0 rgba(255, 0, 85, 0.75), -0.025em -0.05em 0 rgba(0, 240, 255, 0.75),
+               0.025em 0.05em 0 rgba(138, 43, 226, 0.75);
+  animation: glitch 500ms infinite;
+  margin: 0;
+}
+
+.btn-glow {
+  display: inline-block;
+  padding: 0.8rem 2rem;
+  background: transparent;
+  color: var(--neon-cyan);
+  border: 1px solid var(--neon-cyan);
+  border-radius: 100px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 15px rgba(0, 240, 255, 0.2), inset 0 0 15px rgba(0, 240, 255, 0.1);
+}
+
+.btn-glow:hover {
+  background: var(--neon-cyan);
+  color: var(--bg-deep-void);
+  box-shadow: 0 0 25px rgba(0, 240, 255, 0.6);
+  text-shadow: none;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.mt-4 {
+  margin-top: 2rem;
+}
+
+@keyframes glitch {
+  0% { text-shadow: 0.05em 0 0 rgba(255, 0, 85, 0.75), -0.05em -0.025em 0 rgba(0, 240, 255, 0.75), 0.025em 0.05em 0 rgba(138, 43, 226, 0.75); }
+  14% { text-shadow: 0.05em 0 0 rgba(255, 0, 85, 0.75), -0.05em -0.025em 0 rgba(0, 240, 255, 0.75), 0.025em 0.05em 0 rgba(138, 43, 226, 0.75); }
+  15% { text-shadow: -0.05em -0.025em 0 rgba(255, 0, 85, 0.75), 0.025em 0.025em 0 rgba(0, 240, 255, 0.75), -0.05em -0.05em 0 rgba(138, 43, 226, 0.75); }
+  49% { text-shadow: -0.05em -0.025em 0 rgba(255, 0, 85, 0.75), 0.025em 0.025em 0 rgba(0, 240, 255, 0.75), -0.05em -0.05em 0 rgba(138, 43, 226, 0.75); }
+  50% { text-shadow: 0.025em 0.05em 0 rgba(255, 0, 85, 0.75), 0.05em 0 0 rgba(0, 240, 255, 0.75), 0 -0.05em 0 rgba(138, 43, 226, 0.75); }
+  99% { text-shadow: 0.025em 0.05em 0 rgba(255, 0, 85, 0.75), 0.05em 0 0 rgba(0, 240, 255, 0.75), 0 -0.05em 0 rgba(138, 43, 226, 0.75); }
+  100% { text-shadow: -0.025em 0 0 rgba(255, 0, 85, 0.75), -0.025em -0.025em 0 rgba(0, 240, 255, 0.75), -0.025em -0.05em 0 rgba(138, 43, 226, 0.75); }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .glass-header {
+    flex-direction: column;
+    gap: 1rem;
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .footer-content {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+
+  .page-title {
+    font-size: 2rem;
+  }
+}

--- a/examples/lumina-synth-void/templates/404.html
+++ b/examples/lumina-synth-void/templates/404.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main error-page">
+    <div class="glass-panel main-article text-center">
+      <h1 class="glitch-text" data-text="404">404</h1>
+      <h2 class="page-title">Signal Lost in the Void</h2>
+      <p class="content-body">The coordinates you specified don't exist in this sector of the cyberspace.</p>
+      <div class="action-buttons mt-4">
+        <a href="/" class="btn-glow">Return to Nexus</a>
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-synth-void/templates/footer.html
+++ b/examples/lumina-synth-void/templates/footer.html
@@ -1,0 +1,15 @@
+    <footer class="glass-footer">
+      <div class="footer-content">
+        <p>&copy; {{ site.title }}. <span class="glow-text">Powered by Hwaro.</span></p>
+        <div class="social-links">
+          <a href="#">X</a>
+          <a href="#">GitHub</a>
+          <a href="#">Discord</a>
+        </div>
+      </div>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/lumina-synth-void/templates/header.html
+++ b/examples/lumina-synth-void/templates/header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title is defined %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/style.css">
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <!-- Background Elements -->
+  <div class="synth-bg">
+    <div class="glow-orb cyan"></div>
+    <div class="glow-orb magenta"></div>
+    <div class="glow-orb purple"></div>
+    <div class="grid-overlay"></div>
+  </div>
+
+  <div class="site-wrapper">
+    <header class="glass-header">
+      <a href="/" class="site-logo">
+        <span class="logo-text">{{ site.title }}</span>
+      </a>
+      <nav class="main-nav">
+        <a href="/" class="nav-link">Home</a>
+        <a href="/about/" class="nav-link">About</a>
+      </nav>
+    </header>

--- a/examples/lumina-synth-void/templates/page.html
+++ b/examples/lumina-synth-void/templates/page.html
@@ -1,0 +1,12 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <article class="glass-panel main-article">
+      {% if page.title is defined and page.title %}
+        <h1 class="page-title">{{ page.title | e }}</h1>
+      {% endif %}
+      <div class="content-body">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-synth-void/templates/section.html
+++ b/examples/lumina-synth-void/templates/section.html
@@ -1,0 +1,20 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel main-article">
+      {% if page.title is defined %}
+        <h1 class="page-title">{{ page.title | e }}</h1>
+      {% endif %}
+      <div class="content-body">
+        {{ content | safe }}
+      </div>
+
+      {% if section.list %}
+        <div class="section-items">
+          {{ section.list }}
+        </div>
+      {% endif %}
+
+      {{ pagination }}
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-synth-void/templates/shortcodes/alert.html
+++ b/examples/lumina-synth-void/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/lumina-synth-void/templates/taxonomy.html
+++ b/examples/lumina-synth-void/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel main-article">
+      <h1 class="page-title">{{ page.title | e }}</h1>
+      <p class="taxonomy-desc neon-text">Browse all terms in this taxonomy:</p>
+      <div class="content-body terms-grid">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}

--- a/examples/lumina-synth-void/templates/taxonomy_term.html
+++ b/examples/lumina-synth-void/templates/taxonomy_term.html
@@ -1,0 +1,11 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <div class="glass-panel main-article">
+      <h1 class="page-title">{{ page.title | e }}</h1>
+      <p class="taxonomy-desc neon-text">Entities tagged with this signature:</p>
+      <div class="content-body">
+        {{ content | safe }}
+      </div>
+    </div>
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR adds a new example site named `lumina-synth-void` to the `examples/` directory.

The new project features a futuristic, deep space "synth void" theme, utilizing:
- A dark background (`#020108` and `#070514`) with an animated moving grid.
- Glowing neon orbs (`#00f0ff`, `#ff0055`, `#8a2be2`).
- Elegant glassmorphic UI components (`backdrop-filter: blur(16px)`).
- Inter and Space Grotesk fonts.
- Sample content and fully styled templates (`header.html`, `footer.html`, `page.html`, `section.html`, `404.html`, `taxonomy.html`, `taxonomy_term.html`).

Verified with `hwaro build`, `hwaro tool doctor`, `hwaro tool validate`, and visual inspection using a Playwright script.

---
*PR created automatically by Jules for task [17428115450398740409](https://jules.google.com/task/17428115450398740409) started by @hahwul*