### PR TITLE
feat: add neon-synth-grid example theme

### DIFF
--- a/examples/neon-synth-grid/AGENTS.md
+++ b/examples/neon-synth-grid/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neon-synth-grid/config.toml
+++ b/examples/neon-synth-grid/config.toml
@@ -1,0 +1,33 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Neon Synth Grid"
+description = "A cyberpunk neon aesthetic theme"
+base_url = "/"
+
+[plugins]
+processors = ["markdown"]
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+
+[highlight]
+enabled = true
+theme = "atom-one-dark"
+use_cdn = true
+
+[pagination]
+enabled = false
+per_page = 10
+
+[[taxonomies]]
+name = "tags"
+feed = true
+
+[[taxonomies]]
+name = "categories"
+
+[markdown]
+safe = false
+lazy_loading = false

--- a/examples/neon-synth-grid/content/about.md
+++ b/examples/neon-synth-grid/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+date = "2024-01-01"
+description = "About this neon theme"
+template = "page.html"
++++
+
+# About
+This is a custom theme featuring a retro cyberpunk grid and neon styling.

--- a/examples/neon-synth-grid/content/index.md
+++ b/examples/neon-synth-grid/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Home"
+date = "2024-01-01"
+description = "Welcome to the Neon Synth Grid"
+template = "page.html"
++++
+
+# Welcome to the Grid
+Dive into the neon synthscape.

--- a/examples/neon-synth-grid/templates/404.html
+++ b/examples/neon-synth-grid/templates/404.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>404 - Not Found</h1>
+<p>The grid has broken. Return <a href="{{ base_url }}">Home</a>.</p>
+{% endblock %}

--- a/examples/neon-synth-grid/templates/base.html
+++ b/examples/neon-synth-grid/templates/base.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <style>
+        :root {
+            --bg: #090a0f;
+            --grid-color: rgba(255, 0, 255, 0.3);
+            --neon-cyan: #00ffff;
+            --neon-pink: #ff00ff;
+            --text: #ffffff;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--bg);
+            background-image:
+                linear-gradient(transparent 95%, var(--grid-color) 95%),
+                linear-gradient(90deg, transparent 95%, var(--grid-color) 95%);
+            background-size: 40px 40px;
+            color: var(--text);
+            font-family: monospace;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: rgba(9, 10, 15, 0.85);
+            border: 1px solid var(--neon-cyan);
+            box-shadow: 0 0 10px var(--neon-cyan);
+            margin-top: 2rem;
+            flex: 1;
+        }
+        h1, h2, h3 {
+            color: var(--neon-pink);
+            text-shadow: 0 0 5px var(--neon-pink);
+        }
+        a {
+            color: var(--neon-cyan);
+            text-decoration: none;
+        }
+        a:hover {
+            text-shadow: 0 0 5px var(--neon-cyan);
+        }
+        .header, .footer {
+            text-align: center;
+            padding: 1rem;
+            border-bottom: 1px solid var(--neon-pink);
+        }
+        .footer {
+            border-bottom: none;
+            border-top: 1px solid var(--neon-pink);
+            margin-top: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{ site.title }}</h1>
+        <nav>
+            <a href="{{ base_url }}">Home</a> | <a href="{{ base_url }}about/">About</a>
+        </nav>
+    </div>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+    <div class="footer">
+        <p>&copy; 2024 {{ site.title }}</p>
+    </div>
+</body>
+</html>

--- a/examples/neon-synth-grid/templates/page.html
+++ b/examples/neon-synth-grid/templates/page.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<article>
+    <header>
+        <h1>{{ page.title }}</h1>
+    </header>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/examples/neon-synth-grid/templates/section.html
+++ b/examples/neon-synth-grid/templates/section.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+    <h1>{{ page.title }}</h1>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+    <ul class="page-list">
+    {% for p in pages %}
+        <li><a href="{{ base_url }}{{ p.slug }}/">{{ p.title }}</a></li>
+    {% endfor %}
+    </ul>
+</section>
+{% endblock %}

--- a/examples/neon-synth-grid/templates/shortcodes/alert.html
+++ b/examples/neon-synth-grid/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neon-synth-grid/templates/taxonomy.html
+++ b/examples/neon-synth-grid/templates/taxonomy.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ page.title | e }}</h1>
+<ul>
+{% for term in terms %}
+    <li><a href="{{ base_url }}{{ term.path }}/">{{ term.name }}</a> ({{ term.pages | length }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/examples/neon-synth-grid/templates/taxonomy_term.html
+++ b/examples/neon-synth-grid/templates/taxonomy_term.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Term: {{ term.name }}</h1>
+<ul>
+{% for p in pages %}
+    <li><a href="{{ base_url }}{{ p.slug }}/">{{ p.title }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -4897,6 +4897,12 @@
     "portfolio",
     "glassmorphism"
   ],
+  "neon-synth-grid": [
+    "dark",
+    "neon",
+    "cyberpunk",
+    "grid"
+  ],
   "neon-tokyo": [
     "dark",
     "blog",


### PR DESCRIPTION
Adds a new example static site to demonstrate Hwaro's capabilities.
The site is named `neon-synth-grid` and focuses on a custom cyberpunk/neon grid aesthetic design.

Changes include:
- Created the project structure with `hwaro init examples/neon-synth-grid`.
- Custom `base.html` template using CSS grid gradients and neon styling.
- Extracted and modified base page components (`page.html`, `section.html`, `404.html`, `taxonomy.html`, `taxonomy_term.html`) to inherit from the base layout.
- Added sample content in `index.md` and `about.md`.
- Kept configuration minimal in `config.toml`.
- Added the `neon-synth-grid` theme entry to the main `tags.json` registry.

---
*PR created automatically by Jules for task [15243156091131052280](https://jules.google.com/task/15243156091131052280) started by @chei-l*