### PR TITLE
feat: Add holo-cosmos example site

### DIFF
--- a/examples/holo-cosmos/AGENTS.md
+++ b/examples/holo-cosmos/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/holo-cosmos/config.toml
+++ b/examples/holo-cosmos/config.toml
@@ -1,0 +1,18 @@
+base_url = "http://localhost:3000"
+title = "Holo Cosmos"
+description = "A journey through the holographic universe."
+language_code = "en"
+
+[author]
+name = "Holo Architect"
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"
+
+[build]
+minify = true

--- a/examples/holo-cosmos/content/_index.md
+++ b/examples/holo-cosmos/content/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Holo Cosmos"
+description = "A journey through the holographic universe."
++++
+
+Welcome to **Holo Cosmos**. Explore the shimmering frontiers of the digital universe where light and structure merge into an ethereal dance.
+
+This site demonstrates the power and flexibility of Hwaro, blending seamless glassmorphism with vivid neon holographic effects to create a deep, immersive aesthetic.
+
+- **Ethereal Glows**: Fluid gradients that mimic holographic projections.
+- **Glassmorphism**: Translucent interfaces that blur the boundaries between content and void.
+- **Deep Space Aesthetics**: A rich, dark palette designed for maximum contrast and readability.
+
+Ready your sensors and prepare to launch into the unknown.

--- a/examples/holo-cosmos/content/about.md
+++ b/examples/holo-cosmos/content/about.md
@@ -1,0 +1,16 @@
++++
+title = "About Holo Cosmos"
+description = "Discover the origins of the holographic universe."
++++
+
+## The Genesis
+
+Holo Cosmos is an experimental playground for modern web aesthetics, built on top of the ultra-fast Hwaro static site generator. We aim to showcase how simplicity in structure can yield complex and beautiful visual results.
+
+### Features Included
+* Immersive deep space backgrounds
+* Animated neon mesh gradients
+* Frosted glass UI panels (`backdrop-filter`)
+* Elegant typography using Space Grotesk and Inter
+
+Join us on our journey to push the boundaries of digital design.

--- a/examples/holo-cosmos/templates/404.html
+++ b/examples/holo-cosmos/templates/404.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}404 Not Found | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <div style="text-align: center; padding: 4rem 0;">
+        <h1 style="font-size: 6rem; margin-bottom: 0; background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">404</h1>
+        <h2>Signal Lost in the Void</h2>
+        <p style="color: var(--text-muted); margin-top: 1rem;">The sector you are trying to reach does not exist or has been moved.</p>
+        <a href="/" style="display: inline-block; margin-top: 2rem; padding: 0.8rem 2rem; border: 1px solid var(--neon-cyan); border-radius: 30px; color: var(--neon-cyan); text-transform: uppercase; letter-spacing: 0.1em; transition: all 0.3s ease;">Return to Base</a>
+    </div>
+
+    <style>
+        a[href="/"]:hover {
+            background: rgba(0, 240, 255, 0.1);
+            box-shadow: 0 0 15px rgba(0, 240, 255, 0.3);
+            text-decoration: none;
+        }
+    </style>
+{% endblock %}

--- a/examples/holo-cosmos/templates/base.html
+++ b/examples/holo-cosmos/templates/base.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="{{ site.language_code | default('en') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ page.title | default(site.title) }}{% endblock %}</title>
+    <meta name="description" content="{{ page.description | default(site.description) }}">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            /* Color Palette */
+            --bg-deep: #020108;
+            --bg-void: #050212;
+            --neon-cyan: #00f0ff;
+            --neon-magenta: #ff0055;
+            --neon-purple: #9d00ff;
+            --text-main: #e2e8f0;
+            --text-muted: #94a3b8;
+
+            /* Glassmorphism */
+            --glass-bg: rgba(255, 255, 255, 0.03);
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --glass-highlight: rgba(255, 255, 255, 0.15);
+            --glass-blur: blur(16px);
+
+            /* Typography */
+            --font-sans: 'Inter', sans-serif;
+            --font-display: 'Space Grotesk', sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: var(--font-sans);
+            background-color: var(--bg-deep);
+            color: var(--text-main);
+            line-height: 1.6;
+            min-height: 100vh;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        /* Animated Holographic Background */
+        .holo-bg {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: -1;
+            background:
+                radial-gradient(circle at 15% 25%, rgba(0, 240, 255, 0.15) 0%, transparent 40%),
+                radial-gradient(circle at 85% 75%, rgba(255, 0, 85, 0.15) 0%, transparent 40%),
+                radial-gradient(circle at 50% 50%, rgba(157, 0, 255, 0.1) 0%, transparent 50%);
+            animation: holoShift 15s ease-in-out infinite alternate;
+            pointer-events: none;
+        }
+
+        @keyframes holoShift {
+            0% {
+                transform: scale(1) translate(0, 0);
+            }
+            100% {
+                transform: scale(1.1) translate(2%, 2%);
+            }
+        }
+
+        /* Grid Overlay */
+        .grid-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: -1;
+            background-image:
+                linear-gradient(var(--glass-border) 1px, transparent 1px),
+                linear-gradient(90deg, var(--glass-border) 1px, transparent 1px);
+            background-size: 40px 40px;
+            opacity: 0.2;
+            pointer-events: none;
+            perspective: 1000px;
+            transform: rotateX(60deg) translateY(-100px) scale(2);
+            transform-origin: top center;
+            animation: gridMove 20s linear infinite;
+        }
+
+        @keyframes gridMove {
+            0% { background-position: 0 0; }
+            100% { background-position: 0 40px; }
+        }
+
+        /* Layout */
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            position: relative;
+            z-index: 1;
+        }
+
+        /* Header */
+        header {
+            padding: 2rem 0;
+            margin-bottom: 3rem;
+            border-bottom: 1px solid var(--glass-border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .site-title {
+            font-family: var(--font-display);
+            font-size: 1.5rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            text-decoration: none;
+        }
+
+        nav a {
+            color: var(--text-muted);
+            text-decoration: none;
+            margin-left: 1.5rem;
+            font-family: var(--font-display);
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            transition: color 0.3s ease, text-shadow 0.3s ease;
+        }
+
+        nav a:hover {
+            color: var(--neon-cyan);
+            text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+        }
+
+        /* Main Content Glass Panel */
+        main {
+            background: var(--glass-bg);
+            backdrop-filter: var(--glass-blur);
+            -webkit-backdrop-filter: var(--glass-blur);
+            border: 1px solid var(--glass-border);
+            border-radius: 16px;
+            padding: 3rem;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+            position: relative;
+            overflow: hidden;
+        }
+
+        main::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, var(--glass-highlight), transparent);
+        }
+
+        /* Typography inside Main */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-display);
+            color: #fff;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            font-weight: 600;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-top: 0;
+            text-shadow: 0 2px 10px rgba(255, 255, 255, 0.1);
+        }
+
+        h2 {
+            font-size: 1.8rem;
+            color: var(--neon-cyan);
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+            font-size: 1.1rem;
+        }
+
+        a {
+            color: var(--neon-magenta);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        a:hover {
+            color: var(--neon-cyan);
+            text-decoration: underline;
+        }
+
+        ul, ol {
+            margin-bottom: 1.5rem;
+            padding-left: 1.5rem;
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 4rem;
+            padding: 2rem 0;
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            border-top: 1px solid var(--glass-border);
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .container {
+                padding: 1rem;
+            }
+            main {
+                padding: 1.5rem;
+            }
+            h1 {
+                font-size: 2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="holo-bg"></div>
+    <div class="grid-overlay"></div>
+
+    <div class="container">
+        <header>
+            <a href="/" class="site-title">{{ site.title }}</a>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/about">About</a>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            <p>&copy; 2024 {{ site.title }}. Built with Hwaro.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/holo-cosmos/templates/page.html
+++ b/examples/holo-cosmos/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <article>
+        <h1>{{ page.title }}</h1>
+        <div class="content">
+            {{ content | safe }}
+        </div>
+    </article>
+{% endblock %}

--- a/examples/holo-cosmos/templates/section.html
+++ b/examples/holo-cosmos/templates/section.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}{{ section.title | default("Section") }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ section.title | default("Articles") }}</h1>
+
+    {% if content %}
+    <div class="content" style="margin-bottom: 2rem;">
+        {{ content | safe }}
+    </div>
+    {% endif %}
+
+    <ul style="list-style-type: none; padding: 0;">
+        {% for page in section.pages %}
+        <li style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--glass-border);">
+            <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
+            {% if page.description %}
+            <p style="color: var(--text-muted); margin-top: 0.5rem; margin-bottom: 0;">{{ page.description }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/examples/holo-cosmos/templates/taxonomy.html
+++ b/examples/holo-cosmos/templates/taxonomy.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    <p style="color: var(--text-muted); margin-bottom: 2rem;">Browse all terms in this taxonomy:</p>
+    <div class="content">
+        {{ content | safe }}
+    </div>
+{% endblock %}

--- a/examples/holo-cosmos/templates/taxonomy_term.html
+++ b/examples/holo-cosmos/templates/taxonomy_term.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}
+
+{% block content %}
+    <h1>Pages tagged with "{{ page.title }}"</h1>
+    <p style="color: var(--text-muted); margin-bottom: 2rem;">Explore the content related to this term.</p>
+
+    <div class="content" style="margin-bottom: 2rem;">
+        {{ content | safe }}
+    </div>
+
+    <ul style="list-style-type: none; padding: 0;">
+        {% for p in page.pages %}
+        <li style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--glass-border);">
+            <h2><a href="{{ p.permalink }}">{{ p.title }}</a></h2>
+            {% if p.description %}
+            <p style="color: var(--text-muted); margin-top: 0.5rem; margin-bottom: 0;">{{ p.description }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+{% endblock %}


### PR DESCRIPTION
Creates a new standalone Hwaro example site in `examples/holo-cosmos` with a holographic deep space aesthetic, including:
- Dark space background with animated neon holographic gradients (cyan, magenta, purple)
- Glassmorphism panels with `backdrop-filter`
- Inter and Space Grotesk typography
- Base layout and supporting templates (`page.html`, `section.html`, `404.html`, `taxonomy.html`, `taxonomy_term.html`) inheriting from `base.html`
- Validated with `hwaro tool doctor` and `hwaro tool validate`

---
*PR created automatically by Jules for task [5776015082560333740](https://jules.google.com/task/5776015082560333740) started by @hahwul*