### PR TITLE
Add aero-glass-horizon example

### DIFF
--- a/examples/aero-glass-horizon/AGENTS.md
+++ b/examples/aero-glass-horizon/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/aero-glass-horizon/config.toml
+++ b/examples/aero-glass-horizon/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Aero Glass Horizon"
+description = "A sleek aero glassmorphism horizon theme."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/aero-glass-horizon/content/_index.md
+++ b/examples/aero-glass-horizon/content/_index.md
@@ -1,0 +1,15 @@
++++
+title = "Aero Glass Horizon"
+description = "A sleek aero glassmorphism horizon theme."
++++
+
+Welcome to **Aero Glass Horizon**. This Hwaro theme blends the ethereal beauty of a glowing horizon with the modern aesthetics of glassmorphism.
+
+The dark backdrop sets the stage for vivid neon accents—cyan, magenta, and purple—while frosted glass containers and translucent overlays give a sense of depth and elegance.
+
+### Why Aero Glass Horizon?
+- **Immersive Design:** The soft neon horizon pulse and slow-drifting ambient orbs bring the layout to life.
+- **Glassmorphism Built-In:** Clean, readable typography overlays beautifully on semi-transparent panels.
+- **Performance Focused:** Designed with Hwaro, so it's statically generated and blazing fast.
+
+Enjoy the view from the horizon!

--- a/examples/aero-glass-horizon/content/about.md
+++ b/examples/aero-glass-horizon/content/about.md
@@ -1,0 +1,24 @@
++++
+title = "About This Theme"
+description = "Learn more about the Aero Glass Horizon aesthetic."
++++
+
+Aero Glass Horizon is built to push the visual limits of a static site while keeping everything lightweight.
+
+The aesthetic is inspired by deep space vistas, glowing cosmic phenomenon, and modern UI trends that emphasize transparency and layering.
+
+Here are some features you'll notice:
+
+1. **Backdrop Filters:** Used extensively for that sleek glass-pane look.
+2. **Neon Accents:** Soft radial gradients and horizontal lines give structure without feeling boxed in.
+3. **Animated Atmosphere:** Ambient orbs drift lazily in the background.
+
+```html
+<!-- Example of a glassmorphic container -->
+<div class="site-main">
+  <h1>Hello Horizon</h1>
+  <p>Exploring the unknown.</p>
+</div>
+```
+
+Feel free to dive into the code and make it your own!

--- a/examples/aero-glass-horizon/templates/404.html
+++ b/examples/aero-glass-horizon/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="not-found" style="text-align: center; padding: 3rem 0;">
+  <h1 style="font-size: 5rem; margin-bottom: 0;">404</h1>
+  <p style="font-size: 1.25rem; color: var(--text-muted);">Lost in the aero glass horizon.</p>
+  <p><a href="{{ base_url }}/">&larr; Return Home</a></p>
+</div>
+{% endblock content %}

--- a/examples/aero-glass-horizon/templates/base.html
+++ b/examples/aero-glass-horizon/templates/base.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(site.description) | e }}">
+  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+  <style>
+    :root {
+      /* Deep space horizon colors */
+      --bg-top: #0b0f19;
+      --bg-bottom: #030508;
+
+      /* Neon Horizon Glow */
+      --glow-cyan: #00f0ff;
+      --glow-magenta: #ff0055;
+      --glow-purple: #8a2be2;
+
+      /* Typography */
+      --text-main: #f0f4f8;
+      --text-muted: #a0aec0;
+      --font-body: 'Outfit', sans-serif;
+      --font-heading: 'Space Grotesk', sans-serif;
+
+      /* Glassmorphism */
+      --glass-bg: rgba(16, 24, 43, 0.4);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+      --glass-glow: 0 0 15px rgba(0, 240, 255, 0.2);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-body);
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-main);
+      background-color: var(--bg-bottom);
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    /* Abstract Horizon Line & Glow Animations */
+    .horizon-bg {
+      position: fixed;
+      top: 0; left: 0; width: 100%; height: 100vh;
+      z-index: -1;
+      background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
+      overflow: hidden;
+    }
+
+    .horizon-line {
+      position: absolute;
+      top: 50%; left: 0; width: 100%; height: 2px;
+      background: linear-gradient(90deg, transparent, var(--glow-cyan), var(--glow-magenta), var(--glow-purple), transparent);
+      box-shadow: 0 0 20px var(--glow-cyan), 0 0 40px var(--glow-magenta);
+      animation: horizonPulse 4s infinite alternate ease-in-out;
+      transform: translateY(-50%);
+    }
+
+    .ambient-orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(80px);
+      opacity: 0.4;
+      animation: drift 15s infinite alternate ease-in-out;
+    }
+    .orb-1 { width: 400px; height: 400px; background: var(--glow-cyan); top: -100px; left: -100px; }
+    .orb-2 { width: 500px; height: 500px; background: var(--glow-magenta); bottom: -150px; right: -150px; animation-duration: 20s; }
+
+    @keyframes horizonPulse {
+      0% { opacity: 0.6; box-shadow: 0 0 10px var(--glow-cyan); }
+      100% { opacity: 1; box-shadow: 0 0 30px var(--glow-cyan), 0 0 60px var(--glow-magenta); }
+    }
+    @keyframes drift {
+      0% { transform: translate(0, 0); }
+      100% { transform: translate(40px, 40px); }
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 900px; margin: 0 auto; padding: 0 1.5rem; position: relative; z-index: 1; }
+
+    .site-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1.5rem 2rem;
+      margin: 2rem 0;
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: var(--glass-shadow);
+    }
+
+    .site-logo {
+      font-family: var(--font-heading);
+      font-weight: 700; font-size: 1.5rem;
+      color: var(--text-main); text-decoration: none;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      background: linear-gradient(90deg, var(--glow-cyan), var(--glow-magenta));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      text-shadow: 0 0 20px rgba(0, 240, 255, 0.3);
+    }
+
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a {
+      color: var(--text-muted); text-decoration: none; font-size: 1rem;
+      font-weight: 500;
+      transition: color 0.3s, text-shadow 0.3s;
+    }
+    .site-header nav a:hover {
+      color: var(--glow-cyan);
+      text-shadow: 0 0 8px var(--glow-cyan);
+    }
+
+    .site-main {
+      min-height: calc(100vh - 300px);
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: var(--glass-shadow);
+      padding: 2.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .site-footer {
+      padding: 2rem; text-align: center; color: var(--text-muted); font-size: 0.9rem;
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      margin-bottom: 2rem;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-heading);
+      color: var(--text-main);
+      margin-top: 1.5em; margin-bottom: 0.5em; font-weight: 600;
+      letter-spacing: -0.02em;
+    }
+    h1 { font-size: 2.5rem; margin-top: 0; color: var(--glow-cyan); text-shadow: 0 0 15px rgba(0, 240, 255, 0.3); }
+    h2 { font-size: 1.8rem; border-bottom: 1px solid var(--glass-border); padding-bottom: 0.5rem; }
+    h3 { font-size: 1.4rem; }
+
+    p { margin: 1.2em 0; font-size: 1.05rem; }
+
+    a {
+      color: var(--glow-cyan); text-decoration: none;
+      transition: color 0.3s, text-shadow 0.3s;
+    }
+    a:hover {
+      color: var(--glow-magenta);
+      text-shadow: 0 0 10px rgba(255, 0, 85, 0.5);
+    }
+
+    code {
+      background: rgba(0, 0, 0, 0.3);
+      padding: 0.2rem 0.4rem; border-radius: 4px;
+      font-family: 'Space Grotesk', monospace;
+      color: var(--glow-magenta);
+      border: 1px solid rgba(255, 0, 85, 0.3);
+    }
+
+    pre {
+      background: rgba(5, 8, 15, 0.6) !important;
+      padding: 1.5rem; border-radius: 8px; overflow-x: auto;
+      border: 1px solid var(--glass-border);
+      box-shadow: inset 0 0 20px rgba(0,0,0,0.5);
+    }
+    pre code { background: none; padding: 0; border: none; color: inherit; font-size: 0.9rem; }
+
+    hr {
+      border: 0; height: 1px;
+      background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
+      margin: 2rem 0;
+    }
+
+    blockquote {
+      border-left: 4px solid var(--glow-cyan);
+      margin: 1.5rem 0; padding: 1rem 1.5rem;
+      background: rgba(0, 240, 255, 0.05);
+      border-radius: 0 8px 8px 0;
+      font-style: italic;
+    }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
+    ul.section-list li {
+      margin-bottom: 1rem; padding: 1.5rem;
+      background: rgba(255,255,255,0.02);
+      border-radius: 12px; border: 1px solid var(--glass-border);
+      transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
+    }
+    ul.section-list li:hover {
+      transform: translateY(-2px);
+      background: rgba(255,255,255,0.04);
+      box-shadow: var(--glass-glow);
+      border-color: rgba(0, 240, 255, 0.3);
+    }
+    ul.section-list li a { font-family: var(--font-heading); font-size: 1.25rem; font-weight: 600; display: block; margin-bottom: 0.5rem; }
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; }
+
+    nav.pagination { margin: 2rem 0; display: flex; justify-content: center; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    nav.pagination a, nav.pagination span {
+      display: inline-flex; align-items: center; justify-content: center;
+      min-width: 2.5rem; height: 2.5rem; padding: 0 0.75rem;
+      border-radius: 8px; border: 1px solid var(--glass-border);
+      color: var(--text-main); text-decoration: none;
+      background: rgba(255,255,255,0.05);
+      font-family: var(--font-heading); font-weight: 500;
+      transition: all 0.3s;
+    }
+    nav.pagination a:hover {
+      border-color: var(--glow-cyan);
+      color: var(--glow-cyan);
+      box-shadow: 0 0 10px rgba(0, 240, 255, 0.2);
+    }
+    .pagination-current span {
+      border-color: var(--glow-cyan);
+      background: rgba(0, 240, 255, 0.1);
+      color: var(--glow-cyan);
+      box-shadow: 0 0 10px rgba(0, 240, 255, 0.2);
+    }
+    .pagination-disabled span { opacity: 0.3; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; padding: 1.25rem; }
+      .site-main { padding: 1.5rem; }
+      h1 { font-size: 2rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+
+  <div class="horizon-bg">
+    <div class="ambient-orb orb-1"></div>
+    <div class="ambient-orb orb-2"></div>
+    <div class="horizon-line"></div>
+  </div>
+
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+      <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="site-footer">
+      <p>Powered by <a href="https://github.com/hahwul/hwaro">Hwaro</a> &mdash; Aero Glass Horizon theme.</p>
+    </footer>
+  </div>
+
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/aero-glass-horizon/templates/page.html
+++ b/examples/aero-glass-horizon/templates/page.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<article class="page-content">
+  {% if page.title is present %}
+  <header class="page-header">
+    <h1>{{ page.title }}</h1>
+  </header>
+  {% endif %}
+  <div class="content-body">
+    {{ content | safe }}
+  </div>
+</article>
+{% endblock content %}

--- a/examples/aero-glass-horizon/templates/section.html
+++ b/examples/aero-glass-horizon/templates/section.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ page.title | default(page.section | capitalize) }}</h1>
+</header>
+<div class="content-body">
+  {{ content | safe }}
+</div>
+{% if pages is present and pages | length > 0 %}
+<ul class="section-list">
+  {% for p in pages %}
+  <li>
+    <a href="{{ base_url }}{{ p.permalink }}">{{ p.title | default(p.slug) }}</a>
+    {% if p.description is present %}
+    <p class="desc">{{ p.description }}</p>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% if pagination is present and pagination.total_pages > 1 %}
+<nav class="pagination">
+  <ul class="pagination-list">
+    {% if pagination.prev is present %}
+    <li><a href="{{ base_url }}{{ pagination.prev }}" class="pagination-prev">&laquo; Prev</a></li>
+    {% else %}
+    <li class="pagination-disabled"><span>&laquo; Prev</span></li>
+    {% endif %}
+
+    <li class="pagination-current"><span>{{ pagination.current_page }} of {{ pagination.total_pages }}</span></li>
+
+    {% if pagination.next is present %}
+    <li><a href="{{ base_url }}{{ pagination.next }}" class="pagination-next">Next &raquo;</a></li>
+    {% else %}
+    <li class="pagination-disabled"><span>Next &raquo;</span></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}
+{% endif %}
+{% endblock content %}

--- a/examples/aero-glass-horizon/templates/shortcodes/alert.html
+++ b/examples/aero-glass-horizon/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/aero-glass-horizon/templates/taxonomy.html
+++ b/examples/aero-glass-horizon/templates/taxonomy.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ taxonomy.name | capitalize }}</h1>
+</header>
+<ul class="section-list">
+  {% for term in terms %}
+  <li>
+    <a href="{{ base_url }}/{{ taxonomy.name }}/{{ term.slug }}/">{{ term.name }}</a>
+    <span style="float: right; color: var(--text-muted);">{{ term.count }} items</span>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock content %}

--- a/examples/aero-glass-horizon/templates/taxonomy_term.html
+++ b/examples/aero-glass-horizon/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="section-header">
+  <h1>{{ taxonomy.name | capitalize }}: {{ term.name }}</h1>
+</header>
+<ul class="section-list">
+  {% for p in pages %}
+  <li>
+    <a href="{{ base_url }}{{ p.permalink }}">{{ p.title | default(p.slug) }}</a>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock content %}


### PR DESCRIPTION
This PR adds a new example named `aero-glass-horizon` under the `examples/` directory. The example demonstrates an "Aero Glass Horizon" aesthetic, utilizing glassmorphism styles (`backdrop-filter`) and elegant animated horizon glow effects to build out a uniquely designed, responsive static site with sample content, configurations, and correctly inherited base templates.

---
*PR created automatically by Jules for task [11846388171568508989](https://jules.google.com/task/11846388171568508989) started by @hahwul*