### PR TITLE
feat: Add new neon-cyber-core example site

### DIFF
--- a/examples/neon-cyber-core/AGENTS.md
+++ b/examples/neon-cyber-core/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/neon-cyber-core/config.toml
+++ b/examples/neon-cyber-core/config.toml
@@ -1,0 +1,203 @@
+title = "Neon Cyber Core"
+description = "A neon-infused cyber core aesthetic built with Hwaro"
+base_url = "https://examples.hwaro.hahwul.com/neon-cyber-core"
+language = "en"
+theme = ""
+
+[feeds]
+enabled = true
+filename = "rss.xml"
+
+[taxonomies]
+tags = "tags"
+categories = "categories"
+
+[server]
+port = 3000
+watch = true
+
+[highlight]
+enabled = true
+theme = "monokai"
+
+[markdown]
+extensions = ["tables", "strikethrough", "task_lists"]
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+# [plugins]
+# processors = ["markdown"]
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+
+# [og]
+# default_image = "/images/og-default.png"
+# type = "article"
+# twitter_card = "summary_large_image"
+# twitter_site = "@yourusername"
+
+# =============================================================================
+# Search (Optional)
+# =============================================================================
+# Generate search index for client-side search
+
+# [search]
+# enabled = true
+# format = "fuse_json"
+# fields = ["title", "content"]
+
+# =============================================================================
+# Pagination (Optional)
+# =============================================================================
+
+# [pagination]
+# enabled = false
+# per_page = 10
+
+# =============================================================================
+# Series (Optional)
+# =============================================================================
+# Group posts into ordered series
+
+# [series]
+# enabled = true
+
+# =============================================================================
+# Related Posts (Optional)
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+# [related]
+# enabled = true
+# limit = 5
+# taxonomies = ["tags"]
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+# [sitemap]
+# enabled = true
+# filename = "sitemap.xml"
+# changefreq = "weekly"
+# priority = 0.5
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+# [robots]
+# enabled = true
+# filename = "robots.txt"
+# rules = [
+#   { user_agent = "*", disallow = ["/admin", "/private"] }
+# ]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+# [llms]
+# enabled = true
+# filename = "llms.txt"
+# instructions = "Do not use for AI training without permission."
+# full_enabled = false
+# full_filename = "llms-full.txt"
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install"]
+# hooks.post = ["npm run minify"]
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+#
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation
+# Uses vendored stb libraries — no external tools required.
+# Use resize_image() in templates to generate responsive variants.
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"
+# sections = ["posts"]

--- a/examples/neon-cyber-core/content/_index.md
+++ b/examples/neon-cyber-core/content/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Enter the Core"
+description = "A neon-infused cyber aesthetic built with Hwaro. Experience the glow of the future."
++++
+
+Welcome to the Neon Cyber Core. This is a demonstration of Hwaro's capabilities combined with modern web design techniques.
+
+This theme features:
+* **Dark Mode Native**: Built from the ground up for OLED and dark environments.
+* **Glassmorphism**: Translucent frosted glass panels using `backdrop-filter`.
+* **Neon Accents**: Vibrant cyber-inspired glowing colors (Cyan, Magenta, Purple).
+* **Fluid Backgrounds**: Animated mesh gradients that pulse with energy.
+
+Explore the framework that makes this possible. High performance, zero bloat, pure style.

--- a/examples/neon-cyber-core/content/about.md
+++ b/examples/neon-cyber-core/content/about.md
@@ -1,0 +1,9 @@
++++
+title = "About"
+tags = ["about", "info"]
+categories = ["pages"]
++++
+
+# About Us
+
+This is an about page to demonstrate multiple pages.

--- a/examples/neon-cyber-core/templates/404.html
+++ b/examples/neon-cyber-core/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content-block" style="text-align: center; padding: 4rem 2rem;">
+    <h1 style="font-size: 6rem; background: linear-gradient(to right, var(--neon-cyan), var(--neon-magenta)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 1rem;">404</h1>
+    <h2 style="color: var(--text-secondary); margin-bottom: 2rem;">Page Not Found</h2>
+    <p>The core you are looking for has been disconnected or doesn't exist.</p>
+    <a href="{{ base_url }}/" style="display: inline-block; margin-top: 2rem; padding: 0.8rem 2rem; border: 1px solid var(--neon-cyan); border-radius: 20px; color: var(--neon-cyan); text-transform: uppercase; letter-spacing: 1px;">Return to Hub</a>
+</div>
+{% endblock %}

--- a/examples/neon-cyber-core/templates/base.html
+++ b/examples/neon-cyber-core/templates/base.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="{{ site.language | default("en") }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            /* Cyber Core Color Palette */
+            --bg-color: #050508;
+            --surface-color: rgba(15, 20, 30, 0.4);
+            --border-color: rgba(0, 240, 255, 0.2);
+            --text-primary: #e0f2fe;
+            --text-secondary: #94a3b8;
+
+            /* Neon Accents */
+            --neon-cyan: #00f0ff;
+            --neon-magenta: #ff0055;
+            --neon-purple: #8a2be2;
+
+            /* Typography */
+            --font-main: 'Outfit', sans-serif;
+            --font-display: 'Space Grotesk', sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: var(--bg-color);
+            color: var(--text-primary);
+            font-family: var(--font-main);
+            line-height: 1.6;
+            min-height: 100vh;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        /* Animated Background Mesh Gradient */
+        .cyber-bg {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: -1;
+            background:
+                radial-gradient(circle at 15% 50%, rgba(0, 240, 255, 0.08) 0%, transparent 50%),
+                radial-gradient(circle at 85% 30%, rgba(255, 0, 85, 0.08) 0%, transparent 50%),
+                radial-gradient(circle at 50% 80%, rgba(138, 43, 226, 0.08) 0%, transparent 50%);
+            animation: pulse-bg 15s ease-in-out infinite alternate;
+        }
+
+        @keyframes pulse-bg {
+            0% { transform: scale(1); }
+            50% { transform: scale(1.05); }
+            100% { transform: scale(1); }
+        }
+
+        /* Glassmorphism Elements */
+        .glass-panel {
+            background: var(--surface-color);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 1px solid var(--border-color);
+            border-radius: 16px;
+            box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+        }
+
+        header {
+            padding: 2rem 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            font-family: var(--font-display);
+            font-size: 2rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: white;
+            text-decoration: none;
+            position: relative;
+        }
+
+        .logo::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 100%;
+            height: 2px;
+            background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+            box-shadow: 0 0 10px var(--neon-cyan);
+        }
+
+        nav a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            margin-left: 2rem;
+            font-family: var(--font-display);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 0.9rem;
+            transition: color 0.3s ease, text-shadow 0.3s ease;
+        }
+
+        nav a:hover {
+            color: var(--neon-cyan);
+            text-shadow: 0 0 8px var(--neon-cyan);
+        }
+
+        main {
+            min-height: calc(100vh - 200px);
+            padding: 4rem 0;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-display);
+            font-weight: 700;
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--neon-cyan);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        a:hover {
+            color: var(--neon-magenta);
+            text-shadow: 0 0 5px var(--neon-magenta);
+        }
+
+        footer {
+            padding: 3rem 0;
+            text-align: center;
+            border-top: 1px solid rgba(255,255,255,0.05);
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+        }
+
+        /* Generic content styling */
+        .content-area {
+            line-height: 1.8;
+            font-size: 1.1rem;
+        }
+
+        .content-area p {
+            margin-bottom: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="cyber-bg"></div>
+
+    <div class="container">
+        <header>
+            <a href="{{ base_url }}/" class="logo">Neon Core</a>
+            <nav>
+                <a href="{{ base_url }}/">Home</a>
+                <a href="{{ base_url }}/about">About</a>
+            </nav>
+        </header>
+
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+
+        <footer>
+            <p>&copy; {{ site.title }}. Built with Hwaro.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/neon-cyber-core/templates/page.html
+++ b/examples/neon-cyber-core/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content-block">
+    <div style="padding: 2.5rem;" class="content-area">
+        <h1 style="color: var(--neon-cyan); margin-bottom: 2rem;">{{ page.title }}</h1>
+        {{ content | safe }}
+    </div>
+</div>
+{% endblock %}

--- a/examples/neon-cyber-core/templates/section.html
+++ b/examples/neon-cyber-core/templates/section.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+
+{% block content %}
+<style>
+    .hero {
+        text-align: center;
+        padding: 6rem 0;
+        margin-bottom: 4rem;
+        position: relative;
+    }
+
+    .hero-title {
+        font-size: 4rem;
+        background: linear-gradient(to right, var(--neon-cyan), var(--neon-magenta), var(--neon-purple));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin-bottom: 1rem;
+        animation: gradient-shift 5s ease infinite alternate;
+    }
+
+    @keyframes gradient-shift {
+        0% { filter: hue-rotate(0deg); }
+        100% { filter: hue-rotate(45deg); }
+    }
+
+    .hero-subtitle {
+        font-size: 1.2rem;
+        color: var(--text-secondary);
+        max-width: 600px;
+        margin: 0 auto;
+    }
+
+    .card-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 2rem;
+        margin-top: 4rem;
+    }
+
+    .card {
+        padding: 2rem;
+        transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .card::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -100%;
+        width: 100%;
+        height: 2px;
+        background: linear-gradient(90deg, transparent, var(--neon-cyan), transparent);
+        transition: left 0.5s ease;
+    }
+
+    .card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 12px 40px 0 rgba(0, 240, 255, 0.15);
+        border-color: rgba(0, 240, 255, 0.5);
+    }
+
+    .card:hover::before {
+        left: 100%;
+    }
+
+    .card h3 {
+        color: var(--neon-cyan);
+        font-size: 1.5rem;
+        margin-bottom: 1rem;
+    }
+
+    .card p {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
+
+    .content-block {
+        margin-top: 4rem;
+    }
+</style>
+
+<div class="hero">
+    <h1 class="hero-title">{{ page.title | default("Neon Cyber Core") }}</h1>
+    <p class="hero-subtitle">{{ page.description | default(site.description) }}</p>
+</div>
+
+<div class="glass-panel content-block">
+    <div style="padding: 2.5rem;" class="content-area">
+        {{ content | safe }}
+    </div>
+</div>
+
+{% if page.pages is defined and page.pages %}
+<div class="card-grid">
+    {% for post in page.pages %}
+    <a href="{{ post.url }}" class="glass-panel card">
+        <h3>{{ post.title }}</h3>
+        <p>{{ post.description | default(post.content | striptags | truncate(100)) }}</p>
+    </a>
+    {% endfor %}
+</div>
+{% endif %}
+
+{% endblock %}

--- a/examples/neon-cyber-core/templates/shortcodes/alert.html
+++ b/examples/neon-cyber-core/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/neon-cyber-core/templates/taxonomy.html
+++ b/examples/neon-cyber-core/templates/taxonomy.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content-block">
+    <div style="padding: 2.5rem;" class="content-area">
+        <h1 style="color: var(--neon-cyan); margin-bottom: 2rem;">Taxonomies</h1>
+        <ul>
+            {% for name, tax in site.taxonomies %}
+            <li><a href="{{ base_url }}/{{ name }}">{{ name | capitalize }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/examples/neon-cyber-core/templates/taxonomy_term.html
+++ b/examples/neon-cyber-core/templates/taxonomy_term.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel content-block">
+    <div style="padding: 2.5rem;" class="content-area">
+        <h1 style="color: var(--neon-cyan); margin-bottom: 2rem;">{{ taxonomy_term.name }}</h1>
+        <ul>
+            {% for post in taxonomy_pages %}
+            <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -7396,5 +7396,11 @@
     "diy",
     "raw",
     "unconventional"
+  ],
+  "neon-cyber-core": [
+    "dark",
+    "cyberpunk",
+    "neon",
+    "glassmorphism"
   ]
 }


### PR DESCRIPTION
This PR introduces a new example site named `neon-cyber-core`.

It utilizes a creative and elegant neon-infused cyberpunk glassmorphism aesthetic. It uses dark mode natively and features glowing mesh backgrounds, frosted glass panels, and vibrant neon accents (Cyan, Magenta, Purple).

The layout extends correctly using the `base.html` template and ensures all pages (including section, page, taxonomy, and 404 pages) are cohesively styled. Missing config settings have been filled and a custom `AGENTS.md` is generated.

---
*PR created automatically by Jules for task [3879221092889839698](https://jules.google.com/task/3879221092889839698) started by @hahwul*