### PR TITLE
feat: add chroma-bento example site

### DIFF
--- a/examples/chroma-bento/static/css/style.css
+++ b/examples/chroma-bento/static/css/style.css
@@ -1,0 +1,26 @@
+body {
+    margin: 0; padding: 2rem; background: linear-gradient(135deg, #1e1b4b, #312e81, #1e1b4b); color: white; font-family: sans-serif;
+}
+.bento-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; max-width: 1200px; margin: 0 auto;
+}
+.bento-item {
+    background: rgba(255, 255, 255, 0.05); border-radius: 1.5rem; padding: 2rem;
+    backdrop-filter: blur(16px); border: 1px solid rgba(255, 255, 255, 0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+}
+.bento-item:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+    background: rgba(255, 255, 255, 0.1);
+}
+.bento-large { grid-column: span 2; }
+@media (max-width: 768px) {
+    .bento-large { grid-column: span 1; }
+}
+a { color: #818cf8; text-decoration: none; }
+a:hover { color: #a5b4fc; text-decoration: underline; }
+.page-container {
+    max-width: 800px; margin: 0 auto; background: rgba(255, 255, 255, 0.05); border-radius: 1.5rem; padding: 2rem; backdrop-filter: blur(16px); border: 1px solid rgba(255, 255, 255, 0.1);
+}

--- a/examples/chroma-bento/templates/base.html
+++ b/examples/chroma-bento/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+    <meta name="description" content="{{ page.description | e }}">
+    <link rel="stylesheet" href="{{ base_url }}css/style.css">
+</head>
+<body>
+    <header style="max-width: 1200px; margin: 0 auto 2rem; display: flex; justify-content: space-between; align-items: center;">
+        <a href="{{ base_url }}" style="font-size: 1.5rem; font-weight: bold; color: white;">Chroma Bento</a>
+        <nav style="display: flex; gap: 1rem;">
+            <a href="{{ base_url }}">Home</a>
+            <a href="{{ base_url }}about/">About</a>
+        </nav>
+    </header>
+    {% block content %}{% endblock %}
+    <footer style="max-width: 1200px; margin: 4rem auto 0; text-align: center; font-size: 0.9rem; color: #a5b4fc;">
+        Powered by Hwaro
+    </footer>
+</body>
+</html>

--- a/examples/chroma-bento/templates/index.html
+++ b/examples/chroma-bento/templates/index.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<main class="bento-grid">
+    <div class="bento-item bento-large" style="background: linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(236, 72, 153, 0.2)); border-color: rgba(236, 72, 153, 0.3);">
+        <h1 style="margin-top: 0; font-size: 2.5rem; background: linear-gradient(to right, #c084fc, #f472b6); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">{{ page.title }}</h1>
+        <p style="font-size: 1.2rem; color: #e2e8f0;">{{ page.description }}</p>
+    </div>
+    <div class="bento-item">
+        <h2 style="margin-top: 0;">Who am I?</h2>
+        <p>I am a developer who loves crafting beautiful, colorful interfaces.</p>
+    </div>
+    <div class="bento-item">
+        <h2 style="margin-top: 0;">Projects</h2>
+        <p>Check out my latest work on <a href="https://github.com/hahwul/hwaro">Hwaro</a>.</p>
+    </div>
+    <div class="bento-item bento-large">
+        <h2 style="margin-top: 0;">Connect</h2>
+        <p>Find me on the web or send me a message. Let's build something great together.</p>
+        <a href="{{ base_url }}about/" style="display: inline-block; margin-top: 1rem; padding: 0.5rem 1rem; background: rgba(255,255,255,0.1); border-radius: 0.5rem; border: 1px solid rgba(255,255,255,0.2);">Learn more &rarr;</a>
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
Creates a new example site named `chroma-bento` featuring a bento-box glassmorphism design. Includes custom HTML layouts extending a base template, scoped CSS styling, sample content, updated `tags.json`, and an updated configuration. Validated successfully.

---
*PR created automatically by Jules for task [11846388171568511844](https://jules.google.com/task/11846388171568511844) started by @chei-l*