### PR TITLE
Add moonlight-glade custom example project

### DIFF
--- a/examples/moonlight-glade/AGENTS.md
+++ b/examples/moonlight-glade/AGENTS.md
@@ -1,0 +1,257 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   ├── taxonomy.html    # Taxonomy listing
+│   ├── taxonomy_term.html # Taxonomy term page
+│   ├── 404.html         # Error page
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Content
+
+### Pages
+
+Create `.md` files in `content/`. Front matter uses TOML (`+++`).
+
+```toml
++++
+title = "Page Title"
+date = "2024-01-15"
+description = "SEO description"
+draft = false
+tags = ["tag1", "tag2"]
+image = "/images/cover.png"
+weight = 0
+toc = true
+authors = ["Author"]
+template = "page"
+
+[extra]
+custom_field = "value"
++++
+
+Markdown content here.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title | string | Page title (required) |
+| date | string | Publication date (YYYY-MM-DD) |
+| description | string | SEO description |
+| draft | bool | Exclude from production builds |
+| tags | array | Tag taxonomy terms |
+| image | string | Featured image for social sharing |
+| weight | int | Sort order (lower = first) |
+| toc | bool | Enable table of contents |
+| template | string | Custom template name |
+| slug | string | Custom URL slug |
+| aliases | array | Redirect URLs to this page |
+| authors | array | Author names |
+| extra | table | Custom metadata (access via `page.extra`) |
+
+### Sections
+
+A directory with `_index.md` groups related content.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+paginate = 10
++++
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| sort_by | string | Sort by: `date`, `weight`, `title` |
+| paginate | int | Pages per page |
+| transparent | bool | Pass pages to parent section |
+| generate_feeds | bool | Generate RSS feed for this section |
+| page_template | string | Default template for child pages |
+
+### Internal Links
+
+Use `@/` to link to content by source path:
+```markdown
+[Read the post](@/blog/my-post.md)
+[Blog section](@/blog/_index.md)
+```
+
+### Content Summary
+
+Use `<!-- more -->` to define a summary for listings:
+```markdown
+This appears in listings.
+
+<!-- more -->
+
+Full content continues here.
+```
+
+## Templates
+
+### Template Selection
+
+| Content | Template |
+|---------|----------|
+| `content/index.md` | `index.html` or `page.html` |
+| `content/about.md` | `page.html` |
+| `content/blog/_index.md` | `section.html` |
+| `content/blog/post.md` | `page.html` |
+| Taxonomy listing | `taxonomy.html` |
+| Taxonomy term | `taxonomy_term.html` |
+
+### Key Variables
+
+**In page.html:**
+```jinja
+{{ page.title }}          {# Page title #}
+{{ page.date }}           {# Publication date #}
+{{ page.url }}            {# Relative URL #}
+{{ page.description }}    {# SEO description #}
+{{ page.image }}          {# Featured image #}
+{{ page.reading_time }}   {# Reading time in minutes #}
+{{ page.word_count }}     {# Word count #}
+{{ page.extra.field }}    {# Custom front matter #}
+{{ content | safe }}      {# Rendered HTML content #}
+{{ toc | safe }}          {# Table of contents HTML #}
+```
+
+**In section.html:**
+```jinja
+{{ section.title }}
+{{ section.pages }}       {# Array of pages #}
+{{ section.pages_count }}
+{{ section.subsections }} {# Child sections #}
+```
+
+**Global:**
+```jinja
+{{ site.title }}
+{{ site.description }}
+{{ base_url }}
+{{ current_year }}
+```
+
+**SEO (pre-rendered HTML):**
+```jinja
+{{ og_all_tags | safe }}       {# OpenGraph + Twitter meta tags #}
+{{ canonical_tag | safe }}     {# Canonical link #}
+{{ jsonld | safe }}            {# JSON-LD structured data #}
+{{ highlight_tags | safe }}    {# Syntax highlighting CSS + JS #}
+{{ auto_includes | safe }}     {# Auto-included CSS + JS #}
+```
+
+### Navigation
+
+```jinja
+{# Previous/Next page #}
+{% if page.lower %}<a href="{{ page.lower.url }}">← {{ page.lower.title }}</a>{% endif %}
+{% if page.higher %}<a href="{{ page.higher.url }}">{{ page.higher.title }} →</a>{% endif %}
+
+{# Breadcrumbs #}
+{% for ancestor in page.ancestors %}
+  <a href="{{ ancestor.url }}">{{ ancestor.title }}</a> /
+{% endfor %}
+```
+
+### Shortcodes
+
+Reusable components in `templates/shortcodes/`. Use in markdown:
+```markdown
+{{ youtube(id="dQw4w9WgXcQ") }}
+{% alert(type="warning") %}Warning text{% endalert %}
+```
+
+### Common Filters
+
+| Filter | Description |
+|--------|-------------|
+| `safe` | Output raw HTML |
+| `escape` | Escape HTML entities |
+| `default(value="fallback")` | Default value if nil |
+| `truncate(length=100)` | Truncate string |
+| `slugify` | Convert to URL slug |
+| `strip_html` | Remove HTML tags |
+| `markdownify` | Render markdown to HTML |
+| `date(format="%Y-%m-%d")` | Format date |
+| `upper` / `lower` | Case conversion |
+| `join(sep=", ")` | Join array |
+
+## Configuration
+
+Key `config.toml` sections:
+
+```toml
+title = "My Site"
+base_url = "https://example.com"
+
+[highlight]
+enabled = true
+theme = "github-dark"
+
+[search]
+enabled = true
+
+[sitemap]
+enabled = true
+
+[feeds]
+enabled = true
+
+[og]
+default_image = "/images/og.png"
+twitter_card = "summary_large_image"
+
+[[taxonomies]]
+name = "tags"
+```
+
+See [Hwaro Documentation](https://hwaro.hahwul.com/start/config/) for the full configuration reference.
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/moonlight-glade/config.toml
+++ b/examples/moonlight-glade/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Moonlight Glade"
+description = "A mystical and elegant theme for Hwaro."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = "rss.xml"             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/moonlight-glade/content/about.md
+++ b/examples/moonlight-glade/content/about.md
@@ -1,0 +1,8 @@
++++
+title = "About"
+description = "Learn more about the glade."
++++
+
+# About
+
+This is an example theme focusing on unique, elegant, dark-mode aesthetics.

--- a/examples/moonlight-glade/content/index.md
+++ b/examples/moonlight-glade/content/index.md
@@ -1,0 +1,9 @@
++++
+title = "Welcome to Moonlight Glade"
+description = "A serene and mystical place."
+tags = ["nature", "magic"]
++++
+
+# The Glade Awaits
+
+Welcome to a custom example showcasing a dark, elegant design in Hwaro. The moon is bright tonight.

--- a/examples/moonlight-glade/templates/404.html
+++ b/examples/moonlight-glade/templates/404.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="{{ base_url }}/">Return to Home</a></p>
+  </main>
+{% include "footer.html" %}

--- a/examples/moonlight-glade/templates/footer.html
+++ b/examples/moonlight-glade/templates/footer.html
@@ -1,0 +1,8 @@
+    <footer class="site-footer">
+      <p>&copy; Moonlight Glade. Powered by Hwaro.</p>
+    </footer>
+  </div>
+  {{ highlight_js }}
+  {{ auto_includes_js }}
+</body>
+</html>

--- a/examples/moonlight-glade/templates/header.html
+++ b/examples/moonlight-glade/templates/header.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="{{ page_language }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | e }}">
+  <title>{% if page.title %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  {{ og_all_tags }}
+  {{ hreflang_tags }}
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
+
+    :root {
+      --primary: #66fcf1;
+      --primary-dim: rgba(102, 252, 241, 0.2);
+      --text: #c5c6c7;
+      --text-muted: #8b8e91;
+      --border: #1f2833;
+      --bg: #0b0c10;
+      --bg-subtle: #14171d;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Lora', serif;
+      line-height: 1.7;
+      margin: 0;
+      color: var(--text);
+      background: var(--bg);
+      background-image: radial-gradient(circle at 50% 0%, var(--bg-subtle) 0%, var(--bg) 80%);
+    }
+
+    /* Layout */
+    .site-wrapper { max-width: 800px; margin: 0 auto; padding: 0 2rem; position: relative; }
+    .site-wrapper::before {
+      content: '';
+      position: absolute;
+      top: -100px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 400px;
+      height: 400px;
+      background: radial-gradient(circle, rgba(102,252,241,0.05) 0%, transparent 70%);
+      z-index: -1;
+      pointer-events: none;
+    }
+
+    .site-header { display: flex; align-items: center; justify-content: space-between; padding: 2rem 0; border-bottom: 1px solid var(--border); margin-bottom: 3rem; }
+    .site-logo { font-family: 'Cinzel', serif; font-weight: 700; font-size: 1.5rem; color: #fff; text-decoration: none; text-shadow: 0 0 10px rgba(102, 252, 241, 0.3); letter-spacing: 2px; }
+    .site-logo:hover { color: var(--primary); text-shadow: 0 0 15px var(--primary); }
+    .site-header nav { display: flex; gap: 1.5rem; }
+    .site-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.95rem; text-transform: uppercase; letter-spacing: 1px; font-family: 'Cinzel', serif; transition: color 0.3s; }
+    .site-header nav a:hover { color: var(--primary); }
+    .site-main { min-height: calc(100vh - 250px); }
+    .site-footer { margin-top: 4rem; padding: 2rem 0; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.85rem; text-align: center; }
+
+    /* Typography */
+    h1, h2, h3 { font-family: 'Cinzel', serif; line-height: 1.3; margin-top: 2em; margin-bottom: 0.5em; font-weight: 400; color: #fff; }
+    h1 { font-size: 2.2rem; margin-top: 0; text-shadow: 0 0 10px rgba(255,255,255,0.1); border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+    h2 { font-size: 1.6rem; }
+    h3 { font-size: 1.25rem; }
+    p { margin: 1.2em 0; }
+    a { color: var(--primary); text-decoration: none; transition: text-shadow 0.3s; }
+    a:hover { text-shadow: 0 0 8px var(--primary-dim); }
+    code { background: var(--bg-subtle); padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; color: #fff; border: 1px solid var(--border); }
+    pre { background: var(--bg-subtle); padding: 1.2rem; border-radius: 8px; overflow-x: auto; border: 1px solid var(--border); box-shadow: inset 0 0 15px rgba(0,0,0,0.5); }
+    pre code { background: none; padding: 0; border: none; }
+
+    /* Components */
+    ul.section-list { list-style: none; padding: 0; margin: 2rem 0; }
+    ul.section-list li { margin-bottom: 1rem; padding: 1rem 1.25rem; background: var(--bg-subtle); border-radius: 8px; border: 1px solid var(--border); transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s; }
+    ul.section-list li:hover { transform: translateY(-2px); border-color: rgba(102, 252, 241, 0.4); box-shadow: 0 4px 15px rgba(0,0,0,0.4); }
+    ul.section-list li a { font-weight: 500; font-family: 'Cinzel', serif; font-size: 1.1rem; color: #fff; }
+    .taxonomy-desc { color: var(--text-muted); margin-bottom: 1.5rem; font-style: italic; }
+    nav.pagination { margin: 2rem 0; }
+    nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; justify-content: center; }
+    nav.pagination a { display: inline-block; padding: 0.35rem 0.75rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); text-decoration: none; font-family: 'Cinzel', serif; }
+    nav.pagination a:hover { color: var(--primary); border-color: var(--primary); box-shadow: 0 0 8px var(--primary-dim); }
+    .pagination-current span { display: inline-block; padding: 0.35rem 0.75rem; border-radius: 6px; border: 1px solid var(--primary); background: var(--primary-dim); color: #fff; font-family: 'Cinzel', serif; }
+    .pagination-disabled span { display: inline-block; padding: 0.35rem 0.75rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); opacity: 0.4; font-family: 'Cinzel', serif; }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .site-header { flex-direction: column; gap: 1rem; align-items: center; }
+      .site-wrapper { padding: 0 1.25rem; }
+    }
+  </style>
+  {{ highlight_css }}
+  {{ auto_includes_css }}
+</head>
+<body data-section="{{ page.section }}">
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}/" class="site-logo">{{ site.title }}</a>
+            <nav>
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>

--- a/examples/moonlight-glade/templates/page.html
+++ b/examples/moonlight-glade/templates/page.html
@@ -1,0 +1,5 @@
+{% include "header.html" %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/moonlight-glade/templates/section.html
+++ b/examples/moonlight-glade/templates/section.html
@@ -1,0 +1,26 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    {{ content | safe }}
+    <ul class="section-list">
+      {% for p in pages %}
+      <li><a href="{{ base_url }}/{{ p.url }}">{{ p.title | e }}</a></li>
+      {% endfor %}
+    </ul>
+    {% if pagination is defined and pagination.total_pages is defined and pagination.total_pages > 1 %}
+      <nav class="pagination">
+        <ul class="pagination-list">
+          {% if pagination.prev %}<li><a href="{{ base_url }}/{{ pagination.prev }}">Prev</a></li>{% endif %}
+          {% for i in range(1, pagination.total_pages + 1) %}
+            {% if i == pagination.current %}
+              <li class="pagination-current"><span>{{ i }}</span></li>
+            {% else %}
+              <li><a href="{{ base_url }}/{{ pagination.url_pattern | replace(':page', i | string) }}">{{ i }}</a></li>
+            {% endif %}
+          {% endfor %}
+          {% if pagination.next %}<li><a href="{{ base_url }}/{{ pagination.next }}">Next</a></li>{% endif %}
+        </ul>
+      </nav>
+    {% endif %}
+  </main>
+{% include "footer.html" %}

--- a/examples/moonlight-glade/templates/shortcodes/alert.html
+++ b/examples/moonlight-glade/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/moonlight-glade/templates/taxonomy.html
+++ b/examples/moonlight-glade/templates/taxonomy.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}

--- a/examples/moonlight-glade/templates/taxonomy_term.html
+++ b/examples/moonlight-glade/templates/taxonomy_term.html
@@ -1,0 +1,7 @@
+{% include "header.html" %}
+  <main class="site-main">
+    <h1>{{ page.title | e }}</h1>
+    <p class="taxonomy-desc">Posts tagged with this term:</p>
+    {{ content }}
+  </main>
+{% include "footer.html" %}


### PR DESCRIPTION
This PR introduces a brand new, unique example project called `moonlight-glade` to the Hwaro repository. It showcases a highly customized, elegant dark-mode aesthetic. 

Changes include:
* Scaffolded a new site in `examples/moonlight-glade`.
* Configured `config.toml` correctly to pass doctor checks.
* Redesigned the primary `header.html` stylesheet to include Google Fonts (Cinzel, Lora) and glowing CSS elements.
* Adjusted `section.html` to properly loop and parse pages while maintaining valid pagination template structure.
* Updated standard markdown content files. 
* Added required `AGENTS.md`.

---
*PR created automatically by Jules for task [6573633504908762070](https://jules.google.com/task/6573633504908762070) started by @chei-l*