### PR TITLE
feat(examples): add astral-crystal-forge example site

### DIFF
--- a/examples/astral-crystal-forge/AGENTS.md
+++ b/examples/astral-crystal-forge/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - AI Agent Instructions for Hwaro Site
+
+This document provides instructions for AI agents working on this Hwaro-generated website.
+
+## Project Overview
+
+This is a static website built with [Hwaro](https://github.com/hahwul/hwaro), a fast and lightweight static site generator written in Crystal.
+
+## Essential Commands
+
+| Command | Description |
+|---------|-------------|
+| `hwaro build` | Build the site to `public/` directory |
+| `hwaro serve` | Start development server with live reload |
+| `hwaro new <path>` | Create new content from archetype |
+| `hwaro deploy` | Deploy the site (requires configuration) |
+| `hwaro build --drafts` | Include draft content |
+| `hwaro serve -p 8080` | Serve on custom port (default: 3000) |
+| `hwaro build --base-url "https://example.com"` | Set base URL for production |
+
+## Directory Structure
+
+```
+.
+├── config.toml          # Site configuration
+├── content/             # Markdown content files
+│   ├── _index.md        # Homepage content
+│   └── blog/            # Blog section
+│       ├── _index.md    # Section listing page
+│       └── *.md         # Individual pages
+├── templates/           # Jinja2 templates (Crinja)
+│   ├── base.html        # Base layout (optional)
+│   ├── page.html        # Page template
+│   ├── section.html     # Section listing template
+│   └── shortcodes/      # Shortcode templates
+├── static/              # Static assets (copied as-is)
+└── archetypes/          # Content templates for `hwaro new`
+```
+
+## Notes for AI Agents
+
+1. **Front matter is TOML** (`+++`), not YAML (`---`).
+2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
+3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
+4. **Always preview** with `hwaro serve` before committing.
+5. **Validate TOML syntax** in config.toml and front matter after edits.
+6. **Use `{{ base_url }}` prefix** for URLs in templates.
+7. **Escape user content** with `{{ value | escape }}` in templates.
+
+## Full Reference
+
+For detailed documentation on content, templates, configuration, and more:
+
+- [Hwaro Documentation](https://hwaro.hahwul.com)
+- [Configuration Guide](https://hwaro.hahwul.com/start/config/)
+- [Full LLM Reference](https://hwaro.hahwul.com/llms-full.txt) — comprehensive reference optimized for AI agents
+
+To generate the full embedded AGENTS.md locally, run:
+```
+hwaro tool agents-md --local --write
+```
+
+## Site-Specific Instructions
+
+<!-- Add your site-specific rules and conventions below -->

--- a/examples/astral-crystal-forge/config.toml
+++ b/examples/astral-crystal-forge/config.toml
@@ -1,0 +1,353 @@
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+title = "Astral Crystal Forge"
+description = "A dark-themed Hwaro example site featuring a cosmic crystal forge glassmorphism aesthetic."
+base_url = "http://localhost:3000"
+
+# =============================================================================
+# Multilingual (Optional)
+# =============================================================================
+# Enable multilingual routing by defining languages and a default language.
+# Then add language variants using filename suffixes:
+# - content/about.md -> /about/
+# - content/about.ko.md -> /ko/about/
+# - content/about/index.ko.md -> /ko/about/
+
+# default_language = "en"
+#
+# [languages.en]
+# language_name = "English"
+# weight = 1
+#
+# [languages.ko]
+# language_name = "한국어"
+# weight = 2
+
+# =============================================================================
+# Plugins
+# =============================================================================
+# Configure content processors and extensions
+
+[plugins]
+processors = ["markdown"]
+
+# =============================================================================
+# Content Files
+# =============================================================================
+# Publish non-Markdown files from `content/` into the output directory.
+# Example: content/about/profile.jpg -> /about/profile.jpg
+
+[content.files]
+allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+# disallow_extensions = ["psd"]
+# disallow_paths = ["private/**", "**/_*"]
+
+# =============================================================================
+# Syntax Highlighting
+# =============================================================================
+# Code block syntax highlighting using Highlight.js
+
+[highlight]
+enabled = true
+theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+use_cdn = true            # Set to false to use local assets
+
+# =============================================================================
+# OpenGraph & Twitter Cards
+# =============================================================================
+# Default meta tags for social sharing
+# Page-level settings (front matter) override these defaults
+
+[og]
+default_image = "/images/og-default.png"   # Default image for social sharing
+type = "article"                           # OpenGraph type (website, article, etc.)
+twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+# twitter_site = "@yourusername"           # Twitter @username for the site
+# twitter_creator = "@authorusername"      # Twitter @username for content creator
+# fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+# =============================================================================
+# Search Configuration
+# =============================================================================
+# Generates a search index for client-side search (e.g., Fuse.js)
+
+[search]
+enabled = true
+format = "fuse_json"
+fields = ["title", "content"]
+filename = "search.json"
+exclude = []              # Exclude paths or patterns from search index
+
+# =============================================================================
+# Pagination
+# =============================================================================
+# Enable pagination for section listing pages (e.g., /posts/, /blog/).
+# You can override per section in `_index.md` with:
+# - paginate = 10
+# - pagination_enabled = true
+# - sort_by = "date" | "title" | "weight"
+# - reverse = false
+
+[pagination]
+enabled = false
+per_page = 10
+
+# =============================================================================
+# Series
+# =============================================================================
+# Group posts into ordered series for sequential reading.
+# Use `series = "Series Name"` in front matter to assign posts.
+# Use `series_weight = 1` to control ordering within a series.
+
+[series]
+enabled = true
+
+# =============================================================================
+# Related Posts
+# =============================================================================
+# Recommend related content based on shared taxonomy terms
+
+[related]
+enabled = true
+limit = 5
+taxonomies = ["tags"]
+
+# =============================================================================
+# Taxonomies
+# =============================================================================
+# Define content classification systems (tags, categories, etc.)
+
+[[taxonomies]]
+name = "tags"
+feed = true
+sitemap = false
+
+[[taxonomies]]
+name = "categories"
+paginate_by = 5
+
+[[taxonomies]]
+name = "authors"
+
+# =============================================================================
+# Sitemap
+# =============================================================================
+# Generates sitemap.xml for search engine crawlers
+
+[sitemap]
+enabled = true
+filename = "sitemap.xml"
+changefreq = "weekly"
+priority = 0.5
+exclude = []              # Exclude paths or patterns from sitemap
+
+# =============================================================================
+# Robots.txt
+# =============================================================================
+# Controls search engine crawler access
+
+[robots]
+enabled = true
+filename = "robots.txt"
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+
+# =============================================================================
+# LLMs.txt
+# =============================================================================
+# Instructions for AI/LLM crawlers
+
+[llms]
+enabled = true
+filename = "llms.txt"
+instructions = "Do not use for AI training without permission."
+# Optional: Generate a single text file containing all Markdown pages
+full_enabled = false
+full_filename = "llms-full.txt"
+
+# =============================================================================
+# RSS/Atom Feeds
+# =============================================================================
+# Generates RSS or Atom feed for content syndication
+
+[feeds]
+enabled = true
+filename = ""             # Leave empty for default (rss.xml or atom.xml)
+type = "rss"              # "rss" or "atom"
+truncate = 0              # Truncate content to N characters (0 = full content)
+full_content = true       # true = full HTML in feed, false = description/summary only
+limit = 10                # Maximum number of items in feed
+sections = []   # Limit to specific sections, e.g., ["posts"]
+# default_language_only = true  # Multilingual: true = main feed has default language only
+#                               #              false = main feed includes all languages
+
+# =============================================================================
+# Permalinks (Optional)
+# =============================================================================
+# Override the output path for specific sections or taxonomies.
+# Placeholders: :year, :month, :day, :title, :slug, :section
+
+# [permalinks]
+# posts = "/posts/:year/:month/:slug/"
+# tags = "/topic/:slug/"
+
+# =============================================================================
+# Auto Includes (Optional)
+# =============================================================================
+# Automatically load CSS/JS files from static directories
+# Files are included alphabetically - use numeric prefixes for ordering
+# Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+# [auto_includes]
+# enabled = true
+# dirs = ["assets/css", "assets/js"]
+
+# =============================================================================
+# Asset Pipeline (Optional)
+# =============================================================================
+# Bundle, minify, and fingerprint CSS/JS files for production.
+# Use {{ asset(name="main.css") }} in templates to resolve paths.
+
+# [assets]
+# enabled = true
+# minify = true
+# fingerprint = true
+# source_dir = "static"
+# output_dir = "assets"
+
+# [[assets.bundles]]
+# name = "main.css"
+# files = ["css/reset.css", "css/style.css"]
+
+# [[assets.bundles]]
+# name = "app.js"
+# files = ["js/util.js", "js/app.js"]
+
+# =============================================================================
+# Markdown Configuration (Optional)
+# =============================================================================
+# Configure markdown parser behavior
+
+[markdown]
+safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
+lazy_loading = false  # If true, automatically add loading="lazy" to img tags
+emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+
+# =============================================================================
+# Image Processing (Optional)
+# =============================================================================
+# Automatic image resizing and LQIP (Low-Quality Image Placeholder) generation.
+# Uses vendored stb libraries — no external tools required.
+#
+# Use resize_image() in templates:
+#   {% set img = resize_image(path="/images/hero.jpg", width=1024) %}
+#   <img src="{{ img.url }}"
+#        style="background-image: url({{ img.lqip }}); background-size: cover;"
+#        loading="lazy">
+
+# [image_processing]
+# enabled = true
+# widths = [320, 640, 1024, 1280]
+# quality = 85
+#
+# [image_processing.lqip]
+# enabled = true
+# width = 32             # Placeholder width in pixels (8-128)
+# quality = 20           # JPEG quality for placeholder (1-100, lower = smaller)
+
+# =============================================================================
+# Build Hooks (Optional)
+# =============================================================================
+# Run custom shell commands before/after build process
+
+# [build]
+# hooks.pre = ["npm install", "python scripts/preprocess.py"]
+# hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+# =============================================================================
+# PWA (Progressive Web App) (Optional)
+# =============================================================================
+# Generate manifest.json and service worker for offline access and installability
+
+# [pwa]
+# enabled = true
+# name = "My Site"
+# short_name = "Site"
+# theme_color = "#ffffff"
+# background_color = "#ffffff"
+# display = "standalone"
+# start_url = "/"
+# icons = ["static/icon-192.png", "static/icon-512.png"]
+# offline_page = "/offline.html"
+# precache_urls = ["/", "/about/"]
+
+# =============================================================================
+# AMP (Accelerated Mobile Pages) (Optional)
+# =============================================================================
+# Generate AMP-compliant versions of content pages
+
+# [amp]
+# enabled = true
+# path_prefix = "amp"        # Output under /amp/ prefix
+# sections = ["posts"]       # Limit to specific sections (empty = all)
+
+# =============================================================================
+# Auto OG Images (Optional)
+# =============================================================================
+# Auto-generate Open Graph preview images for social sharing
+# Images are created for pages without a custom `image` in front matter
+
+# [og.auto_image]
+# enabled = true
+# background = "#1a1a2e"
+# text_color = "#ffffff"
+# accent_color = "#e94560"
+# font_size = 48
+# logo = "static/logo.png"
+# logo_position = "bottom-left"  # bottom-left, bottom-right, top-left, top-right
+# output_dir = "og-images"
+# show_title = true
+# style = "default"              # default, dots, grid, diagonal, gradient, waves, minimal
+# pattern_opacity = 0.15
+# pattern_scale = 1.0
+# background_image = ""          # Background image file path (embedded as base64)
+# overlay_opacity = 0.5
+# format = "svg"                 # svg or png
+
+# =============================================================================
+# Deployment (Optional)
+# =============================================================================
+# Configure deploy targets for `hwaro deploy`
+#
+# - Local filesystem sync: url = "file://./out"
+# - Remote/object stores: set `command` and use external tools (aws/gsutil/rsync/etc)
+#
+# Placeholders for `command`:
+#   {source} => source directory (default: public)
+#   {url}    => target url
+#   {target} => target name
+
+# [deployment]
+# target = "prod"
+# source_dir = "public"
+# confirm = false
+# dryRun = false
+# maxDeletes = 256      # safety limit (-1 disables)
+
+# [[deployment.targets]]
+# name = "prod"
+# url = "file://./out"
+
+# [[deployment.targets]]
+# name = "s3"
+# url = "s3://my-bucket"
+# command = "aws s3 sync {source}/ {url} --delete"
+
+# [[deployment.matchers]]
+# pattern = "^.+\.css$"
+# cacheControl = "max-age=31536000"
+# gzip = true

--- a/examples/astral-crystal-forge/content/_index.md
+++ b/examples/astral-crystal-forge/content/_index.md
@@ -1,0 +1,45 @@
++++
+title = "Welcome to the Forge"
+description = "Discover the cosmic void glassmorphism aesthetic."
+template = "page"
++++
+
+<div class="hero">
+  <h1>Astral Crystal Forge</h1>
+  <p>A deep space journey into luminous gradients and frosted glass.</p>
+</div>
+
+<div class="glass-panel">
+  <h2>Discover the Void</h2>
+  <p>The <strong>Astral Crystal Forge</strong> aesthetic utilizes a deep void background (`#020108`) complemented by glowing crystalline gradients (cyan, magenta, silver) and translucent frosted glass elements.</p>
+
+  <h3>Key Features</h3>
+  <ul class="section-list">
+    <li>
+      <a href="#">Deep Space Ambiance</a>
+      <div style="font-size: 0.9em; color: var(--text-muted); margin-top: 0.5rem;">
+        An immersive, dark background with ambient moving elements.
+      </div>
+    </li>
+    <li>
+      <a href="#">Frosted Glass</a>
+      <div style="font-size: 0.9em; color: var(--text-muted); margin-top: 0.5rem;">
+        Beautiful panels using backdrop-filter to create a glassmorphism effect.
+      </div>
+    </li>
+    <li>
+      <a href="#">Modern Typography</a>
+      <div style="font-size: 0.9em; color: var(--text-muted); margin-top: 0.5rem;">
+        Utilizing Space Grotesk and Inter for a futuristic yet readable feel.
+      </div>
+    </li>
+  </ul>
+</div>
+
+<div class="glass-panel">
+  <h2>Get Started</h2>
+  <p>To use this aesthetic, clone the example and start building your cosmic static site.</p>
+  <pre><code>hwaro init my-site --scaffold blog-dark
+cd my-site
+hwaro serve</code></pre>
+</div>

--- a/examples/astral-crystal-forge/content/about.md
+++ b/examples/astral-crystal-forge/content/about.md
@@ -1,0 +1,14 @@
++++
+title = "About the Forge"
+description = "Information about the Astral Crystal Forge aesthetic."
+template = "page"
++++
+
+This project demonstrates the powerful customization capabilities of **Hwaro**, a fast static site generator.
+
+The *Astral Crystal Forge* design focuses on:
+- **Depth**: Utilizing overlapping glass panels over animated background orbs.
+- **Contrast**: Bright, luminous text against deep space backgrounds.
+- **Performance**: Lightweight CSS without heavy external frameworks.
+
+Feel free to modify the CSS variables in `base.html` to create your own unique variants!

--- a/examples/astral-crystal-forge/templates/404.html
+++ b/examples/astral-crystal-forge/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel text-center">
+  <h1>404</h1>
+  <h2>Page Not Found</h2>
+  <p>The cosmic void has swallowed this page.</p>
+  <a href="{{ base_url }}/" class="button">Return to Forge</a>
+</div>
+{% endblock %}

--- a/examples/astral-crystal-forge/templates/base.html
+++ b/examples/astral-crystal-forge/templates/base.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="{{ page_language | default(value="en") }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ page.description | default(value=site.description) | e }}">
+  <title>{% if page.title is defined and page.title != "" %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+
+  {% if og_all_tags is defined %}{{ og_all_tags | safe }}{% endif %}
+  {% if hreflang_tags is defined %}{{ hreflang_tags | safe }}{% endif %}
+
+  <style>
+    :root {
+      /* Dark space/void background */
+      --bg-void: #020108;
+
+      /* Glowing crystalline gradients */
+      --crystal-cyan: #00f2fe;
+      --crystal-magenta: #fe00a1;
+      --crystal-silver: #e0e5ec;
+      --crystal-purple: #8a2be2;
+
+      --text-main: #f0f4f8;
+      --text-muted: #a0aec0;
+
+      /* Glassmorphism base */
+      --glass-bg: rgba(20, 25, 45, 0.4);
+      --glass-border: rgba(255, 255, 255, 0.1);
+      --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+
+      --font-sans: 'Inter', sans-serif;
+      --font-display: 'Space Grotesk', sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: var(--font-sans);
+      background-color: var(--bg-void);
+      color: var(--text-main);
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    /* Ambient animated crystalline background */
+    .ambient-crystals {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      z-index: -1;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .crystal-orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(80px);
+      opacity: 0.5;
+      animation: drift 20s infinite alternate ease-in-out;
+    }
+
+    .orb-1 {
+      top: -10%;
+      left: 10%;
+      width: 40vw;
+      height: 40vw;
+      background: radial-gradient(circle, var(--crystal-cyan), transparent 70%);
+      animation-duration: 25s;
+    }
+
+    .orb-2 {
+      bottom: -10%;
+      right: 5%;
+      width: 50vw;
+      height: 50vw;
+      background: radial-gradient(circle, var(--crystal-purple), transparent 70%);
+      animation-duration: 30s;
+      animation-delay: -5s;
+    }
+
+    .orb-3 {
+      top: 40%;
+      left: 60%;
+      width: 30vw;
+      height: 30vw;
+      background: radial-gradient(circle, var(--crystal-magenta), transparent 70%);
+      animation-duration: 22s;
+      animation-delay: -10s;
+    }
+
+    @keyframes drift {
+      0% { transform: translate(0, 0) scale(1); }
+      100% { transform: translate(10%, 15%) scale(1.1); }
+    }
+
+    /* Layout */
+    .site-wrapper {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    /* Glass Header */
+    .site-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.25rem 2rem;
+      margin-top: 2rem;
+      margin-bottom: 3rem;
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      box-shadow: var(--glass-shadow);
+      z-index: 10;
+    }
+
+    .site-logo {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.4rem;
+      text-decoration: none;
+      color: var(--text-main);
+      background: linear-gradient(90deg, var(--crystal-cyan), var(--crystal-silver));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      letter-spacing: -0.5px;
+    }
+
+    .site-nav {
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    .site-nav a {
+      color: var(--text-main);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.3s ease, text-shadow 0.3s ease;
+    }
+
+    .site-nav a:hover {
+      color: var(--crystal-cyan);
+      text-shadow: 0 0 8px rgba(0, 242, 254, 0.5);
+    }
+
+    /* Main Content Area */
+    .site-main {
+      flex: 1;
+    }
+
+    /* Typography */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--text-main);
+      line-height: 1.2;
+      margin-top: 2em;
+      margin-bottom: 0.75em;
+    }
+
+    h1 {
+      font-size: 3rem;
+      margin-top: 0;
+      background: linear-gradient(135deg, var(--text-main), var(--crystal-silver));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      letter-spacing: -1px;
+    }
+
+    h2 { font-size: 2rem; }
+    h3 { font-size: 1.5rem; }
+
+    p {
+      margin-bottom: 1.5em;
+      font-size: 1.05rem;
+      color: var(--text-muted);
+    }
+
+    a {
+      color: var(--crystal-magenta);
+      text-decoration: none;
+      transition: all 0.2s ease;
+    }
+
+    a:hover {
+      color: var(--crystal-cyan);
+    }
+
+    /* Glass Panels */
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      border-radius: 16px;
+      padding: 2.5rem;
+      box-shadow: var(--glass-shadow);
+      margin-bottom: 2rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .glass-panel::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
+    }
+
+    /* Hero Section */
+    .hero {
+      text-align: center;
+      padding: 4rem 2rem;
+    }
+
+    .hero h1 {
+      font-size: 4rem;
+      margin-bottom: 1rem;
+      background: linear-gradient(to right, var(--crystal-cyan), var(--crystal-magenta));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      max-width: 600px;
+      margin: 0 auto 2rem auto;
+    }
+
+    /* Components */
+    .section-list {
+      list-style: none;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .section-list li {
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--glass-border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .section-list li:hover {
+      transform: translateY(-5px);
+      border-color: var(--crystal-cyan);
+      box-shadow: 0 10px 20px rgba(0, 242, 254, 0.1);
+    }
+
+    .section-list a {
+      font-family: var(--font-display);
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--text-main);
+      display: block;
+      margin-bottom: 0.5rem;
+    }
+
+    .section-list a:hover {
+      color: var(--crystal-cyan);
+    }
+
+    /* Footer */
+    .site-footer {
+      text-align: center;
+      padding: 2rem 0;
+      margin-top: 4rem;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      border-top: 1px solid var(--glass-border);
+    }
+
+    /* Utilities */
+    code {
+      background: rgba(255,255,255,0.05);
+      padding: 0.2em 0.4em;
+      border-radius: 4px;
+      font-family: monospace;
+      color: var(--crystal-cyan);
+    }
+
+    pre {
+      background: rgba(0,0,0,0.4);
+      padding: 1.5rem;
+      border-radius: 12px;
+      border: 1px solid var(--glass-border);
+      overflow-x: auto;
+    }
+
+    pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+
+    @media (max-width: 768px) {
+      .hero h1 { font-size: 2.5rem; }
+      .site-header { flex-direction: column; gap: 1rem; padding: 1rem; }
+    }
+  </style>
+
+  {% if highlight_css is defined %}{{ highlight_css | safe }}{% endif %}
+  {% if auto_includes_css is defined %}{{ auto_includes_css | safe }}{% endif %}
+</head>
+<body>
+  <div class="ambient-crystals">
+    <div class="crystal-orb orb-1"></div>
+    <div class="crystal-orb orb-2"></div>
+    <div class="crystal-orb orb-3"></div>
+  </div>
+
+  <div class="site-wrapper">
+    <header class="site-header">
+      <a href="{{ base_url }}" class="site-logo">{{ site.title | e }}</a>
+      <nav class="site-nav">
+        <a href="{{ base_url }}/">Home</a>
+        <a href="{{ base_url }}/about/">About</a>
+      </nav>
+    </header>
+
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; {{ site.title | e }} - A Hwaro Example Site</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/astral-crystal-forge/templates/page.html
+++ b/examples/astral-crystal-forge/templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{{ page.title | e }}</h1>
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+</div>
+{% endblock %}

--- a/examples/astral-crystal-forge/templates/section.html
+++ b/examples/astral-crystal-forge/templates/section.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{{ page.title | e }}</h1>
+  {% if content is defined and content != "" %}
+  <div class="page-content">
+    {{ content | safe }}
+  </div>
+  {% endif %}
+
+  {% if section_pages is defined and section_pages | length > 0 %}
+  <ul class="section-list">
+    {% for p in section_pages %}
+    <li>
+      <a href="{{ base_url }}{{ p.permalink }}">{{ p.title | e }}</a>
+      {% if p.description is defined and p.description != "" %}
+      <div style="font-size: 0.9em; color: var(--text-muted); margin-top: 0.5rem;">
+        {{ p.description | e }}
+      </div>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endblock %}

--- a/examples/astral-crystal-forge/templates/shortcodes/alert.html
+++ b/examples/astral-crystal-forge/templates/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
+  <strong>{{ type | upper }}:</strong> {{ body }}
+</div>

--- a/examples/astral-crystal-forge/templates/taxonomy.html
+++ b/examples/astral-crystal-forge/templates/taxonomy.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{% if taxonomy is defined %}{{ taxonomy.name | capitalize }}{% else %}Taxonomy{% endif %}</h1>
+  {% if taxonomy is defined and terms is defined %}
+  <ul class="section-list">
+    {% for term in terms %}
+    <li>
+      <a href="{{ base_url }}{{ term.permalink }}">{{ term.name | e }} ({{ term.pages | length }})</a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endblock %}

--- a/examples/astral-crystal-forge/templates/taxonomy_term.html
+++ b/examples/astral-crystal-forge/templates/taxonomy_term.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="glass-panel">
+  <h1>{% if taxonomy is defined %}{{ taxonomy.name | capitalize }}{% endif %}: {% if term is defined %}{{ term.name | e }}{% endif %}</h1>
+  {% if term is defined and term.pages is defined %}
+  <ul class="section-list">
+    {% for p in term.pages %}
+    <li>
+      <a href="{{ base_url }}{{ p.permalink }}">{{ p.title | e }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tags.json
+++ b/tags.json
@@ -6238,5 +6238,12 @@
     "neon",
     "blog",
     "portfolio"
+  ],
+  "astral-crystal-forge": [
+    "dark",
+    "glassmorphism",
+    "crystal",
+    "cosmic",
+    "portfolio"
   ]
 }


### PR DESCRIPTION
Adds a new dark-themed Hwaro example site featuring a cosmic crystal forge glassmorphism aesthetic. It utilizes a deep space void background (#020108) with glowing crystalline gradients (cyan, magenta, silver), translucent frosted glass elements (`backdrop-filter: blur(16px)`), and modern typography using the Space Grotesk and Inter fonts.

---
*PR created automatically by Jules for task [1057332514028955778](https://jules.google.com/task/1057332514028955778) started by @hahwul*